### PR TITLE
Change dataflow interface

### DIFF
--- a/src/muz/dataflow/reachability.h
+++ b/src/muz/dataflow/reachability.h
@@ -27,27 +27,34 @@ namespace datalog {
         typedef ast_manager ctx_t;
         static const reachability_info null_fact;
         reachability_info() : m_reachable(false) {}
+        reachability_info(func_decl* sym) : m_reachable(false) {}
 
-        void init_down(const ctx_t& m, const rule* r) {
-            m_reachable = true;
-        }
-
-        bool init_up(const ctx_t& m, const rule* r) {
-            if (m_reachable) 
-                return false;
-            else {
-                m_reachable = true;
-                return true;
+        static void init_down(ctx_t& m, const rule_set& rules, fact_setter<reachability_info>& setter) {
+            const func_decl_set& outputs = rules.get_output_predicates();
+            for (func_decl_set::iterator I = outputs.begin(),
+                E = outputs.end(); I != E; ++I) {
+                reachability_info& fact = setter.get(*I);
+                fact.m_reachable = true;
+                setter.set_changed(*I);
             }
         }
 
+        bool init_up(const ctx_t& m, const rule* r) {
+            if (!m_reachable && r->get_uninterpreted_tail_size() == 0) {
+                m_reachable = true;
+                return true;
+            } else
+                return false;
+        }
+
         void propagate_down(const ctx_t& manager, const rule* r, fact_writer<reachability_info>& tail_facts) const {
-            SASSERT(m_reachable);
-            for (unsigned i = 0; i < r->get_uninterpreted_tail_size(); ++i) {
-                reachability_info& tail_fact = tail_facts.get(i);
-                if (!tail_fact.m_reachable) {
-                    tail_fact.m_reachable = true;
-                    tail_facts.set_changed(i);
+            if (m_reachable) {
+                for (unsigned i = 0; i < r->get_uninterpreted_tail_size(); ++i) {
+                    reachability_info& tail_fact = tail_facts.get(i);
+                    if (!tail_fact.m_reachable) {
+                        tail_fact.m_reachable = true;
+                        tail_facts.set_changed(i);
+                    }
                 }
             }
         }


### PR DESCRIPTION
1. Let facts decide the way they want to initialize the top-down information.
2. Pass the func_decl of a predicate to the fact constructor.
   This allows us to more efficiently allocate ressources for that predicate.