### PR TITLE
Cleanup: avoid defining reserved identifiers

### DIFF
--- a/doc/z3api.dox
+++ b/doc/z3api.dox
@@ -1567,7 +1567,7 @@ PREDEFINED             = Z3_ast_opt:=Z3_ast \
                          Z3_bool_opt:=Z3_bool \
                          Z3_func_interp_opt:=Z3_func_interp \
                          Z3_model_opt:=Z3_model \
-                         __out_opt:=__out
+                         Z3_out_opt:=Z3_out
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then
 # this tag can be used to specify a list of macro names that should be expanded.

--- a/doc/z3code.dox
+++ b/doc/z3code.dox
@@ -822,7 +822,7 @@ INCLUDE_FILE_PATTERNS  =
 # undefined via #undef or recursively expanded use the := operator
 # instead of the = operator.
 
-PREDEFINED             =Z3_ast_opt:=Z3_ast Z3_bool_opt:=Z3_bool Z3_func_interp_opt:=Z3_func_interp Z3_model_opt:=Z3_model __out_opt:=__out
+PREDEFINED             =Z3_ast_opt:=Z3_ast Z3_bool_opt:=Z3_bool Z3_func_interp_opt:=Z3_func_interp Z3_model_opt:=Z3_model Z3_out_opt:=Z3_out
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then
 # this tag can be used to specify a list of macro names that should be expanded.
@@ -831,7 +831,7 @@ PREDEFINED             =Z3_ast_opt:=Z3_ast Z3_bool_opt:=Z3_bool Z3_func_interp_o
 
 EXPAND_AS_DEFINED      =
 
-# Z3_ast_opt Z3_bool_opt Z3_func_interp_opt Z3_model_opt __out_opt
+# Z3_ast_opt Z3_bool_opt Z3_func_interp_opt Z3_model_opt Z3_out_opt
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES (the default) then
 # doxygen's preprocessor will remove all function-like macros that are alone

--- a/src/api/api_arith.cpp
+++ b/src/api/api_arith.cpp
@@ -47,7 +47,7 @@ extern "C" {
         Z3_CATCH_RETURN(0);
     }
 
