### PR TITLE
Fixed stray UTF-8 Byte order mark in ``InterpolationContext.cs``.

### DIFF
--- a/src/api/dotnet/InterpolationContext.cs
+++ b/src/api/dotnet/InterpolationContext.cs
@@ -4,7 +4,7 @@ Copyright (c) 2015 Microsoft Corporation
 
 --*/
 
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;


### PR DESCRIPTION
Old versions of the mono compiler don't like it.