### PR TITLE
fix mix of tab and space in mk_util.py

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -565,7 +565,7 @@ def parse_options():
             if not IS_WINDOWS:
                 raise MKException('x64 compilation mode can only be specified when using Visual Studio')
             VS_X64 = True
-	elif opt in ('--x86'):
+        elif opt in ('--x86'):
             LINUX_X64=False
         elif opt in ('-h', '--help'):
             display_help(0)


### PR DESCRIPTION
allows for building with python3 on my archlinux install.

there was a mix of tabs and spaces in this file.
There are some mixed tab/spaces in the other files, which I'd like to go through and convert to all spaces if you guys are accepting prs.