### PR TITLE
Fix the Python FPRef.__lt__ implementation

### DIFF
--- a/src/api/python/z3.py
+++ b/src/api/python/z3.py
@@ -7808,7 +7808,7 @@ class FPRef(ExprRef):
         return fpLEQ(self, other)
 
     def __lt__(self, other):
-        return fpLEQ(self, other)
+        return fpLT(self, other)
 
     def __ge__(self, other):
         return fpGEQ(self, other)


### PR DESCRIPTION
This looks like it was a typo. I imagine this could have some rather bad consequences, though!