### PR TITLE
Refactor ``mk_all_assembly_infos()`` to use the ``configure_file()`` and misc fixes for dotnet bindings

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -1535,7 +1535,7 @@ class DotNetDLLComponent(Component):
                            ]
                          )
         if DEBUG_MODE:
-            cscCmdLine.extend( ['/define:DEBUG;TRACE',
+            cscCmdLine.extend( ['"/define:DEBUG;TRACE"', # Needs to be quoted due to ``;`` being a shell command separator
                                 '/debug+',
                                 '/debug:full',
                                 '/optimize-'

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -1950,7 +1950,7 @@ class DotNetExampleComponent(ExampleComponent):
         ExampleComponent.__init__(self, name, path)
 
     def is_example(self):
-        return IS_WINDOWS
+        return is_dotnet_enabled()
 
     def mk_makefile(self, out):
         if DOTNET_ENABLED:

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -1969,9 +1969,11 @@ class DotNetExampleComponent(ExampleComponent):
                 out.write(' /platform:x86')
             for csfile in get_cs_files(self.ex_dir):
                 out.write(' ')
-                # HACK
-                win_ex_dir = self.to_ex_dir.replace('/', '\\')
-                out.write(os.path.join(win_ex_dir, csfile))
+                # HACK: I'm not really sure why csc on Windows need to be
+                # given Windows style paths (``\``) here. I thought Windows
+                # supported using ``/`` as a path separator...
+                relative_path = self.to_ex_dir.replace('/', os.path.sep)
+                out.write(os.path.join(relative_path, csfile))
             out.write('\n')
             out.write('_ex_%s: %s\n\n' % (self.name, exefile))
 

--- a/src/api/dotnet/Properties/AssemblyInfo.cs.in
+++ b/src/api/dotnet/Properties/AssemblyInfo.cs.in
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Permissions;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Z3 .NET Interface")]
@@ -16,8 +16,8 @@ using System.Security.Permissions;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -27,11 +27,11 @@ using System.Security.Permissions;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("4.2.0.0")]
 [assembly: AssemblyVersion("@VER_MAJOR@.@VER_MINOR@.@VER_BUILD@.@VER_REVISION@")]

--- a/src/api/dotnet/Properties/AssemblyInfo.cs.in
+++ b/src/api/dotnet/Properties/AssemblyInfo.cs.in
@@ -12,7 +12,7 @@ using System.Security.Permissions;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Z3")]
-[assembly: AssemblyCopyright("Copyright (C) 2006-2014 Microsoft Corporation")]
+[assembly: AssemblyCopyright("Copyright (C) 2006-2015 Microsoft Corporation")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/api/dotnet/Properties/AssemblyInfo.cs.in
+++ b/src/api/dotnet/Properties/AssemblyInfo.cs.in
@@ -34,5 +34,5 @@ using System.Security.Permissions;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("4.2.0.0")]
-[assembly: AssemblyVersion("4.3.2.0")]
-[assembly: AssemblyFileVersion("4.3.2.0")]
+[assembly: AssemblyVersion("@VER_MAJOR@.@VER_MINOR@.@VER_BUILD@.@VER_REVISION@")]
+[assembly: AssemblyFileVersion("@VER_MAJOR@.@VER_MINOR@.@VER_BUILD@.@VER_REVISION@")]


### PR DESCRIPTION
Refactor ``mk_all_assembly_infos()`` to use the ``configure_file()``
function. The old implementation was buggy under Python 3.5 and
unsafe (not using with statements on calls to ``open()``).

This is a rework of #350 .

I quickly tested under Python 3.5 in the environment where I previously had crashes (``UnicodeDecodeError: 'ascii' codec can't decode byte 0xef in position
0: ordinal not in range(128)``)