### PR TITLE
add __hash__ to AstRef

### DIFF
--- a/src/api/python/z3.py
+++ b/src/api/python/z3.py
@@ -284,6 +284,9 @@ class AstRef(Z3PPObject):
     def __repr__(self):
         return obj_to_string(self)
 
+    def __hash__(self):
+        return self.hash()
+
     def sexpr(self):
         """Return an string representing the AST node in s-expression notation.
         


### PR DESCRIPTION
AstRef objects needs to be hashable in order
to be used as keys in python dictionaries.

As example, consider 

```python
from z3 import Bool
X = Bool('x')
d = {}
d[X] = 2
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-4ee3c938faae> in <module>()
----> 1 d[X] = 2

TypeError: unhashable instance
```

With the proposed patch this works.