### PR TITLE
use a base iz3_exception class for exceptions raised during interpolation

### DIFF
--- a/src/interp/iz3base.h
+++ b/src/interp/iz3base.h
@@ -117,7 +117,7 @@ class iz3base : public iz3mgr, public scopes {
 
     /** Interpolator for clauses, to be implemented */
     virtual void interpolate_clause(std::vector<ast> &lits, std::vector<ast> &itps){
-        throw "no interpolator";
+        throw iz3_exception("no interpolator");
     }
 
     ast get_proof_check_assump(range &rng){
@@ -129,7 +129,7 @@ class iz3base : public iz3mgr, public scopes {
     int frame_of_assertion(const ast &ass){
         stl_ext::hash_map<ast,int>::iterator it = frame_map.find(ass);
         if(it == frame_map.end())
-            throw "unknown assertion";
+            throw iz3_exception("unknown assertion");
         return it->second;
     }
   

--- a/src/interp/iz3exception.h
+++ b/src/interp/iz3exception.h
@@ -1,0 +1,28 @@
+/*++
+Copyright (c) 2015 Microsoft Corporation
+
+Module Name:
+
+    iz3exception.h
+
+Abstract:
+
+    Base class for exceptions raised by interpolation routines 
+
+Author:
+
+Notes:
+
+--*/
+#ifndef _IZ3EXCEPTION_H_
+#define _IZ3EXCEPTION_H_
+
+#include "z3_exception.h"
+#include "error_codes.h"
+
+class iz3_exception: public default_exception {
+public:
+    iz3_exception(const std::string &msg): default_exception(msg) {}
+};
+
+#endif

--- a/src/interp/iz3interp.cpp
+++ b/src/interp/iz3interp.cpp
@@ -218,7 +218,7 @@ public:
         iz3secondary *sp = iz3foci::create(this,num,(int *)(parents.empty()?0:&parents[0]));
         int res = sp->interpolate(cnsts, interps);
         if(res != 0)
-            throw "secondary failed";
+            throw iz3_exception("secondary failed");
     }                         
 
     void proof_to_interpolant(z3pf proof,

--- a/src/interp/iz3interp.h
+++ b/src/interp/iz3interp.h
@@ -21,6 +21,7 @@
 #define IZ3_INTERP_H
 
 #include "iz3hash.h"
+#include "iz3exception.h"
 #include "solver.h"
 
 class iz3base;
@@ -35,12 +36,14 @@ public:
 };
 
 /** This object is thrown if a tree interpolation problem is mal-formed */
-struct iz3_bad_tree {
+struct iz3_bad_tree: public iz3_exception {
+    iz3_bad_tree(): iz3_exception("iz3_bad_tree") {}
 };
 
 /** This object is thrown when iz3 fails due to an incompleteness in
     the secondary solver. */
-struct iz3_incompleteness {
+struct iz3_incompleteness: public iz3_exception {
+    iz3_incompleteness(): iz3_exception("iz3_incompleteness") {}
 };
 
 typedef interpolation_options_struct *interpolation_options;

--- a/src/interp/iz3mgr.cpp
+++ b/src/interp/iz3mgr.cpp
@@ -515,7 +515,7 @@ bool iz3mgr::is_farkas_coefficient_negative(const ast &proof, int n){
     symb s = sym(proof);
     bool ok = s->get_parameter(n+2).is_rational(r);
     if(!ok)
-        throw "Bad Farkas coefficient";
+        throw iz3_exception("Bad Farkas coefficient");
     return r.is_neg();
 }
 
@@ -532,7 +532,7 @@ void iz3mgr::get_farkas_coeffs(const ast &proof, std::vector<rational>& rats){
         rational r;
         bool ok = s->get_parameter(i).is_rational(r);
         if(!ok)
-            throw "Bad Farkas coefficient";
+            throw iz3_exception("Bad Farkas coefficient");
 #if 0 
         {
             ast con = conc(prem(proof,i-2));
@@ -577,7 +577,7 @@ void iz3mgr::get_assign_bounds_coeffs(const ast &proof, std::vector<rational>& r
         rational r;
         bool ok = s->get_parameter(i).is_rational(r);
         if(!ok)
-            throw "Bad Farkas coefficient";
+            throw iz3_exception("Bad Farkas coefficient");
         {
             ast con = arg(conc(proof),i-1);
             ast temp = make_real(r); // for debugging
@@ -593,7 +593,7 @@ void iz3mgr::get_assign_bounds_coeffs(const ast &proof, std::vector<rational>& r
     if(rats[1].is_neg()){ // work around bug -- if all coeffs negative, negate them
         for(unsigned i = 1; i < rats.size(); i++){
             if(!rats[i].is_neg())
-                throw "Bad Farkas coefficients";
+                throw iz3_exception("Bad Farkas coefficients");
             rats[i] = -rats[i];
         }
     }
@@ -623,7 +623,7 @@ void iz3mgr::get_assign_bounds_rule_coeffs(const ast &proof, std::vector<rationa
         rational r;
         bool ok = s->get_parameter(i).is_rational(r);
         if(!ok)
-            throw "Bad Farkas coefficient";
+            throw iz3_exception("Bad Farkas coefficient");
         {
             ast con = conc(prem(proof,i-2));
             ast temp = make_real(r); // for debugging
@@ -639,7 +639,7 @@ void iz3mgr::get_assign_bounds_rule_coeffs(const ast &proof, std::vector<rationa
     if(rats[1].is_neg()){ // work around bug -- if all coeffs negative, negate them
         for(unsigned i = 1; i < rats.size(); i++){
             if(!rats[i].is_neg())
-                throw "Bad Farkas coefficients";
+                throw iz3_exception("Bad Farkas coefficients");
             rats[i] = -rats[i];
         }
     }
@@ -671,7 +671,7 @@ void iz3mgr::linear_comb(ast &P, const ast &c, const ast &Q, bool round_off){
             qstrict = true;
             break;
         default:
-            throw "not an inequality";
+            throw iz3_exception("not an inequality");
         }
     }
     else {
@@ -691,7 +691,7 @@ void iz3mgr::linear_comb(ast &P, const ast &c, const ast &Q, bool round_off){
             qstrict = true;
             break;
         default:
-            throw "not an inequality";
+            throw iz3_exception("not an inequality");
         }
     }
     bool pstrict = op(P) == Lt;

--- a/src/interp/iz3mgr.h
+++ b/src/interp/iz3mgr.h
@@ -26,6 +26,7 @@
 #include <functional>
 
 #include "iz3hash.h"
+#include "iz3exception.h"
 
 #include"well_sorted.h"
 #include"arith_decl_plugin.h"

--- a/src/interp/iz3pp.h
+++ b/src/interp/iz3pp.h
@@ -25,7 +25,8 @@
 /** Exception thrown in case of mal-formed tree interpoloation
     specification */
 
-struct iz3pp_bad_tree {
+struct iz3pp_bad_tree: public iz3_exception {
+    iz3pp_bad_tree(): iz3_exception("iz3pp_bad_tree") {}
 };
 
 void iz3pp(ast_manager &m,

--- a/src/interp/iz3proof.h
+++ b/src/interp/iz3proof.h
@@ -57,7 +57,9 @@ class iz3proof {
     typedef prover::ast ast;
 
     /** Object thrown in case of a proof error. */
-    struct proof_error {};
+    struct proof_error: public iz3_exception {
+        proof_error(): iz3_exception("proof_error") {}
+    };
 
     /* Null proof node */
     static const node null = -1;

--- a/src/interp/iz3proof_itp.h
+++ b/src/interp/iz3proof_itp.h
@@ -50,7 +50,9 @@ class iz3proof_itp : public iz3mgr {
     typedef ast node;
 
     /** Object thrown in case of a proof error. */
-    struct proof_error {};
+    struct proof_error: public iz3_exception {
+        proof_error(): iz3_exception("proof_error") {}
+    };
 
 
     /** Make a resolution node with given pivot literal and premises.

--- a/src/interp/iz3translate.cpp
+++ b/src/interp/iz3translate.cpp
@@ -132,7 +132,7 @@ public:
             // if(range_is_empty(r))
             range r = ast_scope(quanted);
             if(range_is_empty(r))
-                throw "can't skolemize";
+                throw iz3_exception("can't skolemize");
             if(frame == INT_MAX || !in_range(frame,r))
                 frame = range_max(r); // this is desperation -- may fail
             if(frame >= frames) frame = frames - 1;
@@ -1086,10 +1086,10 @@ public:
         rational xcoeff = get_first_coefficient(arg(x,0),xvar);
         rational ycoeff = get_first_coefficient(arg(y,0),yvar);
         if(xcoeff == rational(0) || ycoeff == rational(0) || xvar != yvar)
-            throw "bad assign-bounds lemma";
+            throw iz3_exception("bad assign-bounds lemma");
         rational ratio = xcoeff/ycoeff;
         if(denominator(ratio) != rational(1))
-            throw "bad assign-bounds lemma";
+            throw iz3_exception("bad assign-bounds lemma");
         return make_int(ratio); // better be integer!
     }
 
@@ -1098,7 +1098,7 @@ public:
         get_assign_bounds_coeffs(proof,farkas_coeffs);
         int nargs = num_args(con);
         if(nargs != (int)(farkas_coeffs.size()))
-            throw "bad assign-bounds theory lemma";
+            throw iz3_exception("bad assign-bounds theory lemma");
 #if 0
         if(farkas_coeffs[0] != make_int(rational(1)))
             farkas_coeffs[0] = make_int(rational(1));
@@ -1139,7 +1139,7 @@ public:
         get_assign_bounds_rule_coeffs(proof,farkas_coeffs);
         int nargs = num_prems(proof)+1;
         if(nargs != (int)(farkas_coeffs.size()))
-            throw "bad assign-bounds theory lemma";
+            throw iz3_exception("bad assign-bounds theory lemma");
 #if 0
         if(farkas_coeffs[0] != make_int(rational(1)))
             farkas_coeffs[0] = make_int(rational(1));
@@ -1415,7 +1415,7 @@ public:
 
         std::vector<ast> vals = cvec;
         if(!is_sat(cnstrs,new_proof,vals))
-            throw "Proof error!";
+            throw iz3_exception("Proof error!");
         std::vector<rational> rat_farkas_coeffs;
         for(unsigned i = 0; i < cvec.size(); i++){
             ast bar = vals[i];
@@ -1423,7 +1423,7 @@ public:
             if(is_numeral(bar,r))
                 rat_farkas_coeffs.push_back(r);
             else
-                throw "Proof error!";
+                throw iz3_exception("Proof error!");
         }
         rational the_lcd = lcd(rat_farkas_coeffs);
         std::vector<ast> farkas_coeffs;
@@ -1471,7 +1471,7 @@ public:
         ast new_proof;
         std::vector<ast> dummy;
         if(is_sat(npcons,new_proof,dummy))
-            throw "Proof error!";
+            throw iz3_exception("Proof error!");
         pfrule dk = pr(new_proof);
         int nnp = num_prems(new_proof);
         std::vector<Iproof::node> my_prems;
@@ -1532,7 +1532,7 @@ public:
         ast new_proof;
         std::vector<ast> dummy;
         if(is_sat(npcons,new_proof,dummy))
-            throw "Proof error!";
+            throw iz3_exception("Proof error!");
         pfrule dk = pr(new_proof);
         int nnp = num_prems(new_proof);
         std::vector<Iproof::node> my_prems;

--- a/src/interp/iz3translate.h
+++ b/src/interp/iz3translate.h
@@ -35,7 +35,8 @@ class iz3translation : public iz3base {
     virtual ~iz3translation(){}
 
     /** This is thrown when the proof cannot be translated. */
-    struct unsupported {
+    struct unsupported: public iz3_exception {
+        unsupported(): iz3_exception("unsupported") {}
     };
 
     static iz3translation *create(iz3mgr &mgr,

--- a/src/interp/iz3translate_direct.cpp
+++ b/src/interp/iz3translate_direct.cpp
@@ -595,7 +595,9 @@ public:
     }
 
 
-    struct invalid_lemma {};
+    struct invalid_lemma: public iz3_exception {
+        invalid_lemma(): iz3_exception("invalid_lemma") {}
+    };
 
 
 
@@ -846,7 +848,9 @@ public:
             return 1;
     }
 
-    struct non_lit_local_ante {};
+    struct non_lit_local_ante: public iz3_exception {
+        non_lit_local_ante(): iz3_exception("non_lit_local_ante") {}
+    };
 
     bool local_antes_simple;
 


### PR DESCRIPTION
Using a base exception class, derived from z3_exception, makes it possible to
recover gracefully if something goes wrong during the computation of
interpolants.