### PR TITLE
Specify python version required in readme

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ Z3 can be built using Visual Studio Command Prompt and make/g++.
    cd build
    nmake
 
-2) Building Z3 using make/g++ and Python
+2) Building Z3 using make/g++ and Python2
 Execute:
 
    python scripts/mk_make.py


### PR DESCRIPTION
Just a small silly change. Ran into this on linux where python3 is the standard install, and ran python scripts/mk_make.py without thinking about it.

Sorry if pull requests are not the desirable collaboration tool. Feel free to close this.