-    Z3_ast Z3_API Z3_mk_real(__in Z3_context c, int num, int den) {
+    Z3_ast Z3_API Z3_mk_real(Z3_in Z3_context c, int num, int den) {
         Z3_TRY;
         LOG_Z3_mk_real(c, num, den);
         RESET_ERROR_CODE();          

--- a/src/api/api_array.cpp
+++ b/src/api/api_array.cpp
@@ -83,7 +83,7 @@ extern "C" {
         Z3_CATCH_RETURN(0);
     }
   
-    Z3_ast Z3_API Z3_mk_map(__in Z3_context c, __in Z3_func_decl f, unsigned n, __in Z3_ast const* args) {
+    Z3_ast Z3_API Z3_mk_map(Z3_in Z3_context c, Z3_in Z3_func_decl f, unsigned n, Z3_in Z3_ast const* args) {
         Z3_TRY;
         LOG_Z3_mk_map(c, f, n, args);
         RESET_ERROR_CODE();
@@ -108,7 +108,7 @@ extern "C" {
         Z3_CATCH_RETURN(0);
     }
 
-    Z3_ast Z3_API Z3_mk_const_array(__in Z3_context c, __in Z3_sort domain, __in Z3_ast v) {
+    Z3_ast Z3_API Z3_mk_const_array(Z3_in Z3_context c, Z3_in Z3_sort domain, Z3_in Z3_ast v) {
         Z3_TRY;
         LOG_Z3_mk_const_array(c, domain, v);
         RESET_ERROR_CODE(); 
@@ -127,7 +127,7 @@ extern "C" {
         Z3_CATCH_RETURN(0);
     }
 
-    Z3_ast Z3_API Z3_mk_array_default(__in Z3_context c, __in Z3_ast array) {
+    Z3_ast Z3_API Z3_mk_array_default(Z3_in Z3_context c, Z3_in Z3_ast array) {
         Z3_TRY;
         LOG_Z3_mk_array_default(c, array);
         RESET_ERROR_CODE(); 
@@ -142,7 +142,7 @@ extern "C" {
         Z3_CATCH_RETURN(0);
     }
 
-    Z3_ast mk_app_array_core(__in Z3_context c, __in Z3_sort domain, __in Z3_ast v) {
+    Z3_ast mk_app_array_core(Z3_in Z3_context c, Z3_in Z3_sort domain, Z3_in Z3_ast v) {
         RESET_ERROR_CODE();   
         ast_manager & m = mk_c(c)->m();
         expr * _v        = to_expr(v);
@@ -158,13 +158,13 @@ extern "C" {
         return of_ast(r);
     }
 
-    Z3_sort Z3_API Z3_mk_set_sort(__in Z3_context c, __in Z3_sort ty) {
+    Z3_sort Z3_API Z3_mk_set_sort(Z3_in Z3_context c, Z3_in Z3_sort ty) {
         Z3_TRY;
         return Z3_mk_array_sort(c, ty, Z3_mk_bool_sort(c));
         Z3_CATCH_RETURN(0);
     }
 
-    Z3_ast Z3_API Z3_mk_empty_set(__in Z3_context c, __in Z3_sort domain) {
+    Z3_ast Z3_API Z3_mk_empty_set(Z3_in Z3_context c, Z3_in Z3_sort domain) {
         Z3_TRY;
         LOG_Z3_mk_empty_set(c, domain);
         RESET_ERROR_CODE();
@@ -173,7 +173,7 @@ extern "C" {
         Z3_CATCH_RETURN(0);
     }
 
-    Z3_ast Z3_API Z3_mk_full_set(__in Z3_context c, __in Z3_sort domain) {
+    Z3_ast Z3_API Z3_mk_full_set(Z3_in Z3_context c, Z3_in Z3_sort domain) {
         Z3_TRY;
         LOG_Z3_mk_full_set(c, domain);
         RESET_ERROR_CODE();
@@ -188,15 +188,15 @@ extern "C" {
     MK_UNARY(Z3_mk_set_complement, mk_c(c)->get_array_fid(), OP_SET_COMPLEMENT, SKIP);
     MK_BINARY(Z3_mk_set_subset, mk_c(c)->get_array_fid(), OP_SET_SUBSET, SKIP);
     
-    Z3_ast Z3_mk_set_member(__in Z3_context c, __in Z3_ast elem, __in Z3_ast set) {
+    Z3_ast Z3_mk_set_member(Z3_in Z3_context c, Z3_in Z3_ast elem, Z3_in Z3_ast set) {
         return Z3_mk_select(c, set, elem);
     }
 
-    Z3_ast Z3_mk_set_add(__in Z3_context c, __in Z3_ast set, __in Z3_ast elem) {
+    Z3_ast Z3_mk_set_add(Z3_in Z3_context c, Z3_in Z3_ast set, Z3_in Z3_ast elem) {
         return Z3_mk_store(c, set, elem, Z3_mk_true(c));
     }
 
-    Z3_ast Z3_mk_set_del(__in Z3_context c, __in Z3_ast set, __in Z3_ast elem) {
+    Z3_ast Z3_mk_set_del(Z3_in Z3_context c, Z3_in Z3_ast set, Z3_in Z3_ast elem) {
         return Z3_mk_store(c, set, elem, Z3_mk_false(c));
     }
 

--- a/src/api/api_bv.cpp
+++ b/src/api/api_bv.cpp
@@ -159,7 +159,7 @@ Z3_ast Z3_API NAME(Z3_context c, unsigned i, Z3_ast n) {                \
        This function is a shorthand for <tt>shl(1, N-1)</tt>
        where <tt>N</tt> are the number of bits of \c s.
     */
-    Z3_ast Z3_API Z3_mk_bvmsb(__in Z3_context c, __in Z3_sort s) {
+    Z3_ast Z3_API Z3_mk_bvmsb(Z3_in Z3_context c, Z3_in Z3_sort s) {
         Z3_TRY;
         RESET_ERROR_CODE();
         // Not logging this one, since it is just syntax sugar.
@@ -179,19 +179,19 @@ Z3_ast Z3_API NAME(Z3_context c, unsigned i, Z3_ast n) {                \
         Z3_CATCH_RETURN(0);
     }
 
-    Z3_ast Z3_mk_bvsmin(__in Z3_context c, __in Z3_sort s) {
+    Z3_ast Z3_mk_bvsmin(Z3_in Z3_context c, Z3_in Z3_sort s) {
         return Z3_mk_bvmsb(c, s);
     }
 
-    Z3_ast Z3_mk_bvsmax(__in Z3_context c, __in Z3_sort s) {
+    Z3_ast Z3_mk_bvsmax(Z3_in Z3_context c, Z3_in Z3_sort s) {
         return Z3_mk_bvnot(c, Z3_mk_bvmsb(c, s));
     }
 
-    Z3_ast Z3_mk_bvumax(__in Z3_context c, __in Z3_sort s) {
+    Z3_ast Z3_mk_bvumax(Z3_in Z3_context c, Z3_in Z3_sort s) {
         return Z3_mk_int(c, -1, s);
     }
 
-    Z3_ast Z3_API Z3_mk_bvadd_no_overflow(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2, Z3_bool is_signed) {
+    Z3_ast Z3_API Z3_mk_bvadd_no_overflow(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2, Z3_bool is_signed) {
         Z3_TRY;
         RESET_ERROR_CODE();
         if (is_signed) {
@@ -235,7 +235,7 @@ Z3_ast Z3_API NAME(Z3_context c, unsigned i, Z3_ast n) {                \
     }
 
     // only for signed machine integers
-    Z3_ast Z3_API Z3_mk_bvadd_no_underflow(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2) {
+    Z3_ast Z3_API Z3_mk_bvadd_no_underflow(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2) {
         Z3_TRY;
         RESET_ERROR_CODE();
         Z3_ast zero = Z3_mk_int(c, 0, Z3_get_sort(c, t1));
@@ -263,7 +263,7 @@ Z3_ast Z3_API NAME(Z3_context c, unsigned i, Z3_ast n) {                \
     }
 
     // only for signed machine integers
-    Z3_ast Z3_API Z3_mk_bvsub_no_overflow(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2) {
+    Z3_ast Z3_API Z3_mk_bvsub_no_overflow(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2) {
         Z3_TRY;
         RESET_ERROR_CODE();
         Z3_ast minus_t2 = Z3_mk_bvneg(c, t2);
@@ -291,7 +291,7 @@ Z3_ast Z3_API NAME(Z3_context c, unsigned i, Z3_ast n) {                \
         Z3_CATCH_RETURN(0);
     }
 
-    Z3_ast Z3_API Z3_mk_bvsub_no_underflow(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2, Z3_bool is_signed) {
+    Z3_ast Z3_API Z3_mk_bvsub_no_underflow(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2, Z3_bool is_signed) {
         Z3_TRY;
         RESET_ERROR_CODE();
         if (is_signed) {
@@ -316,7 +316,7 @@ Z3_ast Z3_API NAME(Z3_context c, unsigned i, Z3_ast n) {                \
         Z3_CATCH_RETURN(0);
     }
 
-    Z3_ast Z3_API Z3_mk_bvmul_no_overflow(__in Z3_context c, __in Z3_ast n1, __in Z3_ast n2, Z3_bool is_signed) {
+    Z3_ast Z3_API Z3_mk_bvmul_no_overflow(Z3_in Z3_context c, Z3_in Z3_ast n1, Z3_in Z3_ast n2, Z3_bool is_signed) {
         LOG_Z3_mk_bvmul_no_overflow(c, n1, n2, is_signed);
         RESET_ERROR_CODE();
         if (is_signed) {
@@ -328,13 +328,13 @@ Z3_ast Z3_API NAME(Z3_context c, unsigned i, Z3_ast n) {                \
     }
 
     // only for signed machine integers
-    Z3_ast Z3_API Z3_mk_bvmul_no_underflow(__in Z3_context c, __in Z3_ast n1, __in Z3_ast n2) {
+    Z3_ast Z3_API Z3_mk_bvmul_no_underflow(Z3_in Z3_context c, Z3_in Z3_ast n1, Z3_in Z3_ast n2) {
         LOG_Z3_mk_bvmul_no_underflow(c, n1, n2);
         MK_BINARY_BODY(Z3_mk_bvmul_no_underflow, mk_c(c)->get_bv_fid(), OP_BSMUL_NO_UDFL, SKIP);
     }
 
     // only for signed machine integers
-    Z3_ast Z3_API Z3_mk_bvneg_no_overflow(__in Z3_context c, __in Z3_ast t) {
+    Z3_ast Z3_API Z3_mk_bvneg_no_overflow(Z3_in Z3_context c, Z3_in Z3_ast t) {
         Z3_TRY;
         RESET_ERROR_CODE();
         Z3_ast min = Z3_mk_bvsmin(c, Z3_get_sort(c, t));
@@ -346,7 +346,7 @@ Z3_ast Z3_API NAME(Z3_context c, unsigned i, Z3_ast n) {                \
     }
     
     // only for signed machine integers
-    Z3_ast Z3_API Z3_mk_bvsdiv_no_overflow(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2) {
+    Z3_ast Z3_API Z3_mk_bvsdiv_no_overflow(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2) {
         Z3_TRY;
         RESET_ERROR_CODE();
         Z3_sort s = Z3_get_sort(c, t1);

--- a/src/api/api_context.cpp
+++ b/src/api/api_context.cpp
@@ -526,7 +526,7 @@ extern "C" {
         // [Leo]: using exception handling, we don't need global error handlers anymore
     }
 
-    void Z3_API Z3_set_error(__in Z3_context c, __in Z3_error_code e) {
+    void Z3_API Z3_set_error(Z3_in Z3_context c, Z3_in Z3_error_code e) {
         SET_ERROR_CODE(e);
     }
 
@@ -578,7 +578,7 @@ extern "C" {
     
 };
 
-Z3_API ast_manager& Z3_get_manager(__in Z3_context c) {
+Z3_API ast_manager& Z3_get_manager(Z3_in Z3_context c) {
     return mk_c(c)->m();
 }
 

--- a/src/api/api_datalog.cpp
+++ b/src/api/api_datalog.cpp
@@ -304,8 +304,8 @@ extern "C" {
     }
 
     Z3_lbool Z3_API Z3_fixedpoint_query_relations(
-        __in Z3_context c,__in Z3_fixedpoint d, 
-        __in unsigned num_relations, Z3_func_decl const relations[]) {
+        Z3_in Z3_context c,Z3_in Z3_fixedpoint d, 
+        Z3_in unsigned num_relations, Z3_func_decl const relations[]) {
         Z3_TRY;
         LOG_Z3_fixedpoint_query_relations(c, d, num_relations, relations);
         RESET_ERROR_CODE();

--- a/src/api/api_fpa.cpp
+++ b/src/api/api_fpa.cpp
@@ -737,7 +737,7 @@ extern "C" {
         Z3_CATCH_RETURN(0);
     }
 
-    Z3_string Z3_API Z3_fpa_get_numeral_significand_string(__in Z3_context c, __in Z3_ast t) {
+    Z3_string Z3_API Z3_fpa_get_numeral_significand_string(Z3_in Z3_context c, Z3_in Z3_ast t) {
         Z3_TRY;
         LOG_Z3_fpa_get_numeral_significand_string(c, t);
         RESET_ERROR_CODE();
@@ -768,7 +768,7 @@ extern "C" {
 
     }
 
-    Z3_string Z3_API Z3_fpa_get_numeral_exponent_string(__in Z3_context c, __in Z3_ast t) {
+    Z3_string Z3_API Z3_fpa_get_numeral_exponent_string(Z3_in Z3_context c, Z3_in Z3_ast t) {
         Z3_TRY;
         LOG_Z3_fpa_get_numeral_exponent_string(c, t);
         RESET_ERROR_CODE();
@@ -792,7 +792,7 @@ extern "C" {
         Z3_CATCH_RETURN("");
     }
 
-    Z3_bool Z3_API Z3_fpa_get_numeral_exponent_int64(__in Z3_context c, __in Z3_ast t, __out __int64 * n) {
+    Z3_bool Z3_API Z3_fpa_get_numeral_exponent_int64(Z3_in Z3_context c, Z3_in Z3_ast t, Z3_out __int64 * n) {
         Z3_TRY;
         LOG_Z3_fpa_get_numeral_exponent_string(c, t);
         RESET_ERROR_CODE();

--- a/src/api/api_interp.cpp
+++ b/src/api/api_interp.cpp
@@ -208,7 +208,7 @@ extern "C" {
         opts->map[name] = value;
     }
 
-    Z3_ast_vector Z3_API Z3_get_interpolant(__in Z3_context c, __in Z3_ast pf, __in Z3_ast pat, __in Z3_params p){
+    Z3_ast_vector Z3_API Z3_get_interpolant(Z3_in Z3_context c, Z3_in Z3_ast pf, Z3_in Z3_ast pat, Z3_in Z3_params p){
         Z3_TRY;
         LOG_Z3_get_interpolant(c, pf, pat, p);
         RESET_ERROR_CODE();
@@ -241,7 +241,7 @@ extern "C" {
         Z3_CATCH_RETURN(0);
     }
 
-    Z3_lbool Z3_API Z3_compute_interpolant(__in Z3_context c, __in Z3_ast pat, __in Z3_params p, __out Z3_ast_vector *out_interp, __out Z3_model *model){
+    Z3_lbool Z3_API Z3_compute_interpolant(Z3_in Z3_context c, Z3_in Z3_ast pat, Z3_in Z3_params p, Z3_out Z3_ast_vector *out_interp, Z3_out Z3_model *model){
         Z3_TRY;
         LOG_Z3_compute_interpolant(c, pat, p, out_interp, model);
         RESET_ERROR_CODE();
@@ -709,15 +709,15 @@ interpolant formula).
 def_API('Z3_interpolate', BOOL, (_in(CONTEXT), _in(UINT), _in_array(1, AST), _in_array(1, UINT), _in(PARAMS), _out_array(1, AST), _out(MODEL), _out(LITERALS), _in(UINT), _in(UINT), _in_array(9, AST)))
 */
 
-Z3_lbool Z3_API Z3_interpolate(__in Z3_context ctx,
-                               __in unsigned num,
-                               __in_ecount(num) Z3_ast *cnsts,
-                               __in_ecount(num) unsigned *parents,
-                               __in Z3_params options,
-                               __out_ecount(num - 1) Z3_ast *interps,
-                               __out Z3_model *model,
-                               __out Z3_literals *labels,
-                               __in unsigned incremental,
-                               __in unsigned num_theory,
-                               __in_ecount(num_theory) Z3_ast *theory);
+Z3_lbool Z3_API Z3_interpolate(Z3_in Z3_context ctx,
+                               Z3_in unsigned num,
+                               Z3_in_ecount(num) Z3_ast *cnsts,
+                               Z3_in_ecount(num) unsigned *parents,
+                               Z3_in Z3_params options,
+                               Z3_out_ecount(num - 1) Z3_ast *interps,
+                               Z3_out Z3_model *model,
+                               Z3_out Z3_literals *labels,
+                               Z3_in unsigned incremental,
+                               Z3_in unsigned num_theory,
+                               Z3_in_ecount(num_theory) Z3_ast *theory);
 #endif

--- a/src/api/z3.h
+++ b/src/api/z3.h
@@ -30,15 +30,5 @@ Notes:
 #include"z3_interp.h"
 #include"z3_fpa.h"
 
-#undef __in
-#undef __out
-#undef __inout
-#undef __in_z
-#undef __out_z
-#undef __ecount
-#undef __in_ecount
-#undef __out_ecount
-#undef __inout_ecount
-
 #endif
 

--- a/src/api/z3_algebraic.h
+++ b/src/api/z3_algebraic.h
@@ -43,7 +43,7 @@ extern "C" {
 
        def_API('Z3_algebraic_is_value', BOOL, (_in(CONTEXT), _in(AST)))
     */
-    Z3_bool Z3_API Z3_algebraic_is_value(__in Z3_context c, __in Z3_ast a);
+    Z3_bool Z3_API Z3_algebraic_is_value(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return the Z3_TRUE if \c a is positive, and Z3_FALSE otherwise.
@@ -52,7 +52,7 @@ extern "C" {
 
        def_API('Z3_algebraic_is_pos', BOOL, (_in(CONTEXT), _in(AST)))
     */
-    Z3_bool Z3_API Z3_algebraic_is_pos(__in Z3_context c, __in Z3_ast a);
+    Z3_bool Z3_API Z3_algebraic_is_pos(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return the Z3_TRUE if \c a is negative, and Z3_FALSE otherwise.
@@ -61,7 +61,7 @@ extern "C" {
 
        def_API('Z3_algebraic_is_neg', BOOL, (_in(CONTEXT), _in(AST)))
     */
-    Z3_bool Z3_API Z3_algebraic_is_neg(__in Z3_context c, __in Z3_ast a);
+    Z3_bool Z3_API Z3_algebraic_is_neg(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return the Z3_TRUE if \c a is zero, and Z3_FALSE otherwise.
@@ -70,7 +70,7 @@ extern "C" {
 
        def_API('Z3_algebraic_is_zero', BOOL, (_in(CONTEXT), _in(AST)))
     */
-    Z3_bool Z3_API Z3_algebraic_is_zero(__in Z3_context c, __in Z3_ast a);
+    Z3_bool Z3_API Z3_algebraic_is_zero(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return 1 if \c a is positive, 0 if \c a is zero, and -1 if \c a is negative.
@@ -79,7 +79,7 @@ extern "C" {
 
        def_API('Z3_algebraic_sign', INT, (_in(CONTEXT), _in(AST)))
     */
-    int Z3_API Z3_algebraic_sign(__in Z3_context c, __in Z3_ast a);
+    int Z3_API Z3_algebraic_sign(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return the value a + b. 
@@ -90,7 +90,7 @@ extern "C" {
 
        def_API('Z3_algebraic_add', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_algebraic_add(__in Z3_context c, __in Z3_ast a, __in Z3_ast b);    
+    Z3_ast Z3_API Z3_algebraic_add(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_ast b);    
 
     /**
        \brief Return the value a - b. 
@@ -101,7 +101,7 @@ extern "C" {
 
        def_API('Z3_algebraic_sub', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_algebraic_sub(__in Z3_context c, __in Z3_ast a, __in Z3_ast b);    
+    Z3_ast Z3_API Z3_algebraic_sub(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_ast b);    
 
     /**
        \brief Return the value a * b. 
@@ -112,7 +112,7 @@ extern "C" {
 
        def_API('Z3_algebraic_mul', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_algebraic_mul(__in Z3_context c, __in Z3_ast a, __in Z3_ast b);    
+    Z3_ast Z3_API Z3_algebraic_mul(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_ast b);    
     
     /**
        \brief Return the value a / b. 
@@ -124,7 +124,7 @@ extern "C" {
 
        def_API('Z3_algebraic_div', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_algebraic_div(__in Z3_context c, __in Z3_ast a, __in Z3_ast b);    
+    Z3_ast Z3_API Z3_algebraic_div(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_ast b);    
     
     /**
        \brief Return the a^(1/k)
@@ -135,7 +135,7 @@ extern "C" {
 
        def_API('Z3_algebraic_root', AST, (_in(CONTEXT), _in(AST), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_algebraic_root(__in Z3_context c, __in Z3_ast a, __in unsigned k);
+    Z3_ast Z3_API Z3_algebraic_root(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in unsigned k);
 
     /**
        \brief Return the a^k
@@ -145,7 +145,7 @@ extern "C" {
 
        def_API('Z3_algebraic_power', AST, (_in(CONTEXT), _in(AST), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_algebraic_power(__in Z3_context c, __in Z3_ast a, __in unsigned k);
+    Z3_ast Z3_API Z3_algebraic_power(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in unsigned k);
     
     /**
        \brief Return Z3_TRUE if a < b, and Z3_FALSE otherwise.
@@ -155,7 +155,7 @@ extern "C" {
 
        def_API('Z3_algebraic_lt', BOOL, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_bool Z3_API Z3_algebraic_lt(__in Z3_context c, __in Z3_ast a, __in Z3_ast b);    
+    Z3_bool Z3_API Z3_algebraic_lt(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_ast b);    
     
     /**
        \brief Return Z3_TRUE if a > b, and Z3_FALSE otherwise.
@@ -165,7 +165,7 @@ extern "C" {
 
        def_API('Z3_algebraic_gt', BOOL, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_bool Z3_API Z3_algebraic_gt(__in Z3_context c, __in Z3_ast a, __in Z3_ast b);    
+    Z3_bool Z3_API Z3_algebraic_gt(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_ast b);    
 
     /**
        \brief Return Z3_TRUE if a <= b, and Z3_FALSE otherwise.
@@ -175,7 +175,7 @@ extern "C" {
 
        def_API('Z3_algebraic_le', BOOL, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_bool Z3_API Z3_algebraic_le(__in Z3_context c, __in Z3_ast a, __in Z3_ast b);    
+    Z3_bool Z3_API Z3_algebraic_le(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_ast b);    
 
     /**
        \brief Return Z3_TRUE if a >= b, and Z3_FALSE otherwise.
@@ -185,7 +185,7 @@ extern "C" {
 
        def_API('Z3_algebraic_ge', BOOL, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_bool Z3_API Z3_algebraic_ge(__in Z3_context c, __in Z3_ast a, __in Z3_ast b);    
+    Z3_bool Z3_API Z3_algebraic_ge(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_ast b);    
 
     /**
        \brief Return Z3_TRUE if a == b, and Z3_FALSE otherwise.
@@ -195,7 +195,7 @@ extern "C" {
 
        def_API('Z3_algebraic_eq', BOOL, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_bool Z3_API Z3_algebraic_eq(__in Z3_context c, __in Z3_ast a, __in Z3_ast b);    
+    Z3_bool Z3_API Z3_algebraic_eq(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_ast b);    
 
     /**
        \brief Return Z3_TRUE if a != b, and Z3_FALSE otherwise.
@@ -205,7 +205,7 @@ extern "C" {
 
        def_API('Z3_algebraic_neq', BOOL, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_bool Z3_API Z3_algebraic_neq(__in Z3_context c, __in Z3_ast a, __in Z3_ast b);    
+    Z3_bool Z3_API Z3_algebraic_neq(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_ast b);    
 
     /**
        \brief Given a multivariate polynomial p(x_0, ..., x_{n-1}, x_n), returns the 
@@ -217,7 +217,7 @@ extern "C" {
 
        def_API('Z3_algebraic_roots', AST_VECTOR, (_in(CONTEXT), _in(AST), _in(UINT), _in_array(2, AST)))
     */
-    Z3_ast_vector Z3_API Z3_algebraic_roots(__in Z3_context c, __in Z3_ast p, __in unsigned n, __in Z3_ast a[]);    
+    Z3_ast_vector Z3_API Z3_algebraic_roots(Z3_in Z3_context c, Z3_in Z3_ast p, Z3_in unsigned n, Z3_in Z3_ast a[]);    
 
     /**
        \brief Given a multivariate polynomial p(x_0, ..., x_{n-1}), return the 
@@ -228,7 +228,7 @@ extern "C" {
 
        def_API('Z3_algebraic_eval', INT, (_in(CONTEXT), _in(AST), _in(UINT), _in_array(2, AST)))
     */
-    int Z3_API Z3_algebraic_eval(__in Z3_context c, __in Z3_ast p, __in unsigned n, __in Z3_ast a[]);    
+    int Z3_API Z3_algebraic_eval(Z3_in Z3_context c, Z3_in Z3_ast p, Z3_in unsigned n, Z3_in Z3_ast a[]);    
 
     /*@}*/
     /*@}*/

--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -1400,7 +1400,7 @@ extern "C" {
 
        def_API('Z3_global_param_set', VOID, (_in(STRING), _in(STRING)))
     */
-    void Z3_API Z3_global_param_set(__in Z3_string param_id, __in Z3_string param_value);
+    void Z3_API Z3_global_param_set(Z3_in Z3_string param_id, Z3_in Z3_string param_value);
 
 
     /**
@@ -1426,7 +1426,7 @@ extern "C" {
 
        def_API('Z3_global_param_get', BOOL, (_in(STRING), _out(STRING)))
     */
-    Z3_bool_opt Z3_API Z3_global_param_get(__in Z3_string param_id, __out_opt Z3_string_ptr param_value);
+    Z3_bool_opt Z3_API Z3_global_param_get(Z3_in Z3_string param_id, Z3_out_opt Z3_string_ptr param_value);
 
     /*@}*/
 
@@ -1479,7 +1479,7 @@ extern "C" {
 
        def_API('Z3_del_config', VOID, (_in(CONFIG),))
     */
-    void Z3_API Z3_del_config(__in Z3_config c);
+    void Z3_API Z3_del_config(Z3_in Z3_config c);
 
     /**
        \brief Set a configuration parameter.
@@ -1490,7 +1490,7 @@ extern "C" {
 
        def_API('Z3_set_param_value', VOID, (_in(CONFIG), _in(STRING), _in(STRING)))
     */
-    void Z3_API Z3_set_param_value(__in Z3_config c, __in Z3_string param_id, __in Z3_string param_value);
+    void Z3_API Z3_set_param_value(Z3_in Z3_config c, Z3_in Z3_string param_id, Z3_in Z3_string param_value);
     
     /*@}*/
 #endif
@@ -1524,7 +1524,7 @@ extern "C" {
        def_API('Z3_mk_context', CONTEXT, (_in(CONFIG),))
     */
 #ifdef CorML3
-    Z3_context Z3_API Z3_mk_context(__in Z3_config c);
+    Z3_context Z3_API Z3_mk_context(Z3_in Z3_config c);
 #endif
 #ifdef ML4only
 #include <mlx_mk_context_x.idl>
@@ -1551,7 +1551,7 @@ extern "C" {
        
        def_API('Z3_mk_context_rc', CONTEXT, (_in(CONFIG),))
     */
-    Z3_context Z3_API Z3_mk_context_rc(__in Z3_config c);
+    Z3_context Z3_API Z3_mk_context_rc(Z3_in Z3_config c);
 #endif
     
 #ifdef CorML3
@@ -1562,7 +1562,7 @@ extern "C" {
 
        def_API('Z3_del_context', VOID, (_in(CONTEXT),))
     */
-    void Z3_API Z3_del_context(__in Z3_context c);
+    void Z3_API Z3_del_context(Z3_in Z3_context c);
 #endif
     
 #ifdef Conly
@@ -1573,7 +1573,7 @@ extern "C" {
 
        def_API('Z3_inc_ref', VOID, (_in(CONTEXT), _in(AST)))
     */
-    void Z3_API Z3_inc_ref(__in Z3_context c, __in Z3_ast a);
+    void Z3_API Z3_inc_ref(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Decrement the reference counter of the given AST.
@@ -1582,7 +1582,7 @@ extern "C" {
 
        def_API('Z3_dec_ref', VOID, (_in(CONTEXT), _in(AST)))
     */
-    void Z3_API Z3_dec_ref(__in Z3_context c, __in Z3_ast a);
+    void Z3_API Z3_dec_ref(Z3_in Z3_context c, Z3_in Z3_ast a);
 #endif
 
     /**
@@ -1592,7 +1592,7 @@ extern "C" {
 
        def_API('Z3_update_param_value', VOID, (_in(CONTEXT), _in(STRING), _in(STRING)))
     */
-    void Z3_API Z3_update_param_value(__in Z3_context c, __in Z3_string param_id, __in Z3_string param_value);
+    void Z3_API Z3_update_param_value(Z3_in Z3_context c, Z3_in Z3_string param_id, Z3_in Z3_string param_value);
 
 #ifdef CorML4
     /**
@@ -1601,7 +1601,7 @@ extern "C" {
 
        def_API('Z3_interrupt', VOID, (_in(CONTEXT),))
     */
-    void Z3_API Z3_interrupt(__in Z3_context c);
+    void Z3_API Z3_interrupt(Z3_in Z3_context c);
 #endif
 
 
@@ -1623,7 +1623,7 @@ extern "C" {
 
        def_API('Z3_mk_params', PARAMS, (_in(CONTEXT),))
     */
-    Z3_params Z3_API Z3_mk_params(__in Z3_context c);
+    Z3_params Z3_API Z3_mk_params(Z3_in Z3_context c);
     
 #ifdef Conly
     /**
@@ -1631,14 +1631,14 @@ extern "C" {
 
        def_API('Z3_params_inc_ref', VOID, (_in(CONTEXT), _in(PARAMS)))
     */
-    void Z3_API Z3_params_inc_ref(__in Z3_context c, __in Z3_params p);
+    void Z3_API Z3_params_inc_ref(Z3_in Z3_context c, Z3_in Z3_params p);
 
     /**
        \brief Decrement the reference counter of the given parameter set.
 
        def_API('Z3_params_dec_ref', VOID, (_in(CONTEXT), _in(PARAMS)))
     */
-    void Z3_API Z3_params_dec_ref(__in Z3_context c, __in Z3_params p);
+    void Z3_API Z3_params_dec_ref(Z3_in Z3_context c, Z3_in Z3_params p);
 #endif
 
     /**
@@ -1646,28 +1646,28 @@ extern "C" {
 
        def_API('Z3_params_set_bool', VOID, (_in(CONTEXT), _in(PARAMS), _in(SYMBOL), _in(BOOL)))
     */
-    void Z3_API Z3_params_set_bool(__in Z3_context c, __in Z3_params p, __in Z3_symbol k, __in Z3_bool v);
+    void Z3_API Z3_params_set_bool(Z3_in Z3_context c, Z3_in Z3_params p, Z3_in Z3_symbol k, Z3_in Z3_bool v);
 
     /**
        \brief Add a unsigned parameter \c k with value \c v to the parameter set \c p.
        
        def_API('Z3_params_set_uint', VOID, (_in(CONTEXT), _in(PARAMS), _in(SYMBOL), _in(UINT)))
     */
-    void Z3_API Z3_params_set_uint(__in Z3_context c, __in Z3_params p, __in Z3_symbol k, __in unsigned v);
+    void Z3_API Z3_params_set_uint(Z3_in Z3_context c, Z3_in Z3_params p, Z3_in Z3_symbol k, Z3_in unsigned v);
 
     /**
        \brief Add a double parameter \c k with value \c v to the parameter set \c p.
 
        def_API('Z3_params_set_double', VOID, (_in(CONTEXT), _in(PARAMS), _in(SYMBOL), _in(DOUBLE)))
     */
-    void Z3_API Z3_params_set_double(__in Z3_context c, __in Z3_params p, __in Z3_symbol k, __in double v);
+    void Z3_API Z3_params_set_double(Z3_in Z3_context c, Z3_in Z3_params p, Z3_in Z3_symbol k, Z3_in double v);
 
     /**
        \brief Add a symbol parameter \c k with value \c v to the parameter set \c p.
 
        def_API('Z3_params_set_symbol', VOID, (_in(CONTEXT), _in(PARAMS), _in(SYMBOL), _in(SYMBOL)))
     */
-    void Z3_API Z3_params_set_symbol(__in Z3_context c, __in Z3_params p, __in Z3_symbol k, __in Z3_symbol v);
+    void Z3_API Z3_params_set_symbol(Z3_in Z3_context c, Z3_in Z3_params p, Z3_in Z3_symbol k, Z3_in Z3_symbol v);
     
     /**
        \brief Convert a parameter set into a string. This function is mainly used for printing the
@@ -1675,7 +1675,7 @@ extern "C" {
 
        def_API('Z3_params_to_string', STRING, (_in(CONTEXT), _in(PARAMS)))
     */
-    Z3_string Z3_API Z3_params_to_string(__in Z3_context c, __in Z3_params p);
+    Z3_string Z3_API Z3_params_to_string(Z3_in Z3_context c, Z3_in Z3_params p);
 
     /**
        \brief Validate the parameter set \c p against the parameter description set \c d.
@@ -1684,7 +1684,7 @@ extern "C" {
 
        def_API('Z3_params_validate', VOID, (_in(CONTEXT), _in(PARAMS), _in(PARAM_DESCRS)))
     */
-    void Z3_API Z3_params_validate(__in Z3_context c, __in Z3_params p, __in Z3_param_descrs d);
+    void Z3_API Z3_params_validate(Z3_in Z3_context c, Z3_in Z3_params p, Z3_in Z3_param_descrs d);
     
 #endif
 
@@ -1702,14 +1702,14 @@ extern "C" {
 
        def_API('Z3_param_descrs_inc_ref', VOID, (_in(CONTEXT), _in(PARAM_DESCRS)))
     */
-    void Z3_API Z3_param_descrs_inc_ref(__in Z3_context c, __in Z3_param_descrs p);
+    void Z3_API Z3_param_descrs_inc_ref(Z3_in Z3_context c, Z3_in Z3_param_descrs p);
 
     /**
        \brief Decrement the reference counter of the given parameter description set.
 
        def_API('Z3_param_descrs_dec_ref', VOID, (_in(CONTEXT), _in(PARAM_DESCRS)))
     */
-    void Z3_API Z3_param_descrs_dec_ref(__in Z3_context c, __in Z3_param_descrs p);
+    void Z3_API Z3_param_descrs_dec_ref(Z3_in Z3_context c, Z3_in Z3_param_descrs p);
 #endif
     
     /**
@@ -1717,14 +1717,14 @@ extern "C" {
 
        def_API('Z3_param_descrs_get_kind', UINT, (_in(CONTEXT), _in(PARAM_DESCRS), _in(SYMBOL)))
     */
-    Z3_param_kind Z3_API Z3_param_descrs_get_kind(__in Z3_context c, __in Z3_param_descrs p, __in Z3_symbol n);
+    Z3_param_kind Z3_API Z3_param_descrs_get_kind(Z3_in Z3_context c, Z3_in Z3_param_descrs p, Z3_in Z3_symbol n);
     
     /**
        \brief Return the number of parameters in the given parameter description set.
        
        def_API('Z3_param_descrs_size', UINT, (_in(CONTEXT), _in(PARAM_DESCRS)))
     */
-    unsigned Z3_API Z3_param_descrs_size(__in Z3_context c, __in Z3_param_descrs p);
+    unsigned Z3_API Z3_param_descrs_size(Z3_in Z3_context c, Z3_in Z3_param_descrs p);
 
     /**
        \brief Return the number of parameters in the given parameter description set.
@@ -1733,7 +1733,7 @@ extern "C" {
 
        def_API('Z3_param_descrs_get_name', SYMBOL, (_in(CONTEXT), _in(PARAM_DESCRS), _in(UINT)))
     */
-    Z3_symbol Z3_API Z3_param_descrs_get_name(__in Z3_context c, __in Z3_param_descrs p, __in unsigned i);
+    Z3_symbol Z3_API Z3_param_descrs_get_name(Z3_in Z3_context c, Z3_in Z3_param_descrs p, Z3_in unsigned i);
 
     /**
        \brief Convert a parameter description set into a string. This function is mainly used for printing the
@@ -1741,7 +1741,7 @@ extern "C" {
 
        def_API('Z3_param_descrs_to_string', STRING, (_in(CONTEXT), _in(PARAM_DESCRS)))
     */
-    Z3_string Z3_API Z3_param_descrs_to_string(__in Z3_context c, __in Z3_param_descrs p);
+    Z3_string Z3_API Z3_param_descrs_to_string(Z3_in Z3_context c, Z3_in Z3_param_descrs p);
 
     /*@}*/
 #endif
@@ -1771,7 +1771,7 @@ extern "C" {
 
        def_API('Z3_mk_int_symbol', SYMBOL, (_in(CONTEXT), _in(INT)))
     */
-    Z3_symbol Z3_API Z3_mk_int_symbol(__in Z3_context c, __in int i);
+    Z3_symbol Z3_API Z3_mk_int_symbol(Z3_in Z3_context c, Z3_in int i);
 
     /**
        \brief Create a Z3 symbol using a C string.
@@ -1782,7 +1782,7 @@ extern "C" {
 
        def_API('Z3_mk_string_symbol', SYMBOL, (_in(CONTEXT), _in(STRING)))
     */
-    Z3_symbol Z3_API Z3_mk_string_symbol(__in Z3_context c, __in Z3_string s);
+    Z3_symbol Z3_API Z3_mk_string_symbol(Z3_in Z3_context c, Z3_in Z3_string s);
 
     /*@}*/
     
@@ -1806,7 +1806,7 @@ extern "C" {
 
        def_API('Z3_mk_uninterpreted_sort', SORT, (_in(CONTEXT), _in(SYMBOL)))
     */
-    Z3_sort Z3_API Z3_mk_uninterpreted_sort(__in Z3_context c, __in Z3_symbol s);
+    Z3_sort Z3_API Z3_mk_uninterpreted_sort(Z3_in Z3_context c, Z3_in Z3_symbol s);
 
     /**
        \brief Create the Boolean type. 
@@ -1815,7 +1815,7 @@ extern "C" {
 
        def_API('Z3_mk_bool_sort', SORT, (_in(CONTEXT), ))
     */
-    Z3_sort Z3_API Z3_mk_bool_sort(__in Z3_context c);
+    Z3_sort Z3_API Z3_mk_bool_sort(Z3_in Z3_context c);
     
     /**
        \brief Create the integer type.
@@ -1828,7 +1828,7 @@ extern "C" {
 
        def_API('Z3_mk_int_sort', SORT, (_in(CONTEXT), ))
     */
-    Z3_sort Z3_API Z3_mk_int_sort(__in Z3_context c);
+    Z3_sort Z3_API Z3_mk_int_sort(Z3_in Z3_context c);
     
     /**
        \brief Create the real type. 
@@ -1837,7 +1837,7 @@ extern "C" {
 
        def_API('Z3_mk_real_sort', SORT, (_in(CONTEXT), ))
     */
-    Z3_sort Z3_API Z3_mk_real_sort(__in Z3_context c);
+    Z3_sort Z3_API Z3_mk_real_sort(Z3_in Z3_context c);
 
     /**
        \brief Create a bit-vector type of the given size.
@@ -1848,7 +1848,7 @@ extern "C" {
 
        def_API('Z3_mk_bv_sort', SORT, (_in(CONTEXT), _in(UINT)))
     */
-    Z3_sort Z3_API Z3_mk_bv_sort(__in Z3_context c, __in unsigned sz);
+    Z3_sort Z3_API Z3_mk_bv_sort(Z3_in Z3_context c, Z3_in unsigned sz);
 
     /**
        \brief Create a named finite domain sort.
@@ -1863,7 +1863,7 @@ extern "C" {
 
        def_API('Z3_mk_finite_domain_sort', SORT, (_in(CONTEXT), _in(SYMBOL), _in(UINT64)))
     */
-    Z3_sort Z3_API Z3_mk_finite_domain_sort(__in Z3_context c, __in Z3_symbol name, __in unsigned __int64 size);
+    Z3_sort Z3_API Z3_mk_finite_domain_sort(Z3_in Z3_context c, Z3_in Z3_symbol name, Z3_in unsigned __int64 size);
 
     /**
        \brief Create an array type. 
@@ -1876,7 +1876,7 @@ extern "C" {
 
        def_API('Z3_mk_array_sort', SORT, (_in(CONTEXT), _in(SORT), _in(SORT)))
     */
-    Z3_sort Z3_API Z3_mk_array_sort(__in Z3_context c, __in Z3_sort domain, __in Z3_sort range);
+    Z3_sort Z3_API Z3_mk_array_sort(Z3_in Z3_context c, Z3_in Z3_sort domain, Z3_in Z3_sort range);
 
     /**
        \brief Create a tuple type.
@@ -1898,13 +1898,13 @@ extern "C" {
 
        def_API('Z3_mk_tuple_sort', SORT, (_in(CONTEXT), _in(SYMBOL), _in(UINT), _in_array(2, SYMBOL), _in_array(2, SORT), _out(FUNC_DECL), _out_array(2, FUNC_DECL)))
     */
-    Z3_sort Z3_API Z3_mk_tuple_sort(__in Z3_context c, 
-                                        __in Z3_symbol mk_tuple_name, 
-                                        __in unsigned num_fields, 
-                                        __in_ecount(num_fields) Z3_symbol const field_names[],
-                                        __in_ecount(num_fields) Z3_sort const field_sorts[],
-                                        __out Z3_func_decl * mk_tuple_decl,
-                                        __out_ecount(num_fields)  Z3_func_decl proj_decl[]);
+    Z3_sort Z3_API Z3_mk_tuple_sort(Z3_in Z3_context c, 
+                                        Z3_in Z3_symbol mk_tuple_name, 
+                                        Z3_in unsigned num_fields, 
+                                        Z3_in_ecount(num_fields) Z3_symbol const field_names[],
+                                        Z3_in_ecount(num_fields) Z3_sort const field_sorts[],
+                                        Z3_out Z3_func_decl * mk_tuple_decl,
+                                        Z3_out_ecount(num_fields)  Z3_func_decl proj_decl[]);
 
     /**
        \brief Create a enumeration sort.
@@ -1932,12 +1932,12 @@ extern "C" {
 
        def_API('Z3_mk_enumeration_sort', SORT, (_in(CONTEXT), _in(SYMBOL), _in(UINT), _in_array(2, SYMBOL), _out_array(2, FUNC_DECL), _out_array(2, FUNC_DECL)))
     */
-    Z3_sort Z3_API Z3_mk_enumeration_sort(__in Z3_context c, 
-                                          __in Z3_symbol name,
-                                          __in unsigned n,
-                                          __in_ecount(n)  Z3_symbol  const enum_names[],
-                                          __out_ecount(n) Z3_func_decl enum_consts[],
-                                          __out_ecount(n) Z3_func_decl enum_testers[]);
+    Z3_sort Z3_API Z3_mk_enumeration_sort(Z3_in Z3_context c, 
+                                          Z3_in Z3_symbol name,
+                                          Z3_in unsigned n,
+                                          Z3_in_ecount(n)  Z3_symbol  const enum_names[],
+                                          Z3_out_ecount(n) Z3_func_decl enum_consts[],
+                                          Z3_out_ecount(n) Z3_func_decl enum_testers[]);
 
     /**
        \brief Create a list sort
@@ -1960,15 +1960,15 @@ extern "C" {
 
        def_API('Z3_mk_list_sort', SORT, (_in(CONTEXT), _in(SYMBOL), _in(SORT), _out(FUNC_DECL), _out(FUNC_DECL), _out(FUNC_DECL), _out(FUNC_DECL), _out(FUNC_DECL), _out(FUNC_DECL)))
     */
-    Z3_sort Z3_API Z3_mk_list_sort(__in Z3_context c,
-                                   __in Z3_symbol name,
-                                   __in Z3_sort   elem_sort,
-                                   __out Z3_func_decl* nil_decl,
-                                   __out Z3_func_decl* is_nil_decl,
-                                   __out Z3_func_decl* cons_decl,
-                                   __out Z3_func_decl* is_cons_decl,
-                                   __out Z3_func_decl* head_decl,
-                                   __out Z3_func_decl* tail_decl
+    Z3_sort Z3_API Z3_mk_list_sort(Z3_in Z3_context c,
+                                   Z3_in Z3_symbol name,
+                                   Z3_in Z3_sort   elem_sort,
+                                   Z3_out Z3_func_decl* nil_decl,
+                                   Z3_out Z3_func_decl* is_nil_decl,
+                                   Z3_out Z3_func_decl* cons_decl,
+                                   Z3_out Z3_func_decl* is_cons_decl,
+                                   Z3_out Z3_func_decl* head_decl,
+                                   Z3_out Z3_func_decl* tail_decl
                                    );
 
 BEGIN_MLAPI_EXCLUDE
@@ -1989,13 +1989,13 @@ BEGIN_MLAPI_EXCLUDE
 
        def_API('Z3_mk_constructor', CONSTRUCTOR, (_in(CONTEXT), _in(SYMBOL), _in(SYMBOL), _in(UINT), _in_array(3, SYMBOL), _in_array(3, SORT), _in_array(3, UINT)))
     */
-    Z3_constructor Z3_API Z3_mk_constructor(__in Z3_context c,
-                                            __in Z3_symbol name,
-                                            __in Z3_symbol recognizer,
-                                            __in unsigned num_fields,
-                                            __in_ecount(num_fields) Z3_symbol const field_names[],
-                                            __in_ecount(num_fields) Z3_sort_opt const sorts[],
-                                            __in_ecount(num_fields) unsigned sort_refs[]
+    Z3_constructor Z3_API Z3_mk_constructor(Z3_in Z3_context c,
+                                            Z3_in Z3_symbol name,
+                                            Z3_in Z3_symbol recognizer,
+                                            Z3_in unsigned num_fields,
+                                            Z3_in_ecount(num_fields) Z3_symbol const field_names[],
+                                            Z3_in_ecount(num_fields) Z3_sort_opt const sorts[],
+                                            Z3_in_ecount(num_fields) unsigned sort_refs[]
                                             );
     
     /**
@@ -2006,7 +2006,7 @@ BEGIN_MLAPI_EXCLUDE
 
        def_API('Z3_del_constructor', VOID, (_in(CONTEXT), _in(CONSTRUCTOR)))
     */
-    void Z3_API Z3_del_constructor(__in Z3_context c, __in Z3_constructor constr);
+    void Z3_API Z3_del_constructor(Z3_in Z3_context c, Z3_in Z3_constructor constr);
 
     /**
        \brief Create datatype, such as lists, trees, records, enumerations or unions of records. 
@@ -2019,10 +2019,10 @@ BEGIN_MLAPI_EXCLUDE
 
        def_API('Z3_mk_datatype', SORT, (_in(CONTEXT), _in(SYMBOL), _in(UINT), _inout_array(2, CONSTRUCTOR)))
     */
-    Z3_sort Z3_API Z3_mk_datatype(__in Z3_context c,
-                                  __in Z3_symbol name,
-                                  __in unsigned num_constructors,
-                                  __inout_ecount(num_constructors) Z3_constructor constructors[]);
+    Z3_sort Z3_API Z3_mk_datatype(Z3_in Z3_context c,
+                                  Z3_in Z3_symbol name,
+                                  Z3_in unsigned num_constructors,
+                                  Z3_inout_ecount(num_constructors) Z3_constructor constructors[]);
 
 
     /**
@@ -2034,9 +2034,9 @@ BEGIN_MLAPI_EXCLUDE
 
        def_API('Z3_mk_constructor_list', CONSTRUCTOR_LIST, (_in(CONTEXT), _in(UINT), _in_array(1, CONSTRUCTOR)))
     */
-    Z3_constructor_list Z3_API Z3_mk_constructor_list(__in Z3_context c,
-                                                      __in unsigned num_constructors,
-                                                      __in_ecount(num_constructors) Z3_constructor const constructors[]);
+    Z3_constructor_list Z3_API Z3_mk_constructor_list(Z3_in Z3_context c,
+                                                      Z3_in unsigned num_constructors,
+                                                      Z3_in_ecount(num_constructors) Z3_constructor const constructors[]);
 
     /**
        \brief Reclaim memory allocated for constructor list.
@@ -2048,7 +2048,7 @@ BEGIN_MLAPI_EXCLUDE
 
        def_API('Z3_del_constructor_list', VOID, (_in(CONTEXT), _in(CONSTRUCTOR_LIST)))
     */
-    void Z3_API Z3_del_constructor_list(__in Z3_context c, __in Z3_constructor_list clist);
+    void Z3_API Z3_del_constructor_list(Z3_in Z3_context c, Z3_in Z3_constructor_list clist);
                                         
     /**
        \brief Create mutually recursive datatypes.
@@ -2061,11 +2061,11 @@ BEGIN_MLAPI_EXCLUDE
 
        def_API('Z3_mk_datatypes', VOID, (_in(CONTEXT), _in(UINT), _in_array(1, SYMBOL), _out_array(1, SORT), _inout_array(1, CONSTRUCTOR_LIST)))
     */
-    void Z3_API Z3_mk_datatypes(__in Z3_context c,
-                                __in unsigned num_sorts,
-                                __in_ecount(num_sorts) Z3_symbol const sort_names[],
-                                __out_ecount(num_sorts) Z3_sort sorts[],
-                                __inout_ecount(num_sorts) Z3_constructor_list constructor_lists[]);
+    void Z3_API Z3_mk_datatypes(Z3_in Z3_context c,
+                                Z3_in unsigned num_sorts,
+                                Z3_in_ecount(num_sorts) Z3_symbol const sort_names[],
+                                Z3_out_ecount(num_sorts) Z3_sort sorts[],
+                                Z3_inout_ecount(num_sorts) Z3_constructor_list constructor_lists[]);
 
     /**
        \brief Query constructor for declared functions. 
@@ -2079,12 +2079,12 @@ BEGIN_MLAPI_EXCLUDE
 
        def_API('Z3_query_constructor', VOID, (_in(CONTEXT), _in(CONSTRUCTOR), _in(UINT), _out(FUNC_DECL), _out(FUNC_DECL), _out_array(2, FUNC_DECL)))
     */
-    void Z3_API Z3_query_constructor(__in Z3_context c,
-                                     __in Z3_constructor constr,
-                                     __in unsigned num_fields,
-                                     __out Z3_func_decl* constructor,
-                                     __out Z3_func_decl* tester,
-                                     __out_ecount(num_fields) Z3_func_decl accessors[]);
+    void Z3_API Z3_query_constructor(Z3_in Z3_context c,
+                                     Z3_in Z3_constructor constr,
+                                     Z3_in unsigned num_fields,
+                                     Z3_out Z3_func_decl* constructor,
+                                     Z3_out Z3_func_decl* tester,
+                                     Z3_out_ecount(num_fields) Z3_func_decl accessors[]);
 END_MLAPI_EXCLUDE
 
     /*@}*/
@@ -2114,9 +2114,9 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_func_decl', FUNC_DECL, (_in(CONTEXT), _in(SYMBOL), _in(UINT), _in_array(2, SORT), _in(SORT)))
     */
-    Z3_func_decl Z3_API Z3_mk_func_decl(__in Z3_context c, __in Z3_symbol s,
-                                        __in unsigned domain_size, __in_ecount(domain_size) Z3_sort const domain[],
-                                        __in Z3_sort range);
+    Z3_func_decl Z3_API Z3_mk_func_decl(Z3_in Z3_context c, Z3_in Z3_symbol s,
+                                        Z3_in unsigned domain_size, Z3_in_ecount(domain_size) Z3_sort const domain[],
+                                        Z3_in Z3_sort range);
 
     
     /**
@@ -2127,10 +2127,10 @@ END_MLAPI_EXCLUDE
        def_API('Z3_mk_app', AST, (_in(CONTEXT), _in(FUNC_DECL), _in(UINT), _in_array(2, AST)))
     */
     Z3_ast Z3_API Z3_mk_app(
-        __in Z3_context c, 
-        __in Z3_func_decl d,
-        __in unsigned num_args, 
-        __in_ecount(num_args) Z3_ast const args[]);
+        Z3_in Z3_context c, 
+        Z3_in Z3_func_decl d,
+        Z3_in unsigned num_args, 
+        Z3_in_ecount(num_args) Z3_ast const args[]);
 
     /**
        \brief Declare and create a constant.
@@ -2148,7 +2148,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_const', AST, (_in(CONTEXT), _in(SYMBOL), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_const(__in Z3_context c, __in Z3_symbol s, __in Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_const(Z3_in Z3_context c, Z3_in Z3_symbol s, Z3_in Z3_sort ty);
 
     /**
        \brief Declare a fresh constant or function.
@@ -2162,9 +2162,9 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_fresh_func_decl', FUNC_DECL, (_in(CONTEXT), _in(STRING), _in(UINT), _in_array(2, SORT), _in(SORT)))
     */
-    Z3_func_decl Z3_API Z3_mk_fresh_func_decl(__in Z3_context c, __in Z3_string prefix,
-                                                   __in unsigned domain_size, __in_ecount(domain_size) Z3_sort const domain[],
-                                                   __in Z3_sort range);
+    Z3_func_decl Z3_API Z3_mk_fresh_func_decl(Z3_in Z3_context c, Z3_in Z3_string prefix,
+                                                   Z3_in unsigned domain_size, Z3_in_ecount(domain_size) Z3_sort const domain[],
+                                                   Z3_in Z3_sort range);
     
     /**
        \brief Declare and create a fresh constant.
@@ -2181,7 +2181,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_fresh_const', AST, (_in(CONTEXT), _in(STRING), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_fresh_const(__in Z3_context c, __in Z3_string prefix, __in Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_fresh_const(Z3_in Z3_context c, Z3_in Z3_string prefix, Z3_in Z3_sort ty);
     /*@}*/
 
     /**
@@ -2193,14 +2193,14 @@ END_MLAPI_EXCLUDE
         
         def_API('Z3_mk_true', AST, (_in(CONTEXT), ))
     */
-    Z3_ast Z3_API Z3_mk_true(__in Z3_context c);
+    Z3_ast Z3_API Z3_mk_true(Z3_in Z3_context c);
 
     /**
         \brief Create an AST node representing \c false.
 
         def_API('Z3_mk_false', AST, (_in(CONTEXT), ))
     */
-    Z3_ast Z3_API Z3_mk_false(__in Z3_context c);
+    Z3_ast Z3_API Z3_mk_false(Z3_in Z3_context c);
     
     /**
         \brief \mlh mk_eq c l r \endmlh
@@ -2210,7 +2210,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_mk_eq', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_eq(__in Z3_context c, __in Z3_ast l, __in Z3_ast r);
+    Z3_ast Z3_API Z3_mk_eq(Z3_in Z3_context c, Z3_in Z3_ast l, Z3_in Z3_ast r);
     
     /**
        \conly \brief Create an AST node representing <tt>distinct(args[0], ..., args[num_args-1])</tt>.
@@ -2227,7 +2227,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_distinct', AST, (_in(CONTEXT), _in(UINT), _in_array(1, AST)))
     */
-    Z3_ast Z3_API Z3_mk_distinct(__in Z3_context c, __in unsigned num_args, __in_ecount(num_args) Z3_ast const args[]);
+    Z3_ast Z3_API Z3_mk_distinct(Z3_in Z3_context c, Z3_in unsigned num_args, Z3_in_ecount(num_args) Z3_ast const args[]);
 
     /**
         \brief \mlh mk_not c a \endmlh 
@@ -2237,7 +2237,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_mk_not', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_not(__in Z3_context c, __in Z3_ast a);
+    Z3_ast Z3_API Z3_mk_not(Z3_in Z3_context c, Z3_in Z3_ast a);
         
     /**
        \brief \mlh mk_ite c t1 t2 t2 \endmlh 
@@ -2249,7 +2249,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_ite', AST, (_in(CONTEXT), _in(AST), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_ite(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2, __in Z3_ast t3);
+    Z3_ast Z3_API Z3_mk_ite(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2, Z3_in Z3_ast t3);
 
     /**
        \brief \mlh mk_iff c t1 t2 \endmlh
@@ -2259,7 +2259,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_iff', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_iff(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_iff(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_implies c t1 t2 \endmlh
@@ -2269,7 +2269,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_implies', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_implies(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_implies(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
     
     /**
        \brief \mlh mk_xor c t1 t2 \endmlh
@@ -2279,7 +2279,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_xor', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_xor(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_xor(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
     
     /**
        \conly \brief Create an AST node representing <tt>args[0] and ... and args[num_args-1]</tt>.
@@ -2292,7 +2292,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_and', AST, (_in(CONTEXT), _in(UINT), _in_array(1, AST)))
     */
-    Z3_ast Z3_API Z3_mk_and(__in Z3_context c, __in unsigned num_args, __in_ecount(num_args) Z3_ast const args[]);
+    Z3_ast Z3_API Z3_mk_and(Z3_in Z3_context c, Z3_in unsigned num_args, Z3_in_ecount(num_args) Z3_ast const args[]);
     
     /**
        \conly \brief Create an AST node representing <tt>args[0] or ... or args[num_args-1]</tt>.
@@ -2305,7 +2305,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_or', AST, (_in(CONTEXT), _in(UINT), _in_array(1, AST)))
     */
-    Z3_ast Z3_API Z3_mk_or(__in Z3_context c, __in unsigned num_args, __in_ecount(num_args) Z3_ast const args[]);
+    Z3_ast Z3_API Z3_mk_or(Z3_in Z3_context c, Z3_in unsigned num_args, Z3_in_ecount(num_args) Z3_ast const args[]);
     /*@}*/
 
     /**
@@ -2323,7 +2323,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_add', AST, (_in(CONTEXT), _in(UINT), _in_array(1, AST)))
     */
-    Z3_ast Z3_API Z3_mk_add(__in Z3_context c, __in unsigned num_args, __in_ecount(num_args) Z3_ast const args[]);
+    Z3_ast Z3_API Z3_mk_add(Z3_in Z3_context c, Z3_in unsigned num_args, Z3_in_ecount(num_args) Z3_ast const args[]);
     
     /**
        \conly \brief Create an AST node representing <tt>args[0] * ... * args[num_args-1]</tt>.
@@ -2337,7 +2337,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_mul', AST, (_in(CONTEXT), _in(UINT), _in_array(1, AST)))
     */
-    Z3_ast Z3_API Z3_mk_mul(__in Z3_context c, __in unsigned num_args, __in_ecount(num_args) Z3_ast const args[]);
+    Z3_ast Z3_API Z3_mk_mul(Z3_in Z3_context c, Z3_in unsigned num_args, Z3_in_ecount(num_args) Z3_ast const args[]);
     
     /**
        \conly \brief Create an AST node representing <tt>args[0] - ... - args[num_args - 1]</tt>.
@@ -2350,7 +2350,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_sub', AST, (_in(CONTEXT), _in(UINT), _in_array(1, AST)))
     */
-    Z3_ast Z3_API Z3_mk_sub(__in Z3_context c, __in unsigned num_args, __in_ecount(num_args) Z3_ast const args[]);
+    Z3_ast Z3_API Z3_mk_sub(Z3_in Z3_context c, Z3_in unsigned num_args, Z3_in_ecount(num_args) Z3_ast const args[]);
 
     /**
        \conly \brief Create an AST node representing <tt>-arg</tt>.
@@ -2360,7 +2360,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_unary_minus', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_unary_minus(__in Z3_context c, __in Z3_ast arg);
+    Z3_ast Z3_API Z3_mk_unary_minus(Z3_in Z3_context c, Z3_in Z3_ast arg);
 
     /**
        \conly \brief Create an AST node representing <tt>arg1 div arg2</tt>.
@@ -2372,7 +2372,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_div', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_div(__in Z3_context c, __in Z3_ast arg1, __in Z3_ast arg2);
+    Z3_ast Z3_API Z3_mk_div(Z3_in Z3_context c, Z3_in Z3_ast arg1, Z3_in Z3_ast arg2);
 
     /**
        \conly \brief Create an AST node representing <tt>arg1 mod arg2</tt>.
@@ -2382,7 +2382,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_mod', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_mod(__in Z3_context c, __in Z3_ast arg1, __in Z3_ast arg2);
+    Z3_ast Z3_API Z3_mk_mod(Z3_in Z3_context c, Z3_in Z3_ast arg1, Z3_in Z3_ast arg2);
 
     /**
        \conly \brief Create an AST node representing <tt>arg1 rem arg2</tt>.
@@ -2392,7 +2392,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_rem', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_rem(__in Z3_context c, __in Z3_ast arg1, __in Z3_ast arg2);
+    Z3_ast Z3_API Z3_mk_rem(Z3_in Z3_context c, Z3_in Z3_ast arg1, Z3_in Z3_ast arg2);
 
     /**
        \conly \brief Create an AST node representing <tt>arg1^arg2</tt>.
@@ -2401,7 +2401,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_power', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_power(__in Z3_context c, __in Z3_ast arg1, __in Z3_ast arg2);
+    Z3_ast Z3_API Z3_mk_power(Z3_in Z3_context c, Z3_in Z3_ast arg1, Z3_in Z3_ast arg2);
 
     /**
         \brief \mlh mk_lt c t1 t2 \endmlh 
@@ -2411,7 +2411,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_mk_lt', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_lt(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_lt(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
         \brief \mlh mk_le c t1 t2 \endmlh
@@ -2421,7 +2421,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_mk_le', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_le(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_le(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
         \brief \mlh mk_gt c t1 t2 \endmlh
@@ -2431,7 +2431,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_mk_gt', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_gt(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_gt(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
         \brief \mlh mk_ge c t1 t2 \endmlh
@@ -2441,7 +2441,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_mk_ge', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_ge(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_ge(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
         \brief \mlh mk_int2real c t1 \endmlh
@@ -2461,7 +2461,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_mk_int2real', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_int2real(__in Z3_context c, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_int2real(Z3_in Z3_context c, Z3_in Z3_ast t1);
 
     /**
         \brief \mlh mk_real2int c t1 \endmlh
@@ -2475,7 +2475,7 @@ END_MLAPI_EXCLUDE
         
         def_API('Z3_mk_real2int', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_real2int(__in Z3_context c, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_real2int(Z3_in Z3_context c, Z3_in Z3_ast t1);
 
     /**
         \brief \mlh mk_is_int c t1 \endmlh
@@ -2486,7 +2486,7 @@ END_MLAPI_EXCLUDE
         
         def_API('Z3_mk_is_int', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_is_int(__in Z3_context c, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_is_int(Z3_in Z3_context c, Z3_in Z3_ast t1);
     /*@}*/
 
     /**
@@ -2501,7 +2501,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvnot', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvnot(__in Z3_context c, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_bvnot(Z3_in Z3_context c, Z3_in Z3_ast t1);
 
     /**
        \brief \mlh mk_bvredand c t1 \endmlh
@@ -2511,7 +2511,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvredand', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvredand(__in Z3_context c, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_bvredand(Z3_in Z3_context c, Z3_in Z3_ast t1);
 
     /**
        \brief \mlh mk_bvredor c t1 \endmlh
@@ -2521,7 +2521,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_bvredor', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvredor(__in Z3_context c, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_bvredor(Z3_in Z3_context c, Z3_in Z3_ast t1);
 
     /**
        \brief \mlh mk_bvand c t1 t2 \endmlh
@@ -2531,7 +2531,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_bvand', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvand(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvand(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvor c t1 t2 \endmlh
@@ -2541,7 +2541,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvor', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvor(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvor(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvxor c t1 t2 \endmlh
@@ -2551,7 +2551,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_bvxor', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvxor(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvxor(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvnand c t1 t2 \endmlh
@@ -2561,7 +2561,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvnand', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvnand(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvnand(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvnor c t1 t2 \endmlh
@@ -2571,7 +2571,7 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_mk_bvnor', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvnor(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvnor(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvxnor c t1 t2 \endmlh
@@ -2581,7 +2581,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvxnor', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvxnor(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvxnor(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvneg c t1 \endmlh
@@ -2591,7 +2591,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvneg', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvneg(__in Z3_context c, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_bvneg(Z3_in Z3_context c, Z3_in Z3_ast t1);
     
     /**
         \brief \mlh mk_bvadd c t1 t2 \endmlh
@@ -2601,7 +2601,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_mk_bvadd', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvadd(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvadd(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
         \brief \mlh mk_bvsub c t1 t2 \endmlh
@@ -2611,7 +2611,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_mk_bvsub', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvsub(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvsub(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
     
     /**
         \brief \mlh mk_bvmul c t1 t2 \endmlh
@@ -2621,7 +2621,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_mk_bvmul', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvmul(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvmul(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
         \brief \mlh mk_bvudiv c t1 t2 \endmlh
@@ -2635,7 +2635,7 @@ END_MLAPI_EXCLUDE
         
         def_API('Z3_mk_bvudiv', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvudiv(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvudiv(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
         \brief \mlh mk_bvsdiv c t1 t2 \endmlh
@@ -2653,7 +2653,7 @@ END_MLAPI_EXCLUDE
     
         def_API('Z3_mk_bvsdiv', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvsdiv(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvsdiv(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvurem c t1 t2 \endmlh
@@ -2667,7 +2667,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvurem', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvurem(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvurem(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvsrem c t1 t2 \endmlh
@@ -2684,7 +2684,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvsrem', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvsrem(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvsrem(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvsmod c t1 t2 \endmlh
@@ -2698,7 +2698,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvsmod', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvsmod(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvsmod(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvult c t1 t2 \endmlh
@@ -2708,7 +2708,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_bvult', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvult(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvult(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
     
     /**
        \brief \mlh mk_bvslt c t1 t2 \endmlh
@@ -2726,7 +2726,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvslt', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvslt(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvslt(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvule c t1 t2 \endmlh
@@ -2736,7 +2736,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvule', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvule(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvule(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvsle c t1 t2 \endmlh
@@ -2746,7 +2746,7 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_mk_bvsle', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvsle(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvsle(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvuge c t1 t2 \endmlh
@@ -2756,7 +2756,7 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_mk_bvuge', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvuge(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvuge(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvsge c t1 t2 \endmlh
@@ -2766,7 +2766,7 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_mk_bvsge', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvsge(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvsge(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvugt c t1 t2 \endmlh
@@ -2776,7 +2776,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvugt', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvugt(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvugt(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvsgt c t1 t2 \endmlh
@@ -2786,7 +2786,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_bvsgt', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvsgt(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvsgt(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_concat c t1 t2 \endmlh
@@ -2799,7 +2799,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_concat', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_concat(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_concat(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
     
     /**
        \brief \mlh mk_extract c high low t1 \endmlh
@@ -2811,7 +2811,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_extract', AST, (_in(CONTEXT), _in(UINT), _in(UINT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_extract(__in Z3_context c, __in unsigned high, __in unsigned low, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_extract(Z3_in Z3_context c, Z3_in unsigned high, Z3_in unsigned low, Z3_in Z3_ast t1);
 
     /**
        \brief \mlh mk_sign_ext c i t1 \endmlh
@@ -2823,7 +2823,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_sign_ext', AST, (_in(CONTEXT), _in(UINT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_sign_ext(__in Z3_context c, __in unsigned i, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_sign_ext(Z3_in Z3_context c, Z3_in unsigned i, Z3_in Z3_ast t1);
 
     /**
        \brief \mlh mk_zero_ext c i t1 \endmlh
@@ -2835,7 +2835,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_zero_ext', AST, (_in(CONTEXT), _in(UINT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_zero_ext(__in Z3_context c, __in unsigned i, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_zero_ext(Z3_in Z3_context c, Z3_in unsigned i, Z3_in Z3_ast t1);
 
     /**
        \brief \mlh mk_repeat c i t1 \endmlh
@@ -2845,7 +2845,7 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_mk_repeat', AST, (_in(CONTEXT), _in(UINT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_repeat(__in Z3_context c, __in unsigned i, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_repeat(Z3_in Z3_context c, Z3_in unsigned i, Z3_in Z3_ast t1);
 
     /**
        \brief \mlh mk_bvshl c t1 t2 \endmlh
@@ -2862,7 +2862,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvshl', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvshl(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvshl(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvlshr c t1 t2 \endmlh
@@ -2879,7 +2879,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvlshr', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvlshr(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvlshr(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvashr c t1 t2 \endmlh
@@ -2897,7 +2897,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvashr', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvashr(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvashr(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
     
     /**
        \brief \mlh mk_rotate_left c i t1 \endmlh
@@ -2907,7 +2907,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_rotate_left', AST, (_in(CONTEXT), _in(UINT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_rotate_left(__in Z3_context c, __in unsigned i, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_rotate_left(Z3_in Z3_context c, Z3_in unsigned i, Z3_in Z3_ast t1);
     
     /**
        \brief \mlh mk_rotate_right c i t1 \endmlh
@@ -2917,7 +2917,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_rotate_right', AST, (_in(CONTEXT), _in(UINT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_rotate_right(__in Z3_context c, __in unsigned i, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_rotate_right(Z3_in Z3_context c, Z3_in unsigned i, Z3_in Z3_ast t1);
 
     /**
        \brief \mlh mk_ext_rotate_left c t1 t2 \endmlh
@@ -2927,7 +2927,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_ext_rotate_left', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_ext_rotate_left(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_ext_rotate_left(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_ext_rotate_right c t1 t2 \endmlh
@@ -2937,7 +2937,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_ext_rotate_right', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_ext_rotate_right(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_ext_rotate_right(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
     
     /**
        \brief \mlh mk_int2bv c n t1 \endmlh
@@ -2951,7 +2951,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_int2bv', AST, (_in(CONTEXT), _in(UINT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_int2bv(__in Z3_context c, __in unsigned n, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_int2bv(Z3_in Z3_context c, Z3_in unsigned n, Z3_in Z3_ast t1);
 
     /**
        \brief \mlh mk_bv2int c t1 is_signed \endmlh
@@ -2969,7 +2969,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bv2int', AST, (_in(CONTEXT), _in(AST), _in(BOOL)))
     */
-    Z3_ast Z3_API Z3_mk_bv2int(__in Z3_context c,__in Z3_ast t1, Z3_bool is_signed);
+    Z3_ast Z3_API Z3_mk_bv2int(Z3_in Z3_context c,Z3_in Z3_ast t1, Z3_bool is_signed);
 
     /**
        \brief \mlh mk_bvadd_no_overflow c t1 t2 is_signed \endmlh
@@ -2980,7 +2980,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvadd_no_overflow', AST, (_in(CONTEXT), _in(AST), _in(AST), _in(BOOL)))
     */
-    Z3_ast Z3_API Z3_mk_bvadd_no_overflow(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2, Z3_bool is_signed);
+    Z3_ast Z3_API Z3_mk_bvadd_no_overflow(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2, Z3_bool is_signed);
 
     /**
        \brief \mlh mk_bvadd_no_underflow c t1 t2 \endmlh
@@ -2991,7 +2991,7 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_mk_bvadd_no_underflow', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvadd_no_underflow(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvadd_no_underflow(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvsub_no_overflow c t1 t2 \endmlh
@@ -3002,7 +3002,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_bvsub_no_overflow', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvsub_no_overflow(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvsub_no_overflow(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvsub_no_underflow c t1 t2 is_signed \endmlh
@@ -3013,7 +3013,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvsub_no_underflow', AST, (_in(CONTEXT), _in(AST), _in(AST), _in(BOOL)))
     */
-    Z3_ast Z3_API Z3_mk_bvsub_no_underflow(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2, Z3_bool is_signed);
+    Z3_ast Z3_API Z3_mk_bvsub_no_underflow(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2, Z3_bool is_signed);
 
     /**
        \brief \mlh mk_bvsdiv_no_overflow c t1 t2 \endmlh
@@ -3024,7 +3024,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_bvsdiv_no_overflow', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvsdiv_no_overflow(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvsdiv_no_overflow(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
        \brief \mlh mk_bvneg_no_overflow c t1 \endmlh
@@ -3035,7 +3035,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvneg_no_overflow', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvneg_no_overflow(__in Z3_context c, __in Z3_ast t1);
+    Z3_ast Z3_API Z3_mk_bvneg_no_overflow(Z3_in Z3_context c, Z3_in Z3_ast t1);
 
     /**
        \brief \mlh mk_bvmul_no_overflow c t1 t2 is_signed \endmlh
@@ -3046,7 +3046,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_mk_bvmul_no_overflow', AST, (_in(CONTEXT), _in(AST), _in(AST), _in(BOOL)))
     */
-    Z3_ast Z3_API Z3_mk_bvmul_no_overflow(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2, Z3_bool is_signed);
+    Z3_ast Z3_API Z3_mk_bvmul_no_overflow(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2, Z3_bool is_signed);
 
     /**
        \brief \mlh mk_bvmul_no_underflow c t1 t2 \endmlh
@@ -3057,7 +3057,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bvmul_no_underflow', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_bvmul_no_underflow(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_bvmul_no_underflow(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
     /*@}*/
 
     /**
@@ -3079,7 +3079,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_select', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_select(__in Z3_context c, __in Z3_ast a, __in Z3_ast i);
+    Z3_ast Z3_API Z3_mk_select(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_ast i);
     
     /**
        \brief \mlh mk_store c a i v \endmlh
@@ -3098,7 +3098,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_store', AST, (_in(CONTEXT), _in(AST), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_store(__in Z3_context c, __in Z3_ast a, __in Z3_ast i, __in Z3_ast v);
+    Z3_ast Z3_API Z3_mk_store(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_ast i, Z3_in Z3_ast v);
 
     /**
         \brief Create the constant array.
@@ -3112,7 +3112,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_mk_const_array', AST, (_in(CONTEXT), _in(SORT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_const_array(__in Z3_context c, __in Z3_sort domain, __in Z3_ast v);
+    Z3_ast Z3_API Z3_mk_const_array(Z3_in Z3_context c, Z3_in Z3_sort domain, Z3_in Z3_ast v);
 
     /**
        \brief \mlh mk_map f n args \endmlh
@@ -3128,7 +3128,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_map', AST, (_in(CONTEXT), _in(FUNC_DECL), _in(UINT), _in_array(2, AST)))
     */
-    Z3_ast Z3_API Z3_mk_map(__in Z3_context c, __in Z3_func_decl f, unsigned n, __in Z3_ast const* args);
+    Z3_ast Z3_API Z3_mk_map(Z3_in Z3_context c, Z3_in Z3_func_decl f, unsigned n, Z3_in Z3_ast const* args);
 
     /**
         \brief Access the array default value.
@@ -3140,7 +3140,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_mk_array_default', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_array_default(__in Z3_context c, __in Z3_ast array);
+    Z3_ast Z3_API Z3_mk_array_default(Z3_in Z3_context c, Z3_in Z3_ast array);
     /*@}*/
 
     /**
@@ -3152,21 +3152,21 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_set_sort', SORT, (_in(CONTEXT), _in(SORT)))
     */
-    Z3_sort Z3_API Z3_mk_set_sort(__in Z3_context c, __in Z3_sort ty);
+    Z3_sort Z3_API Z3_mk_set_sort(Z3_in Z3_context c, Z3_in Z3_sort ty);
 
     /**
         \brief Create the empty set.
 
         def_API('Z3_mk_empty_set', AST, (_in(CONTEXT), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_empty_set(__in Z3_context c, __in Z3_sort domain);
+    Z3_ast Z3_API Z3_mk_empty_set(Z3_in Z3_context c, Z3_in Z3_sort domain);
 
     /**
         \brief Create the full set.
 
         def_API('Z3_mk_full_set', AST, (_in(CONTEXT), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_full_set(__in Z3_context c, __in Z3_sort domain);
+    Z3_ast Z3_API Z3_mk_full_set(Z3_in Z3_context c, Z3_in Z3_sort domain);
 
     /**
        \brief Add an element to a set.
@@ -3175,7 +3175,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_set_add', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_set_add(__in Z3_context c, __in Z3_ast set, __in Z3_ast elem);
+    Z3_ast Z3_API Z3_mk_set_add(Z3_in Z3_context c, Z3_in Z3_ast set, Z3_in Z3_ast elem);
 
     /**
        \brief Remove an element to a set.
@@ -3184,35 +3184,35 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_set_del', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_set_del(__in Z3_context c, __in Z3_ast set, __in Z3_ast elem);
+    Z3_ast Z3_API Z3_mk_set_del(Z3_in Z3_context c, Z3_in Z3_ast set, Z3_in Z3_ast elem);
 
     /**
        \brief Take the union of a list of sets.
 
        def_API('Z3_mk_set_union', AST, (_in(CONTEXT), _in(UINT), _in_array(1, AST)))
     */
-    Z3_ast Z3_API Z3_mk_set_union(__in Z3_context c, __in unsigned num_args, __in_ecount(num_args) Z3_ast const args[]);
+    Z3_ast Z3_API Z3_mk_set_union(Z3_in Z3_context c, Z3_in unsigned num_args, Z3_in_ecount(num_args) Z3_ast const args[]);
 
     /**
        \brief Take the intersection of a list of sets.
 
        def_API('Z3_mk_set_intersect', AST, (_in(CONTEXT), _in(UINT), _in_array(1, AST)))
     */
-    Z3_ast Z3_API Z3_mk_set_intersect(__in Z3_context c, __in unsigned num_args, __in_ecount(num_args) Z3_ast const args[]);
+    Z3_ast Z3_API Z3_mk_set_intersect(Z3_in Z3_context c, Z3_in unsigned num_args, Z3_in_ecount(num_args) Z3_ast const args[]);
 
     /**
        \brief Take the set difference between two sets.
 
        def_API('Z3_mk_set_difference', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_set_difference(__in Z3_context c, __in Z3_ast arg1, __in Z3_ast arg2);
+    Z3_ast Z3_API Z3_mk_set_difference(Z3_in Z3_context c, Z3_in Z3_ast arg1, Z3_in Z3_ast arg2);
 
     /**
        \brief Take the complement of a set.
 
        def_API('Z3_mk_set_complement', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_set_complement(__in Z3_context c, __in Z3_ast arg);
+    Z3_ast Z3_API Z3_mk_set_complement(Z3_in Z3_context c, Z3_in Z3_ast arg);
 
     /**
        \brief Check for set membership.
@@ -3221,14 +3221,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_set_member', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_set_member(__in Z3_context c, __in Z3_ast elem, __in Z3_ast set);
+    Z3_ast Z3_API Z3_mk_set_member(Z3_in Z3_context c, Z3_in Z3_ast elem, Z3_in Z3_ast set);
 
     /**
        \brief Check for subsetness of sets.
 
        def_API('Z3_mk_set_subset', AST, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_set_subset(__in Z3_context c, __in Z3_ast arg1, __in Z3_ast arg2);
+    Z3_ast Z3_API Z3_mk_set_subset(Z3_in Z3_context c, Z3_in Z3_ast arg1, Z3_in Z3_ast arg2);
     /*@}*/
 
     /**
@@ -3256,7 +3256,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_numeral', AST, (_in(CONTEXT), _in(STRING), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_numeral(__in Z3_context c, __in Z3_string numeral, __in Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_numeral(Z3_in Z3_context c, Z3_in Z3_string numeral, Z3_in Z3_sort ty);
 
     /**
        \brief Create a real from a fraction.
@@ -3273,7 +3273,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_real', AST, (_in(CONTEXT), _in(INT), _in(INT)))
     */
-    Z3_ast Z3_API Z3_mk_real(__in Z3_context c, __in int num, __in int den);
+    Z3_ast Z3_API Z3_mk_real(Z3_in Z3_context c, Z3_in int num, Z3_in int den);
     
     /**
        \brief Create a numeral of an int, bit-vector, or finite-domain sort. 
@@ -3285,7 +3285,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_int', AST, (_in(CONTEXT), _in(INT), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_int(__in Z3_context c, __in int v, __in Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_int(Z3_in Z3_context c, Z3_in int v, Z3_in Z3_sort ty);
     
 #ifdef Conly
     /**
@@ -3298,7 +3298,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_unsigned_int', AST, (_in(CONTEXT), _in(UINT), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_unsigned_int(__in Z3_context c, __in unsigned v, __in Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_unsigned_int(Z3_in Z3_context c, Z3_in unsigned v, Z3_in Z3_sort ty);
 #endif
 
     /**
@@ -3311,7 +3311,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_int64', AST, (_in(CONTEXT), _in(INT64), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_int64(__in Z3_context c, __in __int64 v, __in Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_int64(Z3_in Z3_context c, Z3_in __int64 v, Z3_in Z3_sort ty);
 
 #ifdef Conly
     /**
@@ -3324,7 +3324,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_unsigned_int64', AST, (_in(CONTEXT), _in(UINT64), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_unsigned_int64(__in Z3_context c, __in unsigned __int64 v, __in Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_unsigned_int64(Z3_in Z3_context c, Z3_in unsigned __int64 v, Z3_in Z3_sort ty);
 #endif
 
     /*@}*/
@@ -3355,8 +3355,8 @@ END_MLAPI_EXCLUDE
        def_API('Z3_mk_pattern', PATTERN, (_in(CONTEXT), _in(UINT), _in_array(1, AST)))
     */
     Z3_pattern Z3_API Z3_mk_pattern(
-        __in Z3_context c,
-        __in unsigned num_patterns, __in_ecount(num_patterns) Z3_ast const terms[]);
+        Z3_in Z3_context c,
+        Z3_in unsigned num_patterns, Z3_in_ecount(num_patterns) Z3_ast const terms[]);
 
     /**
        \brief Create a bound variable.
@@ -3387,7 +3387,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_bound', AST, (_in(CONTEXT), _in(UINT), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_bound(__in Z3_context c, __in unsigned index, __in Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_bound(Z3_in Z3_context c, Z3_in unsigned index, Z3_in Z3_sort ty);
     
     /**
        \brief Create a forall formula. It takes an expression \c body that contains bound variables
@@ -3422,11 +3422,11 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_forall', AST, (_in(CONTEXT), _in(UINT), _in(UINT), _in_array(2, PATTERN), _in(UINT), _in_array(4, SORT), _in_array(4, SYMBOL), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_forall(__in Z3_context c, __in unsigned weight,
-                               __in unsigned num_patterns, __in_ecount(num_patterns) Z3_pattern const patterns[],
-                               __in unsigned num_decls, __in_ecount(num_decls) Z3_sort const sorts[],
-                               __in_ecount(num_decls) Z3_symbol const decl_names[],
-                               __in Z3_ast body);
+    Z3_ast Z3_API Z3_mk_forall(Z3_in Z3_context c, Z3_in unsigned weight,
+                               Z3_in unsigned num_patterns, Z3_in_ecount(num_patterns) Z3_pattern const patterns[],
+                               Z3_in unsigned num_decls, Z3_in_ecount(num_decls) Z3_sort const sorts[],
+                               Z3_in_ecount(num_decls) Z3_symbol const decl_names[],
+                               Z3_in Z3_ast body);
 
     /**
        \brief Create an exists formula. Similar to #Z3_mk_forall.
@@ -3438,11 +3438,11 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_exists', AST, (_in(CONTEXT), _in(UINT), _in(UINT), _in_array(2, PATTERN), _in(UINT), _in_array(4, SORT), _in_array(4, SYMBOL), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_exists(__in Z3_context c, __in unsigned weight,
-                               __in unsigned num_patterns, __in_ecount(num_patterns) Z3_pattern const patterns[],
-                               __in unsigned num_decls, __in_ecount(num_decls) Z3_sort const sorts[],
-                               __in_ecount(num_decls) Z3_symbol const decl_names[],
-                               __in Z3_ast body);
+    Z3_ast Z3_API Z3_mk_exists(Z3_in Z3_context c, Z3_in unsigned weight,
+                               Z3_in unsigned num_patterns, Z3_in_ecount(num_patterns) Z3_pattern const patterns[],
+                               Z3_in unsigned num_decls, Z3_in_ecount(num_decls) Z3_sort const sorts[],
+                               Z3_in_ecount(num_decls) Z3_symbol const decl_names[],
+                               Z3_in Z3_ast body);
 
     /**
        \brief Create a quantifier - universal or existential, with pattern hints. 
@@ -3466,13 +3466,13 @@ END_MLAPI_EXCLUDE
        def_API('Z3_mk_quantifier', AST, (_in(CONTEXT), _in(BOOL), _in(UINT), _in(UINT), _in_array(3, PATTERN), _in(UINT), _in_array(5, SORT), _in_array(5, SYMBOL), _in(AST)))
     */
     Z3_ast Z3_API Z3_mk_quantifier(
-        __in Z3_context c, 
-        __in Z3_bool is_forall, 
-        __in unsigned weight, 
-        __in unsigned num_patterns, __in_ecount(num_patterns) Z3_pattern const patterns[], 
-        __in unsigned num_decls, __in_ecount(num_decls) Z3_sort const sorts[], 
-        __in_ecount(num_decls) Z3_symbol const decl_names[], 
-        __in Z3_ast body);
+        Z3_in Z3_context c, 
+        Z3_in Z3_bool is_forall, 
+        Z3_in unsigned weight, 
+        Z3_in unsigned num_patterns, Z3_in_ecount(num_patterns) Z3_pattern const patterns[], 
+        Z3_in unsigned num_decls, Z3_in_ecount(num_decls) Z3_sort const sorts[], 
+        Z3_in_ecount(num_decls) Z3_symbol const decl_names[], 
+        Z3_in Z3_ast body);
 
 
     /**
@@ -3500,16 +3500,16 @@ END_MLAPI_EXCLUDE
        def_API('Z3_mk_quantifier_ex', AST, (_in(CONTEXT), _in(BOOL), _in(UINT), _in(SYMBOL), _in(SYMBOL), _in(UINT), _in_array(5, PATTERN), _in(UINT), _in_array(7, AST), _in(UINT), _in_array(9, SORT), _in_array(9, SYMBOL), _in(AST)))
     */
     Z3_ast Z3_API Z3_mk_quantifier_ex(
-        __in Z3_context c, 
-        __in Z3_bool is_forall, 
-        __in unsigned weight, 
-        __in Z3_symbol quantifier_id,
-        __in Z3_symbol skolem_id,
-        __in unsigned num_patterns, __in_ecount(num_patterns) Z3_pattern const patterns[], 
-        __in unsigned num_no_patterns, __in_ecount(num_no_patterns) Z3_ast const no_patterns[], 
-        __in unsigned num_decls, __in_ecount(num_decls) Z3_sort const sorts[], 
-        __in_ecount(num_decls) Z3_symbol const decl_names[], 
-        __in Z3_ast body);
+        Z3_in Z3_context c, 
+        Z3_in Z3_bool is_forall, 
+        Z3_in unsigned weight, 
+        Z3_in Z3_symbol quantifier_id,
+        Z3_in Z3_symbol skolem_id,
+        Z3_in unsigned num_patterns, Z3_in_ecount(num_patterns) Z3_pattern const patterns[], 
+        Z3_in unsigned num_no_patterns, Z3_in_ecount(num_no_patterns) Z3_ast const no_patterns[], 
+        Z3_in unsigned num_decls, Z3_in_ecount(num_decls) Z3_sort const sorts[], 
+        Z3_in_ecount(num_decls) Z3_symbol const decl_names[], 
+        Z3_in Z3_ast body);
 
     /**
        \brief Create a universal quantifier using a list of constants that
@@ -3530,13 +3530,13 @@ END_MLAPI_EXCLUDE
        def_API('Z3_mk_forall_const', AST, (_in(CONTEXT), _in(UINT), _in(UINT), _in_array(2, APP), _in(UINT), _in_array(4, PATTERN), _in(AST)))
     */
     Z3_ast Z3_API Z3_mk_forall_const(
-        __in Z3_context c, 
+        Z3_in Z3_context c, 
         unsigned weight,
         unsigned num_bound,
-        __in_ecount(num_bound) Z3_app const bound[],
+        Z3_in_ecount(num_bound) Z3_app const bound[],
         unsigned num_patterns,
-        __in_ecount(num_patterns) Z3_pattern const patterns[],
-        __in Z3_ast body
+        Z3_in_ecount(num_patterns) Z3_pattern const patterns[],
+        Z3_in Z3_ast body
         );
 
     /**
@@ -3560,13 +3560,13 @@ END_MLAPI_EXCLUDE
        def_API('Z3_mk_exists_const', AST, (_in(CONTEXT), _in(UINT), _in(UINT), _in_array(2, APP), _in(UINT), _in_array(4, PATTERN), _in(AST)))
     */
     Z3_ast Z3_API Z3_mk_exists_const(
-        __in Z3_context c, 
+        Z3_in Z3_context c, 
         unsigned weight,
         unsigned num_bound,
-        __in_ecount(num_bound) Z3_app const bound[],
+        Z3_in_ecount(num_bound) Z3_app const bound[],
         unsigned num_patterns,
-        __in_ecount(num_patterns) Z3_pattern const patterns[],
-        __in Z3_ast body
+        Z3_in_ecount(num_patterns) Z3_pattern const patterns[],
+        Z3_in Z3_ast body
         );
 
     /**
@@ -3577,12 +3577,12 @@ END_MLAPI_EXCLUDE
        def_API('Z3_mk_quantifier_const', AST, (_in(CONTEXT), _in(BOOL), _in(UINT), _in(UINT), _in_array(3, APP), _in(UINT), _in_array(5, PATTERN), _in(AST)))
     */
     Z3_ast Z3_API Z3_mk_quantifier_const(
-        __in Z3_context c, 
+        Z3_in Z3_context c, 
         Z3_bool is_forall,
         unsigned weight,
-        unsigned num_bound,  __in_ecount(num_bound) Z3_app const bound[],
-        unsigned num_patterns, __in_ecount(num_patterns) Z3_pattern const patterns[],
-        __in Z3_ast body
+        unsigned num_bound,  Z3_in_ecount(num_bound) Z3_app const bound[],
+        unsigned num_patterns, Z3_in_ecount(num_patterns) Z3_pattern const patterns[],
+        Z3_in Z3_ast body
         );
 
 
@@ -3595,15 +3595,15 @@ END_MLAPI_EXCLUDE
        def_API('Z3_mk_quantifier_const_ex', AST, (_in(CONTEXT), _in(BOOL), _in(UINT), _in(SYMBOL), _in(SYMBOL), _in(UINT), _in_array(5, APP), _in(UINT), _in_array(7, PATTERN), _in(UINT), _in_array(9, AST), _in(AST)))
     */
     Z3_ast Z3_API Z3_mk_quantifier_const_ex(
-        __in Z3_context c, 
+        Z3_in Z3_context c, 
         Z3_bool is_forall,
         unsigned weight,
-        __in Z3_symbol quantifier_id,
-        __in Z3_symbol skolem_id,
-        unsigned num_bound,  __in_ecount(num_bound) Z3_app const bound[],
-        unsigned num_patterns, __in_ecount(num_patterns) Z3_pattern const patterns[],
-        unsigned num_no_patterns, __in_ecount(num_no_patterns) Z3_ast const no_patterns[],
-        __in Z3_ast body
+        Z3_in Z3_symbol quantifier_id,
+        Z3_in Z3_symbol skolem_id,
+        unsigned num_bound,  Z3_in_ecount(num_bound) Z3_app const bound[],
+        unsigned num_patterns, Z3_in_ecount(num_patterns) Z3_pattern const patterns[],
+        unsigned num_no_patterns, Z3_in_ecount(num_no_patterns) Z3_ast const no_patterns[],
+        Z3_in Z3_ast body
         );
 
     /*@}*/
@@ -3632,7 +3632,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_symbol_kind', UINT, (_in(CONTEXT), _in(SYMBOL)))
     */
-    Z3_symbol_kind Z3_API Z3_get_symbol_kind(__in Z3_context c, __in Z3_symbol s);
+    Z3_symbol_kind Z3_API Z3_get_symbol_kind(Z3_in Z3_context c, Z3_in Z3_symbol s);
 
     /**
        \brief \mlh get_symbol_int c s \endmlh
@@ -3644,7 +3644,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_symbol_int', INT, (_in(CONTEXT), _in(SYMBOL)))
     */
-    int Z3_API Z3_get_symbol_int(__in Z3_context c, __in Z3_symbol s);
+    int Z3_API Z3_get_symbol_int(Z3_in Z3_context c, Z3_in Z3_symbol s);
     
     /**
        \brief \mlh get_symbol_string c s \endmlh
@@ -3660,7 +3660,7 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_get_symbol_string', STRING, (_in(CONTEXT), _in(SYMBOL)))
     */
-    Z3_string Z3_API Z3_get_symbol_string(__in Z3_context c, __in Z3_symbol s);
+    Z3_string Z3_API Z3_get_symbol_string(Z3_in Z3_context c, Z3_in Z3_symbol s);
 
 
     /**
@@ -3676,7 +3676,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_sort_name', SYMBOL, (_in(CONTEXT), _in(SORT)))
     */
-    Z3_symbol Z3_API Z3_get_sort_name(__in Z3_context c, __in Z3_sort d);
+    Z3_symbol Z3_API Z3_get_sort_name(Z3_in Z3_context c, Z3_in Z3_sort d);
 
     /**
         \brief Return a unique identifier for \c s.
@@ -3684,7 +3684,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_get_sort_id', UINT, (_in(CONTEXT), _in(SORT)))
     */
-    unsigned Z3_API Z3_get_sort_id(__in Z3_context c, Z3_sort s);
+    unsigned Z3_API Z3_get_sort_id(Z3_in Z3_context c, Z3_sort s);
 
     /**
        \mlonly {4 {L Redundant low-level API}} \endmlonly
@@ -3696,7 +3696,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_sort_to_ast', AST, (_in(CONTEXT), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_sort_to_ast(__in Z3_context c, __in Z3_sort s);
+    Z3_ast Z3_API Z3_sort_to_ast(Z3_in Z3_context c, Z3_in Z3_sort s);
     
     /**
        \brief compare sorts.
@@ -3704,7 +3704,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_is_eq_sort', BOOL, (_in(CONTEXT), _in(SORT), _in(SORT)))
     */
-    Z3_bool Z3_API Z3_is_eq_sort(__in Z3_context c, __in Z3_sort s1, __in Z3_sort s2);
+    Z3_bool Z3_API Z3_is_eq_sort(Z3_in Z3_context c, Z3_in Z3_sort s1, Z3_in Z3_sort s2);
 
     /**
        \brief Return the sort kind (e.g., array, tuple, int, bool, etc).
@@ -3713,7 +3713,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_sort_kind', UINT, (_in(CONTEXT), _in(SORT)))
     */
-    Z3_sort_kind Z3_API Z3_get_sort_kind(__in Z3_context c, __in Z3_sort t);
+    Z3_sort_kind Z3_API Z3_get_sort_kind(Z3_in Z3_context c, Z3_in Z3_sort t);
 
 
     /**
@@ -3727,7 +3727,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_bv_sort_size', UINT, (_in(CONTEXT), _in(SORT)))
     */
-    unsigned Z3_API Z3_get_bv_sort_size(__in Z3_context c, __in Z3_sort t);
+    unsigned Z3_API Z3_get_bv_sort_size(Z3_in Z3_context c, Z3_in Z3_sort t);
 
     /**
         \conly \brief Store the size of the sort in \c r. Return Z3_FALSE if the call failed.
@@ -3736,7 +3736,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_get_finite_domain_sort_size', BOOL, (_in(CONTEXT), _in(SORT), _out(UINT64)))
     */
-    Z3_bool_opt Z3_API Z3_get_finite_domain_sort_size(__in Z3_context c, __in Z3_sort s, __out_opt unsigned __int64* r);
+    Z3_bool_opt Z3_API Z3_get_finite_domain_sort_size(Z3_in Z3_context c, Z3_in Z3_sort s, Z3_out_opt unsigned __int64* r);
 
 
     /**
@@ -3750,7 +3750,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_array_sort_domain', SORT, (_in(CONTEXT), _in(SORT)))
     */
-    Z3_sort Z3_API Z3_get_array_sort_domain(__in Z3_context c, __in Z3_sort t);
+    Z3_sort Z3_API Z3_get_array_sort_domain(Z3_in Z3_context c, Z3_in Z3_sort t);
 
     /**
        \brief \mlh get_array_sort_range c t \endmlh 
@@ -3763,7 +3763,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_array_sort_range', SORT, (_in(CONTEXT), _in(SORT)))
     */
-    Z3_sort Z3_API Z3_get_array_sort_range(__in Z3_context c, __in Z3_sort t);
+    Z3_sort Z3_API Z3_get_array_sort_range(Z3_in Z3_context c, Z3_in Z3_sort t);
 
 
     /**
@@ -3778,7 +3778,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_get_tuple_sort_mk_decl', FUNC_DECL, (_in(CONTEXT), _in(SORT)))
     */
-    Z3_func_decl Z3_API Z3_get_tuple_sort_mk_decl(__in Z3_context c, __in Z3_sort t);
+    Z3_func_decl Z3_API Z3_get_tuple_sort_mk_decl(Z3_in Z3_context c, Z3_in Z3_sort t);
     
     /**
        \brief \mlh get_tuple_sort_num_fields c t \endmlh
@@ -3791,7 +3791,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_tuple_sort_num_fields', UINT, (_in(CONTEXT), _in(SORT)))
     */
-    unsigned Z3_API Z3_get_tuple_sort_num_fields(__in Z3_context c, __in Z3_sort t);
+    unsigned Z3_API Z3_get_tuple_sort_num_fields(Z3_in Z3_context c, Z3_in Z3_sort t);
 
     /**
        \brief \mlh get_tuple_sort_field_decl c t i \endmlh
@@ -3806,7 +3806,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_get_tuple_sort_field_decl', FUNC_DECL, (_in(CONTEXT), _in(SORT), _in(UINT)))
     */
-    Z3_func_decl Z3_API Z3_get_tuple_sort_field_decl(__in Z3_context c, __in Z3_sort t, __in unsigned i);
+    Z3_func_decl Z3_API Z3_get_tuple_sort_field_decl(Z3_in Z3_context c, Z3_in Z3_sort t, Z3_in unsigned i);
 
     /**
         \brief Return number of constructors for datatype.
@@ -3820,7 +3820,7 @@ END_MLAPI_EXCLUDE
         def_API('Z3_get_datatype_sort_num_constructors', UINT, (_in(CONTEXT), _in(SORT)))
     */
     unsigned Z3_API Z3_get_datatype_sort_num_constructors(
-        __in Z3_context c, __in Z3_sort t);
+        Z3_in Z3_context c, Z3_in Z3_sort t);
 
     /**
         \brief Return idx'th constructor.
@@ -3835,7 +3835,7 @@ END_MLAPI_EXCLUDE
         def_API('Z3_get_datatype_sort_constructor', FUNC_DECL, (_in(CONTEXT), _in(SORT), _in(UINT)))
     */
     Z3_func_decl Z3_API Z3_get_datatype_sort_constructor(
-        __in Z3_context c, __in Z3_sort t, unsigned idx);
+        Z3_in Z3_context c, Z3_in Z3_sort t, unsigned idx);
 
     /**
         \brief Return idx'th recognizer.
@@ -3850,7 +3850,7 @@ END_MLAPI_EXCLUDE
         def_API('Z3_get_datatype_sort_recognizer', FUNC_DECL, (_in(CONTEXT), _in(SORT), _in(UINT)))
     */
     Z3_func_decl Z3_API Z3_get_datatype_sort_recognizer(
-        __in Z3_context c, __in Z3_sort t, unsigned idx);
+        Z3_in Z3_context c, Z3_in Z3_sort t, unsigned idx);
 
     /**
         \brief Return idx_a'th accessor for the idx_c'th constructor.
@@ -3866,7 +3866,7 @@ END_MLAPI_EXCLUDE
         def_API('Z3_get_datatype_sort_constructor_accessor', FUNC_DECL, (_in(CONTEXT), _in(SORT), _in(UINT), _in(UINT)))
     */
     Z3_func_decl Z3_API Z3_get_datatype_sort_constructor_accessor(
-        __in Z3_context c, __in Z3_sort t, unsigned idx_c, unsigned idx_a);
+        Z3_in Z3_context c, Z3_in Z3_sort t, unsigned idx_c, unsigned idx_a);
 
 
     /**
@@ -3878,7 +3878,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_get_relation_arity', UINT, (_in(CONTEXT), _in(SORT)))
     */
-    unsigned Z3_API Z3_get_relation_arity(__in Z3_context c, __in Z3_sort s);
+    unsigned Z3_API Z3_get_relation_arity(Z3_in Z3_context c, Z3_in Z3_sort s);
 
     /**
         \brief Return sort at i'th column of relation sort.
@@ -3890,7 +3890,7 @@ END_MLAPI_EXCLUDE
         
         def_API('Z3_get_relation_column', SORT, (_in(CONTEXT), _in(SORT), _in(UINT)))
     */
-    Z3_sort Z3_API Z3_get_relation_column(__in Z3_context c, __in Z3_sort s, unsigned col);
+    Z3_sort Z3_API Z3_get_relation_column(Z3_in Z3_context c, Z3_in Z3_sort s, unsigned col);
 
 
     /**
@@ -3903,7 +3903,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_func_decl_to_ast', AST, (_in(CONTEXT), _in(FUNC_DECL)))
     */
-    Z3_ast Z3_API Z3_func_decl_to_ast(__in Z3_context c, __in Z3_func_decl f);
+    Z3_ast Z3_API Z3_func_decl_to_ast(Z3_in Z3_context c, Z3_in Z3_func_decl f);
 
     /**
        \brief compare terms.
@@ -3911,7 +3911,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_is_eq_func_decl', BOOL, (_in(CONTEXT), _in(FUNC_DECL), _in(FUNC_DECL)))
     */
-    Z3_bool Z3_API Z3_is_eq_func_decl(__in Z3_context c, __in Z3_func_decl f1, Z3_func_decl f2);
+    Z3_bool Z3_API Z3_is_eq_func_decl(Z3_in Z3_context c, Z3_in Z3_func_decl f1, Z3_func_decl f2);
 
     /**
         \brief Return a unique identifier for \c f.
@@ -3919,21 +3919,21 @@ END_MLAPI_EXCLUDE
     
         def_API('Z3_get_func_decl_id', UINT, (_in(CONTEXT), _in(FUNC_DECL)))
     */
-    unsigned Z3_API Z3_get_func_decl_id(__in Z3_context c, Z3_func_decl f);
+    unsigned Z3_API Z3_get_func_decl_id(Z3_in Z3_context c, Z3_func_decl f);
 
     /**
        \brief Return the constant declaration name as a symbol. 
     
        def_API('Z3_get_decl_name', SYMBOL, (_in(CONTEXT), _in(FUNC_DECL)))
     */
-    Z3_symbol Z3_API Z3_get_decl_name(__in Z3_context c, __in Z3_func_decl d);
+    Z3_symbol Z3_API Z3_get_decl_name(Z3_in Z3_context c, Z3_in Z3_func_decl d);
 
     /**
        \brief Return declaration kind corresponding to declaration.
 
        def_API('Z3_get_decl_kind', UINT, (_in(CONTEXT), _in(FUNC_DECL)))
     */
-    Z3_decl_kind Z3_API Z3_get_decl_kind(__in Z3_context c, __in Z3_func_decl d);
+    Z3_decl_kind Z3_API Z3_get_decl_kind(Z3_in Z3_context c, Z3_in Z3_func_decl d);
 
     /**
        \brief Return the number of parameters of the given declaration.
@@ -3942,7 +3942,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_domain_size', UINT, (_in(CONTEXT), _in(FUNC_DECL)))
     */
-    unsigned Z3_API Z3_get_domain_size(__in Z3_context c, __in Z3_func_decl d);
+    unsigned Z3_API Z3_get_domain_size(Z3_in Z3_context c, Z3_in Z3_func_decl d);
 
     /**
        \brief Alias for \c Z3_get_domain_size.
@@ -3951,7 +3951,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_arity', UINT, (_in(CONTEXT), _in(FUNC_DECL)))
     */
-    unsigned Z3_API Z3_get_arity(__in Z3_context c, __in Z3_func_decl d);
+    unsigned Z3_API Z3_get_arity(Z3_in Z3_context c, Z3_in Z3_func_decl d);
 
     /**
        \brief \mlh get_domain c d i \endmlh
@@ -3963,7 +3963,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_get_domain', SORT, (_in(CONTEXT), _in(FUNC_DECL), _in(UINT)))
     */
-    Z3_sort Z3_API Z3_get_domain(__in Z3_context c, __in Z3_func_decl d, __in unsigned i);
+    Z3_sort Z3_API Z3_get_domain(Z3_in Z3_context c, Z3_in Z3_func_decl d, Z3_in unsigned i);
 
 #ifdef ML4only
 #include <mlx_get_domains.idl>
@@ -3978,14 +3978,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_range', SORT, (_in(CONTEXT), _in(FUNC_DECL)))
     */
-    Z3_sort Z3_API Z3_get_range(__in Z3_context c, __in Z3_func_decl d);
+    Z3_sort Z3_API Z3_get_range(Z3_in Z3_context c, Z3_in Z3_func_decl d);
 
     /**
        \brief Return the number of parameters associated with a declaration.
 
        def_API('Z3_get_decl_num_parameters', UINT, (_in(CONTEXT), _in(FUNC_DECL)))
     */
-    unsigned Z3_API Z3_get_decl_num_parameters(__in Z3_context c, __in Z3_func_decl d);
+    unsigned Z3_API Z3_get_decl_num_parameters(Z3_in Z3_context c, Z3_in Z3_func_decl d);
 
     /**
        \brief Return the parameter type associated with a declaration.
@@ -3996,7 +3996,7 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_get_decl_parameter_kind', UINT, (_in(CONTEXT), _in(FUNC_DECL), _in(UINT)))
     */
-    Z3_parameter_kind Z3_API Z3_get_decl_parameter_kind(__in Z3_context c, __in Z3_func_decl d, unsigned idx);
+    Z3_parameter_kind Z3_API Z3_get_decl_parameter_kind(Z3_in Z3_context c, Z3_in Z3_func_decl d, unsigned idx);
 
     /**
        \brief Return the integer value associated with an integer parameter.
@@ -4005,7 +4005,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_decl_int_parameter', INT, (_in(CONTEXT), _in(FUNC_DECL), _in(UINT)))
     */
-    int Z3_API Z3_get_decl_int_parameter(__in Z3_context c, __in Z3_func_decl d, unsigned idx);
+    int Z3_API Z3_get_decl_int_parameter(Z3_in Z3_context c, Z3_in Z3_func_decl d, unsigned idx);
 
     /**
        \brief Return the double value associated with an double parameter.
@@ -4014,7 +4014,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_decl_double_parameter', DOUBLE, (_in(CONTEXT), _in(FUNC_DECL), _in(UINT)))
     */
-    double Z3_API Z3_get_decl_double_parameter(__in Z3_context c, __in Z3_func_decl d, unsigned idx);
+    double Z3_API Z3_get_decl_double_parameter(Z3_in Z3_context c, Z3_in Z3_func_decl d, unsigned idx);
 
     /**
        \brief Return the double value associated with an double parameter.
@@ -4023,7 +4023,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_decl_symbol_parameter', SYMBOL, (_in(CONTEXT), _in(FUNC_DECL), _in(UINT)))
     */
-    Z3_symbol Z3_API Z3_get_decl_symbol_parameter(__in Z3_context c, __in Z3_func_decl d, unsigned idx);
+    Z3_symbol Z3_API Z3_get_decl_symbol_parameter(Z3_in Z3_context c, Z3_in Z3_func_decl d, unsigned idx);
 
     /**
        \brief Return the sort value associated with a sort parameter.
@@ -4032,7 +4032,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_decl_sort_parameter', SORT, (_in(CONTEXT), _in(FUNC_DECL), _in(UINT)))
     */
-    Z3_sort Z3_API Z3_get_decl_sort_parameter(__in Z3_context c, __in Z3_func_decl d, unsigned idx);
+    Z3_sort Z3_API Z3_get_decl_sort_parameter(Z3_in Z3_context c, Z3_in Z3_func_decl d, unsigned idx);
 
     /**
        \brief Return the expresson value associated with an expression parameter.
@@ -4041,7 +4041,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_decl_ast_parameter', AST, (_in(CONTEXT), _in(FUNC_DECL), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_get_decl_ast_parameter(__in Z3_context c, __in Z3_func_decl d, unsigned idx);
+    Z3_ast Z3_API Z3_get_decl_ast_parameter(Z3_in Z3_context c, Z3_in Z3_func_decl d, unsigned idx);
 
     /**
        \brief Return the expresson value associated with an expression parameter.
@@ -4050,7 +4050,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_decl_func_decl_parameter', FUNC_DECL, (_in(CONTEXT), _in(FUNC_DECL), _in(UINT)))
     */
-    Z3_func_decl Z3_API Z3_get_decl_func_decl_parameter(__in Z3_context c, __in Z3_func_decl d, unsigned idx);
+    Z3_func_decl Z3_API Z3_get_decl_func_decl_parameter(Z3_in Z3_context c, Z3_in Z3_func_decl d, unsigned idx);
 
     /**
        \brief Return the rational value, as a string, associated with a rational parameter.
@@ -4059,7 +4059,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_decl_rational_parameter', STRING, (_in(CONTEXT), _in(FUNC_DECL), _in(UINT)))
     */
-    Z3_string Z3_API Z3_get_decl_rational_parameter(__in Z3_context c, __in Z3_func_decl d, unsigned idx);
+    Z3_string Z3_API Z3_get_decl_rational_parameter(Z3_in Z3_context c, Z3_in Z3_func_decl d, unsigned idx);
 
     /**
        \mlonly {3 {L Applications}} \endmlonly
@@ -4071,14 +4071,14 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_app_to_ast', AST, (_in(CONTEXT), _in(APP)))
     */
-    Z3_ast Z3_API Z3_app_to_ast(__in Z3_context c, __in Z3_app a);
+    Z3_ast Z3_API Z3_app_to_ast(Z3_in Z3_context c, Z3_in Z3_app a);
 
     /**
        \brief Return the declaration of a constant or function application.
 
        def_API('Z3_get_app_decl', FUNC_DECL, (_in(CONTEXT), _in(APP)))
     */
-    Z3_func_decl Z3_API Z3_get_app_decl(__in Z3_context c, __in Z3_app a);
+    Z3_func_decl Z3_API Z3_get_app_decl(Z3_in Z3_context c, Z3_in Z3_app a);
 
     /**
        \brief \mlh get_app_num_args c a \endmlh
@@ -4087,7 +4087,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_app_num_args', UINT, (_in(CONTEXT), _in(APP)))
     */
-    unsigned Z3_API Z3_get_app_num_args(__in Z3_context c, __in Z3_app a);
+    unsigned Z3_API Z3_get_app_num_args(Z3_in Z3_context c, Z3_in Z3_app a);
 
     /**
        \brief \mlh get_app_arg c a i \endmlh
@@ -4097,7 +4097,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_app_arg', AST, (_in(CONTEXT), _in(APP), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_get_app_arg(__in Z3_context c, __in Z3_app a, __in unsigned i);
+    Z3_ast Z3_API Z3_get_app_arg(Z3_in Z3_context c, Z3_in Z3_app a, Z3_in unsigned i);
 
 #ifdef ML4only
 #include <mlx_get_app_args.idl>
@@ -4118,7 +4118,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_is_eq_ast', BOOL, (_in(CONTEXT), _in(AST), _in(AST)))
     */
-    Z3_bool Z3_API Z3_is_eq_ast(__in Z3_context c, __in Z3_ast t1, Z3_ast t2);
+    Z3_bool Z3_API Z3_is_eq_ast(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_ast t2);
 
     /**
         \brief Return a unique identifier for \c t.
@@ -4132,7 +4132,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_get_ast_id', UINT, (_in(CONTEXT), _in(AST)))
     */
-    unsigned Z3_API Z3_get_ast_id(__in Z3_context c, Z3_ast t);
+    unsigned Z3_API Z3_get_ast_id(Z3_in Z3_context c, Z3_ast t);
 
     /**
        \brief Return a hash code for the given AST.
@@ -4142,7 +4142,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_ast_hash', UINT, (_in(CONTEXT), _in(AST)))
     */
-    unsigned Z3_API Z3_get_ast_hash(__in Z3_context c, __in Z3_ast a);
+    unsigned Z3_API Z3_get_ast_hash(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return the sort of an AST node.
@@ -4151,45 +4151,45 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_get_sort', SORT, (_in(CONTEXT), _in(AST)))
     */
-    Z3_sort Z3_API Z3_get_sort(__in Z3_context c, __in Z3_ast a);
+    Z3_sort Z3_API Z3_get_sort(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return true if the given expression \c t is well sorted.
        
        def_API('Z3_is_well_sorted', BOOL, (_in(CONTEXT), _in(AST)))
     */
-    Z3_bool Z3_API Z3_is_well_sorted(__in Z3_context c, __in Z3_ast t);
+    Z3_bool Z3_API Z3_is_well_sorted(Z3_in Z3_context c, Z3_in Z3_ast t);
 
     /**
        \brief Return Z3_L_TRUE if \c a is true, Z3_L_FALSE if it is false, and Z3_L_UNDEF otherwise.
 
        def_API('Z3_get_bool_value', UINT, (_in(CONTEXT), _in(AST)))
     */
-    Z3_lbool Z3_API Z3_get_bool_value(__in Z3_context c, __in Z3_ast a);
+    Z3_lbool Z3_API Z3_get_bool_value(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return the kind of the given AST.
 
        def_API('Z3_get_ast_kind', UINT, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast_kind Z3_API Z3_get_ast_kind(__in Z3_context c, __in Z3_ast a);
+    Z3_ast_kind Z3_API Z3_get_ast_kind(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
       def_API('Z3_is_app', BOOL, (_in(CONTEXT), _in(AST)))      
     */
-    Z3_bool Z3_API Z3_is_app(__in Z3_context c, __in Z3_ast a);
+    Z3_bool Z3_API Z3_is_app(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
       def_API('Z3_is_numeral_ast', BOOL, (_in(CONTEXT), _in(AST)))
     */
-    Z3_bool Z3_API Z3_is_numeral_ast(__in Z3_context c, __in Z3_ast a);
+    Z3_bool Z3_API Z3_is_numeral_ast(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return true if the give AST is a real algebraic number.
     
        def_API('Z3_is_algebraic_number', BOOL, (_in(CONTEXT), _in(AST)))
     */
-    Z3_bool Z3_API Z3_is_algebraic_number(__in Z3_context c, __in Z3_ast a);
+    Z3_bool Z3_API Z3_is_algebraic_number(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Convert an \c ast into an \c APP_AST. \conly This is just type casting.
@@ -4198,7 +4198,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_to_app', APP, (_in(CONTEXT), _in(AST)))
     */
-    Z3_app Z3_API Z3_to_app(__in Z3_context c, __in Z3_ast a);
+    Z3_app Z3_API Z3_to_app(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Convert an AST into a FUNC_DECL_AST. This is just type casting.
@@ -4207,7 +4207,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_to_func_decl', FUNC_DECL, (_in(CONTEXT), _in(AST)))
     */
-    Z3_func_decl Z3_API Z3_to_func_decl(__in Z3_context c, __in Z3_ast a);
+    Z3_func_decl Z3_API Z3_to_func_decl(Z3_in Z3_context c, Z3_in Z3_ast a);
 
 
     /**
@@ -4229,7 +4229,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_numeral_string', STRING, (_in(CONTEXT), _in(AST)))
     */
-    Z3_string Z3_API Z3_get_numeral_string(__in Z3_context c, __in Z3_ast a);
+    Z3_string Z3_API Z3_get_numeral_string(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return numeral as a string in decimal notation.
@@ -4239,7 +4239,7 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_get_numeral_decimal_string', STRING, (_in(CONTEXT), _in(AST), _in(UINT)))       
     */
-    Z3_string Z3_API Z3_get_numeral_decimal_string(__in Z3_context c, __in Z3_ast a, __in unsigned precision);
+    Z3_string Z3_API Z3_get_numeral_decimal_string(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in unsigned precision);
 
     /**
        \brief Return the numerator (as a numeral AST) of a numeral AST of sort Real.
@@ -4248,7 +4248,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_numerator', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_get_numerator(__in Z3_context c, __in Z3_ast a);
+    Z3_ast Z3_API Z3_get_numerator(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return the denominator (as a numeral AST) of a numeral AST of sort Real.
@@ -4257,7 +4257,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_denominator', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_get_denominator(__in Z3_context c, __in Z3_ast a);
+    Z3_ast Z3_API Z3_get_denominator(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return numeral value, as a pair of 64 bit numbers if the representation fits.
@@ -4273,7 +4273,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_numeral_small', BOOL, (_in(CONTEXT), _in(AST), _out(INT64), _out(INT64)))
     */
-    Z3_bool Z3_API Z3_get_numeral_small(__in Z3_context c, __in Z3_ast a, __out __int64* num, __out __int64* den);
+    Z3_bool Z3_API Z3_get_numeral_small(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_out __int64* num, Z3_out __int64* den);
 
     /**
        \brief \mlh get_numeral_int c v \endmlh
@@ -4286,7 +4286,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_numeral_int', BOOL, (_in(CONTEXT), _in(AST), _out(INT)))
     */
-    Z3_bool Z3_API Z3_get_numeral_int(__in Z3_context c, __in Z3_ast v, __out int* i);
+    Z3_bool Z3_API Z3_get_numeral_int(Z3_in Z3_context c, Z3_in Z3_ast v, Z3_out int* i);
 
 #ifdef Conly
     /**
@@ -4300,7 +4300,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_numeral_uint', BOOL, (_in(CONTEXT), _in(AST), _out(UINT)))
     */
-    Z3_bool Z3_API Z3_get_numeral_uint(__in Z3_context c, __in Z3_ast v, __out unsigned* u);
+    Z3_bool Z3_API Z3_get_numeral_uint(Z3_in Z3_context c, Z3_in Z3_ast v, Z3_out unsigned* u);
 #endif
 
 #ifdef Conly
@@ -4315,7 +4315,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_numeral_uint64', BOOL, (_in(CONTEXT), _in(AST), _out(UINT64)))
     */
-    Z3_bool Z3_API Z3_get_numeral_uint64(__in Z3_context c, __in Z3_ast v, __out unsigned __int64* u);
+    Z3_bool Z3_API Z3_get_numeral_uint64(Z3_in Z3_context c, Z3_in Z3_ast v, Z3_out unsigned __int64* u);
 #endif
 
     /**
@@ -4329,7 +4329,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_numeral_int64', BOOL, (_in(CONTEXT), _in(AST), _out(INT64)))
     */
-    Z3_bool Z3_API Z3_get_numeral_int64(__in Z3_context c, __in Z3_ast v, __out __int64* i);
+    Z3_bool Z3_API Z3_get_numeral_int64(Z3_in Z3_context c, Z3_in Z3_ast v, Z3_out __int64* i);
 
     /**
        \brief \mlh get_numeral_rational_int64 c x y\endmlh
@@ -4342,7 +4342,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_numeral_rational_int64', BOOL, (_in(CONTEXT), _in(AST), _out(INT64), _out(INT64)))
     */
-    Z3_bool Z3_API Z3_get_numeral_rational_int64(__in Z3_context c, __in Z3_ast v, __out __int64* num, __out __int64* den);
+    Z3_bool Z3_API Z3_get_numeral_rational_int64(Z3_in Z3_context c, Z3_in Z3_ast v, Z3_out __int64* num, Z3_out __int64* den);
     
     /**
        \brief Return a lower bound for the given real algebraic number. 
@@ -4353,7 +4353,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_algebraic_number_lower', AST, (_in(CONTEXT), _in(AST), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_get_algebraic_number_lower(__in Z3_context c, __in Z3_ast a, __in unsigned precision);
+    Z3_ast Z3_API Z3_get_algebraic_number_lower(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in unsigned precision);
 
     /**
        \brief Return a upper bound for the given real algebraic number. 
@@ -4377,7 +4377,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_pattern_to_ast', AST, (_in(CONTEXT), _in(PATTERN)))
     */
-    Z3_ast Z3_API Z3_pattern_to_ast(__in Z3_context c, __in Z3_pattern p);
+    Z3_ast Z3_API Z3_pattern_to_ast(Z3_in Z3_context c, Z3_in Z3_pattern p);
 
 #ifdef ML4only
 #include <mlx_get_pattern_terms.idl>
@@ -4388,14 +4388,14 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_get_pattern_num_terms', UINT, (_in(CONTEXT), _in(PATTERN)))
     */
-    unsigned Z3_API Z3_get_pattern_num_terms(__in Z3_context c, __in Z3_pattern p);
+    unsigned Z3_API Z3_get_pattern_num_terms(Z3_in Z3_context c, Z3_in Z3_pattern p);
     
     /**
        \brief Return i'th ast in pattern.
 
        def_API('Z3_get_pattern', AST, (_in(CONTEXT), _in(PATTERN), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_get_pattern(__in Z3_context c, __in Z3_pattern p, __in unsigned idx);
+    Z3_ast Z3_API Z3_get_pattern(Z3_in Z3_context c, Z3_in Z3_pattern p, Z3_in unsigned idx);
 
 
     /**
@@ -4409,7 +4409,7 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_get_index_value', UINT, (_in(CONTEXT), _in(AST)))
     */
-    unsigned Z3_API Z3_get_index_value(__in Z3_context c, __in Z3_ast a);
+    unsigned Z3_API Z3_get_index_value(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Determine if quantifier is universal.
@@ -4418,7 +4418,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_is_quantifier_forall', BOOL, (_in(CONTEXT), _in(AST)))       
     */
-    Z3_bool Z3_API Z3_is_quantifier_forall(__in Z3_context c, __in Z3_ast a);
+    Z3_bool Z3_API Z3_is_quantifier_forall(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Obtain weight of quantifier.
@@ -4427,7 +4427,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_quantifier_weight', UINT, (_in(CONTEXT), _in(AST)))       
     */
-    unsigned Z3_API Z3_get_quantifier_weight(__in Z3_context c, __in Z3_ast a);
+    unsigned Z3_API Z3_get_quantifier_weight(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return number of patterns used in quantifier.
@@ -4436,7 +4436,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_quantifier_num_patterns', UINT, (_in(CONTEXT), _in(AST)))
     */
-    unsigned Z3_API Z3_get_quantifier_num_patterns(__in Z3_context c, __in Z3_ast a);
+    unsigned Z3_API Z3_get_quantifier_num_patterns(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return i'th pattern.
@@ -4445,7 +4445,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_quantifier_pattern_ast', PATTERN, (_in(CONTEXT), _in(AST), _in(UINT)))
     */
-    Z3_pattern Z3_API Z3_get_quantifier_pattern_ast(__in Z3_context c, __in Z3_ast a, unsigned i);
+    Z3_pattern Z3_API Z3_get_quantifier_pattern_ast(Z3_in Z3_context c, Z3_in Z3_ast a, unsigned i);
 
     /**
        \brief Return number of no_patterns used in quantifier.
@@ -4454,7 +4454,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_quantifier_num_no_patterns', UINT, (_in(CONTEXT), _in(AST)))
     */
-    unsigned Z3_API Z3_get_quantifier_num_no_patterns(__in Z3_context c, __in Z3_ast a);
+    unsigned Z3_API Z3_get_quantifier_num_no_patterns(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return i'th no_pattern.
@@ -4463,7 +4463,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_quantifier_no_pattern_ast', AST, (_in(CONTEXT), _in(AST), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_get_quantifier_no_pattern_ast(__in Z3_context c, __in Z3_ast a, unsigned i);
+    Z3_ast Z3_API Z3_get_quantifier_no_pattern_ast(Z3_in Z3_context c, Z3_in Z3_ast a, unsigned i);
 
     /**
        \brief Return number of bound variables of quantifier.
@@ -4472,7 +4472,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_quantifier_num_bound', UINT, (_in(CONTEXT), _in(AST)))
     */
-    unsigned Z3_API Z3_get_quantifier_num_bound(__in Z3_context c, __in Z3_ast a);
+    unsigned Z3_API Z3_get_quantifier_num_bound(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
        \brief Return symbol of the i'th bound variable.
@@ -4481,7 +4481,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_quantifier_bound_name', SYMBOL, (_in(CONTEXT), _in(AST), _in(UINT)))
     */
-    Z3_symbol Z3_API Z3_get_quantifier_bound_name(__in Z3_context c, __in Z3_ast a, unsigned i);
+    Z3_symbol Z3_API Z3_get_quantifier_bound_name(Z3_in Z3_context c, Z3_in Z3_ast a, unsigned i);
 
     /**
        \brief Return sort of the i'th bound variable.
@@ -4490,7 +4490,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_get_quantifier_bound_sort', SORT, (_in(CONTEXT), _in(AST), _in(UINT)))
     */
-    Z3_sort Z3_API Z3_get_quantifier_bound_sort(__in Z3_context c, __in Z3_ast a, unsigned i);
+    Z3_sort Z3_API Z3_get_quantifier_bound_sort(Z3_in Z3_context c, Z3_in Z3_ast a, unsigned i);
 
     /**
        \brief Return body of quantifier.
@@ -4499,7 +4499,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_get_quantifier_body', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_get_quantifier_body(__in Z3_context c, __in Z3_ast a);
+    Z3_ast Z3_API Z3_get_quantifier_body(Z3_in Z3_context c, Z3_in Z3_ast a);
 
 
     /**
@@ -4513,7 +4513,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_simplify', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_simplify(__in Z3_context c, __in Z3_ast a);
+    Z3_ast Z3_API Z3_simplify(Z3_in Z3_context c, Z3_in Z3_ast a);
 
 #ifdef CorML4
     /**
@@ -4525,21 +4525,21 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_simplify_ex', AST, (_in(CONTEXT), _in(AST), _in(PARAMS)))
     */
-    Z3_ast Z3_API Z3_simplify_ex(__in Z3_context c, __in Z3_ast a, __in Z3_params p);
+    Z3_ast Z3_API Z3_simplify_ex(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in Z3_params p);
 
     /**
        \brief Return a string describing all available parameters.
     
        def_API('Z3_simplify_get_help', STRING, (_in(CONTEXT),))
     */
-    Z3_string Z3_API Z3_simplify_get_help(__in Z3_context c);
+    Z3_string Z3_API Z3_simplify_get_help(Z3_in Z3_context c);
 
     /**
        \brief Return the parameter description set for the simplify procedure.
 
        def_API('Z3_simplify_get_param_descrs', PARAM_DESCRS, (_in(CONTEXT),))
     */
-    Z3_param_descrs Z3_API Z3_simplify_get_param_descrs(__in Z3_context c);
+    Z3_param_descrs Z3_API Z3_simplify_get_param_descrs(Z3_in Z3_context c);
 #endif
     
     /*@}*/
@@ -4557,7 +4557,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_update_term', AST, (_in(CONTEXT), _in(AST), _in(UINT), _in_array(2, AST)))
     */
-    Z3_ast Z3_API Z3_update_term(__in Z3_context c, __in Z3_ast a, __in unsigned num_args, __in_ecount(num_args) Z3_ast const args[]);
+    Z3_ast Z3_API Z3_update_term(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in unsigned num_args, Z3_in_ecount(num_args) Z3_ast const args[]);
 
     /**
        \brief Substitute every occurrence of <tt>from[i]</tt> in \c a with <tt>to[i]</tt>, for \c i smaller than \c num_exprs.
@@ -4566,11 +4566,11 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_substitute', AST, (_in(CONTEXT), _in(AST), _in(UINT), _in_array(2, AST), _in_array(2, AST)))
     */
-    Z3_ast Z3_API Z3_substitute(__in Z3_context c, 
-                                __in Z3_ast a, 
-                                __in unsigned num_exprs, 
-                                __in_ecount(num_exprs) Z3_ast const from[], 
-                                __in_ecount(num_exprs) Z3_ast const to[]);
+    Z3_ast Z3_API Z3_substitute(Z3_in Z3_context c, 
+                                Z3_in Z3_ast a, 
+                                Z3_in unsigned num_exprs, 
+                                Z3_in_ecount(num_exprs) Z3_ast const from[], 
+                                Z3_in_ecount(num_exprs) Z3_ast const to[]);
 
     /**
        \brief Substitute the free variables in \c a with the expressions in \c to.
@@ -4578,10 +4578,10 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_substitute_vars', AST, (_in(CONTEXT), _in(AST), _in(UINT), _in_array(2, AST)))
     */
-    Z3_ast Z3_API Z3_substitute_vars(__in Z3_context c, 
-                                     __in Z3_ast a, 
-                                     __in unsigned num_exprs, 
-                                     __in_ecount(num_exprs) Z3_ast const to[]);
+    Z3_ast Z3_API Z3_substitute_vars(Z3_in Z3_context c, 
+                                     Z3_in Z3_ast a, 
+                                     Z3_in unsigned num_exprs, 
+                                     Z3_in_ecount(num_exprs) Z3_ast const to[]);
 
 #ifdef CorML4
     /**
@@ -4591,7 +4591,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_translate', AST, (_in(CONTEXT), _in(AST), _in(CONTEXT)))
     */
-    Z3_ast Z3_API Z3_translate(__in Z3_context source, __in Z3_ast a, __in Z3_context target);
+    Z3_ast Z3_API Z3_translate(Z3_in Z3_context source, Z3_in Z3_ast a, Z3_in Z3_context target);
 #endif
     
     /*@}*/
@@ -4611,14 +4611,14 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_model_inc_ref', VOID, (_in(CONTEXT), _in(MODEL)))
     */
-    void Z3_API Z3_model_inc_ref(__in Z3_context c, __in Z3_model m);
+    void Z3_API Z3_model_inc_ref(Z3_in Z3_context c, Z3_in Z3_model m);
 
     /**
        \brief Decrement the reference counter of the given model.
 
        def_API('Z3_model_dec_ref', VOID, (_in(CONTEXT), _in(MODEL)))
     */
-    void Z3_API Z3_model_dec_ref(__in Z3_context c, __in Z3_model m);
+    void Z3_API Z3_model_dec_ref(Z3_in Z3_context c, Z3_in Z3_model m);
 #endif
     
     /**
@@ -4641,7 +4641,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_model_eval', BOOL, (_in(CONTEXT), _in(MODEL), _in(AST), _in(BOOL), _out(AST)))
     */
-    Z3_bool_opt Z3_API Z3_model_eval(__in Z3_context c, __in Z3_model m, __in Z3_ast t, __in Z3_bool model_completion, __out_opt Z3_ast * v);
+    Z3_bool_opt Z3_API Z3_model_eval(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in Z3_ast t, Z3_in Z3_bool model_completion, Z3_out_opt Z3_ast * v);
 
     /**
        \mlonly {4 {L Low-level API}} \endmlonly
@@ -4657,7 +4657,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_model_get_const_interp', AST, (_in(CONTEXT), _in(MODEL), _in(FUNC_DECL)))
     */
-    Z3_ast_opt Z3_API Z3_model_get_const_interp(__in Z3_context c, __in Z3_model m, __in Z3_func_decl a);
+    Z3_ast_opt Z3_API Z3_model_get_const_interp(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in Z3_func_decl a);
 
     /**
        \brief Return the interpretation of the function \c f in the model \c m.
@@ -4672,7 +4672,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_model_get_func_interp', FUNC_INTERP, (_in(CONTEXT), _in(MODEL), _in(FUNC_DECL)))
     */
-    Z3_func_interp_opt Z3_API Z3_model_get_func_interp(__in Z3_context c, __in Z3_model m, __in Z3_func_decl f);
+    Z3_func_interp_opt Z3_API Z3_model_get_func_interp(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in Z3_func_decl f);
 
     /**
        \brief Return the number of constants assigned by the given model.
@@ -4681,7 +4681,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_model_get_num_consts', UINT, (_in(CONTEXT), _in(MODEL)))
     */
-    unsigned Z3_API Z3_model_get_num_consts(__in Z3_context c, __in Z3_model m);
+    unsigned Z3_API Z3_model_get_num_consts(Z3_in Z3_context c, Z3_in Z3_model m);
 
     /**
        \brief \mlh model_get_const_decl c m i \endmlh
@@ -4693,7 +4693,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_model_get_const_decl', FUNC_DECL, (_in(CONTEXT), _in(MODEL), _in(UINT)))
     */
-    Z3_func_decl Z3_API Z3_model_get_const_decl(__in Z3_context c, __in Z3_model m, __in unsigned i);
+    Z3_func_decl Z3_API Z3_model_get_const_decl(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in unsigned i);
     
     /**
        \brief Return the number of function interpretations in the given model.
@@ -4703,7 +4703,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_model_get_num_funcs', UINT, (_in(CONTEXT), _in(MODEL)))
     */
-    unsigned Z3_API Z3_model_get_num_funcs(__in Z3_context c, __in Z3_model m);
+    unsigned Z3_API Z3_model_get_num_funcs(Z3_in Z3_context c, Z3_in Z3_model m);
     
     /**
        \brief \mlh model_get_func_decl c m i \endmlh
@@ -4715,7 +4715,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_model_get_func_decl', FUNC_DECL, (_in(CONTEXT), _in(MODEL), _in(UINT)))
     */
-    Z3_func_decl Z3_API Z3_model_get_func_decl(__in Z3_context c, __in Z3_model m, __in unsigned i);
+    Z3_func_decl Z3_API Z3_model_get_func_decl(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in unsigned i);
     
     /**
        \brief Return the number of uninterpreted sorts that \c m assigs an interpretation to.
@@ -4729,7 +4729,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_model_get_num_sorts', UINT, (_in(CONTEXT), _in(MODEL)))
     */
-    unsigned Z3_API Z3_model_get_num_sorts(__in Z3_context c, __in Z3_model m);
+    unsigned Z3_API Z3_model_get_num_sorts(Z3_in Z3_context c, Z3_in Z3_model m);
 
     /**
        \brief Return a uninterpreted sort that \c m assigns an interpretation.
@@ -4741,7 +4741,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_model_get_sort', SORT, (_in(CONTEXT), _in(MODEL), _in(UINT)))
     */
-    Z3_sort Z3_API Z3_model_get_sort(__in Z3_context c, __in Z3_model m, __in unsigned i);
+    Z3_sort Z3_API Z3_model_get_sort(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in unsigned i);
 
     /**
        \brief Return the finite set of distinct values that represent the interpretation for sort \c s.
@@ -4751,7 +4751,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_model_get_sort_universe', AST_VECTOR, (_in(CONTEXT), _in(MODEL), _in(SORT)))
     */
-    Z3_ast_vector Z3_API Z3_model_get_sort_universe(__in Z3_context c, __in Z3_model m, __in Z3_sort s);
+    Z3_ast_vector Z3_API Z3_model_get_sort_universe(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in Z3_sort s);
     
     /**
        \brief The <tt>(_ as-array f)</tt> AST node is a construct for assigning interpretations for arrays in Z3.
@@ -4764,7 +4764,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_is_as_array', BOOL, (_in(CONTEXT), _in(AST)))
     */
-    Z3_bool Z3_API Z3_is_as_array(__in Z3_context c, __in Z3_ast a);
+    Z3_bool Z3_API Z3_is_as_array(Z3_in Z3_context c, Z3_in Z3_ast a);
     
     /**
        \brief Return the function declaration \c f associated with a <tt>(_ as_array f)</tt> node.
@@ -4773,7 +4773,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_as_array_func_decl', FUNC_DECL, (_in(CONTEXT), _in(AST)))
     */
-    Z3_func_decl Z3_API Z3_get_as_array_func_decl(__in Z3_context c, __in Z3_ast a);
+    Z3_func_decl Z3_API Z3_get_as_array_func_decl(Z3_in Z3_context c, Z3_in Z3_ast a);
 
 #ifdef Conly
     /**
@@ -4781,14 +4781,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_func_interp_inc_ref', VOID, (_in(CONTEXT), _in(FUNC_INTERP)))
     */
-    void Z3_API Z3_func_interp_inc_ref(__in Z3_context c, __in Z3_func_interp f);
+    void Z3_API Z3_func_interp_inc_ref(Z3_in Z3_context c, Z3_in Z3_func_interp f);
 
     /**
        \brief Decrement the reference counter of the given Z3_func_interp object.
 
        def_API('Z3_func_interp_dec_ref', VOID, (_in(CONTEXT), _in(FUNC_INTERP)))
     */
-    void Z3_API Z3_func_interp_dec_ref(__in Z3_context c, __in Z3_func_interp f);
+    void Z3_API Z3_func_interp_dec_ref(Z3_in Z3_context c, Z3_in Z3_func_interp f);
 #endif
 
     /**
@@ -4800,7 +4800,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_func_interp_get_num_entries', UINT, (_in(CONTEXT), _in(FUNC_INTERP)))
     */
-    unsigned Z3_API Z3_func_interp_get_num_entries(__in Z3_context c, __in Z3_func_interp f);
+    unsigned Z3_API Z3_func_interp_get_num_entries(Z3_in Z3_context c, Z3_in Z3_func_interp f);
 
     /**
        \brief Return a "point" of the given function intepretation. It represents the
@@ -4812,7 +4812,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_func_interp_get_entry', FUNC_ENTRY, (_in(CONTEXT), _in(FUNC_INTERP), _in(UINT)))
     */
-    Z3_func_entry Z3_API Z3_func_interp_get_entry(__in Z3_context c, __in Z3_func_interp f, unsigned i);
+    Z3_func_entry Z3_API Z3_func_interp_get_entry(Z3_in Z3_context c, Z3_in Z3_func_interp f, unsigned i);
     
     /**
        \brief Return the 'else' value of the given function interpretation.
@@ -4822,14 +4822,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_func_interp_get_else', AST, (_in(CONTEXT), _in(FUNC_INTERP)))
     */
-    Z3_ast Z3_API Z3_func_interp_get_else(__in Z3_context c, __in Z3_func_interp f);
+    Z3_ast Z3_API Z3_func_interp_get_else(Z3_in Z3_context c, Z3_in Z3_func_interp f);
     
     /**
        \brief Return the arity (number of arguments) of the given function interpretation.
 
        def_API('Z3_func_interp_get_arity', UINT, (_in(CONTEXT), _in(FUNC_INTERP)))
     */
-    unsigned Z3_API Z3_func_interp_get_arity(__in Z3_context c, __in Z3_func_interp f);
+    unsigned Z3_API Z3_func_interp_get_arity(Z3_in Z3_context c, Z3_in Z3_func_interp f);
 
 #ifdef Conly
     /**
@@ -4837,14 +4837,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_func_entry_inc_ref', VOID, (_in(CONTEXT), _in(FUNC_ENTRY)))
     */
-    void Z3_API Z3_func_entry_inc_ref(__in Z3_context c, __in Z3_func_entry e);
+    void Z3_API Z3_func_entry_inc_ref(Z3_in Z3_context c, Z3_in Z3_func_entry e);
 
     /**
        \brief Decrement the reference counter of the given Z3_func_entry object.
 
        def_API('Z3_func_entry_dec_ref', VOID, (_in(CONTEXT), _in(FUNC_ENTRY)))
     */
-    void Z3_API Z3_func_entry_dec_ref(__in Z3_context c, __in Z3_func_entry e);
+    void Z3_API Z3_func_entry_dec_ref(Z3_in Z3_context c, Z3_in Z3_func_entry e);
 #endif
     
     /**
@@ -4857,7 +4857,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_func_entry_get_value', AST, (_in(CONTEXT), _in(FUNC_ENTRY)))
     */
-    Z3_ast Z3_API Z3_func_entry_get_value(__in Z3_context c, __in Z3_func_entry e);
+    Z3_ast Z3_API Z3_func_entry_get_value(Z3_in Z3_context c, Z3_in Z3_func_entry e);
 
     /**
        \brief Return the number of arguments in a Z3_func_entry object.
@@ -4866,7 +4866,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_func_entry_get_num_args', UINT, (_in(CONTEXT), _in(FUNC_ENTRY)))
     */
-    unsigned Z3_API Z3_func_entry_get_num_args(__in Z3_context c, __in Z3_func_entry e);
+    unsigned Z3_API Z3_func_entry_get_num_args(Z3_in Z3_context c, Z3_in Z3_func_entry e);
     
     /**
        \brief Return an argument of a Z3_func_entry object.
@@ -4877,7 +4877,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_func_entry_get_arg', AST, (_in(CONTEXT), _in(FUNC_ENTRY), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_func_entry_get_arg(__in Z3_context c, __in Z3_func_entry e, __in unsigned i);
+    Z3_ast Z3_API Z3_func_entry_get_arg(Z3_in Z3_context c, Z3_in Z3_func_entry e, Z3_in unsigned i);
 
     /*@}*/
 #endif // CorML4
@@ -4892,7 +4892,7 @@ END_MLAPI_EXCLUDE
        
        extra_API('Z3_open_log', INT, (_in(STRING),))
     */
-    Z3_bool Z3_API Z3_open_log(__in Z3_string filename);
+    Z3_bool Z3_API Z3_open_log(Z3_in Z3_string filename);
 
     /**
        \brief Append user-defined string to interaction log.
@@ -4903,7 +4903,7 @@ END_MLAPI_EXCLUDE
 
        extra_API('Z3_append_log', VOID, (_in(STRING),))
     */
-    void Z3_API Z3_append_log(__in Z3_string string);
+    void Z3_API Z3_append_log(Z3_in Z3_string string);
 
     /**
        \brief Close interaction log.
@@ -4920,7 +4920,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_toggle_warning_messages', VOID, (_in(BOOL),))
     */
-    void Z3_API Z3_toggle_warning_messages(__in Z3_bool enabled);
+    void Z3_API Z3_toggle_warning_messages(Z3_in Z3_bool enabled);
 
     /*@}*/
 
@@ -4946,7 +4946,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_set_ast_print_mode', VOID, (_in(CONTEXT), _in(PRINT_MODE)))
     */
-    void Z3_API Z3_set_ast_print_mode(__in Z3_context c, __in Z3_ast_print_mode mode);
+    void Z3_API Z3_set_ast_print_mode(Z3_in Z3_context c, Z3_in Z3_ast_print_mode mode);
 
     /**
        \brief Convert the given AST node into a string.
@@ -4959,22 +4959,22 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_ast_to_string', STRING, (_in(CONTEXT), _in(AST)))
     */
-    Z3_string Z3_API Z3_ast_to_string(__in Z3_context c, __in Z3_ast a);
+    Z3_string Z3_API Z3_ast_to_string(Z3_in Z3_context c, Z3_in Z3_ast a);
 
     /**
       def_API('Z3_pattern_to_string', STRING, (_in(CONTEXT), _in(PATTERN)))
     */
-    Z3_string Z3_API Z3_pattern_to_string(__in Z3_context c, __in Z3_pattern p);
+    Z3_string Z3_API Z3_pattern_to_string(Z3_in Z3_context c, Z3_in Z3_pattern p);
 
     /**
       def_API('Z3_sort_to_string', STRING, (_in(CONTEXT), _in(SORT)))
     */
-    Z3_string Z3_API Z3_sort_to_string(__in Z3_context c, __in Z3_sort s);
+    Z3_string Z3_API Z3_sort_to_string(Z3_in Z3_context c, Z3_in Z3_sort s);
     
     /**
       def_API('Z3_func_decl_to_string', STRING, (_in(CONTEXT), _in(FUNC_DECL)))
     */
-    Z3_string Z3_API Z3_func_decl_to_string(__in Z3_context c, __in Z3_func_decl d);
+    Z3_string Z3_API Z3_func_decl_to_string(Z3_in Z3_context c, Z3_in Z3_func_decl d);
 
     /**
        \brief Convert the given model into a string.
@@ -4985,7 +4985,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_model_to_string', STRING, (_in(CONTEXT), _in(MODEL)))
     */
-    Z3_string Z3_API Z3_model_to_string(__in Z3_context c, __in Z3_model m);
+    Z3_string Z3_API Z3_model_to_string(Z3_in Z3_context c, Z3_in Z3_model m);
 
     /**
        \brief Convert the given benchmark into SMT-LIB formatted string.
@@ -5005,14 +5005,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_benchmark_to_smtlib_string', STRING, (_in(CONTEXT), _in(STRING), _in(STRING), _in(STRING), _in(STRING), _in(UINT), _in_array(5, AST), _in(AST)))
     */
-    Z3_string Z3_API Z3_benchmark_to_smtlib_string(__in   Z3_context c, 
-                                                   __in Z3_string name,
-                                                   __in Z3_string logic,
-                                                   __in Z3_string status,
-                                                   __in Z3_string attributes,
-                                                   __in   unsigned num_assumptions,
-                                                   __in_ecount(num_assumptions) Z3_ast const assumptions[],
-                                                   __in   Z3_ast formula);
+    Z3_string Z3_API Z3_benchmark_to_smtlib_string(Z3_in   Z3_context c, 
+                                                   Z3_in Z3_string name,
+                                                   Z3_in Z3_string logic,
+                                                   Z3_in Z3_string status,
+                                                   Z3_in Z3_string attributes,
+                                                   Z3_in   unsigned num_assumptions,
+                                                   Z3_in_ecount(num_assumptions) Z3_ast const assumptions[],
+                                                   Z3_in   Z3_ast formula);
 
     /*@}*/
 
@@ -5030,28 +5030,28 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_parse_smtlib2_string', AST, (_in(CONTEXT), _in(STRING), _in(UINT), _in_array(2, SYMBOL), _in_array(2, SORT), _in(UINT), _in_array(5, SYMBOL), _in_array(5, FUNC_DECL)))
     */
-    Z3_ast Z3_API Z3_parse_smtlib2_string(__in Z3_context c, 
-                                          __in Z3_string str,
-                                          __in unsigned num_sorts,
-                                          __in_ecount(num_sorts) Z3_symbol const sort_names[],
-                                          __in_ecount(num_sorts) Z3_sort const sorts[],
-                                          __in unsigned num_decls,
-                                          __in_ecount(num_decls) Z3_symbol const decl_names[],
-                                          __in_ecount(num_decls) Z3_func_decl const decls[]);
+    Z3_ast Z3_API Z3_parse_smtlib2_string(Z3_in Z3_context c, 
+                                          Z3_in Z3_string str,
+                                          Z3_in unsigned num_sorts,
+                                          Z3_in_ecount(num_sorts) Z3_symbol const sort_names[],
+                                          Z3_in_ecount(num_sorts) Z3_sort const sorts[],
+                                          Z3_in unsigned num_decls,
+                                          Z3_in_ecount(num_decls) Z3_symbol const decl_names[],
+                                          Z3_in_ecount(num_decls) Z3_func_decl const decls[]);
     
     /**
        \brief Similar to #Z3_parse_smtlib2_string, but reads the benchmark from a file.
 
        def_API('Z3_parse_smtlib2_file', AST, (_in(CONTEXT), _in(STRING), _in(UINT), _in_array(2, SYMBOL), _in_array(2, SORT), _in(UINT), _in_array(5, SYMBOL), _in_array(5, FUNC_DECL)))
     */
-    Z3_ast Z3_API Z3_parse_smtlib2_file(__in Z3_context c, 
-                                        __in Z3_string file_name,
-                                        __in unsigned num_sorts,
-                                        __in_ecount(num_sorts) Z3_symbol const sort_names[],
-                                        __in_ecount(num_sorts) Z3_sort const sorts[],
-                                        __in unsigned num_decls,
-                                        __in_ecount(num_decls) Z3_symbol const decl_names[],
-                                        __in_ecount(num_decls) Z3_func_decl const decls[]);
+    Z3_ast Z3_API Z3_parse_smtlib2_file(Z3_in Z3_context c, 
+                                        Z3_in Z3_string file_name,
+                                        Z3_in unsigned num_sorts,
+                                        Z3_in_ecount(num_sorts) Z3_symbol const sort_names[],
+                                        Z3_in_ecount(num_sorts) Z3_sort const sorts[],
+                                        Z3_in unsigned num_decls,
+                                        Z3_in_ecount(num_decls) Z3_symbol const decl_names[],
+                                        Z3_in_ecount(num_decls) Z3_func_decl const decls[]);
 
 #ifdef ML4only
 #include <mlx_parse_smtlib.idl>
@@ -5076,14 +5076,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_parse_smtlib_string', VOID, (_in(CONTEXT), _in(STRING), _in(UINT), _in_array(2, SYMBOL), _in_array(2, SORT), _in(UINT), _in_array(5, SYMBOL), _in_array(5, FUNC_DECL)))
     */
-    void Z3_API Z3_parse_smtlib_string(__in Z3_context c, 
-                                       __in Z3_string str,
-                                       __in unsigned num_sorts,
-                                       __in_ecount(num_sorts) Z3_symbol const sort_names[],
-                                       __in_ecount(num_sorts) Z3_sort const sorts[],
-                                       __in unsigned num_decls,
-                                       __in_ecount(num_decls) Z3_symbol const decl_names[],
-                                       __in_ecount(num_decls) Z3_func_decl const decls[]                     
+    void Z3_API Z3_parse_smtlib_string(Z3_in Z3_context c, 
+                                       Z3_in Z3_string str,
+                                       Z3_in unsigned num_sorts,
+                                       Z3_in_ecount(num_sorts) Z3_symbol const sort_names[],
+                                       Z3_in_ecount(num_sorts) Z3_sort const sorts[],
+                                       Z3_in unsigned num_decls,
+                                       Z3_in_ecount(num_decls) Z3_symbol const decl_names[],
+                                       Z3_in_ecount(num_decls) Z3_func_decl const decls[]                     
                                        );
 
     /**
@@ -5091,14 +5091,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_parse_smtlib_file', VOID, (_in(CONTEXT), _in(STRING), _in(UINT), _in_array(2, SYMBOL), _in_array(2, SORT), _in(UINT), _in_array(5, SYMBOL), _in_array(5, FUNC_DECL)))
     */
-    void Z3_API Z3_parse_smtlib_file(__in Z3_context c, 
-                                     __in Z3_string file_name,
-                                     __in unsigned num_sorts,
-                                     __in_ecount(num_sorts) Z3_symbol const sort_names[],
-                                     __in_ecount(num_sorts) Z3_sort const sorts[],
-                                     __in unsigned num_decls,
-                                     __in_ecount(num_decls) Z3_symbol const decl_names[],
-                                     __in_ecount(num_decls) Z3_func_decl const decls[]  
+    void Z3_API Z3_parse_smtlib_file(Z3_in Z3_context c, 
+                                     Z3_in Z3_string file_name,
+                                     Z3_in unsigned num_sorts,
+                                     Z3_in_ecount(num_sorts) Z3_symbol const sort_names[],
+                                     Z3_in_ecount(num_sorts) Z3_sort const sorts[],
+                                     Z3_in unsigned num_decls,
+                                     Z3_in_ecount(num_decls) Z3_symbol const decl_names[],
+                                     Z3_in_ecount(num_decls) Z3_func_decl const decls[]  
                                      );
 
     /**
@@ -5106,7 +5106,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_smtlib_num_formulas', UINT, (_in(CONTEXT), ))
     */
-    unsigned Z3_API Z3_get_smtlib_num_formulas(__in Z3_context c);
+    unsigned Z3_API Z3_get_smtlib_num_formulas(Z3_in Z3_context c);
 
     /**
        \brief \mlh get_smtlib_formula c i \endmlh
@@ -5116,14 +5116,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_smtlib_formula', AST, (_in(CONTEXT), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_get_smtlib_formula(__in Z3_context c, __in unsigned i);
+    Z3_ast Z3_API Z3_get_smtlib_formula(Z3_in Z3_context c, Z3_in unsigned i);
 
     /**
        \brief Return the number of SMTLIB assumptions parsed by #Z3_parse_smtlib_string or #Z3_parse_smtlib_file.
 
        def_API('Z3_get_smtlib_num_assumptions', UINT, (_in(CONTEXT), ))
     */
-    unsigned Z3_API Z3_get_smtlib_num_assumptions(__in Z3_context c);
+    unsigned Z3_API Z3_get_smtlib_num_assumptions(Z3_in Z3_context c);
 
     /**
        \brief \mlh get_smtlib_assumption c i \endmlh
@@ -5133,14 +5133,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_smtlib_assumption', AST, (_in(CONTEXT), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_get_smtlib_assumption(__in Z3_context c, __in unsigned i);
+    Z3_ast Z3_API Z3_get_smtlib_assumption(Z3_in Z3_context c, Z3_in unsigned i);
 
     /**
        \brief Return the number of declarations parsed by #Z3_parse_smtlib_string or #Z3_parse_smtlib_file.
 
        def_API('Z3_get_smtlib_num_decls', UINT, (_in(CONTEXT), ))
     */
-    unsigned Z3_API Z3_get_smtlib_num_decls(__in Z3_context c);
+    unsigned Z3_API Z3_get_smtlib_num_decls(Z3_in Z3_context c);
 
     /**
        \brief \mlh get_smtlib_decl c i \endmlh
@@ -5150,14 +5150,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_smtlib_decl', FUNC_DECL, (_in(CONTEXT), _in(UINT)))
     */
-    Z3_func_decl Z3_API Z3_get_smtlib_decl(__in Z3_context c, __in unsigned i);
+    Z3_func_decl Z3_API Z3_get_smtlib_decl(Z3_in Z3_context c, Z3_in unsigned i);
 
     /**
        \brief Return the number of sorts parsed by #Z3_parse_smtlib_string or #Z3_parse_smtlib_file.
 
        def_API('Z3_get_smtlib_num_sorts', UINT, (_in(CONTEXT), ))
     */
-    unsigned Z3_API Z3_get_smtlib_num_sorts(__in Z3_context c);
+    unsigned Z3_API Z3_get_smtlib_num_sorts(Z3_in Z3_context c);
 
     /**
        \brief \mlh get_smtlib_sort c i \endmlh
@@ -5167,7 +5167,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_smtlib_sort', SORT, (_in(CONTEXT), _in(UINT)))
     */
-    Z3_sort Z3_API Z3_get_smtlib_sort(__in Z3_context c, __in unsigned i);
+    Z3_sort Z3_API Z3_get_smtlib_sort(Z3_in Z3_context c, Z3_in unsigned i);
 
 BEGIN_MLAPI_EXCLUDE
     /**
@@ -5176,7 +5176,7 @@ BEGIN_MLAPI_EXCLUDE
 
        def_API('Z3_get_smtlib_error', STRING, (_in(CONTEXT), ))
     */
-    Z3_string Z3_API Z3_get_smtlib_error(__in Z3_context c);
+    Z3_string Z3_API Z3_get_smtlib_error(Z3_in Z3_context c);
 END_MLAPI_EXCLUDE
 
     /*@}*/
@@ -5198,7 +5198,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_error_code', UINT, (_in(CONTEXT), ))
     */
-    Z3_error_code Z3_API Z3_get_error_code(__in Z3_context c);
+    Z3_error_code Z3_API Z3_get_error_code(Z3_in Z3_context c);
 
     /**
        \brief Register a Z3 error handler.
@@ -5212,7 +5212,7 @@ END_MLAPI_EXCLUDE
 
        \sa Z3_get_error_code
     */
-    void Z3_API Z3_set_error_handler(__in Z3_context c, __in Z3_error_handler h);
+    void Z3_API Z3_set_error_handler(Z3_in Z3_context c, Z3_in Z3_error_handler h);
 #endif
     
     /**
@@ -5220,7 +5220,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_set_error', VOID, (_in(CONTEXT), _in(ERROR_CODE)))
     */
-    void Z3_API Z3_set_error(__in Z3_context c, __in Z3_error_code e);
+    void Z3_API Z3_set_error(Z3_in Z3_context c, Z3_in Z3_error_code e);
 
 #ifdef Conly
     /**
@@ -5230,7 +5230,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_error_msg', STRING, (_in(ERROR_CODE),))
     */
-    Z3_string Z3_API Z3_get_error_msg(__in Z3_error_code err);
+    Z3_string Z3_API Z3_get_error_msg(Z3_in Z3_error_code err);
 #endif
     
 BEGIN_MLAPI_EXCLUDE
@@ -5239,7 +5239,7 @@ BEGIN_MLAPI_EXCLUDE
 
        def_API('Z3_get_error_msg_ex', STRING, (_in(CONTEXT), _in(ERROR_CODE)))
     */
-    Z3_string Z3_API Z3_get_error_msg_ex(__in Z3_context c, __in Z3_error_code err);
+    Z3_string Z3_API Z3_get_error_msg_ex(Z3_in Z3_context c, Z3_in Z3_error_code err);
 END_MLAPI_EXCLUDE
 #ifdef ML4only
 #include <mlx_get_error_msg.idl>
@@ -5259,7 +5259,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_version', VOID, (_out(UINT), _out(UINT), _out(UINT), _out(UINT)))
     */
-    void Z3_API Z3_get_version(__out unsigned * major, __out unsigned * minor, __out unsigned * build_number, __out unsigned * revision_number);
+    void Z3_API Z3_get_version(Z3_out unsigned * major, Z3_out unsigned * minor, Z3_out unsigned * build_number, Z3_out unsigned * revision_number);
  
     /**
        \brief Enable tracing messages tagged as \c tag when Z3 is compiled in debug mode.
@@ -5267,7 +5267,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_enable_trace', VOID, (_in(STRING),))
     */
-    void Z3_API Z3_enable_trace(__in Z3_string tag);
+    void Z3_API Z3_enable_trace(Z3_in Z3_string tag);
 
     /**
        \brief Disable tracing messages tagged as \c tag when Z3 is compiled in debug mode.
@@ -5275,7 +5275,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_disable_trace', VOID, (_in(STRING),))
     */
-    void Z3_API Z3_disable_trace(__in Z3_string tag);
+    void Z3_API Z3_disable_trace(Z3_in Z3_string tag);
  
 #ifdef CorML3
     /**
@@ -5304,21 +5304,21 @@ END_MLAPI_EXCLUDE
     //
     // callbacks and void* don't work with CAMLIDL.
     // 
-    typedef Z3_bool Z3_reduce_eq_callback_fptr(__in Z3_theory t, __in Z3_ast a, __in Z3_ast b, __out Z3_ast * r);
+    typedef Z3_bool Z3_reduce_eq_callback_fptr(Z3_in Z3_theory t, Z3_in Z3_ast a, Z3_in Z3_ast b, Z3_out Z3_ast * r);
 
-    typedef Z3_bool Z3_reduce_app_callback_fptr(__in Z3_theory, __in Z3_func_decl, __in unsigned, __in Z3_ast const [], __out Z3_ast *);
+    typedef Z3_bool Z3_reduce_app_callback_fptr(Z3_in Z3_theory, Z3_in Z3_func_decl, Z3_in unsigned, Z3_in Z3_ast const [], Z3_out Z3_ast *);
 
-    typedef Z3_bool Z3_reduce_distinct_callback_fptr(__in Z3_theory, __in unsigned, __in Z3_ast const [], __out Z3_ast *);
+    typedef Z3_bool Z3_reduce_distinct_callback_fptr(Z3_in Z3_theory, Z3_in unsigned, Z3_in Z3_ast const [], Z3_out Z3_ast *);
 
-    typedef void Z3_theory_callback_fptr(__in Z3_theory t);
+    typedef void Z3_theory_callback_fptr(Z3_in Z3_theory t);
     
-    typedef Z3_bool Z3_theory_final_check_callback_fptr(__in Z3_theory);
+    typedef Z3_bool Z3_theory_final_check_callback_fptr(Z3_in Z3_theory);
     
-    typedef void Z3_theory_ast_callback_fptr(__in Z3_theory, __in Z3_ast);
+    typedef void Z3_theory_ast_callback_fptr(Z3_in Z3_theory, Z3_in Z3_ast);
     
-    typedef void Z3_theory_ast_bool_callback_fptr(__in Z3_theory, __in Z3_ast, __in Z3_bool);
+    typedef void Z3_theory_ast_bool_callback_fptr(Z3_in Z3_theory, Z3_in Z3_ast, Z3_in Z3_bool);
     
-    typedef void Z3_theory_ast_ast_callback_fptr(__in Z3_theory, __in Z3_ast, __in Z3_ast);
+    typedef void Z3_theory_ast_ast_callback_fptr(Z3_in Z3_theory, Z3_in Z3_ast, Z3_in Z3_ast);
 
 #endif
 
@@ -5331,42 +5331,42 @@ END_MLAPI_EXCLUDE
        \conly \c data is a pointer to an external data-structure that may be used to store
        \conly theory specific additional data.
     */
-    Z3_theory Z3_API Z3_mk_theory(__in Z3_context c, __in Z3_string th_name, __in Z3_theory_data data);
+    Z3_theory Z3_API Z3_mk_theory(Z3_in Z3_context c, Z3_in Z3_string th_name, Z3_in Z3_theory_data data);
 
     /**
        \brief Return a pointer to the external data-structure supplied to the function #Z3_mk_theory.
 
        \see Z3_mk_theory
     */
-    Z3_theory_data Z3_API Z3_theory_get_ext_data(__in Z3_theory t);
+    Z3_theory_data Z3_API Z3_theory_get_ext_data(Z3_in Z3_theory t);
 #endif
 
     /**
        \brief Create an interpreted theory sort.
     */
-    Z3_sort Z3_API Z3_theory_mk_sort(__in Z3_context c, __in Z3_theory t, __in Z3_symbol s);
+    Z3_sort Z3_API Z3_theory_mk_sort(Z3_in Z3_context c, Z3_in Z3_theory t, Z3_in Z3_symbol s);
     
     /**
        \brief Create an interpreted theory constant value. Values are assumed to be different from each other.
     */
-    Z3_ast Z3_API Z3_theory_mk_value(__in Z3_context c, __in Z3_theory t, __in Z3_symbol n, __in Z3_sort s);
+    Z3_ast Z3_API Z3_theory_mk_value(Z3_in Z3_context c, Z3_in Z3_theory t, Z3_in Z3_symbol n, Z3_in Z3_sort s);
 
     /**
        \brief Create an interpreted constant for the given theory.
     */
-    Z3_ast Z3_API Z3_theory_mk_constant(__in Z3_context c, __in Z3_theory t, __in Z3_symbol n, __in Z3_sort s);
+    Z3_ast Z3_API Z3_theory_mk_constant(Z3_in Z3_context c, Z3_in Z3_theory t, Z3_in Z3_symbol n, Z3_in Z3_sort s);
     
     /**
        \brief Create an interpreted function declaration for the given theory.
     */
-    Z3_func_decl Z3_API Z3_theory_mk_func_decl(__in Z3_context c, __in Z3_theory t, __in Z3_symbol n,
-                                               __in unsigned domain_size, __in_ecount(domain_size) Z3_sort const domain[],
-                                               __in Z3_sort range);
+    Z3_func_decl Z3_API Z3_theory_mk_func_decl(Z3_in Z3_context c, Z3_in Z3_theory t, Z3_in Z3_symbol n,
+                                               Z3_in unsigned domain_size, Z3_in_ecount(domain_size) Z3_sort const domain[],
+                                               Z3_in Z3_sort range);
 
     /**
        \brief Return the context where the given theory is installed.
     */
-    Z3_context Z3_API Z3_theory_get_context(__in Z3_theory t);
+    Z3_context Z3_API Z3_theory_get_context(Z3_in Z3_theory t);
 
 
 #ifdef Conly
@@ -5380,7 +5380,7 @@ END_MLAPI_EXCLUDE
        \see Z3_mk_theory 
        \conly \see Z3_theory_get_ext_data
     */
-    void Z3_API Z3_set_delete_callback(__in Z3_theory t, __in Z3_theory_callback_fptr f);
+    void Z3_API Z3_set_delete_callback(Z3_in Z3_theory t, Z3_in Z3_theory_callback_fptr f);
     
     /**
        \brief Set a callback for simplifying operators of the given theory.
@@ -5395,7 +5395,7 @@ END_MLAPI_EXCLUDE
 
        \conly If <tt>f(t, d, n, args, r)</tt> returns false, then \c r is ignored, and Z3 assumes that no simplification was performed.
     */
-    void Z3_API Z3_set_reduce_app_callback(__in Z3_theory t, __in Z3_reduce_app_callback_fptr f);
+    void Z3_API Z3_set_reduce_app_callback(Z3_in Z3_theory t, Z3_in Z3_reduce_app_callback_fptr f);
     
     /**
        \brief Set a callback for simplifying the atom <tt>s_1 = s_2</tt>, when the
@@ -5410,7 +5410,7 @@ END_MLAPI_EXCLUDE
          
        \conly If <tt>f(t, s_1, s_2, r)</tt> returns false, then \c r is ignored, and Z3 assumes that no simplification was performed.
     */
-    void Z3_API Z3_set_reduce_eq_callback(__in Z3_theory t, __in Z3_reduce_eq_callback_fptr f);
+    void Z3_API Z3_set_reduce_eq_callback(Z3_in Z3_theory t, Z3_in Z3_reduce_eq_callback_fptr f);
 
     /**
        \brief Set a callback for simplifying the atom <tt>distinct(s_1, ..., s_n)</tt>, when the
@@ -5425,7 +5425,7 @@ END_MLAPI_EXCLUDE
          
        \conly If <tt>f(t, n, args, r)</tt> returns false, then \c r is ignored, and Z3 assumes that no simplification was performed.
     */
-    void Z3_API Z3_set_reduce_distinct_callback(__in Z3_theory t, __in Z3_reduce_distinct_callback_fptr f);
+    void Z3_API Z3_set_reduce_distinct_callback(Z3_in Z3_theory t, Z3_in Z3_reduce_distinct_callback_fptr f);
     
     /**
        \brief Set a callback that is invoked when a theory application
@@ -5442,7 +5442,7 @@ END_MLAPI_EXCLUDE
        \remark An expression \c n added to the logical context at search level \c n,
        will remain in the logical context until this level is backtracked.
     */
-    void Z3_API Z3_set_new_app_callback(__in Z3_theory t, __in Z3_theory_ast_callback_fptr f);
+    void Z3_API Z3_set_new_app_callback(Z3_in Z3_theory t, Z3_in Z3_theory_ast_callback_fptr f);
 
     /**
        \brief Set a callback that is invoked when an expression of
@@ -5460,7 +5460,7 @@ END_MLAPI_EXCLUDE
        \remark An expression \c n added to the logical context at search level \c n,
        will remain in the logical context until this level is backtracked.
     */
-    void Z3_API Z3_set_new_elem_callback(__in Z3_theory t, __in Z3_theory_ast_callback_fptr f);
+    void Z3_API Z3_set_new_elem_callback(Z3_in Z3_theory t, Z3_in Z3_theory_ast_callback_fptr f);
 
     /**
        \brief Set a callback that is invoked when Z3 starts searching for a
@@ -5469,7 +5469,7 @@ END_MLAPI_EXCLUDE
        \conly The callback has the form <tt>f(t)</tt>, where
        \conly - \c t is the given theory
     */
-    void Z3_API Z3_set_init_search_callback(__in Z3_theory t, __in Z3_theory_callback_fptr f);
+    void Z3_API Z3_set_init_search_callback(Z3_in Z3_theory t, Z3_in Z3_theory_callback_fptr f);
         
     /**
        \brief Set a callback that is invoked when Z3 creates a
@@ -5480,7 +5480,7 @@ END_MLAPI_EXCLUDE
        \conly The callback has the form <tt>f(t)</tt>, where
        \conly - \c t is the given theory
     */
-    void Z3_API Z3_set_push_callback(__in Z3_theory t, __in Z3_theory_callback_fptr f);
+    void Z3_API Z3_set_push_callback(Z3_in Z3_theory t, Z3_in Z3_theory_callback_fptr f);
  
     /**
        \brief Set a callback that is invoked when Z3 backtracks a
@@ -5491,7 +5491,7 @@ END_MLAPI_EXCLUDE
        \conly The callback has the form <tt>f(t)</tt>, where
        \conly - \c t is the given theory
     */
-    void Z3_API Z3_set_pop_callback(__in Z3_theory t, __in Z3_theory_callback_fptr f);
+    void Z3_API Z3_set_pop_callback(Z3_in Z3_theory t, Z3_in Z3_theory_callback_fptr f);
 
     /**
        \brief Set a callback that is invoked when Z3 restarts the
@@ -5500,7 +5500,7 @@ END_MLAPI_EXCLUDE
        \conly The callback has the form <tt>f(t)</tt>, where
        \conly - \c t is the given theory
     */
-    void Z3_API Z3_set_restart_callback(__in Z3_theory t, __in Z3_theory_callback_fptr f);
+    void Z3_API Z3_set_restart_callback(Z3_in Z3_theory t, Z3_in Z3_theory_callback_fptr f);
 
     /**
        \brief Set a callback that is invoked when the logical context
@@ -5510,7 +5510,7 @@ END_MLAPI_EXCLUDE
        \conly The callback has the form <tt>f(t)</tt>, where
        \conly - \c t is the given theory
     */
-    void Z3_API Z3_set_reset_callback(__in Z3_theory t, __in Z3_theory_callback_fptr f);
+    void Z3_API Z3_set_reset_callback(Z3_in Z3_theory t, Z3_in Z3_theory_callback_fptr f);
 
     /**
        \brief Set a callback that is invoked before Z3 starts building a model.
@@ -5524,7 +5524,7 @@ END_MLAPI_EXCLUDE
        and it will assume that it was not possible to decide if the asserted constraints
        are satisfiable or not.
     */
-    void Z3_API Z3_set_final_check_callback(__in Z3_theory t, __in Z3_theory_final_check_callback_fptr f);
+    void Z3_API Z3_set_final_check_callback(Z3_in Z3_theory t, Z3_in Z3_theory_final_check_callback_fptr f);
 
     /**
        \brief Set a callback that is invoked when an equality <tt>s_1 = s_2</tt>
@@ -5535,7 +5535,7 @@ END_MLAPI_EXCLUDE
        \conly   - \c s_1 is the left-hand-side
        \conly   - \c s_2 is the right-hand-side
     */
-    void Z3_API Z3_set_new_eq_callback(__in Z3_theory t, __in Z3_theory_ast_ast_callback_fptr f);
+    void Z3_API Z3_set_new_eq_callback(Z3_in Z3_theory t, Z3_in Z3_theory_ast_ast_callback_fptr f);
 
     /**
        \brief Set a callback that is invoked when a disequality <tt>s_1 != s_2</tt>
@@ -5546,7 +5546,7 @@ END_MLAPI_EXCLUDE
        \conly   - \c s_1 is the left-hand-side
        \conly   - \c s_2 is the right-hand-side
     */
-    void Z3_API Z3_set_new_diseq_callback(__in Z3_theory t, __in Z3_theory_ast_ast_callback_fptr f);
+    void Z3_API Z3_set_new_diseq_callback(Z3_in Z3_theory t, Z3_in Z3_theory_ast_ast_callback_fptr f);
 
     /**
        \brief Set a callback that is invoked when a theory predicate is assigned to true/false by Z3.
@@ -5556,7 +5556,7 @@ END_MLAPI_EXCLUDE
        \conly   - \c p is the assigned predicate.
        \conly   - \c v is the value (true/false) assigned to \c p.
     */
-    void Z3_API Z3_set_new_assignment_callback(__in Z3_theory t, __in Z3_theory_ast_bool_callback_fptr f);
+    void Z3_API Z3_set_new_assignment_callback(Z3_in Z3_theory t, Z3_in Z3_theory_ast_bool_callback_fptr f);
 
     /**
        \brief Set a callback that is invoked when an expression is
@@ -5567,7 +5567,7 @@ END_MLAPI_EXCLUDE
        \conly   - \c t is the given theory
        \conly   - \c n is the relevant expression
     */
-    void Z3_API Z3_set_new_relevant_callback(__in Z3_theory t, __in Z3_theory_ast_callback_fptr f);
+    void Z3_API Z3_set_new_relevant_callback(Z3_in Z3_theory t, Z3_in Z3_theory_ast_callback_fptr f);
 
 #endif
 
@@ -5585,7 +5585,7 @@ END_MLAPI_EXCLUDE
        Z3 tracks the theory axioms asserted. So, multiple assertions of the same axiom are
        ignored.
     */
-    void Z3_API Z3_theory_assert_axiom(__in Z3_theory t, __in Z3_ast ax);
+    void Z3_API Z3_theory_assert_axiom(Z3_in Z3_theory t, Z3_in Z3_ast ax);
 
     /**
        \brief Inform to the logical context that \c lhs and \c rhs have the same interpretation
@@ -5594,7 +5594,7 @@ END_MLAPI_EXCLUDE
 
        For more information, see the paper "Model-Based Theory Combination" in the Z3 website.
     */
-    void Z3_API Z3_theory_assume_eq(__in Z3_theory t, __in Z3_ast lhs, __in Z3_ast rhs);
+    void Z3_API Z3_theory_assume_eq(Z3_in Z3_theory t, Z3_in Z3_ast lhs, Z3_in Z3_ast rhs);
 
     /**
        \brief Enable/disable the simplification of theory axioms asserted using #Z3_theory_assert_axiom.
@@ -5602,12 +5602,12 @@ END_MLAPI_EXCLUDE
        That is, the reduce theory callbacks are not invoked for theory axioms.
        The default behavior is useful when asserting axioms stating properties of theory operators.
     */
-    void Z3_API Z3_theory_enable_axiom_simplification(__in Z3_theory t, __in Z3_bool flag);
+    void Z3_API Z3_theory_enable_axiom_simplification(Z3_in Z3_theory t, Z3_in Z3_bool flag);
 
     /**
        \brief Return the root of the equivalence class containing \c n.
     */
-    Z3_ast Z3_API Z3_theory_get_eqc_root(__in Z3_theory t, __in Z3_ast n);
+    Z3_ast Z3_API Z3_theory_get_eqc_root(Z3_in Z3_theory t, Z3_in Z3_ast n);
     
     /**
        \brief Return the next element in the equivalence class containing \c n.
@@ -5623,56 +5623,56 @@ END_MLAPI_EXCLUDE
            while (curr != n);
        \endcode
     */
-    Z3_ast Z3_API Z3_theory_get_eqc_next(__in Z3_theory t, __in Z3_ast n);
+    Z3_ast Z3_API Z3_theory_get_eqc_next(Z3_in Z3_theory t, Z3_in Z3_ast n);
 
     /**
        \brief Return the number of parents of \c n that are operators of the given theory. 
     */
-    unsigned Z3_API Z3_theory_get_num_parents(__in Z3_theory t, __in Z3_ast n);
+    unsigned Z3_API Z3_theory_get_num_parents(Z3_in Z3_theory t, Z3_in Z3_ast n);
     
     /**
        \brief Return the i-th parent of \c n. 
        See #Z3_theory_get_num_parents. 
     */
-    Z3_ast Z3_API Z3_theory_get_parent(__in Z3_theory t, __in Z3_ast n, __in unsigned i);
+    Z3_ast Z3_API Z3_theory_get_parent(Z3_in Z3_theory t, Z3_in Z3_ast n, Z3_in unsigned i);
 
     /**
        \brief Return \c Z3_TRUE if \c n is an interpreted theory value.
     */
-    Z3_bool Z3_API Z3_theory_is_value(__in Z3_theory t, __in Z3_ast n);
+    Z3_bool Z3_API Z3_theory_is_value(Z3_in Z3_theory t, Z3_in Z3_ast n);
 
     /**
        \brief Return \c Z3_TRUE if \c d is an interpreted theory declaration.
     */
-    Z3_bool Z3_API Z3_theory_is_decl(__in Z3_theory t, __in Z3_func_decl d);
+    Z3_bool Z3_API Z3_theory_is_decl(Z3_in Z3_theory t, Z3_in Z3_func_decl d);
     
     /**
        \brief Return the number of expressions of the given theory in
        the logical context. These are the expressions notified using the
        callback #Z3_set_new_elem_callback.
     */
-    unsigned Z3_API Z3_theory_get_num_elems(__in Z3_theory t);
+    unsigned Z3_API Z3_theory_get_num_elems(Z3_in Z3_theory t);
     
     /**
        \brief Return the i-th elem of the given theory in the logical context.
        
        \see Z3_theory_get_num_elems
     */
-    Z3_ast Z3_API Z3_theory_get_elem(__in Z3_theory t, __in unsigned i);
+    Z3_ast Z3_API Z3_theory_get_elem(Z3_in Z3_theory t, Z3_in unsigned i);
 
     /**
        \brief Return the number of theory applications in the logical
        context. These are the expressions notified using the callback
        #Z3_set_new_app_callback.
     */
-    unsigned Z3_API Z3_theory_get_num_apps(__in Z3_theory t);
+    unsigned Z3_API Z3_theory_get_num_apps(Z3_in Z3_theory t);
     
     /**
        \brief Return the i-th application of the given theory in the logical context.
        
        \see Z3_theory_get_num_apps
     */
-    Z3_ast Z3_API Z3_theory_get_app(__in Z3_theory t, __in unsigned i);
+    Z3_ast Z3_API Z3_theory_get_app(Z3_in Z3_theory t, Z3_in unsigned i);
 
     /*@}*/
 
@@ -5692,7 +5692,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_fixedpoint', FIXEDPOINT, (_in(CONTEXT), ))
     */
-    Z3_fixedpoint Z3_API Z3_mk_fixedpoint(__in Z3_context c);
+    Z3_fixedpoint Z3_API Z3_mk_fixedpoint(Z3_in Z3_context c);
 
 #ifdef Conly
     /**
@@ -5700,14 +5700,14 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_fixedpoint_inc_ref', VOID, (_in(CONTEXT), _in(FIXEDPOINT)))
     */
-    void Z3_API Z3_fixedpoint_inc_ref(__in Z3_context c,__in Z3_fixedpoint d);
+    void Z3_API Z3_fixedpoint_inc_ref(Z3_in Z3_context c,Z3_in Z3_fixedpoint d);
 
     /**
        \brief Decrement the reference counter of the given fixedpoint context.
 
        def_API('Z3_fixedpoint_dec_ref', VOID, (_in(CONTEXT), _in(FIXEDPOINT)))
     */
-    void Z3_API Z3_fixedpoint_dec_ref(__in Z3_context c,__in Z3_fixedpoint d);
+    void Z3_API Z3_fixedpoint_dec_ref(Z3_in Z3_context c,Z3_in Z3_fixedpoint d);
 #endif
 
     /**
@@ -5722,7 +5722,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_fixedpoint_add_rule', VOID, (_in(CONTEXT), _in(FIXEDPOINT), _in(AST), _in(SYMBOL)))
     */
-    void Z3_API Z3_fixedpoint_add_rule(__in Z3_context c,__in Z3_fixedpoint d, __in Z3_ast rule, __in Z3_symbol name);
+    void Z3_API Z3_fixedpoint_add_rule(Z3_in Z3_context c,Z3_in Z3_fixedpoint d, Z3_in Z3_ast rule, Z3_in Z3_symbol name);
 
     /**
        \brief Add a Database fact. 
@@ -5741,9 +5741,9 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_fixedpoint_add_fact', VOID, (_in(CONTEXT), _in(FIXEDPOINT), _in(FUNC_DECL), _in(UINT), _in_array(3, UINT)))
     */
-    void Z3_API Z3_fixedpoint_add_fact(__in Z3_context c,__in Z3_fixedpoint d, 
-                                       __in Z3_func_decl r, 
-                                       __in unsigned num_args, __in_ecount(num_args) unsigned args[]);
+    void Z3_API Z3_fixedpoint_add_fact(Z3_in Z3_context c,Z3_in Z3_fixedpoint d, 
+                                       Z3_in Z3_func_decl r, 
+                                       Z3_in unsigned num_args, Z3_in_ecount(num_args) unsigned args[]);
 
     /**
        \brief Assert a constraint to the fixedpoint context.
@@ -5753,7 +5753,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_fixedpoint_assert', VOID, (_in(CONTEXT), _in(FIXEDPOINT), _in(AST)))
     */
-    void Z3_API Z3_fixedpoint_assert(__in Z3_context c,__in Z3_fixedpoint d, __in Z3_ast axiom);
+    void Z3_API Z3_fixedpoint_assert(Z3_in Z3_context c,Z3_in Z3_fixedpoint d, Z3_in Z3_ast axiom);
 
     /**
         \brief Pose a query against the asserted rules.
@@ -5770,7 +5770,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_fixedpoint_query', INT, (_in(CONTEXT), _in(FIXEDPOINT), _in(AST)))
     */
-    Z3_lbool Z3_API Z3_fixedpoint_query(__in Z3_context c,__in Z3_fixedpoint d, __in Z3_ast query);
+    Z3_lbool Z3_API Z3_fixedpoint_query(Z3_in Z3_context c,Z3_in Z3_fixedpoint d, Z3_in Z3_ast query);
 
     /**
         \brief Pose multiple queries against the asserted rules.
@@ -5785,8 +5785,8 @@ END_MLAPI_EXCLUDE
         def_API('Z3_fixedpoint_query_relations', INT, (_in(CONTEXT), _in(FIXEDPOINT), _in(UINT), _in_array(2, FUNC_DECL)))
     */
     Z3_lbool Z3_API Z3_fixedpoint_query_relations(
-        __in Z3_context c,__in Z3_fixedpoint d, 
-        __in unsigned num_relations, __in_ecount(num_relations) Z3_func_decl const relations[]);
+        Z3_in Z3_context c,Z3_in Z3_fixedpoint d, 
+        Z3_in unsigned num_relations, Z3_in_ecount(num_relations) Z3_func_decl const relations[]);
 
     /**
        \brief Retrieve a formula that encodes satisfying answers to the query.
@@ -5801,7 +5801,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_fixedpoint_get_answer', AST, (_in(CONTEXT), _in(FIXEDPOINT)))
     */    
-    Z3_ast Z3_API Z3_fixedpoint_get_answer(__in Z3_context c,__in Z3_fixedpoint d);
+    Z3_ast Z3_API Z3_fixedpoint_get_answer(Z3_in Z3_context c,Z3_in Z3_fixedpoint d);
 
     /**
        \brief Retrieve a string that describes the last status returned by #Z3_fixedpoint_query.
@@ -5810,7 +5810,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_fixedpoint_get_reason_unknown', STRING, (_in(CONTEXT), _in(FIXEDPOINT) ))
     */
-    Z3_string Z3_API Z3_fixedpoint_get_reason_unknown(__in Z3_context c,__in Z3_fixedpoint d);
+    Z3_string Z3_API Z3_fixedpoint_get_reason_unknown(Z3_in Z3_context c,Z3_in Z3_fixedpoint d);
 
     /**
        \brief Update a named rule. 
@@ -5818,7 +5818,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_fixedpoint_update_rule', VOID, (_in(CONTEXT), _in(FIXEDPOINT), _in(AST), _in(SYMBOL)))
     */
-    void Z3_API Z3_fixedpoint_update_rule(__in Z3_context c, __in Z3_fixedpoint d, __in Z3_ast a, __in Z3_symbol name);
+    void Z3_API Z3_fixedpoint_update_rule(Z3_in Z3_context c, Z3_in Z3_fixedpoint d, Z3_in Z3_ast a, Z3_in Z3_symbol name);
     
     /**
        \brief Query the PDR engine for the maximal levels properties are known about predicate.
@@ -5862,7 +5862,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_fixedpoint_get_statistics', STATS, (_in(CONTEXT), _in(FIXEDPOINT)))
     */
-    Z3_stats Z3_API Z3_fixedpoint_get_statistics(__in Z3_context c,__in Z3_fixedpoint d);
+    Z3_stats Z3_API Z3_fixedpoint_get_statistics(Z3_in Z3_context c,Z3_in Z3_fixedpoint d);
 
     /**
        \brief Register relation as Fixedpoint defined.
@@ -5872,7 +5872,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_fixedpoint_register_relation', VOID, (_in(CONTEXT), _in(FIXEDPOINT), _in(FUNC_DECL)))
     */
-    void Z3_API Z3_fixedpoint_register_relation(__in Z3_context c,__in Z3_fixedpoint d, __in Z3_func_decl f);
+    void Z3_API Z3_fixedpoint_register_relation(Z3_in Z3_context c,Z3_in Z3_fixedpoint d, Z3_in Z3_func_decl f);
 
     /**
        \brief Configure the predicate representation.
@@ -5884,11 +5884,11 @@ END_MLAPI_EXCLUDE
        def_API('Z3_fixedpoint_set_predicate_representation', VOID, (_in(CONTEXT), _in(FIXEDPOINT), _in(FUNC_DECL), _in(UINT), _in_array(3, SYMBOL)))
     */
     void Z3_API Z3_fixedpoint_set_predicate_representation(
-        __in Z3_context c,
-        __in Z3_fixedpoint d, 
-        __in Z3_func_decl f, 
-        __in unsigned num_relations, 
-        __in_ecount(num_relations) Z3_symbol const relation_kinds[]);
+        Z3_in Z3_context c,
+        Z3_in Z3_fixedpoint d, 
+        Z3_in Z3_func_decl f, 
+        Z3_in unsigned num_relations, 
+        Z3_in_ecount(num_relations) Z3_symbol const relation_kinds[]);
                 
     /**
        \brief Retrieve set of rules from fixedpoint context.
@@ -5896,8 +5896,8 @@ END_MLAPI_EXCLUDE
        def_API('Z3_fixedpoint_get_rules', AST_VECTOR, (_in(CONTEXT),_in(FIXEDPOINT)))
      */
     Z3_ast_vector Z3_API Z3_fixedpoint_get_rules(
-        __in Z3_context c,
-        __in Z3_fixedpoint f);
+        Z3_in Z3_context c,
+        Z3_in Z3_fixedpoint f);
 
     /**
        \brief Retrieve set of background assertions from fixedpoint context.
@@ -5905,29 +5905,29 @@ END_MLAPI_EXCLUDE
        def_API('Z3_fixedpoint_get_assertions', AST_VECTOR, (_in(CONTEXT),_in(FIXEDPOINT)))
      */
     Z3_ast_vector Z3_API Z3_fixedpoint_get_assertions(
-        __in Z3_context c,
-        __in Z3_fixedpoint f);
+        Z3_in Z3_context c,
+        Z3_in Z3_fixedpoint f);
 
     /**
        \brief Set parameters on fixedpoint context.       
 
        def_API('Z3_fixedpoint_set_params', VOID, (_in(CONTEXT), _in(FIXEDPOINT), _in(PARAMS)))
     */
-    void Z3_API Z3_fixedpoint_set_params(__in Z3_context c, __in Z3_fixedpoint f, __in Z3_params p);
+    void Z3_API Z3_fixedpoint_set_params(Z3_in Z3_context c, Z3_in Z3_fixedpoint f, Z3_in Z3_params p);
 
     /**
        \brief Return a string describing all fixedpoint available parameters.
        
        def_API('Z3_fixedpoint_get_help', STRING, (_in(CONTEXT), _in(FIXEDPOINT)))
     */
-    Z3_string Z3_API Z3_fixedpoint_get_help(__in Z3_context c, __in Z3_fixedpoint f);
+    Z3_string Z3_API Z3_fixedpoint_get_help(Z3_in Z3_context c, Z3_in Z3_fixedpoint f);
 
     /**
        \brief Return the parameter description set for the given fixedpoint object.
 
        def_API('Z3_fixedpoint_get_param_descrs', PARAM_DESCRS, (_in(CONTEXT), _in(FIXEDPOINT)))
     */
-    Z3_param_descrs Z3_API Z3_fixedpoint_get_param_descrs(__in Z3_context c, __in Z3_fixedpoint f);
+    Z3_param_descrs Z3_API Z3_fixedpoint_get_param_descrs(Z3_in Z3_context c, Z3_in Z3_fixedpoint f);
 
     /**
        \brief Print the current rules and background axioms as a string.
@@ -5939,10 +5939,10 @@ END_MLAPI_EXCLUDE
        def_API('Z3_fixedpoint_to_string', STRING, (_in(CONTEXT), _in(FIXEDPOINT), _in(UINT), _in_array(2, AST)))
     */
     Z3_string Z3_API Z3_fixedpoint_to_string(
-        __in Z3_context c, 
-        __in Z3_fixedpoint f,
-        __in unsigned num_queries,
-        __in_ecount(num_queries) Z3_ast queries[]);
+        Z3_in Z3_context c, 
+        Z3_in Z3_fixedpoint f,
+        Z3_in unsigned num_queries,
+        Z3_in_ecount(num_queries) Z3_ast queries[]);
 
     /**
        \brief Parse an SMT-LIB2 string with fixedpoint rules. 
@@ -5956,9 +5956,9 @@ END_MLAPI_EXCLUDE
        def_API('Z3_fixedpoint_from_string', AST_VECTOR, (_in(CONTEXT), _in(FIXEDPOINT), _in(STRING)))
     */
     Z3_ast_vector Z3_API Z3_fixedpoint_from_string(
-        __in Z3_context c, 
-        __in Z3_fixedpoint f,
-        __in Z3_string s);
+        Z3_in Z3_context c, 
+        Z3_in Z3_fixedpoint f,
+        Z3_in Z3_string s);
 
     /**
        \brief Parse an SMT-LIB2 file with fixedpoint rules. 
@@ -5972,9 +5972,9 @@ END_MLAPI_EXCLUDE
        def_API('Z3_fixedpoint_from_file', AST_VECTOR, (_in(CONTEXT), _in(FIXEDPOINT), _in(STRING)))
     */
     Z3_ast_vector Z3_API Z3_fixedpoint_from_file(
-        __in Z3_context c, 
-        __in Z3_fixedpoint f,
-        __in Z3_string s);
+        Z3_in Z3_context c, 
+        Z3_in Z3_fixedpoint f,
+        Z3_in Z3_string s);
 
     /**
        \brief Create a backtracking point.
@@ -6006,20 +6006,20 @@ END_MLAPI_EXCLUDE
     */
 
     typedef void Z3_fixedpoint_reduce_assign_callback_fptr(
-        __in void*, __in Z3_func_decl, 
-        __in unsigned, __in Z3_ast const [], 
-        __in unsigned, __in Z3_ast const []); 
+        Z3_in void*, Z3_in Z3_func_decl, 
+        Z3_in unsigned, Z3_in Z3_ast const [], 
+        Z3_in unsigned, Z3_in Z3_ast const []); 
 
     typedef void Z3_fixedpoint_reduce_app_callback_fptr(
-        __in void*, __in Z3_func_decl, 
-        __in unsigned, __in Z3_ast const [], 
-        __out Z3_ast*);
+        Z3_in void*, Z3_in Z3_func_decl, 
+        Z3_in unsigned, Z3_in Z3_ast const [], 
+        Z3_out Z3_ast*);
         
 
     /**
        \brief Initialize the context with a user-defined state.   
     */
-    void Z3_API Z3_fixedpoint_init(__in Z3_context c,__in Z3_fixedpoint d, __in void* state);
+    void Z3_API Z3_fixedpoint_init(Z3_in Z3_context c,Z3_in Z3_fixedpoint d, Z3_in void* state);
 
     /**
        \brief Register a callback to destructive updates.
@@ -6027,14 +6027,14 @@ END_MLAPI_EXCLUDE
        Registers are identified with terms encoded as fresh constants,          
     */
     void Z3_API Z3_fixedpoint_set_reduce_assign_callback(
-        __in Z3_context c,__in Z3_fixedpoint d, __in Z3_fixedpoint_reduce_assign_callback_fptr cb);
+        Z3_in Z3_context c,Z3_in Z3_fixedpoint d, Z3_in Z3_fixedpoint_reduce_assign_callback_fptr cb);
     
     /**
        \brief Register a callback for buildling terms based on 
        the relational operators.
     */
     void Z3_API Z3_fixedpoint_set_reduce_app_callback(
-        __in Z3_context c,__in Z3_fixedpoint d, __in Z3_fixedpoint_reduce_app_callback_fptr cb);
+        Z3_in Z3_context c,Z3_in Z3_fixedpoint d, Z3_in Z3_fixedpoint_reduce_app_callback_fptr cb);
         
 #endif
 #endif
@@ -6055,7 +6055,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_ast_vector', AST_VECTOR, (_in(CONTEXT),))
     */
-    Z3_ast_vector Z3_API Z3_mk_ast_vector(__in Z3_context c);
+    Z3_ast_vector Z3_API Z3_mk_ast_vector(Z3_in Z3_context c);
     
 #ifdef Conly
     /**
@@ -6063,14 +6063,14 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_ast_vector_inc_ref', VOID, (_in(CONTEXT), _in(AST_VECTOR)))
     */
-    void Z3_API Z3_ast_vector_inc_ref(__in Z3_context c, __in Z3_ast_vector v);
+    void Z3_API Z3_ast_vector_inc_ref(Z3_in Z3_context c, Z3_in Z3_ast_vector v);
     
     /**
        \brief Decrement the reference counter of the given AST vector.
 
        def_API('Z3_ast_vector_dec_ref', VOID, (_in(CONTEXT), _in(AST_VECTOR)))
     */
-    void Z3_API Z3_ast_vector_dec_ref(__in Z3_context c, __in Z3_ast_vector v);
+    void Z3_API Z3_ast_vector_dec_ref(Z3_in Z3_context c, Z3_in Z3_ast_vector v);
 #endif
     
     /**
@@ -6078,7 +6078,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_ast_vector_size', UINT, (_in(CONTEXT), _in(AST_VECTOR)))
     */
-    unsigned Z3_API Z3_ast_vector_size(__in Z3_context c, __in Z3_ast_vector v);
+    unsigned Z3_API Z3_ast_vector_size(Z3_in Z3_context c, Z3_in Z3_ast_vector v);
 
     /**
        \brief Return the AST at position \c i in the AST vector \c v.
@@ -6087,7 +6087,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_ast_vector_get', AST, (_in(CONTEXT), _in(AST_VECTOR), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_ast_vector_get(__in Z3_context c, __in Z3_ast_vector v, __in unsigned i);    
+    Z3_ast Z3_API Z3_ast_vector_get(Z3_in Z3_context c, Z3_in Z3_ast_vector v, Z3_in unsigned i);    
 
     /**
        \brief Update position \c i of the AST vector \c v with the AST \c a. 
@@ -6096,35 +6096,35 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_ast_vector_set', VOID, (_in(CONTEXT), _in(AST_VECTOR), _in(UINT), _in(AST)))
     */
-    void Z3_API Z3_ast_vector_set(__in Z3_context c, __in Z3_ast_vector v, __in unsigned i, __in Z3_ast a);    
+    void Z3_API Z3_ast_vector_set(Z3_in Z3_context c, Z3_in Z3_ast_vector v, Z3_in unsigned i, Z3_in Z3_ast a);    
 
     /**
        \brief Resize the AST vector \c v. 
 
        def_API('Z3_ast_vector_resize', VOID, (_in(CONTEXT), _in(AST_VECTOR), _in(UINT)))
     */
-    void Z3_API Z3_ast_vector_resize(__in Z3_context c, __in Z3_ast_vector v, __in unsigned n);
+    void Z3_API Z3_ast_vector_resize(Z3_in Z3_context c, Z3_in Z3_ast_vector v, Z3_in unsigned n);
 
     /**
        \brief Add the AST \c a in the end of the AST vector \c v. The size of \c v is increased by one.
 
        def_API('Z3_ast_vector_push', VOID, (_in(CONTEXT), _in(AST_VECTOR), _in(AST)))
     */
-    void Z3_API Z3_ast_vector_push(__in Z3_context c, __in Z3_ast_vector v, __in Z3_ast a);        
+    void Z3_API Z3_ast_vector_push(Z3_in Z3_context c, Z3_in Z3_ast_vector v, Z3_in Z3_ast a);        
 
     /**
        \brief Translate the AST vector \c v from context \c s into an AST vector in context \c t.
 
        def_API('Z3_ast_vector_translate', AST_VECTOR, (_in(CONTEXT), _in(AST_VECTOR), _in(CONTEXT)))
     */
-    Z3_ast_vector Z3_API Z3_ast_vector_translate(__in Z3_context s, __in Z3_ast_vector v, __in Z3_context t);        
+    Z3_ast_vector Z3_API Z3_ast_vector_translate(Z3_in Z3_context s, Z3_in Z3_ast_vector v, Z3_in Z3_context t);        
 
     /**
        \brief Convert AST vector into a string.
     
        def_API('Z3_ast_vector_to_string', STRING, (_in(CONTEXT), _in(AST_VECTOR)))
     */
-    Z3_string Z3_API Z3_ast_vector_to_string(__in Z3_context c, __in Z3_ast_vector v);
+    Z3_string Z3_API Z3_ast_vector_to_string(Z3_in Z3_context c, Z3_in Z3_ast_vector v);
 
     /*@}*/
 
@@ -6141,7 +6141,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_ast_map', AST_MAP, (_in(CONTEXT),) )
     */
-    Z3_ast_map Z3_API Z3_mk_ast_map(__in Z3_context c);
+    Z3_ast_map Z3_API Z3_mk_ast_map(Z3_in Z3_context c);
 
 #ifdef Conly
     /**
@@ -6149,14 +6149,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_ast_map_inc_ref', VOID, (_in(CONTEXT), _in(AST_MAP)))
     */
-    void Z3_API Z3_ast_map_inc_ref(__in Z3_context c, __in Z3_ast_map m);
+    void Z3_API Z3_ast_map_inc_ref(Z3_in Z3_context c, Z3_in Z3_ast_map m);
     
     /**
        \brief Decrement the reference counter of the given AST map.
        
        def_API('Z3_ast_map_dec_ref', VOID, (_in(CONTEXT), _in(AST_MAP)))
     */
-    void Z3_API Z3_ast_map_dec_ref(__in Z3_context c, __in Z3_ast_map m);
+    void Z3_API Z3_ast_map_dec_ref(Z3_in Z3_context c, Z3_in Z3_ast_map m);
 #endif
     
     /**
@@ -6164,7 +6164,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_ast_map_contains', BOOL, (_in(CONTEXT), _in(AST_MAP), _in(AST)))
     */
-    Z3_bool Z3_API Z3_ast_map_contains(__in Z3_context c, __in Z3_ast_map m, __in Z3_ast k);
+    Z3_bool Z3_API Z3_ast_map_contains(Z3_in Z3_context c, Z3_in Z3_ast_map m, Z3_in Z3_ast k);
 
     /**
        \brief Return the value associated with the key \c k.
@@ -6173,49 +6173,49 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_ast_map_find', AST, (_in(CONTEXT), _in(AST_MAP), _in(AST)))
     */
-    Z3_ast Z3_API Z3_ast_map_find(__in Z3_context c, __in Z3_ast_map m, __in Z3_ast k);
+    Z3_ast Z3_API Z3_ast_map_find(Z3_in Z3_context c, Z3_in Z3_ast_map m, Z3_in Z3_ast k);
 
     /**
        \brief Store/Replace a new key, value pair in the given map.
 
        def_API('Z3_ast_map_insert', VOID, (_in(CONTEXT), _in(AST_MAP), _in(AST), _in(AST)))
     */
-    void Z3_API Z3_ast_map_insert(__in Z3_context c, __in Z3_ast_map m, __in Z3_ast k, __in Z3_ast v);
+    void Z3_API Z3_ast_map_insert(Z3_in Z3_context c, Z3_in Z3_ast_map m, Z3_in Z3_ast k, Z3_in Z3_ast v);
 
     /**
        \brief Erase a key from the map.
 
        def_API('Z3_ast_map_erase', VOID, (_in(CONTEXT), _in(AST_MAP), _in(AST)))
     */
-    void Z3_API Z3_ast_map_erase(__in Z3_context c, __in Z3_ast_map m, __in Z3_ast k);
+    void Z3_API Z3_ast_map_erase(Z3_in Z3_context c, Z3_in Z3_ast_map m, Z3_in Z3_ast k);
 
     /**
        \brief Remove all keys from the given map.
 
        def_API('Z3_ast_map_reset', VOID, (_in(CONTEXT), _in(AST_MAP)))
     */
-    void Z3_API Z3_ast_map_reset(__in Z3_context c, __in Z3_ast_map m);
+    void Z3_API Z3_ast_map_reset(Z3_in Z3_context c, Z3_in Z3_ast_map m);
     
     /**
        \brief Return the size of the given map.
 
        def_API('Z3_ast_map_size', UINT, (_in(CONTEXT), _in(AST_MAP)))
     */
-    unsigned Z3_API Z3_ast_map_size(__in Z3_context c, __in Z3_ast_map m);
+    unsigned Z3_API Z3_ast_map_size(Z3_in Z3_context c, Z3_in Z3_ast_map m);
 
     /**
        \brief Return the keys stored in the given map.
        
        def_API('Z3_ast_map_keys', AST_VECTOR, (_in(CONTEXT), _in(AST_MAP)))
     */
-    Z3_ast_vector Z3_API Z3_ast_map_keys(__in Z3_context c, __in Z3_ast_map m);
+    Z3_ast_vector Z3_API Z3_ast_map_keys(Z3_in Z3_context c, Z3_in Z3_ast_map m);
 
     /**
        \brief Convert the given map into a string.
 
        def_API('Z3_ast_map_to_string', STRING, (_in(CONTEXT), _in(AST_MAP)))
     */
-    Z3_string Z3_API Z3_ast_map_to_string(__in Z3_context c, __in Z3_ast_map m);
+    Z3_string Z3_API Z3_ast_map_to_string(Z3_in Z3_context c, Z3_in Z3_ast_map m);
 
     /*@}*/
     
@@ -6241,7 +6241,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_goal', GOAL, (_in(CONTEXT), _in(BOOL), _in(BOOL), _in(BOOL)))
     */
-    Z3_goal Z3_API Z3_mk_goal(__in Z3_context c, __in Z3_bool models, __in Z3_bool unsat_cores, __in Z3_bool proofs);
+    Z3_goal Z3_API Z3_mk_goal(Z3_in Z3_context c, Z3_in Z3_bool models, Z3_in Z3_bool unsat_cores, Z3_in Z3_bool proofs);
     
 #ifdef Conly
     /**
@@ -6249,14 +6249,14 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_goal_inc_ref', VOID, (_in(CONTEXT), _in(GOAL)))
     */
-    void Z3_API Z3_goal_inc_ref(__in Z3_context c, __in Z3_goal g);
+    void Z3_API Z3_goal_inc_ref(Z3_in Z3_context c, Z3_in Z3_goal g);
 
     /**
        \brief Decrement the reference counter of the given goal.
 
        def_API('Z3_goal_dec_ref', VOID, (_in(CONTEXT), _in(GOAL)))
     */
-    void Z3_API Z3_goal_dec_ref(__in Z3_context c, __in Z3_goal g);
+    void Z3_API Z3_goal_dec_ref(Z3_in Z3_context c, Z3_in Z3_goal g);
 #endif
 
     /**
@@ -6266,42 +6266,42 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_goal_precision', UINT, (_in(CONTEXT), _in(GOAL)))
     */
-    Z3_goal_prec Z3_API Z3_goal_precision(__in Z3_context c, __in Z3_goal g);
+    Z3_goal_prec Z3_API Z3_goal_precision(Z3_in Z3_context c, Z3_in Z3_goal g);
 
     /**
        \brief Add a new formula \c a to the given goal. 
        
        def_API('Z3_goal_assert', VOID, (_in(CONTEXT), _in(GOAL), _in(AST)))
     */
-    void Z3_API Z3_goal_assert(__in Z3_context c, __in Z3_goal g, __in Z3_ast a);
+    void Z3_API Z3_goal_assert(Z3_in Z3_context c, Z3_in Z3_goal g, Z3_in Z3_ast a);
     
     /**
        \brief Return true if the given goal contains the formula \c false.
 
        def_API('Z3_goal_inconsistent', BOOL, (_in(CONTEXT), _in(GOAL)))
     */
-    Z3_bool Z3_API Z3_goal_inconsistent(__in Z3_context c, __in Z3_goal g);
+    Z3_bool Z3_API Z3_goal_inconsistent(Z3_in Z3_context c, Z3_in Z3_goal g);
 
     /**
        \brief Return the depth of the given goal. It tracks how many transformations were applied to it.
 
        def_API('Z3_goal_depth', UINT, (_in(CONTEXT), _in(GOAL)))
     */
-    unsigned Z3_API Z3_goal_depth(__in Z3_context c, __in Z3_goal g);
+    unsigned Z3_API Z3_goal_depth(Z3_in Z3_context c, Z3_in Z3_goal g);
 
     /**
        \brief Erase all formulas from the given goal.
        
        def_API('Z3_goal_reset', VOID, (_in(CONTEXT), _in(GOAL)))
     */
-    void Z3_API Z3_goal_reset(__in Z3_context c, __in Z3_goal g);
+    void Z3_API Z3_goal_reset(Z3_in Z3_context c, Z3_in Z3_goal g);
 
     /**
        \brief Return the number of formulas in the given goal.
 
        def_API('Z3_goal_size', UINT, (_in(CONTEXT), _in(GOAL)))
     */
-    unsigned Z3_API Z3_goal_size(__in Z3_context c, __in Z3_goal g);
+    unsigned Z3_API Z3_goal_size(Z3_in Z3_context c, Z3_in Z3_goal g);
     
     /**
        \brief Return a formula from the given goal.
@@ -6310,42 +6310,42 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_goal_formula', AST, (_in(CONTEXT), _in(GOAL), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_goal_formula(__in Z3_context c, __in Z3_goal g, __in unsigned idx);
+    Z3_ast Z3_API Z3_goal_formula(Z3_in Z3_context c, Z3_in Z3_goal g, Z3_in unsigned idx);
     
     /**
        \brief Return the number of formulas, subformulas and terms in the given goal.
 
        def_API('Z3_goal_num_exprs', UINT, (_in(CONTEXT), _in(GOAL)))
     */
-    unsigned Z3_API Z3_goal_num_exprs(__in Z3_context c, __in Z3_goal g);
+    unsigned Z3_API Z3_goal_num_exprs(Z3_in Z3_context c, Z3_in Z3_goal g);
     
     /**
        \brief Return true if the goal is empty, and it is precise or the product of a under approximation.
 
        def_API('Z3_goal_is_decided_sat', BOOL, (_in(CONTEXT), _in(GOAL)))
     */
-    Z3_bool Z3_API Z3_goal_is_decided_sat(__in Z3_context c, __in Z3_goal g);
+    Z3_bool Z3_API Z3_goal_is_decided_sat(Z3_in Z3_context c, Z3_in Z3_goal g);
     
     /**
        \brief Return true if the goal contains false, and it is precise or the product of an over approximation.
 
        def_API('Z3_goal_is_decided_unsat', BOOL, (_in(CONTEXT), _in(GOAL)))
     */
-    Z3_bool Z3_API Z3_goal_is_decided_unsat(__in Z3_context c, __in Z3_goal g);
+    Z3_bool Z3_API Z3_goal_is_decided_unsat(Z3_in Z3_context c, Z3_in Z3_goal g);
 
     /**
        \brief Copy a goal \c g from the context \c source to a the context \c target.
 
        def_API('Z3_goal_translate', GOAL, (_in(CONTEXT), _in(GOAL), _in(CONTEXT)))
     */
-    Z3_goal Z3_API Z3_goal_translate(__in Z3_context source, __in Z3_goal g, __in Z3_context target);
+    Z3_goal Z3_API Z3_goal_translate(Z3_in Z3_context source, Z3_in Z3_goal g, Z3_in Z3_context target);
     
     /**
        \brief Convert a goal into a string.
 
        def_API('Z3_goal_to_string', STRING, (_in(CONTEXT), _in(GOAL)))
     */
-    Z3_string Z3_API Z3_goal_to_string(__in Z3_context c, __in Z3_goal g);
+    Z3_string Z3_API Z3_goal_to_string(Z3_in Z3_context c, Z3_in Z3_goal g);
 
     /*@}*/
 
@@ -6363,7 +6363,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_tactic', TACTIC, (_in(CONTEXT), _in(STRING)))
     */
-    Z3_tactic Z3_API Z3_mk_tactic(__in Z3_context c, __in Z3_string name);
+    Z3_tactic Z3_API Z3_mk_tactic(Z3_in Z3_context c, Z3_in Z3_string name);
 
 #ifdef Conly
     /**
@@ -6371,14 +6371,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_tactic_inc_ref', VOID, (_in(CONTEXT), _in(TACTIC)))
     */
-    void Z3_API Z3_tactic_inc_ref(__in Z3_context c, __in Z3_tactic t);
+    void Z3_API Z3_tactic_inc_ref(Z3_in Z3_context c, Z3_in Z3_tactic t);
 
     /**
        \brief Decrement the reference counter of the given tactic.
        
        def_API('Z3_tactic_dec_ref', VOID, (_in(CONTEXT), _in(TACTIC)))
     */
-    void Z3_API Z3_tactic_dec_ref(__in Z3_context c, __in Z3_tactic g);
+    void Z3_API Z3_tactic_dec_ref(Z3_in Z3_context c, Z3_in Z3_tactic g);
 #endif
     
     /**
@@ -6391,7 +6391,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_probe', PROBE, (_in(CONTEXT), _in(STRING)))
     */
-    Z3_probe Z3_API Z3_mk_probe(__in Z3_context c, __in Z3_string name);
+    Z3_probe Z3_API Z3_mk_probe(Z3_in Z3_context c, Z3_in Z3_string name);
 
 #ifdef Conly
     /**
@@ -6399,14 +6399,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_probe_inc_ref', VOID, (_in(CONTEXT), _in(PROBE)))
     */
-    void Z3_API Z3_probe_inc_ref(__in Z3_context c, __in Z3_probe p);
+    void Z3_API Z3_probe_inc_ref(Z3_in Z3_context c, Z3_in Z3_probe p);
 
     /**
        \brief Decrement the reference counter of the given probe.
 
        def_API('Z3_probe_dec_ref', VOID, (_in(CONTEXT), _in(PROBE)))
     */
-    void Z3_API Z3_probe_dec_ref(__in Z3_context c, __in Z3_probe p);
+    void Z3_API Z3_probe_dec_ref(Z3_in Z3_context c, Z3_in Z3_probe p);
 #endif
 
     /**
@@ -6415,7 +6415,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_tactic_and_then', TACTIC, (_in(CONTEXT), _in(TACTIC), _in(TACTIC)))
     */
-    Z3_tactic Z3_API Z3_tactic_and_then(__in Z3_context c, __in Z3_tactic t1, __in Z3_tactic t2);
+    Z3_tactic Z3_API Z3_tactic_and_then(Z3_in Z3_context c, Z3_in Z3_tactic t1, Z3_in Z3_tactic t2);
 
     /**
        \brief Return a tactic that first applies \c t1 to a given goal,
@@ -6423,14 +6423,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_tactic_or_else', TACTIC, (_in(CONTEXT), _in(TACTIC), _in(TACTIC)))
     */
-    Z3_tactic Z3_API Z3_tactic_or_else(__in Z3_context c, __in Z3_tactic t1, __in Z3_tactic t2);
+    Z3_tactic Z3_API Z3_tactic_or_else(Z3_in Z3_context c, Z3_in Z3_tactic t1, Z3_in Z3_tactic t2);
 
     /**
        \brief Return a tactic that applies the given tactics in parallel.
 
        def_API('Z3_tactic_par_or', TACTIC, (_in(CONTEXT), _in(UINT), _in_array(1, TACTIC)))
     */
-    Z3_tactic Z3_API Z3_tactic_par_or(__in Z3_context c, __in unsigned num, __in_ecount(num) Z3_tactic const ts[]);
+    Z3_tactic Z3_API Z3_tactic_par_or(Z3_in Z3_context c, Z3_in unsigned num, Z3_in_ecount(num) Z3_tactic const ts[]);
 
     /**
        \brief Return a tactic that applies \c t1 to a given goal and then \c t2
@@ -6438,7 +6438,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_tactic_par_and_then', TACTIC, (_in(CONTEXT), _in(TACTIC), _in(TACTIC)))
     */
-    Z3_tactic Z3_API Z3_tactic_par_and_then(__in Z3_context c, __in Z3_tactic t1, __in Z3_tactic t2);
+    Z3_tactic Z3_API Z3_tactic_par_and_then(Z3_in Z3_context c, Z3_in Z3_tactic t1, Z3_in Z3_tactic t2);
     
     /**
        \brief Return a tactic that applies \c t to a given goal for \c ms milliseconds.
@@ -6446,7 +6446,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_tactic_try_for', TACTIC, (_in(CONTEXT), _in(TACTIC), _in(UINT)))
      */
-    Z3_tactic Z3_API Z3_tactic_try_for(__in Z3_context c, __in Z3_tactic t, __in unsigned ms);
+    Z3_tactic Z3_API Z3_tactic_try_for(Z3_in Z3_context c, Z3_in Z3_tactic t, Z3_in unsigned ms);
 
     /**
        \brief Return a tactic that applies \c t to a given goal is the probe \c p evaluates to true.
@@ -6454,7 +6454,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_tactic_when', TACTIC, (_in(CONTEXT), _in(PROBE), _in(TACTIC)))
     */
-    Z3_tactic Z3_API Z3_tactic_when(__in Z3_context c, __in Z3_probe p, __in Z3_tactic t);
+    Z3_tactic Z3_API Z3_tactic_when(Z3_in Z3_context c, Z3_in Z3_probe p, Z3_in Z3_tactic t);
     
     /**
        \brief Return a tactic that applies \c t1 to a given goal if the probe \c p evaluates to true,
@@ -6462,7 +6462,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_tactic_cond', TACTIC, (_in(CONTEXT), _in(PROBE), _in(TACTIC), _in(TACTIC)))
      */
-    Z3_tactic Z3_API Z3_tactic_cond(__in Z3_context c, __in Z3_probe p, __in Z3_tactic t1, __in Z3_tactic t2);
+    Z3_tactic Z3_API Z3_tactic_cond(Z3_in Z3_context c, Z3_in Z3_probe p, Z3_in Z3_tactic t1, Z3_in Z3_tactic t2);
     
     /**
        \brief Return a tactic that keeps applying \c t until the goal is not modified anymore or the maximum
@@ -6470,28 +6470,28 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_tactic_repeat', TACTIC, (_in(CONTEXT), _in(TACTIC), _in(UINT)))
     */
-    Z3_tactic Z3_API Z3_tactic_repeat(__in Z3_context c, __in Z3_tactic t, unsigned max);
+    Z3_tactic Z3_API Z3_tactic_repeat(Z3_in Z3_context c, Z3_in Z3_tactic t, unsigned max);
 
     /**
        \brief Return a tactic that just return the given goal.
 
        def_API('Z3_tactic_skip', TACTIC, (_in(CONTEXT),))
     */
-    Z3_tactic Z3_API Z3_tactic_skip(__in Z3_context c);
+    Z3_tactic Z3_API Z3_tactic_skip(Z3_in Z3_context c);
 
     /**
        \brief Return a tactic that always fails.
 
        def_API('Z3_tactic_fail', TACTIC, (_in(CONTEXT),))
     */
-    Z3_tactic Z3_API Z3_tactic_fail(__in Z3_context c);
+    Z3_tactic Z3_API Z3_tactic_fail(Z3_in Z3_context c);
 
     /**
        \brief Return a tactic that fails if the probe \c p evaluates to false.
 
        def_API('Z3_tactic_fail_if', TACTIC, (_in(CONTEXT), _in(PROBE)))
     */
-    Z3_tactic Z3_API Z3_tactic_fail_if(__in Z3_context c, __in Z3_probe p);
+    Z3_tactic Z3_API Z3_tactic_fail_if(Z3_in Z3_context c, Z3_in Z3_probe p);
 
     /**
        \brief Return a tactic that fails if the goal is not trivially satisfiable (i.e., empty) or
@@ -6499,21 +6499,21 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_tactic_fail_if_not_decided', TACTIC, (_in(CONTEXT),))
     */
-    Z3_tactic Z3_API Z3_tactic_fail_if_not_decided(__in Z3_context c);
+    Z3_tactic Z3_API Z3_tactic_fail_if_not_decided(Z3_in Z3_context c);
 
     /**
        \brief Return a tactic that applies \c t using the given set of parameters.
 
        def_API('Z3_tactic_using_params', TACTIC, (_in(CONTEXT), _in(TACTIC), _in(PARAMS)))
     */
-    Z3_tactic Z3_API Z3_tactic_using_params(__in Z3_context c, __in Z3_tactic t, __in Z3_params p);
+    Z3_tactic Z3_API Z3_tactic_using_params(Z3_in Z3_context c, Z3_in Z3_tactic t, Z3_in Z3_params p);
 
     /**
        \brief Return a probe that always evaluates to val.
 
        def_API('Z3_probe_const', PROBE, (_in(CONTEXT), _in(DOUBLE)))
     */
-    Z3_probe Z3_API Z3_probe_const(__in Z3_context x, __in double val);
+    Z3_probe Z3_API Z3_probe_const(Z3_in Z3_context x, Z3_in double val);
 
     /**
        \brief Return a probe that evaluates to "true" when the value returned by \c p1 is less than the value returned by \c p2.
@@ -6522,7 +6522,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_probe_lt', PROBE, (_in(CONTEXT), _in(PROBE), _in(PROBE)))
     */
-    Z3_probe Z3_API Z3_probe_lt(__in Z3_context x, __in Z3_probe p1, __in Z3_probe p2);
+    Z3_probe Z3_API Z3_probe_lt(Z3_in Z3_context x, Z3_in Z3_probe p1, Z3_in Z3_probe p2);
 
     /**
        \brief Return a probe that evaluates to "true" when the value returned by \c p1 is greater than the value returned by \c p2.
@@ -6531,7 +6531,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_probe_gt', PROBE, (_in(CONTEXT), _in(PROBE), _in(PROBE)))
     */
-    Z3_probe Z3_API Z3_probe_gt(__in Z3_context x, __in Z3_probe p1, __in Z3_probe p2);
+    Z3_probe Z3_API Z3_probe_gt(Z3_in Z3_context x, Z3_in Z3_probe p1, Z3_in Z3_probe p2);
 
     /**
        \brief Return a probe that evaluates to "true" when the value returned by \c p1 is less than or equal to the value returned by \c p2.
@@ -6540,7 +6540,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_probe_le', PROBE, (_in(CONTEXT), _in(PROBE), _in(PROBE)))
     */
-    Z3_probe Z3_API Z3_probe_le(__in Z3_context x, __in Z3_probe p1, __in Z3_probe p2);
+    Z3_probe Z3_API Z3_probe_le(Z3_in Z3_context x, Z3_in Z3_probe p1, Z3_in Z3_probe p2);
 
     /**
        \brief Return a probe that evaluates to "true" when the value returned by \c p1 is greater than or equal to the value returned by \c p2.
@@ -6549,7 +6549,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_probe_ge', PROBE, (_in(CONTEXT), _in(PROBE), _in(PROBE))) 
     */
-    Z3_probe Z3_API Z3_probe_ge(__in Z3_context x, __in Z3_probe p1, __in Z3_probe p2);
+    Z3_probe Z3_API Z3_probe_ge(Z3_in Z3_context x, Z3_in Z3_probe p1, Z3_in Z3_probe p2);
 
     /**
        \brief Return a probe that evaluates to "true" when the value returned by \c p1 is equal to the value returned by \c p2.
@@ -6558,7 +6558,7 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_probe_eq', PROBE, (_in(CONTEXT), _in(PROBE), _in(PROBE)))
     */
-    Z3_probe Z3_API Z3_probe_eq(__in Z3_context x, __in Z3_probe p1, __in Z3_probe p2);
+    Z3_probe Z3_API Z3_probe_eq(Z3_in Z3_context x, Z3_in Z3_probe p1, Z3_in Z3_probe p2);
 
     /**
        \brief Return a probe that evaluates to "true" when \c p1 and \c p2 evaluates to true.
@@ -6567,7 +6567,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_probe_and', PROBE, (_in(CONTEXT), _in(PROBE), _in(PROBE)))
     */
-    Z3_probe Z3_API Z3_probe_and(__in Z3_context x, __in Z3_probe p1, __in Z3_probe p2);
+    Z3_probe Z3_API Z3_probe_and(Z3_in Z3_context x, Z3_in Z3_probe p1, Z3_in Z3_probe p2);
  
     /**
        \brief Return a probe that evaluates to "true" when \c p1 or \c p2 evaluates to true.
@@ -6576,7 +6576,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_probe_or', PROBE, (_in(CONTEXT), _in(PROBE), _in(PROBE)))
     */
-    Z3_probe Z3_API Z3_probe_or(__in Z3_context x, __in Z3_probe p1, __in Z3_probe p2);
+    Z3_probe Z3_API Z3_probe_or(Z3_in Z3_context x, Z3_in Z3_probe p1, Z3_in Z3_probe p2);
 
     /**
        \brief Return a probe that evaluates to "true" when \c p does not evaluate to true.
@@ -6585,14 +6585,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_probe_not', PROBE, (_in(CONTEXT), _in(PROBE)))
     */
-    Z3_probe Z3_API Z3_probe_not(__in Z3_context x, __in Z3_probe p);
+    Z3_probe Z3_API Z3_probe_not(Z3_in Z3_context x, Z3_in Z3_probe p);
 
     /**
        \brief Return the number of builtin tactics available in Z3.
 
        def_API('Z3_get_num_tactics', UINT, (_in(CONTEXT),))
     */
-    unsigned Z3_API Z3_get_num_tactics(__in Z3_context c);
+    unsigned Z3_API Z3_get_num_tactics(Z3_in Z3_context c);
 
     /**
        \brief Return the name of the idx tactic.
@@ -6601,14 +6601,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_tactic_name', STRING, (_in(CONTEXT), _in(UINT)))
     */
-    Z3_string Z3_API Z3_get_tactic_name(__in Z3_context c, unsigned i);
+    Z3_string Z3_API Z3_get_tactic_name(Z3_in Z3_context c, unsigned i);
 
     /**
        \brief Return the number of builtin probes available in Z3.
 
        def_API('Z3_get_num_probes', UINT, (_in(CONTEXT),))
     */
-    unsigned Z3_API Z3_get_num_probes(__in Z3_context c);
+    unsigned Z3_API Z3_get_num_probes(Z3_in Z3_context c);
 
     /**
        \brief Return the name of the i probe.
@@ -6617,35 +6617,35 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_get_probe_name', STRING, (_in(CONTEXT), _in(UINT)))
     */
-    Z3_string Z3_API Z3_get_probe_name(__in Z3_context c, unsigned i);
+    Z3_string Z3_API Z3_get_probe_name(Z3_in Z3_context c, unsigned i);
 
     /**
        \brief Return a string containing a description of parameters accepted by the given tactic.
 
        def_API('Z3_tactic_get_help', STRING, (_in(CONTEXT), _in(TACTIC)))
     */
-    Z3_string Z3_API Z3_tactic_get_help(__in Z3_context c, __in Z3_tactic t);
+    Z3_string Z3_API Z3_tactic_get_help(Z3_in Z3_context c, Z3_in Z3_tactic t);
 
     /**
        \brief Return the parameter description set for the given tactic object.
 
        def_API('Z3_tactic_get_param_descrs', PARAM_DESCRS, (_in(CONTEXT), _in(TACTIC)))
     */
-    Z3_param_descrs Z3_API Z3_tactic_get_param_descrs(__in Z3_context c, __in Z3_tactic t);
+    Z3_param_descrs Z3_API Z3_tactic_get_param_descrs(Z3_in Z3_context c, Z3_in Z3_tactic t);
 
     /**
        \brief Return a string containing a description of the tactic with the given name.
 
        def_API('Z3_tactic_get_descr', STRING, (_in(CONTEXT), _in(STRING)))
     */
-    Z3_string Z3_API Z3_tactic_get_descr(__in Z3_context c, __in Z3_string name);
+    Z3_string Z3_API Z3_tactic_get_descr(Z3_in Z3_context c, Z3_in Z3_string name);
     
     /**
        \brief Return a string containing a description of the probe with the given name.
 
        def_API('Z3_probe_get_descr', STRING, (_in(CONTEXT), _in(STRING)))
     */
-    Z3_string Z3_API Z3_probe_get_descr(__in Z3_context c, __in Z3_string name);
+    Z3_string Z3_API Z3_probe_get_descr(Z3_in Z3_context c, Z3_in Z3_string name);
 
     /**
        \brief Execute the probe over the goal. The probe always produce a double value.
@@ -6653,14 +6653,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_probe_apply', DOUBLE, (_in(CONTEXT), _in(PROBE), _in(GOAL)))
     */
-    double Z3_API Z3_probe_apply(__in Z3_context c, __in Z3_probe p, __in Z3_goal g);
+    double Z3_API Z3_probe_apply(Z3_in Z3_context c, Z3_in Z3_probe p, Z3_in Z3_goal g);
 
     /**
        \brief Apply tactic \c t to the goal \c g.
        
        def_API('Z3_tactic_apply', APPLY_RESULT, (_in(CONTEXT), _in(TACTIC), _in(GOAL)))
     */
-    Z3_apply_result Z3_API Z3_tactic_apply(__in Z3_context c, __in Z3_tactic t, __in Z3_goal g);
+    Z3_apply_result Z3_API Z3_tactic_apply(Z3_in Z3_context c, Z3_in Z3_tactic t, Z3_in Z3_goal g);
 
     /**
        \brief Apply tactic \c t to the goal \c g using the parameter set \c p.
@@ -6675,14 +6675,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_apply_result_inc_ref', VOID, (_in(CONTEXT), _in(APPLY_RESULT)))
     */
-    void Z3_API Z3_apply_result_inc_ref(__in Z3_context c, __in Z3_apply_result r);
+    void Z3_API Z3_apply_result_inc_ref(Z3_in Z3_context c, Z3_in Z3_apply_result r);
 
     /**
        \brief Decrement the reference counter of the given \c Z3_apply_result object.
 
        def_API('Z3_apply_result_dec_ref', VOID, (_in(CONTEXT), _in(APPLY_RESULT)))
     */
-    void Z3_API Z3_apply_result_dec_ref(__in Z3_context c, __in Z3_apply_result r);
+    void Z3_API Z3_apply_result_dec_ref(Z3_in Z3_context c, Z3_in Z3_apply_result r);
 #endif
     
     /**
@@ -6690,14 +6690,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_apply_result_to_string', STRING, (_in(CONTEXT), _in(APPLY_RESULT)))
     */
-    Z3_string Z3_API Z3_apply_result_to_string(__in Z3_context c, __in Z3_apply_result r);
+    Z3_string Z3_API Z3_apply_result_to_string(Z3_in Z3_context c, Z3_in Z3_apply_result r);
     
     /**
        \brief Return the number of subgoals in the \c Z3_apply_result object returned by #Z3_tactic_apply.
 
        def_API('Z3_apply_result_get_num_subgoals', UINT, (_in(CONTEXT), _in(APPLY_RESULT)))
     */
-    unsigned Z3_API Z3_apply_result_get_num_subgoals(__in Z3_context c, __in Z3_apply_result r);
+    unsigned Z3_API Z3_apply_result_get_num_subgoals(Z3_in Z3_context c, Z3_in Z3_apply_result r);
 
     /**
        \brief Return one of the subgoals in the \c Z3_apply_result object returned by #Z3_tactic_apply.
@@ -6706,7 +6706,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_apply_result_get_subgoal', GOAL, (_in(CONTEXT), _in(APPLY_RESULT), _in(UINT)))
     */ 
-    Z3_goal Z3_API Z3_apply_result_get_subgoal(__in Z3_context c, __in Z3_apply_result r, __in unsigned i);
+    Z3_goal Z3_API Z3_apply_result_get_subgoal(Z3_in Z3_context c, Z3_in Z3_apply_result r, Z3_in unsigned i);
     
     /**
        \brief Convert a model for the subgoal \c Z3_apply_result_get_subgoal(c, r, i) into a model for the original goal \c g.
@@ -6714,7 +6714,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_apply_result_convert_model', MODEL, (_in(CONTEXT), _in(APPLY_RESULT), _in(UINT), _in(MODEL)))
     */
-    Z3_model Z3_API Z3_apply_result_convert_model(__in Z3_context c, __in Z3_apply_result r, __in unsigned i, __in Z3_model m);
+    Z3_model Z3_API Z3_apply_result_convert_model(Z3_in Z3_context c, Z3_in Z3_apply_result r, Z3_in unsigned i, Z3_in Z3_model m);
 
     /*@}*/
 
@@ -6733,7 +6733,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_solver', SOLVER, (_in(CONTEXT),))
     */
-    Z3_solver Z3_API Z3_mk_solver(__in Z3_context c);
+    Z3_solver Z3_API Z3_mk_solver(Z3_in Z3_context c);
 
     /**
        \brief Create a new (incremental) solver.
@@ -6747,7 +6747,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_simple_solver', SOLVER, (_in(CONTEXT),))
     */
-    Z3_solver Z3_API Z3_mk_simple_solver(__in Z3_context c);
+    Z3_solver Z3_API Z3_mk_simple_solver(Z3_in Z3_context c);
 
     /**
        \brief Create a new solver customized for the given logic.
@@ -6758,7 +6758,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_solver_for_logic', SOLVER, (_in(CONTEXT), _in(SYMBOL)))
     */
-    Z3_solver Z3_API Z3_mk_solver_for_logic(__in Z3_context c, __in Z3_symbol logic);
+    Z3_solver Z3_API Z3_mk_solver_for_logic(Z3_in Z3_context c, Z3_in Z3_symbol logic);
 
     /**
        \brief Create a new solver that is implemented using the given tactic.
@@ -6767,28 +6767,28 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_solver_from_tactic', SOLVER, (_in(CONTEXT), _in(TACTIC)))
     */
-    Z3_solver Z3_API Z3_mk_solver_from_tactic(__in Z3_context c, __in Z3_tactic t);
+    Z3_solver Z3_API Z3_mk_solver_from_tactic(Z3_in Z3_context c, Z3_in Z3_tactic t);
 
     /**
        \brief Return a string describing all solver available parameters.
 
        def_API('Z3_solver_get_help', STRING, (_in(CONTEXT), _in(SOLVER)))
     */
-    Z3_string Z3_API Z3_solver_get_help(__in Z3_context c, __in Z3_solver s);
+    Z3_string Z3_API Z3_solver_get_help(Z3_in Z3_context c, Z3_in Z3_solver s);
 
     /**
        \brief Return the parameter description set for the given solver object.
 
        def_API('Z3_solver_get_param_descrs', PARAM_DESCRS, (_in(CONTEXT), _in(SOLVER)))
     */
-    Z3_param_descrs Z3_API Z3_solver_get_param_descrs(__in Z3_context c, __in Z3_solver s);
+    Z3_param_descrs Z3_API Z3_solver_get_param_descrs(Z3_in Z3_context c, Z3_in Z3_solver s);
 
     /**
        \brief Set the given solver using the given parameters.
 
        def_API('Z3_solver_set_params', VOID, (_in(CONTEXT), _in(SOLVER), _in(PARAMS)))
     */
-    void Z3_API Z3_solver_set_params(__in Z3_context c, __in Z3_solver s, __in Z3_params p);
+    void Z3_API Z3_solver_set_params(Z3_in Z3_context c, Z3_in Z3_solver s, Z3_in Z3_params p);
     
 #ifdef Conly
     /**
@@ -6796,14 +6796,14 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_solver_inc_ref', VOID, (_in(CONTEXT), _in(SOLVER)))
     */
-    void Z3_API Z3_solver_inc_ref(__in Z3_context c, __in Z3_solver s);
+    void Z3_API Z3_solver_inc_ref(Z3_in Z3_context c, Z3_in Z3_solver s);
 
     /**
        \brief Decrement the reference counter of the given solver.
 
        def_API('Z3_solver_dec_ref', VOID, (_in(CONTEXT), _in(SOLVER)))
     */
-    void Z3_API Z3_solver_dec_ref(__in Z3_context c, __in Z3_solver s);
+    void Z3_API Z3_solver_dec_ref(Z3_in Z3_context c, Z3_in Z3_solver s);
 #endif
     
     /**
@@ -6815,7 +6815,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_solver_push', VOID, (_in(CONTEXT), _in(SOLVER)))
     */
-    void Z3_API Z3_solver_push(__in Z3_context c, __in Z3_solver s);
+    void Z3_API Z3_solver_push(Z3_in Z3_context c, Z3_in Z3_solver s);
 
     /**
        \brief Backtrack \c n backtracking points.
@@ -6826,14 +6826,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_solver_pop', VOID, (_in(CONTEXT), _in(SOLVER), _in(UINT)))
     */
-    void Z3_API Z3_solver_pop(__in Z3_context c, __in Z3_solver s, unsigned n);
+    void Z3_API Z3_solver_pop(Z3_in Z3_context c, Z3_in Z3_solver s, unsigned n);
 
     /**
        \brief Remove all assertions from the solver.
 
        def_API('Z3_solver_reset', VOID, (_in(CONTEXT), _in(SOLVER)))
     */
-    void Z3_API Z3_solver_reset(__in Z3_context c, __in Z3_solver s);
+    void Z3_API Z3_solver_reset(Z3_in Z3_context c, Z3_in Z3_solver s);
     
     /**
        \brief Return the number of backtracking points.
@@ -6843,7 +6843,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_solver_get_num_scopes', UINT, (_in(CONTEXT), _in(SOLVER)))
     */
-    unsigned Z3_API Z3_solver_get_num_scopes(__in Z3_context c, __in Z3_solver s);
+    unsigned Z3_API Z3_solver_get_num_scopes(Z3_in Z3_context c, Z3_in Z3_solver s);
     
     /**
        \brief Assert a constraint into the solver.
@@ -6853,7 +6853,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_solver_assert', VOID, (_in(CONTEXT), _in(SOLVER), _in(AST)))
     */
-    void Z3_API Z3_solver_assert(__in Z3_context c, __in Z3_solver s, __in Z3_ast a);
+    void Z3_API Z3_solver_assert(Z3_in Z3_context c, Z3_in Z3_solver s, Z3_in Z3_ast a);
 
     /**
        \brief Assert a constraint \c a into the solver, and track it (in the unsat) core using
@@ -6869,14 +6869,14 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_solver_assert_and_track', VOID, (_in(CONTEXT), _in(SOLVER), _in(AST), _in(AST)))
     */
-    void Z3_API Z3_solver_assert_and_track(__in Z3_context c, __in Z3_solver s, __in Z3_ast a, __in Z3_ast p);
+    void Z3_API Z3_solver_assert_and_track(Z3_in Z3_context c, Z3_in Z3_solver s, Z3_in Z3_ast a, Z3_in Z3_ast p);
     
     /**
        \brief Return the set of asserted formulas as a goal object.
     
        def_API('Z3_solver_get_assertions', AST_VECTOR, (_in(CONTEXT), _in(SOLVER)))       
     */
-    Z3_ast_vector Z3_API Z3_solver_get_assertions(__in Z3_context c, __in Z3_solver s);
+    Z3_ast_vector Z3_API Z3_solver_get_assertions(Z3_in Z3_context c, Z3_in Z3_solver s);
     
     /**
        \brief Check whether the assertions in a given solver are consistent or not.
@@ -6894,7 +6894,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_solver_check', INT, (_in(CONTEXT), _in(SOLVER)))
     */
-    Z3_lbool Z3_API Z3_solver_check(__in Z3_context c, __in Z3_solver s);
+    Z3_lbool Z3_API Z3_solver_check(Z3_in Z3_context c, Z3_in Z3_solver s);
 
     /**
        \brief Check whether the assertions in the given solver and
@@ -6907,8 +6907,8 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_solver_check_assumptions', INT, (_in(CONTEXT), _in(SOLVER), _in(UINT), _in_array(2, AST)))
     */
-    Z3_lbool Z3_API Z3_solver_check_assumptions(__in Z3_context c, __in Z3_solver s, 
-                                                __in unsigned num_assumptions, __in_ecount(num_assumptions) Z3_ast const assumptions[]);
+    Z3_lbool Z3_API Z3_solver_check_assumptions(Z3_in Z3_context c, Z3_in Z3_solver s, 
+                                                Z3_in unsigned num_assumptions, Z3_in_ecount(num_assumptions) Z3_ast const assumptions[]);
 
     /**
        \brief Retrieve the model for the last #Z3_solver_check or #Z3_solver_check_assumptions
@@ -6918,7 +6918,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_solver_get_model', MODEL, (_in(CONTEXT), _in(SOLVER)))
     */
-    Z3_model Z3_API Z3_solver_get_model(__in Z3_context c, __in Z3_solver s);
+    Z3_model Z3_API Z3_solver_get_model(Z3_in Z3_context c, Z3_in Z3_solver s);
 
     /**
        \brief Retrieve the proof for the last #Z3_solver_check or #Z3_solver_check_assumptions
@@ -6929,7 +6929,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_solver_get_proof', AST, (_in(CONTEXT), _in(SOLVER)))
     */
-    Z3_ast Z3_API Z3_solver_get_proof(__in Z3_context c, __in Z3_solver s);
+    Z3_ast Z3_API Z3_solver_get_proof(Z3_in Z3_context c, Z3_in Z3_solver s);
 
     /**
        \brief Retrieve the unsat core for the last #Z3_solver_check_assumptions
@@ -6937,7 +6937,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_solver_get_unsat_core', AST_VECTOR, (_in(CONTEXT), _in(SOLVER)))
     */
-    Z3_ast_vector Z3_API Z3_solver_get_unsat_core(__in Z3_context c, __in Z3_solver s);
+    Z3_ast_vector Z3_API Z3_solver_get_unsat_core(Z3_in Z3_context c, Z3_in Z3_solver s);
     
     /**
        \brief Return a brief justification for an "unknown" result (i.e., Z3_L_UNDEF) for
@@ -6945,7 +6945,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_solver_get_reason_unknown', STRING, (_in(CONTEXT), _in(SOLVER)))
     */
-    Z3_string Z3_API Z3_solver_get_reason_unknown(__in Z3_context c, __in Z3_solver s);
+    Z3_string Z3_API Z3_solver_get_reason_unknown(Z3_in Z3_context c, Z3_in Z3_solver s);
     
     /**
        \brief Return statistics for the given solver.
@@ -6954,14 +6954,14 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_solver_get_statistics', STATS, (_in(CONTEXT), _in(SOLVER)))
     */
-    Z3_stats Z3_API Z3_solver_get_statistics(__in Z3_context c, __in Z3_solver s);
+    Z3_stats Z3_API Z3_solver_get_statistics(Z3_in Z3_context c, Z3_in Z3_solver s);
     
     /**
        \brief Convert a solver into a string.
 
        def_API('Z3_solver_to_string', STRING, (_in(CONTEXT), _in(SOLVER)))
     */
-    Z3_string Z3_API Z3_solver_to_string(__in Z3_context c, __in Z3_solver s);
+    Z3_string Z3_API Z3_solver_to_string(Z3_in Z3_context c, Z3_in Z3_solver s);
 
     /*@}*/
 
@@ -6978,7 +6978,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_stats_to_string', STRING, (_in(CONTEXT), _in(STATS)))
     */
-    Z3_string Z3_API Z3_stats_to_string(__in Z3_context c, __in Z3_stats s);
+    Z3_string Z3_API Z3_stats_to_string(Z3_in Z3_context c, Z3_in Z3_stats s);
     
     /**
        \mlonly {4 {L Low-level API}} \endmlonly
@@ -6990,14 +6990,14 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_stats_inc_ref', VOID, (_in(CONTEXT), _in(STATS)))
     */
-    void Z3_API Z3_stats_inc_ref(__in Z3_context c, __in Z3_stats s);
+    void Z3_API Z3_stats_inc_ref(Z3_in Z3_context c, Z3_in Z3_stats s);
 
     /**
        \brief Decrement the reference counter of the given statistics object.
 
        def_API('Z3_stats_dec_ref', VOID, (_in(CONTEXT), _in(STATS)))
     */
-    void Z3_API Z3_stats_dec_ref(__in Z3_context c, __in Z3_stats s);
+    void Z3_API Z3_stats_dec_ref(Z3_in Z3_context c, Z3_in Z3_stats s);
 #endif
     
     /**
@@ -7005,7 +7005,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_stats_size', UINT, (_in(CONTEXT), _in(STATS)))
     */
-    unsigned Z3_API Z3_stats_size(__in Z3_context c, __in Z3_stats s);
+    unsigned Z3_API Z3_stats_size(Z3_in Z3_context c, Z3_in Z3_stats s);
 
     /**
        \brief Return the key (a string) for a particular statistical data.
@@ -7014,7 +7014,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_stats_get_key', STRING, (_in(CONTEXT), _in(STATS), _in(UINT)))
     */
-    Z3_string Z3_API Z3_stats_get_key(__in Z3_context c, __in Z3_stats s, __in unsigned idx);
+    Z3_string Z3_API Z3_stats_get_key(Z3_in Z3_context c, Z3_in Z3_stats s, Z3_in unsigned idx);
 
     /**
        \brief Return Z3_TRUE if the given statistical data is a unsigned integer.
@@ -7023,7 +7023,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_stats_is_uint', BOOL, (_in(CONTEXT), _in(STATS), _in(UINT)))
     */
-    Z3_bool Z3_API Z3_stats_is_uint(__in Z3_context c, __in Z3_stats s, __in unsigned idx);
+    Z3_bool Z3_API Z3_stats_is_uint(Z3_in Z3_context c, Z3_in Z3_stats s, Z3_in unsigned idx);
 
     /**
        \brief Return Z3_TRUE if the given statistical data is a double.
@@ -7032,7 +7032,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_stats_is_double', BOOL, (_in(CONTEXT), _in(STATS), _in(UINT)))
     */
-    Z3_bool Z3_API Z3_stats_is_double(__in Z3_context c, __in Z3_stats s, __in unsigned idx);
+    Z3_bool Z3_API Z3_stats_is_double(Z3_in Z3_context c, Z3_in Z3_stats s, Z3_in unsigned idx);
     
     /**
        \brief Return the unsigned value of the given statistical data.
@@ -7041,7 +7041,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_stats_get_uint_value', UINT, (_in(CONTEXT), _in(STATS), _in(UINT)))
     */
-    unsigned Z3_API Z3_stats_get_uint_value(__in Z3_context c, __in Z3_stats s, __in unsigned idx);
+    unsigned Z3_API Z3_stats_get_uint_value(Z3_in Z3_context c, Z3_in Z3_stats s, Z3_in unsigned idx);
 
     /**
        \brief Return the double value of the given statistical data.
@@ -7050,7 +7050,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_stats_get_double_value', DOUBLE, (_in(CONTEXT), _in(STATS), _in(UINT)))
     */
-    double Z3_API Z3_stats_get_double_value(__in Z3_context c, __in Z3_stats s, __in unsigned idx);
+    double Z3_API Z3_stats_get_double_value(Z3_in Z3_context c, Z3_in Z3_stats s, Z3_in unsigned idx);
     
     /*@}*/
 #endif
@@ -7073,10 +7073,10 @@ END_MLAPI_EXCLUDE
        def_API('Z3_mk_injective_function', FUNC_DECL, (_in(CONTEXT), _in(SYMBOL), _in(UINT), _in_array(2, SORT), _in(SORT)))
     */
     Z3_func_decl Z3_API Z3_mk_injective_function(
-        __in Z3_context c, 
-        __in Z3_symbol s, 
-        unsigned domain_size, __in_ecount(domain_size) Z3_sort const domain[],
-        __in Z3_sort range
+        Z3_in Z3_context c, 
+        Z3_in Z3_symbol s, 
+        unsigned domain_size, Z3_in_ecount(domain_size) Z3_sort const domain[],
+        Z3_in Z3_sort range
         );
 
     /*@}*/
@@ -7099,7 +7099,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_set_logic', VOID, (_in(CONTEXT), _in(STRING)))
     */
-    Z3_bool Z3_API Z3_set_logic(__in Z3_context c, __in Z3_string logic);
+    Z3_bool Z3_API Z3_set_logic(Z3_in Z3_context c, Z3_in Z3_string logic);
     
     /**
         \brief Create a backtracking point.
@@ -7114,7 +7114,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_push', VOID, (_in(CONTEXT),))
     */
-    void Z3_API Z3_push(__in Z3_context c);
+    void Z3_API Z3_push(Z3_in Z3_context c);
     
     /**
        \brief Backtrack.
@@ -7131,7 +7131,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_pop', VOID, (_in(CONTEXT), _in(UINT)))
     */
-    void Z3_API Z3_pop(__in Z3_context c, __in unsigned num_scopes);
+    void Z3_API Z3_pop(Z3_in Z3_context c, Z3_in unsigned num_scopes);
 
     /**
        \brief Retrieve the current scope level.
@@ -7145,7 +7145,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_num_scopes', UINT, (_in(CONTEXT),))
     */
-    unsigned Z3_API Z3_get_num_scopes(__in Z3_context c);
+    unsigned Z3_API Z3_get_num_scopes(Z3_in Z3_context c);
     
     /**
        \conly \brief Persist AST through num_scopes pops.
@@ -7168,7 +7168,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_persist_ast', VOID, (_in(CONTEXT), _in(AST), _in(UINT)))
     */
-    void Z3_API Z3_persist_ast(__in Z3_context c, __in Z3_ast a, __in unsigned num_scopes);
+    void Z3_API Z3_persist_ast(Z3_in Z3_context c, Z3_in Z3_ast a, Z3_in unsigned num_scopes);
 
     /**
        \brief Assert a constraint into the logical context.
@@ -7186,7 +7186,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_assert_cnstr', VOID, (_in(CONTEXT), _in(AST)))
     */
-    void Z3_API Z3_assert_cnstr(__in Z3_context c, __in Z3_ast a);
+    void Z3_API Z3_assert_cnstr(Z3_in Z3_context c, Z3_in Z3_ast a);
     
     /**
        \brief Check whether the given logical context is consistent or not.
@@ -7211,7 +7211,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_check_and_get_model', INT, (_in(CONTEXT), _out(MODEL)))
     */
-    Z3_lbool Z3_API Z3_check_and_get_model(__in Z3_context c, __out Z3_model * m);
+    Z3_lbool Z3_API Z3_check_and_get_model(Z3_in Z3_context c, Z3_out Z3_model * m);
     
     /**
        \brief Check whether the given logical context is consistent or not.
@@ -7224,7 +7224,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_check', INT, (_in(CONTEXT),))
     */
-    Z3_lbool Z3_API Z3_check(__in Z3_context c);
+    Z3_lbool Z3_API Z3_check(Z3_in Z3_context c);
 
     /**
        \brief Check whether the given logical context and optional assumptions is consistent or not.
@@ -7265,10 +7265,10 @@ END_MLAPI_EXCLUDE
        def_API('Z3_check_assumptions', INT, (_in(CONTEXT), _in(UINT), _in_array(1, AST), _out(MODEL), _out(AST), _out(UINT), _out_array2(1, 5, AST)))
     */
     Z3_lbool Z3_API Z3_check_assumptions(
-        __in Z3_context c, 
-        __in unsigned num_assumptions, __in_ecount(num_assumptions) Z3_ast const assumptions[], 
-        __out Z3_model * m, __out Z3_ast* proof, 
-        __inout unsigned* core_size, __inout_ecount(num_assumptions) Z3_ast core[]
+        Z3_in Z3_context c, 
+        Z3_in unsigned num_assumptions, Z3_in_ecount(num_assumptions) Z3_ast const assumptions[], 
+        Z3_out Z3_model * m, Z3_out Z3_ast* proof, 
+        Z3_inout unsigned* core_size, Z3_inout_ecount(num_assumptions) Z3_ast core[]
         );
 #endif
 
@@ -7297,11 +7297,11 @@ END_MLAPI_EXCLUDE
        def_API('Z3_get_implied_equalities', UINT, (_in(CONTEXT), _in(SOLVER), _in(UINT), _in_array(2, AST), _out_array(2, UINT)))
     */
     Z3_lbool Z3_API Z3_get_implied_equalities(
-        __in Z3_context c, 
-        __in Z3_solver  s, 
-        __in unsigned num_terms,
-        __in_ecount(num_terms) Z3_ast const terms[],
-        __out_ecount(num_terms) unsigned class_ids[]
+        Z3_in Z3_context c, 
+        Z3_in Z3_solver  s, 
+        Z3_in unsigned num_terms,
+        Z3_in_ecount(num_terms) Z3_ast const terms[],
+        Z3_out_ecount(num_terms) unsigned class_ids[]
         );
 #endif
 
@@ -7320,7 +7320,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_del_model', VOID, (_in(CONTEXT), _in(MODEL)))
     */
-    void Z3_API Z3_del_model(__in Z3_context c, __in Z3_model m);
+    void Z3_API Z3_del_model(Z3_in Z3_context c, Z3_in Z3_model m);
 
     /*@}*/
 
@@ -7340,7 +7340,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_soft_check_cancel', VOID, (_in(CONTEXT), ))
     */
-    void Z3_API Z3_soft_check_cancel(__in Z3_context c);
+    void Z3_API Z3_soft_check_cancel(Z3_in Z3_context c);
 
     /**
        \brief Retrieve reason for search failure.
@@ -7352,7 +7352,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_search_failure', UINT, (_in(CONTEXT), ))
     */
-    Z3_search_failure Z3_API Z3_get_search_failure(__in Z3_context c);
+    Z3_search_failure Z3_API Z3_get_search_failure(Z3_in Z3_context c);
 
     /*@}*/
 
@@ -7379,7 +7379,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_mk_label', AST, (_in(CONTEXT), _in(SYMBOL), _in(BOOL), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_label(__in Z3_context c, __in Z3_symbol s, Z3_bool is_pos, Z3_ast f);
+    Z3_ast Z3_API Z3_mk_label(Z3_in Z3_context c, Z3_in Z3_symbol s, Z3_bool is_pos, Z3_ast f);
 
     /**
         \brief Retrieve the set of labels that were relevant in
@@ -7394,7 +7394,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_get_relevant_labels', LITERALS, (_in(CONTEXT), ))
     */
-    Z3_literals Z3_API Z3_get_relevant_labels(__in Z3_context c);
+    Z3_literals Z3_API Z3_get_relevant_labels(Z3_in Z3_context c);
 
     /**
         \brief Retrieve the set of literals that satisfy the current context.
@@ -7408,7 +7408,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_get_relevant_literals', LITERALS, (_in(CONTEXT), ))
     */
-    Z3_literals Z3_API Z3_get_relevant_literals(__in Z3_context c);
+    Z3_literals Z3_API Z3_get_relevant_literals(Z3_in Z3_context c);
 
     /**
         \brief Retrieve the set of literals that whose assignment were 
@@ -7423,7 +7423,7 @@ END_MLAPI_EXCLUDE
         
         def_API('Z3_get_guessed_literals', LITERALS, (_in(CONTEXT), ))
     */
-    Z3_literals Z3_API Z3_get_guessed_literals(__in Z3_context c);
+    Z3_literals Z3_API Z3_get_guessed_literals(Z3_in Z3_context c);
 
     /**
        \brief Delete a labels context.
@@ -7434,7 +7434,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_del_literals', VOID, (_in(CONTEXT), _in(LITERALS)))
     */
-    void Z3_API Z3_del_literals(__in Z3_context c, __in Z3_literals lbls);
+    void Z3_API Z3_del_literals(Z3_in Z3_context c, Z3_in Z3_literals lbls);
 
     /**
        \brief Retrieve the number of label symbols that were returned.
@@ -7445,7 +7445,7 @@ END_MLAPI_EXCLUDE
 
         def_API('Z3_get_num_literals', UINT, (_in(CONTEXT), _in(LITERALS)))
     */
-    unsigned Z3_API Z3_get_num_literals(__in Z3_context c, __in Z3_literals lbls);
+    unsigned Z3_API Z3_get_num_literals(Z3_in Z3_context c, Z3_in Z3_literals lbls);
 
     /**
        \brief Retrieve label symbol at idx.
@@ -7454,7 +7454,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_label_symbol', SYMBOL, (_in(CONTEXT), _in(LITERALS), _in(UINT)))
     */
-    Z3_symbol Z3_API Z3_get_label_symbol(__in Z3_context c, __in Z3_literals lbls, __in unsigned idx);
+    Z3_symbol Z3_API Z3_get_label_symbol(Z3_in Z3_context c, Z3_in Z3_literals lbls, Z3_in unsigned idx);
 
     /**
        \brief Retrieve literal expression at idx.
@@ -7463,7 +7463,7 @@ END_MLAPI_EXCLUDE
        
        def_API('Z3_get_literal', AST, (_in(CONTEXT), _in(LITERALS), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_get_literal(__in Z3_context c, __in Z3_literals lbls, __in unsigned idx);
+    Z3_ast Z3_API Z3_get_literal(Z3_in Z3_context c, Z3_in Z3_literals lbls, Z3_in unsigned idx);
 
     /**
        \brief Disable label.
@@ -7476,7 +7476,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_disable_literal', VOID, (_in(CONTEXT), _in(LITERALS), _in(UINT)))
     */
-    void Z3_API Z3_disable_literal(__in Z3_context c, __in Z3_literals lbls, __in unsigned idx);
+    void Z3_API Z3_disable_literal(Z3_in Z3_context c, Z3_in Z3_literals lbls, Z3_in unsigned idx);
 
     /**
        \brief Block subsequent checks using the remaining enabled labels.
@@ -7485,7 +7485,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_block_literals', VOID, (_in(CONTEXT), _in(LITERALS)))
     */
-    void Z3_API Z3_block_literals(__in Z3_context c, __in Z3_literals lbls);
+    void Z3_API Z3_block_literals(Z3_in Z3_context c, Z3_in Z3_literals lbls);
 
     /*@}*/
 
@@ -7505,7 +7505,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_model_num_constants', UINT, (_in(CONTEXT), _in(MODEL)))
     */
-    unsigned Z3_API Z3_get_model_num_constants(__in Z3_context c, __in Z3_model m);
+    unsigned Z3_API Z3_get_model_num_constants(Z3_in Z3_context c, Z3_in Z3_model m);
 
     /**
        \brief \mlh get_model_constant c m i \endmlh
@@ -7519,7 +7519,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_model_constant', FUNC_DECL, (_in(CONTEXT), _in(MODEL), _in(UINT)))
     */
-    Z3_func_decl Z3_API Z3_get_model_constant(__in Z3_context c, __in Z3_model m, __in unsigned i);
+    Z3_func_decl Z3_API Z3_get_model_constant(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in unsigned i);
     
     /**
        \brief Return the number of function interpretations in the given model.
@@ -7531,7 +7531,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_model_num_funcs', UINT, (_in(CONTEXT), _in(MODEL)))
     */
-    unsigned Z3_API Z3_get_model_num_funcs(__in Z3_context c, __in Z3_model m);
+    unsigned Z3_API Z3_get_model_num_funcs(Z3_in Z3_context c, Z3_in Z3_model m);
     
     /**
        \brief \mlh get_model_func_decl c m i \endmlh
@@ -7545,7 +7545,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_model_func_decl', FUNC_DECL, (_in(CONTEXT), _in(MODEL), _in(UINT)))
     */
-    Z3_func_decl Z3_API Z3_get_model_func_decl(__in Z3_context c, __in Z3_model m, __in unsigned i);
+    Z3_func_decl Z3_API Z3_get_model_func_decl(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in unsigned i);
 
     /**
        \brief Return the value of the given constant or function 
@@ -7555,7 +7555,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_eval_func_decl', BOOL, (_in(CONTEXT), _in(MODEL), _in(FUNC_DECL), _out(AST)))
     */
-    Z3_bool Z3_API Z3_eval_func_decl(__in Z3_context c, __in Z3_model m, __in Z3_func_decl decl, __out Z3_ast* v);
+    Z3_bool Z3_API Z3_eval_func_decl(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in Z3_func_decl decl, Z3_out Z3_ast* v);
 
     /**
        \brief \mlh is_array_value c v \endmlh
@@ -7572,7 +7572,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_is_array_value', BOOL, (_in(CONTEXT), _in(MODEL), _in(AST), _out(UINT)))
     */
-    Z3_bool Z3_API Z3_is_array_value(__in Z3_context c, __in Z3_model m, __in Z3_ast v, __out unsigned* num_entries);
+    Z3_bool Z3_API Z3_is_array_value(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in Z3_ast v, Z3_out unsigned* num_entries);
 
     /**
        \brief \mlh get_array_value c v \endmlh
@@ -7585,13 +7585,13 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_array_value', VOID, (_in(CONTEXT), _in(MODEL), _in(AST), _in(UINT), _out_array(3, AST), _out_array(3, AST), _out (AST)))
     */
-    void Z3_API Z3_get_array_value(__in Z3_context c, 
-                                   __in Z3_model m,
-                                   __in Z3_ast v,
-                                   __in unsigned num_entries,
-                                   __inout_ecount(num_entries) Z3_ast indices[],
-                                   __inout_ecount(num_entries) Z3_ast values[],
-                                   __out Z3_ast* else_value
+    void Z3_API Z3_get_array_value(Z3_in Z3_context c, 
+                                   Z3_in Z3_model m,
+                                   Z3_in Z3_ast v,
+                                   Z3_in unsigned num_entries,
+                                   Z3_inout_ecount(num_entries) Z3_ast indices[],
+                                   Z3_inout_ecount(num_entries) Z3_ast values[],
+                                   Z3_out Z3_ast* else_value
                                    );
 
     /**
@@ -7613,7 +7613,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_model_func_else', AST, (_in(CONTEXT), _in(MODEL), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_get_model_func_else(__in Z3_context c, __in Z3_model m, __in unsigned i);
+    Z3_ast Z3_API Z3_get_model_func_else(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in unsigned i);
 
     /**
        \brief \mlh get_model_func_num_entries c m i \endmlh
@@ -7634,7 +7634,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_model_func_num_entries', UINT, (_in(CONTEXT), _in(MODEL), _in(UINT)))
     */
-    unsigned Z3_API Z3_get_model_func_num_entries(__in Z3_context c, __in Z3_model m, __in unsigned i);
+    unsigned Z3_API Z3_get_model_func_num_entries(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in unsigned i);
     
     /**
        \brief \mlh get_model_func_entry_num_args c m i j \endmlh
@@ -7660,10 +7660,10 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_model_func_entry_num_args', UINT, (_in(CONTEXT), _in(MODEL), _in(UINT), _in(UINT)))
     */
-    unsigned Z3_API Z3_get_model_func_entry_num_args(__in Z3_context c,
-                                                     __in Z3_model m,
-                                                     __in unsigned i,
-                                                     __in unsigned j);
+    unsigned Z3_API Z3_get_model_func_entry_num_args(Z3_in Z3_context c,
+                                                     Z3_in Z3_model m,
+                                                     Z3_in unsigned i,
+                                                     Z3_in unsigned j);
     
     /**
        \brief \mlh get_model_func_entry_arg c m i j k \endmlh
@@ -7690,11 +7690,11 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_model_func_entry_arg', AST, (_in(CONTEXT), _in(MODEL), _in(UINT), _in(UINT), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_get_model_func_entry_arg(__in Z3_context c,
-                                                __in Z3_model m,
-                                                __in unsigned i,
-                                                __in unsigned j,
-                                                __in unsigned k);
+    Z3_ast Z3_API Z3_get_model_func_entry_arg(Z3_in Z3_context c,
+                                                Z3_in Z3_model m,
+                                                Z3_in unsigned i,
+                                                Z3_in unsigned j,
+                                                Z3_in unsigned k);
     
     /**
        \brief \mlh get_model_func_entry_value c m i j \endmlh
@@ -7719,10 +7719,10 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_get_model_func_entry_value', AST, (_in(CONTEXT), _in(MODEL), _in(UINT), _in(UINT)))
     */
-    Z3_ast Z3_API Z3_get_model_func_entry_value(__in Z3_context c,
-                                                  __in Z3_model m,
-                                                  __in unsigned i,
-                                                  __in unsigned j);
+    Z3_ast Z3_API Z3_get_model_func_entry_value(Z3_in Z3_context c,
+                                                  Z3_in Z3_model m,
+                                                  Z3_in unsigned i,
+                                                  Z3_in unsigned j);
     
     /**
        \brief \mlh eval c m t \endmlh
@@ -7743,7 +7743,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_eval', BOOL, (_in(CONTEXT), _in(MODEL), _in(AST), _out(AST)))
     */
-    Z3_bool Z3_API Z3_eval(__in Z3_context c, __in Z3_model m, __in Z3_ast t, __out Z3_ast * v);
+    Z3_bool Z3_API Z3_eval(Z3_in Z3_context c, Z3_in Z3_model m, Z3_in Z3_ast t, Z3_out Z3_ast * v);
 
     /**
        \brief Evaluate declaration given values.
@@ -7755,11 +7755,11 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_eval_decl', BOOL, (_in(CONTEXT), _in(MODEL), _in(FUNC_DECL), _in(UINT), _in_array(3, AST), _out(AST)))
     */
-    Z3_bool Z3_API Z3_eval_decl(__in Z3_context c, __in Z3_model m, 
-                                __in Z3_func_decl d, 
-                                __in unsigned num_args,
-                                __in_ecount(num_args) Z3_ast const args[],
-                                __out Z3_ast* v);
+    Z3_bool Z3_API Z3_eval_decl(Z3_in Z3_context c, Z3_in Z3_model m, 
+                                Z3_in Z3_func_decl d, 
+                                Z3_in unsigned num_args,
+                                Z3_in_ecount(num_args) Z3_ast const args[],
+                                Z3_out Z3_ast* v);
 
     /*@}*/
 
@@ -7783,7 +7783,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_context_to_string', STRING, (_in(CONTEXT),))
     */
-    Z3_string Z3_API Z3_context_to_string(__in Z3_context c);
+    Z3_string Z3_API Z3_context_to_string(Z3_in Z3_context c);
 
     /**
        \brief Return runtime statistics as a string.
@@ -7800,7 +7800,7 @@ END_MLAPI_EXCLUDE
 
        def_API('Z3_statistics_to_string', STRING, (_in(CONTEXT),))
     */
-    Z3_string Z3_API Z3_statistics_to_string(__in Z3_context c);
+    Z3_string Z3_API Z3_statistics_to_string(Z3_in Z3_context c);
 
     /**
        \brief Extract satisfying assignment from context as a conjunction.
@@ -7815,7 +7815,7 @@ END_MLAPI_EXCLUDE
     
        def_API('Z3_get_context_assignment', AST, (_in(CONTEXT),))
     */
-    Z3_ast Z3_API Z3_get_context_assignment(__in Z3_context c);
+    Z3_ast Z3_API Z3_get_context_assignment(Z3_in Z3_context c);
 
     /*@}*/
 #endif

--- a/src/api/z3_fpa.h
+++ b/src/api/z3_fpa.h
@@ -42,7 +42,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_rounding_mode_sort', SORT, (_in(CONTEXT),))
     */
-    Z3_sort Z3_API Z3_mk_fpa_rounding_mode_sort(__in Z3_context c);
+    Z3_sort Z3_API Z3_mk_fpa_rounding_mode_sort(Z3_in Z3_context c);
 
     /**
         \brief Create a numeral of RoundingMode sort which represents the NearestTiesToEven rounding mode.
@@ -51,7 +51,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_round_nearest_ties_to_even', AST, (_in(CONTEXT),))
     */
-    Z3_ast Z3_API Z3_mk_fpa_round_nearest_ties_to_even(__in Z3_context c);
+    Z3_ast Z3_API Z3_mk_fpa_round_nearest_ties_to_even(Z3_in Z3_context c);
 
     /**
         \brief Create a numeral of RoundingMode sort which represents the NearestTiesToEven rounding mode.
@@ -60,7 +60,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_rne', AST, (_in(CONTEXT),))
     */
-    Z3_ast Z3_API Z3_mk_fpa_rne(__in Z3_context c);
+    Z3_ast Z3_API Z3_mk_fpa_rne(Z3_in Z3_context c);
 
     /**
         \brief Create a numeral of RoundingMode sort which represents the NearestTiesToAway rounding mode.
@@ -69,7 +69,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_round_nearest_ties_to_away', AST, (_in(CONTEXT),))
     */
-    Z3_ast Z3_API Z3_mk_fpa_round_nearest_ties_to_away(__in Z3_context c);
+    Z3_ast Z3_API Z3_mk_fpa_round_nearest_ties_to_away(Z3_in Z3_context c);
 
     /**
         \brief Create a numeral of RoundingMode sort which represents the NearestTiesToAway rounding mode.
@@ -78,7 +78,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_rna', AST, (_in(CONTEXT),))
     */
-    Z3_ast Z3_API Z3_mk_fpa_rna(__in Z3_context c);
+    Z3_ast Z3_API Z3_mk_fpa_rna(Z3_in Z3_context c);
 
     /**
         \brief Create a numeral of RoundingMode sort which represents the TowardPositive rounding mode.
@@ -87,7 +87,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_round_toward_positive', AST, (_in(CONTEXT),))
     */
-    Z3_ast Z3_API Z3_mk_fpa_round_toward_positive(__in Z3_context c);
+    Z3_ast Z3_API Z3_mk_fpa_round_toward_positive(Z3_in Z3_context c);
 
     /**
         \brief Create a numeral of RoundingMode sort which represents the TowardPositive rounding mode.
@@ -96,7 +96,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_rtp', AST, (_in(CONTEXT),))
     */
-    Z3_ast Z3_API Z3_mk_fpa_rtp(__in Z3_context c);
+    Z3_ast Z3_API Z3_mk_fpa_rtp(Z3_in Z3_context c);
 
     /**
         \brief Create a numeral of RoundingMode sort which represents the TowardNegative rounding mode.
@@ -105,7 +105,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_round_toward_negative', AST, (_in(CONTEXT),))
     */
-    Z3_ast Z3_API Z3_mk_fpa_round_toward_negative(__in Z3_context c);
+    Z3_ast Z3_API Z3_mk_fpa_round_toward_negative(Z3_in Z3_context c);
 
     /**
         \brief Create a numeral of RoundingMode sort which represents the TowardNegative rounding mode.
@@ -114,7 +114,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_rtn', AST, (_in(CONTEXT),))
     */
-    Z3_ast Z3_API Z3_mk_fpa_rtn(__in Z3_context c);
+    Z3_ast Z3_API Z3_mk_fpa_rtn(Z3_in Z3_context c);
 
     /**
         \brief Create a numeral of RoundingMode sort which represents the TowardZero rounding mode.
@@ -123,7 +123,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_round_toward_zero', AST, (_in(CONTEXT),))
     */
-    Z3_ast Z3_API Z3_mk_fpa_round_toward_zero(__in Z3_context c);
+    Z3_ast Z3_API Z3_mk_fpa_round_toward_zero(Z3_in Z3_context c);
 
     /**
         \brief Create a numeral of RoundingMode sort which represents the TowardZero rounding mode.
@@ -132,7 +132,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_rtz', AST, (_in(CONTEXT),))
     */
-    Z3_ast Z3_API Z3_mk_fpa_rtz(__in Z3_context c);
+    Z3_ast Z3_API Z3_mk_fpa_rtz(Z3_in Z3_context c);
 
     /**
         \brief Create a FloatingPoint sort.
@@ -145,7 +145,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_sort', SORT, (_in(CONTEXT), _in(UINT), _in(UINT)))        
     */
-    Z3_sort Z3_API Z3_mk_fpa_sort(__in Z3_context c, __in unsigned ebits, __in unsigned sbits);
+    Z3_sort Z3_API Z3_mk_fpa_sort(Z3_in Z3_context c, Z3_in unsigned ebits, Z3_in unsigned sbits);
 
     /**
         \brief Create the half-precision (16-bit) FloatingPoint sort.
@@ -154,7 +154,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_sort_half', SORT, (_in(CONTEXT),))
     */
-    Z3_sort Z3_API Z3_mk_fpa_sort_half(__in Z3_context c);
+    Z3_sort Z3_API Z3_mk_fpa_sort_half(Z3_in Z3_context c);
 
     /**
         \brief Create the half-precision (16-bit) FloatingPoint sort.
@@ -163,7 +163,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_sort_16', SORT, (_in(CONTEXT),))
     */
-    Z3_sort Z3_API Z3_mk_fpa_sort_16(__in Z3_context c);
+    Z3_sort Z3_API Z3_mk_fpa_sort_16(Z3_in Z3_context c);
 
     /**
         \brief Create the single-precision (32-bit) FloatingPoint sort.
@@ -172,7 +172,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_sort_single', SORT, (_in(CONTEXT),))
     */
-    Z3_sort Z3_API Z3_mk_fpa_sort_single(__in Z3_context c);
+    Z3_sort Z3_API Z3_mk_fpa_sort_single(Z3_in Z3_context c);
 
     /**
         \brief Create the single-precision (32-bit) FloatingPoint sort.
@@ -181,7 +181,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_sort_32', SORT, (_in(CONTEXT),))
     */
-    Z3_sort Z3_API Z3_mk_fpa_sort_32(__in Z3_context c);
+    Z3_sort Z3_API Z3_mk_fpa_sort_32(Z3_in Z3_context c);
 
     /**
         \brief Create the double-precision (64-bit) FloatingPoint sort.
@@ -190,7 +190,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_sort_double', SORT, (_in(CONTEXT),))
     */
-    Z3_sort Z3_API Z3_mk_fpa_sort_double(__in Z3_context c);
+    Z3_sort Z3_API Z3_mk_fpa_sort_double(Z3_in Z3_context c);
 
     /**
         \brief Create the double-precision (64-bit) FloatingPoint sort.
@@ -199,7 +199,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_sort_64', SORT, (_in(CONTEXT),))
     */
-    Z3_sort Z3_API Z3_mk_fpa_sort_64(__in Z3_context c);
+    Z3_sort Z3_API Z3_mk_fpa_sort_64(Z3_in Z3_context c);
 
     /**
         \brief Create the quadruple-precision (128-bit) FloatingPoint sort.
@@ -208,7 +208,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_sort_quadruple', SORT, (_in(CONTEXT),))
     */
-    Z3_sort Z3_API Z3_mk_fpa_sort_quadruple(__in Z3_context c);
+    Z3_sort Z3_API Z3_mk_fpa_sort_quadruple(Z3_in Z3_context c);
 
     /**
         \brief Create the quadruple-precision (128-bit) FloatingPoint sort.
@@ -217,7 +217,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_sort_128', SORT, (_in(CONTEXT),))
     */
-    Z3_sort Z3_API Z3_mk_fpa_sort_128(__in Z3_context c);
+    Z3_sort Z3_API Z3_mk_fpa_sort_128(Z3_in Z3_context c);
 
     /**
         \brief Create a floating-point NaN of sort s.
@@ -227,7 +227,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_nan', AST, (_in(CONTEXT),_in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_nan(__in Z3_context c, __in Z3_sort s);
+    Z3_ast Z3_API Z3_mk_fpa_nan(Z3_in Z3_context c, Z3_in Z3_sort s);
 
     /**
         \brief Create a floating-point infinity of sort s.
@@ -240,7 +240,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_inf', AST, (_in(CONTEXT),_in(SORT),_in(BOOL)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_inf(__in Z3_context c, __in Z3_sort s, __in Z3_bool negative);
+    Z3_ast Z3_API Z3_mk_fpa_inf(Z3_in Z3_context c, Z3_in Z3_sort s, Z3_in Z3_bool negative);
 
     /**
         \brief Create a floating-point zero of sort s.
@@ -253,7 +253,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_zero', AST, (_in(CONTEXT),_in(SORT),_in(BOOL)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_zero(__in Z3_context c, __in Z3_sort s, __in Z3_bool negative);
+    Z3_ast Z3_API Z3_mk_fpa_zero(Z3_in Z3_context c, Z3_in Z3_sort s, Z3_in Z3_bool negative);
 
     /**
         \brief Create an expression of FloatingPoint sort from three bit-vector expressions.
@@ -271,7 +271,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_fp', AST, (_in(CONTEXT), _in(AST), _in(AST), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_fp(__in Z3_context c, __in Z3_ast sgn, __in Z3_ast exp, __in Z3_ast sig);
+    Z3_ast Z3_API Z3_mk_fpa_fp(Z3_in Z3_context c, Z3_in Z3_ast sgn, Z3_in Z3_ast exp, Z3_in Z3_ast sig);
 
     /**
         \brief Create a numeral of FloatingPoint sort from a float.
@@ -289,7 +289,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_numeral_float', AST, (_in(CONTEXT), _in(FLOAT), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_numeral_float(__in Z3_context c, __in float v, __in Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_fpa_numeral_float(Z3_in Z3_context c, Z3_in float v, Z3_in Z3_sort ty);
 
     /**
         \brief Create a numeral of FloatingPoint sort from a double. 
@@ -307,7 +307,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_numeral_double', AST, (_in(CONTEXT), _in(DOUBLE), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_numeral_double(__in Z3_context c, __in double v, __in Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_fpa_numeral_double(Z3_in Z3_context c, Z3_in double v, Z3_in Z3_sort ty);
 
     /**
         \brief Create a numeral of FloatingPoint sort from a signed integer.
@@ -322,7 +322,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_numeral_int', AST, (_in(CONTEXT), _in(INT), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_numeral_int(__in Z3_context c, __in signed v, Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_fpa_numeral_int(Z3_in Z3_context c, Z3_in signed v, Z3_sort ty);
 
     /**
         \brief Create a numeral of FloatingPoint sort from a sign bit and two integers.
@@ -339,7 +339,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_numeral_int_uint', AST, (_in(CONTEXT), _in(BOOL), _in(INT), _in(UINT), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_numeral_int_uint(__in Z3_context c, __in Z3_bool sgn, __in signed exp, __in unsigned sig, Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_fpa_numeral_int_uint(Z3_in Z3_context c, Z3_in Z3_bool sgn, Z3_in signed exp, Z3_in unsigned sig, Z3_sort ty);
 
     /**
         \brief Create a numeral of FloatingPoint sort from a sign bit and two 64-bit integers.
@@ -356,7 +356,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_numeral_int64_uint64', AST, (_in(CONTEXT), _in(BOOL), _in(INT64), _in(UINT64), _in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_numeral_int64_uint64(__in Z3_context c, __in Z3_bool sgn, __in __int64 exp, __in __uint64 sig, Z3_sort ty);
+    Z3_ast Z3_API Z3_mk_fpa_numeral_int64_uint64(Z3_in Z3_context c, Z3_in Z3_bool sgn, Z3_in __int64 exp, Z3_in __uint64 sig, Z3_sort ty);
 
     /**
         \brief Floating-point absolute value
@@ -366,7 +366,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_abs', AST, (_in(CONTEXT),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_abs(__in Z3_context c, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_abs(Z3_in Z3_context c, Z3_in Z3_ast t);
    
     /**
         \brief Floating-point negation
@@ -376,7 +376,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_neg', AST, (_in(CONTEXT),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_neg(__in Z3_context c, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_neg(Z3_in Z3_context c, Z3_in Z3_ast t);
    
     /**
         \brief Floating-point addition
@@ -390,7 +390,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_add', AST, (_in(CONTEXT),_in(AST),_in(AST),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_add(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_fpa_add(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
    
     /**
         \brief Floating-point subtraction
@@ -404,7 +404,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_sub', AST, (_in(CONTEXT),_in(AST),_in(AST),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_sub(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t1, __in Z3_ast t2);   
+    Z3_ast Z3_API Z3_mk_fpa_sub(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t1, Z3_in Z3_ast t2);   
    
     /**
         \brief Floating-point multiplication
@@ -418,7 +418,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_mul', AST, (_in(CONTEXT),_in(AST),_in(AST),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_mul(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t1, __in Z3_ast t2);   
+    Z3_ast Z3_API Z3_mk_fpa_mul(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t1, Z3_in Z3_ast t2);   
    
     /**
         \brief Floating-point division
@@ -432,7 +432,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_div', AST, (_in(CONTEXT),_in(AST),_in(AST),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_div(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t1, __in Z3_ast t2);    
+    Z3_ast Z3_API Z3_mk_fpa_div(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t1, Z3_in Z3_ast t2);    
    
     /**
         \brief Floating-point fused multiply-add.
@@ -449,7 +449,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_fma', AST, (_in(CONTEXT),_in(AST),_in(AST),_in(AST),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_fma(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t1, __in Z3_ast t2, __in Z3_ast t3);
+    Z3_ast Z3_API Z3_mk_fpa_fma(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t1, Z3_in Z3_ast t2, Z3_in Z3_ast t3);
    
     /**
         \brief Floating-point square root
@@ -462,7 +462,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_sqrt', AST, (_in(CONTEXT),_in(AST),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_sqrt(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_sqrt(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t);
    
     /**
         \brief Floating-point remainder
@@ -475,7 +475,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_rem', AST, (_in(CONTEXT),_in(AST),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_rem(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_fpa_rem(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
         \brief Floating-point roundToIntegral. Rounds a floating-point number to 
@@ -489,7 +489,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_round_to_integral', AST, (_in(CONTEXT),_in(AST),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_round_to_integral(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_round_to_integral(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t);
 
     /**
         \brief Minimum of floating-point numbers.
@@ -502,7 +502,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_min', AST, (_in(CONTEXT),_in(AST),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_min(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_fpa_min(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
         \brief Maximum of floating-point numbers.
@@ -515,7 +515,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_max', AST, (_in(CONTEXT),_in(AST),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_max(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_fpa_max(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
    
      /**
         \brief Floating-point less than or equal.
@@ -528,7 +528,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_leq', AST, (_in(CONTEXT),_in(AST),_in(AST)))
     */      
-    Z3_ast Z3_API Z3_mk_fpa_leq(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_fpa_leq(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
      /**
         \brief Floating-point less than.
@@ -541,7 +541,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_lt', AST, (_in(CONTEXT),_in(AST),_in(AST)))
     */      
-    Z3_ast Z3_API Z3_mk_fpa_lt(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_fpa_lt(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
         
     /**
         \brief Floating-point greater than or equal.
@@ -554,7 +554,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_geq', AST, (_in(CONTEXT),_in(AST),_in(AST)))
     */      
-    Z3_ast Z3_API Z3_mk_fpa_geq(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_fpa_geq(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
         \brief Floating-point greater than.
@@ -567,7 +567,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_gt', AST, (_in(CONTEXT),_in(AST),_in(AST)))
     */      
-    Z3_ast Z3_API Z3_mk_fpa_gt(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_fpa_gt(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
 
     /**
         \brief Floating-point equality.
@@ -582,7 +582,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_eq', AST, (_in(CONTEXT),_in(AST),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_eq(__in Z3_context c, __in Z3_ast t1, __in Z3_ast t2);
+    Z3_ast Z3_API Z3_mk_fpa_eq(Z3_in Z3_context c, Z3_in Z3_ast t1, Z3_in Z3_ast t2);
    
     /**
         \brief Predicate indicating whether t is a normal floating-point number.
@@ -594,7 +594,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_is_normal', AST, (_in(CONTEXT),_in(AST)))
     */      
-    Z3_ast Z3_API Z3_mk_fpa_is_normal(__in Z3_context c, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_is_normal(Z3_in Z3_context c, Z3_in Z3_ast t);
 
     /**
         \brief Predicate indicating whether t is a subnormal floating-point number.
@@ -606,7 +606,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_is_subnormal', AST, (_in(CONTEXT),_in(AST)))
     */      
-    Z3_ast Z3_API Z3_mk_fpa_is_subnormal(__in Z3_context c, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_is_subnormal(Z3_in Z3_context c, Z3_in Z3_ast t);
 
     /**
         \brief Predicate indicating whether t is a floating-point number with zero value, i.e., +zero or -zero.
@@ -618,7 +618,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_is_zero', AST, (_in(CONTEXT),_in(AST)))
     */      
-    Z3_ast Z3_API Z3_mk_fpa_is_zero(__in Z3_context c, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_is_zero(Z3_in Z3_context c, Z3_in Z3_ast t);
 
    /**
         \brief Predicate indicating whether t is a floating-point number representing +oo or -oo.
@@ -630,7 +630,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_is_infinite', AST, (_in(CONTEXT),_in(AST)))
     */      
-    Z3_ast Z3_API Z3_mk_fpa_is_infinite(__in Z3_context c, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_is_infinite(Z3_in Z3_context c, Z3_in Z3_ast t);
 
     /**
         \brief Predicate indicating whether t is a NaN.
@@ -642,7 +642,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_is_nan', AST, (_in(CONTEXT),_in(AST)))
     */      
-    Z3_ast Z3_API Z3_mk_fpa_is_nan(__in Z3_context c, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_is_nan(Z3_in Z3_context c, Z3_in Z3_ast t);
 
     /**
         \brief Predicate indicating whether t is a negative floating-point number.
@@ -654,7 +654,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_is_negative', AST, (_in(CONTEXT),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_is_negative(__in Z3_context c, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_is_negative(Z3_in Z3_context c, Z3_in Z3_ast t);
 
     /**
         \brief Predicate indicating whether t is a positive floating-point number.
@@ -666,7 +666,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_is_positive', AST, (_in(CONTEXT),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_is_positive(__in Z3_context c, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_is_positive(Z3_in Z3_context c, Z3_in Z3_ast t);
 
     /**
         \brief Conversion of a single IEEE 754-2008 bit-vector into a floating-point number.
@@ -684,7 +684,7 @@ extern "C" {
      
         def_API('Z3_mk_fpa_to_fp_bv', AST, (_in(CONTEXT),_in(AST),_in(SORT)))
     */      
-    Z3_ast Z3_API Z3_mk_fpa_to_fp_bv(__in Z3_context c, __in Z3_ast bv, __in Z3_sort s);
+    Z3_ast Z3_API Z3_mk_fpa_to_fp_bv(Z3_in Z3_context c, Z3_in Z3_ast bv, Z3_in Z3_sort s);
 
     /**
         \brief Conversion of a FloatingPoint term into another term of different FloatingPoint sort.
@@ -702,7 +702,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_to_fp_float', AST, (_in(CONTEXT),_in(AST),_in(AST),_in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_to_fp_float(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t, __in Z3_sort s);
+    Z3_ast Z3_API Z3_mk_fpa_to_fp_float(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t, Z3_in Z3_sort s);
 
     /**
         \brief Conversion of a term of real sort into a term of FloatingPoint sort.
@@ -720,7 +720,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_to_fp_real', AST, (_in(CONTEXT),_in(AST),_in(AST),_in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_to_fp_real(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t, __in Z3_sort s);
+    Z3_ast Z3_API Z3_mk_fpa_to_fp_real(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t, Z3_in Z3_sort s);
 
     /**
         \brief Conversion of a 2's complement signed bit-vector term into a term of FloatingPoint sort.
@@ -739,7 +739,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_to_fp_signed', AST, (_in(CONTEXT),_in(AST),_in(AST),_in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_to_fp_signed(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t, __in Z3_sort s);
+    Z3_ast Z3_API Z3_mk_fpa_to_fp_signed(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t, Z3_in Z3_sort s);
 
     /**
         \brief Conversion of a 2's complement unsigned bit-vector term into a term of FloatingPoint sort.
@@ -758,7 +758,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_to_fp_unsigned', AST, (_in(CONTEXT),_in(AST),_in(AST),_in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_to_fp_unsigned(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t, __in Z3_sort s);
+    Z3_ast Z3_API Z3_mk_fpa_to_fp_unsigned(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t, Z3_in Z3_sort s);
 
     /**
         \brief Conversion of a floating-point term into an unsigned bit-vector.
@@ -774,7 +774,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_to_ubv', AST, (_in(CONTEXT),_in(AST),_in(AST),_in(UINT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_to_ubv(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t, __in unsigned sz);
+    Z3_ast Z3_API Z3_mk_fpa_to_ubv(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t, Z3_in unsigned sz);
 
     /**
         \brief Conversion of a floating-point term into a signed bit-vector.
@@ -790,7 +790,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_to_sbv', AST, (_in(CONTEXT),_in(AST),_in(AST),_in(UINT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_to_sbv(__in Z3_context c, __in Z3_ast rm, __in Z3_ast t, __in unsigned sz);
+    Z3_ast Z3_API Z3_mk_fpa_to_sbv(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast t, Z3_in unsigned sz);
 
     /**
         \brief Conversion of a floating-point term into a real-numbered term.
@@ -804,7 +804,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_to_real', AST, (_in(CONTEXT),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_to_real(__in Z3_context c, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_to_real(Z3_in Z3_context c, Z3_in Z3_ast t);
 
 
     /**
@@ -820,7 +820,7 @@ extern "C" {
 
         def_API('Z3_fpa_get_ebits', UINT, (_in(CONTEXT),_in(SORT)))
     */
-    unsigned Z3_API Z3_fpa_get_ebits(__in Z3_context c, __in Z3_sort s);
+    unsigned Z3_API Z3_fpa_get_ebits(Z3_in Z3_context c, Z3_in Z3_sort s);
 
     /**
         \brief Retrieves the number of bits reserved for the significand in a FloatingPoint sort.
@@ -830,7 +830,7 @@ extern "C" {
 
         def_API('Z3_fpa_get_sbits', UINT, (_in(CONTEXT),_in(SORT)))
     */
-    unsigned Z3_API Z3_fpa_get_sbits(__in Z3_context c, __in Z3_sort s);
+    unsigned Z3_API Z3_fpa_get_sbits(Z3_in Z3_context c, Z3_in Z3_sort s);
 
     /**
         \brief Retrieves the sign of a floating-point literal.
@@ -843,7 +843,7 @@ extern "C" {
 
         def_API('Z3_fpa_get_numeral_sign', BOOL, (_in(CONTEXT), _in(AST), _out(INT)))
     */
-    Z3_bool Z3_API Z3_fpa_get_numeral_sign(__in Z3_context c, __in Z3_ast t, __out int * sgn);
+    Z3_bool Z3_API Z3_fpa_get_numeral_sign(Z3_in Z3_context c, Z3_in Z3_ast t, Z3_out int * sgn);
 
     /**
         \brief Return the significand value of a floating-point numeral as a string.
@@ -856,7 +856,7 @@ extern "C" {
 
         def_API('Z3_fpa_get_numeral_significand_string', STRING, (_in(CONTEXT), _in(AST)))
     */
-    Z3_string Z3_API Z3_fpa_get_numeral_significand_string(__in Z3_context c, __in Z3_ast t);
+    Z3_string Z3_API Z3_fpa_get_numeral_significand_string(Z3_in Z3_context c, Z3_in Z3_ast t);
 
     /**
         \brief Return the exponent value of a floating-point numeral as a string
@@ -866,7 +866,7 @@ extern "C" {
 
         def_API('Z3_fpa_get_numeral_exponent_string', STRING, (_in(CONTEXT), _in(AST)))
     */
-    Z3_string Z3_API Z3_fpa_get_numeral_exponent_string(__in Z3_context c, __in Z3_ast t);
+    Z3_string Z3_API Z3_fpa_get_numeral_exponent_string(Z3_in Z3_context c, Z3_in Z3_ast t);
 
     /**
         \brief Return the exponent value of a floating-point numeral as a signed 64-bit integer
@@ -877,7 +877,7 @@ extern "C" {
 
         def_API('Z3_fpa_get_numeral_exponent_int64', BOOL, (_in(CONTEXT), _in(AST), _out(INT64)))
     */
-    Z3_bool Z3_API Z3_fpa_get_numeral_exponent_int64(__in Z3_context c, __in Z3_ast t, __out __int64 * n);
+    Z3_bool Z3_API Z3_fpa_get_numeral_exponent_int64(Z3_in Z3_context c, Z3_in Z3_ast t, Z3_out __int64 * n);
 
     /**
         \brief Conversion of a floating-point term into a bit-vector term in IEEE 754-2008 format.
@@ -894,7 +894,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_to_ieee_bv', AST, (_in(CONTEXT),_in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_to_ieee_bv(__in Z3_context c, __in Z3_ast t);
+    Z3_ast Z3_API Z3_mk_fpa_to_ieee_bv(Z3_in Z3_context c, Z3_in Z3_ast t);
 
     /**
         \brief Conversion of a real-sorted significand and an integer-sorted exponent into a term of FloatingPoint sort.
@@ -913,7 +913,7 @@ extern "C" {
 
         def_API('Z3_mk_fpa_to_fp_int_real', AST, (_in(CONTEXT),_in(AST),_in(AST),_in(AST),_in(SORT)))
     */
-    Z3_ast Z3_API Z3_mk_fpa_to_fp_int_real(__in Z3_context c, __in Z3_ast rm, __in Z3_ast exp, __in Z3_ast sig, __in Z3_sort s);
+    Z3_ast Z3_API Z3_mk_fpa_to_fp_int_real(Z3_in Z3_context c, Z3_in Z3_ast rm, Z3_in Z3_ast exp, Z3_in Z3_ast sig, Z3_in Z3_sort s);
 
     /*@}*/
 

--- a/src/api/z3_interp.h
+++ b/src/api/z3_interp.h
@@ -43,7 +43,7 @@ extern "C" {
 
     def_API('Z3_mk_interpolant', AST, (_in(CONTEXT), _in(AST)))
     */
-    Z3_ast Z3_API Z3_mk_interpolant(__in Z3_context c, __in Z3_ast a);
+    Z3_ast Z3_API Z3_mk_interpolant(Z3_in Z3_context c, Z3_in Z3_ast a);
 
 
     /** \brief This function generates a Z3 context suitable for generation of
@@ -62,7 +62,7 @@ extern "C" {
 
     */
 
-    Z3_context Z3_API Z3_mk_interpolation_context(__in Z3_config cfg);
+    Z3_context Z3_API Z3_mk_interpolation_context(Z3_in Z3_config cfg);
 
     /** Compute an interpolant from a refutation. This takes a proof of
         "false" from a set of formulas C, and an interpolation
@@ -130,7 +130,7 @@ extern "C" {
         def_API('Z3_get_interpolant', AST_VECTOR, (_in(CONTEXT), _in(AST), _in(AST), _in(PARAMS)))
         */
 
-    Z3_ast_vector Z3_API Z3_get_interpolant(__in Z3_context c, __in Z3_ast pf, __in Z3_ast pat, __in Z3_params p);
+    Z3_ast_vector Z3_API Z3_get_interpolant(Z3_in Z3_context c, Z3_in Z3_ast pf, Z3_in Z3_ast pat, Z3_in Z3_params p);
 
     /* Compute an interpolant for an unsatisfiable conjunction of formulas.
 
@@ -164,11 +164,11 @@ extern "C" {
        def_API('Z3_compute_interpolant', INT, (_in(CONTEXT), _in(AST), _in(PARAMS), _out(AST_VECTOR), _out(MODEL)))
        */
 
-    Z3_lbool Z3_API Z3_compute_interpolant(__in Z3_context c, 
-                                           __in Z3_ast pat, 
-                                           __in Z3_params p, 
-                                           __out Z3_ast_vector *interp, 
-                                           __out Z3_model *model);
+    Z3_lbool Z3_API Z3_compute_interpolant(Z3_in Z3_context c, 
+                                           Z3_in Z3_ast pat, 
+                                           Z3_in Z3_params p, 
+                                           Z3_out Z3_ast_vector *interp, 
+                                           Z3_out Z3_model *model);
 
     /** Return a string summarizing cumulative time used for
         interpolation.  This string is purely for entertainment purposes
@@ -180,7 +180,7 @@ extern "C" {
         def_API('Z3_interpolation_profile', STRING, (_in(CONTEXT),))
         */
 
-    Z3_string Z3_API Z3_interpolation_profile(__in Z3_context ctx);
+    Z3_string Z3_API Z3_interpolation_profile(Z3_in Z3_context ctx);
 
     /**
        \brief Read an interpolation problem from file.
@@ -219,14 +219,14 @@ extern "C" {
 
        */
 
-    int Z3_API Z3_read_interpolation_problem(__in Z3_context ctx,
-                                             __out unsigned *num,
-                                             __out Z3_ast *cnsts[],
-                                             __out unsigned *parents[],
-                                             __in Z3_string filename,
-                                             __out_opt Z3_string_ptr error,
-                                             __out unsigned *num_theory,
-                                             __out Z3_ast *theory[]);
+    int Z3_API Z3_read_interpolation_problem(Z3_in Z3_context ctx,
+                                             Z3_out unsigned *num,
+                                             Z3_out Z3_ast *cnsts[],
+                                             Z3_out unsigned *parents[],
+                                             Z3_in Z3_string filename,
+                                             Z3_out_opt Z3_string_ptr error,
+                                             Z3_out unsigned *num_theory,
+                                             Z3_out Z3_ast *theory[]);
 
 
 
@@ -250,14 +250,14 @@ extern "C" {
         def_API('Z3_check_interpolant', INT, (_in(CONTEXT), _in(UINT), _in_array(1, AST), _in_array(1, UINT), _in_array(1, AST), _out(STRING), _in(UINT), _in_array(6, AST)))
         */
 
-    int Z3_API Z3_check_interpolant(__in Z3_context ctx,
-                                    __in unsigned num,
-                                    __in_ecount(num) Z3_ast cnsts[],
-                                    __in_ecount(num) unsigned parents[],
-                                    __in_ecount(num - 1) Z3_ast *interps,
-                                    __out_opt Z3_string_ptr error,
-                                    __in unsigned num_theory,
-                                    __in_ecount(num_theory) Z3_ast theory[]);
+    int Z3_API Z3_check_interpolant(Z3_in Z3_context ctx,
+                                    Z3_in unsigned num,
+                                    Z3_in_ecount(num) Z3_ast cnsts[],
+                                    Z3_in_ecount(num) unsigned parents[],
+                                    Z3_in_ecount(num - 1) Z3_ast *interps,
+                                    Z3_out_opt Z3_string_ptr error,
+                                    Z3_in unsigned num_theory,
+                                    Z3_in_ecount(num_theory) Z3_ast theory[]);
 
     /** Write an interpolation problem to file suitable for reading with
         Z3_read_interpolation_problem. The output file is a sequence
@@ -275,13 +275,13 @@ extern "C" {
         def_API('Z3_write_interpolation_problem', VOID, (_in(CONTEXT), _in(UINT), _in_array(1, AST), _in_array(1, UINT), _in(STRING), _in(UINT), _in_array(5, AST)))
         */
 
-    void Z3_API  Z3_write_interpolation_problem(__in Z3_context ctx,
-                                                __in unsigned num,
-                                                __in_ecount(num) Z3_ast cnsts[],
-                                                __in_ecount(num) unsigned parents[],
-                                                __in Z3_string filename,
-                                                __in unsigned num_theory,
-                                                __in_ecount(num_theory) Z3_ast theory[]);
+    void Z3_API  Z3_write_interpolation_problem(Z3_in Z3_context ctx,
+                                                Z3_in unsigned num,
+                                                Z3_in_ecount(num) Z3_ast cnsts[],
+                                                Z3_in_ecount(num) unsigned parents[],
+                                                Z3_in Z3_string filename,
+                                                Z3_in unsigned num_theory,
+                                                Z3_in_ecount(num_theory) Z3_ast theory[]);
 
     /*@}*/
     /*@}*/

--- a/src/api/z3_macros.h
+++ b/src/api/z3_macros.h
@@ -1,33 +1,49 @@
-#ifndef __in
-#define __in
+#ifdef __in
+#define Z3_in __in
+#else
+#define Z3_in
 #endif
 
-#ifndef __out
-#define __out
+#ifdef __out
+#define Z3_out __out
+#else
+#define Z3_out
 #endif
 
-#ifndef __out_opt
-#define __out_opt __out
+#ifdef __out_opt
+#define Z3_out_opt __out_opt
+#else
+#define Z3_out_opt Z3_out
 #endif
 
-#ifndef __ecount
-#define __ecount(num_args)
+#ifdef __ecount
+#define Z3_ecount(num_args) __ecount(num_args)
+#else
+#define Z3_ecount(num_args)
 #endif 
 
-#ifndef __in_ecount
-#define __in_ecount(num_args) __in __ecount(num_args)
+#ifdef __in_ecount
+#define Z3_in_ecount(num_args) __in_ecount(num_args)
+#else
+#define Z3_in_ecount(num_args) Z3_in Z3_ecount(num_args)
 #endif 
 
-#ifndef __out_ecount
-#define __out_ecount(num_args) __out __ecount(num_args)
+#ifdef __out_ecount
+#define Z3_out_ecount(num_args) __out_ecount(num_args)
+#else
+#define Z3_out_ecount(num_args) Z3_out Z3_ecount(num_args)
 #endif 
 
-#ifndef __inout_ecount
-#define __inout_ecount(num_args) __in __out __ecount(num_args)
+#ifdef __inout_ecount
+#define Z3_inout_ecount(num_args) __inout_ecount(num_args)
+#else
+#define Z3_inout_ecount(num_args) Z3_inout Z3_ecount(num_args)
 #endif 
 
-#ifndef __inout
-#define __inout __in __out
+#ifdef __inout
+#define Z3_inout __inout
+#else
+#define Z3_inout Z3_in Z3_out
 #endif
 
 #ifndef Z3_bool_opt

--- a/src/api/z3_polynomial.h
+++ b/src/api/z3_polynomial.h
@@ -48,7 +48,7 @@ extern "C" {
 
        def_API('Z3_polynomial_subresultants', AST_VECTOR, (_in(CONTEXT), _in(AST), _in(AST), _in(AST)))
     */
-    Z3_ast_vector Z3_API Z3_polynomial_subresultants(__in Z3_context c, __in Z3_ast p, __in Z3_ast q, __in Z3_ast x);
+    Z3_ast_vector Z3_API Z3_polynomial_subresultants(Z3_in Z3_context c, Z3_in Z3_ast p, Z3_in Z3_ast q, Z3_in Z3_ast x);
 
 
     /*@}*/

--- a/src/api/z3_private.h
+++ b/src/api/z3_private.h
@@ -34,7 +34,7 @@ extern "C" {
 [pointer_default(ref)] interface Z3 {
 #endif // CAMLIDL  
 
-    Z3_bool Z3_API Z3_get_numeral_rational(__in Z3_context c, __in Z3_ast a, rational& r);
+    Z3_bool Z3_API Z3_get_numeral_rational(Z3_in Z3_context c, Z3_in Z3_ast a, rational& r);
 
 #ifndef CAMLIDL
 #ifdef __cplusplus

--- a/src/api/z3_rcf.h
+++ b/src/api/z3_rcf.h
@@ -43,42 +43,42 @@ extern "C" {
 
        def_API('Z3_rcf_del', VOID, (_in(CONTEXT), _in(RCF_NUM)))
     */
-    void Z3_API Z3_rcf_del(__in Z3_context c, __in Z3_rcf_num a);
+    void Z3_API Z3_rcf_del(Z3_in Z3_context c, Z3_in Z3_rcf_num a);
 
     /**
        \brief Return a RCF rational using the given string.
 
        def_API('Z3_rcf_mk_rational', RCF_NUM, (_in(CONTEXT), _in(STRING)))
     */
-    Z3_rcf_num Z3_API Z3_rcf_mk_rational(__in Z3_context c, __in Z3_string val);
+    Z3_rcf_num Z3_API Z3_rcf_mk_rational(Z3_in Z3_context c, Z3_in Z3_string val);
 
     /**
        \brief Return a RCF small integer.
 
        def_API('Z3_rcf_mk_small_int', RCF_NUM, (_in(CONTEXT), _in(INT)))
     */
-    Z3_rcf_num Z3_API Z3_rcf_mk_small_int(__in Z3_context c, __in int val);
+    Z3_rcf_num Z3_API Z3_rcf_mk_small_int(Z3_in Z3_context c, Z3_in int val);
 
     /**
        \brief Return Pi
 
        def_API('Z3_rcf_mk_pi', RCF_NUM, (_in(CONTEXT),))
     */
-    Z3_rcf_num Z3_API Z3_rcf_mk_pi(__in Z3_context c);
+    Z3_rcf_num Z3_API Z3_rcf_mk_pi(Z3_in Z3_context c);
 
     /**
        \brief Return e (Euler's constant)
 
        def_API('Z3_rcf_mk_e', RCF_NUM, (_in(CONTEXT),))
     */
-    Z3_rcf_num Z3_API Z3_rcf_mk_e(__in Z3_context c);
+    Z3_rcf_num Z3_API Z3_rcf_mk_e(Z3_in Z3_context c);
 
     /**
        \brief Return a new infinitesimal that is smaller than all elements in the Z3 field.
 
        def_API('Z3_rcf_mk_infinitesimal', RCF_NUM, (_in(CONTEXT),))
     */
-    Z3_rcf_num Z3_API Z3_rcf_mk_infinitesimal(__in Z3_context c);
+    Z3_rcf_num Z3_API Z3_rcf_mk_infinitesimal(Z3_in Z3_context c);
 
     /**
        \brief Store in roots the roots of the polynomial <tt>a[n-1]*x^{n-1} + ... + a[0]</tt>.
@@ -89,112 +89,112 @@ extern "C" {
 
        def_API('Z3_rcf_mk_roots', UINT, (_in(CONTEXT), _in(UINT), _in_array(1, RCF_NUM), _out_array(1, RCF_NUM)))
     */
-    unsigned Z3_API Z3_rcf_mk_roots(__in Z3_context c, __in unsigned n, __in_ecount(n) Z3_rcf_num const a[], __out_ecount(n) Z3_rcf_num roots[]);
+    unsigned Z3_API Z3_rcf_mk_roots(Z3_in Z3_context c, Z3_in unsigned n, Z3_in_ecount(n) Z3_rcf_num const a[], Z3_out_ecount(n) Z3_rcf_num roots[]);
 
     /**
        \brief Return the value a + b. 
 
        def_API('Z3_rcf_add', RCF_NUM, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
-    Z3_rcf_num Z3_API Z3_rcf_add(__in Z3_context c, __in Z3_rcf_num a, __in Z3_rcf_num b);
+    Z3_rcf_num Z3_API Z3_rcf_add(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in Z3_rcf_num b);
 
     /**
        \brief Return the value a - b. 
 
        def_API('Z3_rcf_sub', RCF_NUM, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
-    Z3_rcf_num Z3_API Z3_rcf_sub(__in Z3_context c, __in Z3_rcf_num a, __in Z3_rcf_num b);
+    Z3_rcf_num Z3_API Z3_rcf_sub(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in Z3_rcf_num b);
 
     /**
        \brief Return the value a * b. 
 
        def_API('Z3_rcf_mul', RCF_NUM, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
-    Z3_rcf_num Z3_API Z3_rcf_mul(__in Z3_context c, __in Z3_rcf_num a, __in Z3_rcf_num b);
+    Z3_rcf_num Z3_API Z3_rcf_mul(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in Z3_rcf_num b);
 
     /**
        \brief Return the value a / b. 
 
        def_API('Z3_rcf_div', RCF_NUM, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
-    Z3_rcf_num Z3_API Z3_rcf_div(__in Z3_context c, __in Z3_rcf_num a, __in Z3_rcf_num b);
+    Z3_rcf_num Z3_API Z3_rcf_div(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in Z3_rcf_num b);
     
     /**
        \brief Return the value -a
 
        def_API('Z3_rcf_neg', RCF_NUM, (_in(CONTEXT), _in(RCF_NUM)))
     */
-    Z3_rcf_num Z3_API Z3_rcf_neg(__in Z3_context c, __in Z3_rcf_num a);
+    Z3_rcf_num Z3_API Z3_rcf_neg(Z3_in Z3_context c, Z3_in Z3_rcf_num a);
 
     /**
        \brief Return the value 1/a
 
        def_API('Z3_rcf_inv', RCF_NUM, (_in(CONTEXT), _in(RCF_NUM)))
     */
-    Z3_rcf_num Z3_API Z3_rcf_inv(__in Z3_context c, __in Z3_rcf_num a);
+    Z3_rcf_num Z3_API Z3_rcf_inv(Z3_in Z3_context c, Z3_in Z3_rcf_num a);
 
     /**
        \brief Return the value a^k
 
        def_API('Z3_rcf_power', RCF_NUM, (_in(CONTEXT), _in(RCF_NUM), _in(UINT)))
     */
-    Z3_rcf_num Z3_API Z3_rcf_power(__in Z3_context c, __in Z3_rcf_num a, __in unsigned k);
+    Z3_rcf_num Z3_API Z3_rcf_power(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in unsigned k);
 
     /**
        \brief Return Z3_TRUE if a < b
 
        def_API('Z3_rcf_lt', BOOL, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
-    Z3_bool Z3_API Z3_rcf_lt(__in Z3_context c, __in Z3_rcf_num a, __in Z3_rcf_num b);
+    Z3_bool Z3_API Z3_rcf_lt(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in Z3_rcf_num b);
 
     /**
        \brief Return Z3_TRUE if a > b
 
        def_API('Z3_rcf_gt', BOOL, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
-    Z3_bool Z3_API Z3_rcf_gt(__in Z3_context c, __in Z3_rcf_num a, __in Z3_rcf_num b);
+    Z3_bool Z3_API Z3_rcf_gt(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in Z3_rcf_num b);
 
     /**
        \brief Return Z3_TRUE if a <= b
 
        def_API('Z3_rcf_le', BOOL, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
-    Z3_bool Z3_API Z3_rcf_le(__in Z3_context c, __in Z3_rcf_num a, __in Z3_rcf_num b);
+    Z3_bool Z3_API Z3_rcf_le(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in Z3_rcf_num b);
 
     /**
        \brief Return Z3_TRUE if a >= b
 
        def_API('Z3_rcf_ge', BOOL, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
-    Z3_bool Z3_API Z3_rcf_ge(__in Z3_context c, __in Z3_rcf_num a, __in Z3_rcf_num b);
+    Z3_bool Z3_API Z3_rcf_ge(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in Z3_rcf_num b);
 
     /**
        \brief Return Z3_TRUE if a == b
 
        def_API('Z3_rcf_eq', BOOL, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
-    Z3_bool Z3_API Z3_rcf_eq(__in Z3_context c, __in Z3_rcf_num a, __in Z3_rcf_num b);
+    Z3_bool Z3_API Z3_rcf_eq(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in Z3_rcf_num b);
 
     /**
        \brief Return Z3_TRUE if a != b
 
        def_API('Z3_rcf_neq', BOOL, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
-    Z3_bool Z3_API Z3_rcf_neq(__in Z3_context c, __in Z3_rcf_num a, __in Z3_rcf_num b);
+    Z3_bool Z3_API Z3_rcf_neq(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in Z3_rcf_num b);
 
     /**
        \brief Convert the RCF numeral into a string.
 
        def_API('Z3_rcf_num_to_string', STRING, (_in(CONTEXT), _in(RCF_NUM), _in(BOOL), _in(BOOL)))
     */
-    Z3_string Z3_API Z3_rcf_num_to_string(__in Z3_context c, __in Z3_rcf_num a, __in Z3_bool compact, __in Z3_bool html);
+    Z3_string Z3_API Z3_rcf_num_to_string(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in Z3_bool compact, Z3_in Z3_bool html);
 
     /**
        \brief Convert the RCF numeral into a string in decimal notation.
 
        def_API('Z3_rcf_num_to_decimal_string', STRING, (_in(CONTEXT), _in(RCF_NUM), _in(UINT)))
     */
-    Z3_string Z3_API Z3_rcf_num_to_decimal_string(__in Z3_context c, __in Z3_rcf_num a, __in unsigned prec);
+    Z3_string Z3_API Z3_rcf_num_to_decimal_string(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_in unsigned prec);
 
     /**
        \brief Extract the "numerator" and "denominator" of the given RCF numeral.
@@ -202,7 +202,7 @@ extern "C" {
 
        def_API('Z3_rcf_get_numerator_denominator', VOID, (_in(CONTEXT), _in(RCF_NUM), _out(RCF_NUM), _out(RCF_NUM)))
     */
-    void Z3_API Z3_rcf_get_numerator_denominator(__in Z3_context c, __in Z3_rcf_num a, __out Z3_rcf_num * n, __out Z3_rcf_num * d);
+    void Z3_API Z3_rcf_get_numerator_denominator(Z3_in Z3_context c, Z3_in Z3_rcf_num a, Z3_out Z3_rcf_num * n, Z3_out Z3_rcf_num * d);
 
     /*@}*/
     /*@}*/

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -513,7 +513,7 @@ inline unsigned ast_array_hash(T * const * array, unsigned size, unsigned init_v
         switch (size) {
         case 2:
             b += array[1]->hash();
-            __fallthrough;
+            Z3_fallthrough;
         case 1:
             c += array[0]->hash();
         }

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -1500,7 +1500,7 @@ br_status bv_rewriter::mk_bv_xor(unsigned num, expr * const * args, expr_ref & r
             result = m_util.mk_bv_not(new_args[1]);
             return BR_DONE;
         }
-        __fallthrough;
+        Z3_fallthrough;
     default:
         if (m_bv_sort_ac)
             std::sort(new_args.begin(), new_args.end(), ast_to_lt());

--- a/src/smt/smt_almost_cg_table.cpp
+++ b/src/smt/smt_almost_cg_table.cpp
@@ -67,7 +67,7 @@ namespace smt {
             switch (num_args) {
             case 2:
                 b += arg_hash(n, 1);
-                __fallthrough;
+                Z3_fallthrough;
             case 1:
                 c += arg_hash(n, 0);
             }

--- a/src/smt/smt_cg_table.cpp
+++ b/src/smt/smt_cg_table.cpp
@@ -127,7 +127,7 @@ namespace smt {
         switch (i) {
         case 2:
             b += n->get_arg(1)->get_root()->hash();
-            __fallthrough;
+            Z3_fallthrough;
         case 1:
             c += n->get_arg(0)->get_root()->hash();
         }

--- a/src/util/hash.cpp
+++ b/src/util/hash.cpp
@@ -44,38 +44,38 @@ unsigned string_hash(const char * str, unsigned length, unsigned init_value) {
     switch(len) {        /* all the case statements fall through */
     case 11: 
         c+=((unsigned)str[10]<<24);
-        __fallthrough;
+        Z3_fallthrough;
     case 10: 
         c+=((unsigned)str[9]<<16);
-        __fallthrough;
+        Z3_fallthrough;
     case 9 : 
         c+=((unsigned)str[8]<<8);
-        __fallthrough;
+        Z3_fallthrough;
         /* the first byte of c is reserved for the length */
     case 8 : 
         b+=((unsigned)str[7]<<24);
-        __fallthrough;
+        Z3_fallthrough;
     case 7 : 
         b+=((unsigned)str[6]<<16);
-        __fallthrough;
+        Z3_fallthrough;
     case 6 : 
         b+=((unsigned)str[5]<<8);
-        __fallthrough;
+        Z3_fallthrough;
     case 5 : 
         b+=str[4];
-        __fallthrough;
+        Z3_fallthrough;
     case 4 : 
         a+=((unsigned)str[3]<<24);
-        __fallthrough;
+        Z3_fallthrough;
     case 3 : 
         a+=((unsigned)str[2]<<16);
-        __fallthrough;
+        Z3_fallthrough;
     case 2 : 
         a+=((unsigned)str[1]<<8);
-        __fallthrough;
+        Z3_fallthrough;
     case 1 : 
         a+=str[0];
-        __fallthrough;
+        Z3_fallthrough;
         /* case 0: nothing left to add */
     }
     mix(a,b,c);

--- a/src/util/hash.h
+++ b/src/util/hash.h
@@ -22,10 +22,6 @@ Revision History:
 #include<algorithm>
 #include"util.h"
 
-#ifndef __fallthrough
-#define __fallthrough
-#endif
-
 #define mix(a,b,c)              \
 {                               \
   a -= b; a -= c; a ^= (c>>13); \
@@ -116,7 +112,7 @@ unsigned get_composite_hash(Composite app, unsigned n, GetKindHashProc const & k
         switch (n) {
         case 2:
             b += chasher(app, 1);
-            __fallthrough;
+            Z3_fallthrough;
         case 1:
             c += chasher(app, 0);
         }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -273,20 +273,16 @@ bool has_duplicates(const IT & begin, const IT & end) {
     return false;
 }
 
-#ifndef __out
-#define __out
-#endif
-
-#ifndef __in
-#define __in
-#endif
-
-#ifndef __inout
-#define __inout
-#endif
-
-#ifndef __fallthrough
-#define __fallthrough
+#ifdef __fallthrough
+# define Z3_fallthrough __fallthrough
+#elif defined(__has_cpp_attribute)
+# if __has_cpp_attribute(clang::fallthrough)
+#  define Z3_fallthrough [[clang::fallthrough]]
+# else
+#  define Z3_fallthrough
+# endif
+#else
+# define Z3_fallthrough
 #endif
 
 #ifndef _WINDOWS


### PR DESCRIPTION
These can cause problems when building against certain C++ standard
libraries. In particular, some versions of libstdc++ use __out as a variable
name, which conflicts with the SAL __out macro.

Also start using [[clang::fallthrough]] when compiling with Clang.