### PR TITLE
Provide `unsupported` location when verbose is set

### DIFF
--- a/src/parsers/smt2/smt2parser.cpp
+++ b/src/parsers/smt2/smt2parser.cpp
@@ -2265,6 +2265,7 @@ namespace smt2 {
                 consume_sexpr();
             }
             m_ctx.print_unsupported(s);
+            IF_VERBOSE(1, error("unsupported symbol"););
             next();
             return;
         }


### PR DESCRIPTION
While writing `z3-mode` (an interactive development environment for z3), I realized that `unsupported symbol` did not provide location information. This is a simple patch that throws a location (column & line) information when z3 has verbose set.

If you would like this behavior to be conditional on some other `param`, I would be happy to make the change.