### PR TITLE
pass the correct context into And() when doing Tactic.as_expr()

### DIFF
--- a/src/api/python/z3.py
+++ b/src/api/python/z3.py
@@ -4862,7 +4862,7 @@ class Goal(Z3PPObject):
         elif sz == 1:
             return self.get(0)
         else:
-            return And([ self.get(i) for i in range(len(self)) ])
+            return And([ self.get(i) for i in range(len(self)) ], self.ctx)
 
 #########################################
 #


### PR DESCRIPTION
Z3 contexts apparently shouldn't be shared across different threads. For some reason, `And` takes a context rather than using one from its arguments. However, the `as_expr()` call of a `Tactic` doesn't pass the context in properly, and `z3.main_ctx()` ends up being used. This means that calling `as_expr` on an expression with a different context than the main one will give you a result on which `as_expr()` will throw an exception. This PR fixes that.

I've signed all the contribution paperwork for previous PRs.