### PR TITLE
revamp cancellation logic

### DIFF
--- a/src/api/api_algebraic.cpp
+++ b/src/api/api_algebraic.cpp
@@ -372,7 +372,7 @@ extern "C" {
         }
         scoped_anum_vector roots(_am);
         {
-            cancel_eh<algebraic_numbers::manager> eh(_am);
+            cancel_eh<reslimit> eh(mk_c(c)->m().limit());
             api::context::set_interruptable si(*(mk_c(c)), eh);
             scoped_timer timer(mk_c(c)->params().m_timeout, &eh);
             vector_var2anum v2a(as);
@@ -407,7 +407,7 @@ extern "C" {
             return 0;
         }
         {
-            cancel_eh<algebraic_numbers::manager> eh(_am);
+            cancel_eh<reslimit> eh(mk_c(c)->m().limit());
             api::context::set_interruptable si(*(mk_c(c)), eh);
             scoped_timer timer(mk_c(c)->params().m_timeout, &eh);
             vector_var2anum v2a(as);

--- a/src/api/api_ast.cpp
+++ b/src/api/api_ast.cpp
@@ -671,7 +671,7 @@ extern "C" {
         bool     use_ctrl_c  = p.get_bool("ctrl_c", false);
         th_rewriter m_rw(m, p);
         expr_ref    result(m);
-        cancel_eh<th_rewriter> eh(m_rw);
+        cancel_eh<reslimit> eh(m.limit());
         api::context::set_interruptable si(*(mk_c(c)), eh);
         {
             scoped_ctrl_c ctrlc(eh, false, use_ctrl_c);

--- a/src/api/api_context.cpp
+++ b/src/api/api_context.cpp
@@ -75,7 +75,8 @@ namespace api {
         m_dtutil(m()),
         m_last_result(m()),
         m_ast_trail(m()),
-        m_replay_stack() {
+        m_replay_stack(),
+        m_pmanager(m_limit) {
 
         m_error_code = Z3_OK;
         m_print_mode = Z3_PRINT_SMTLIB_FULL;
@@ -122,9 +123,8 @@ namespace api {
         {
             if (m_interruptable)
                 (*m_interruptable)();
-            m().set_cancel(true);
-            if (m_rcf_manager.get() != 0)
-                m_rcf_manager->set_cancel(true);
+            m_limit.cancel();
+            m().limit().cancel();
         }
     }
     
@@ -323,7 +323,7 @@ namespace api {
     // -----------------------
     realclosure::manager & context::rcfm() {
         if (m_rcf_manager.get() == 0) {
-            m_rcf_manager = alloc(realclosure::manager, m_rcf_qm);
+            m_rcf_manager = alloc(realclosure::manager, m_limit, m_rcf_qm);
         }
         return *(m_rcf_manager.get());
     }

--- a/src/api/api_context.h
+++ b/src/api/api_context.h
@@ -187,10 +187,12 @@ namespace api {
         //
         // -----------------------
     private:
+        reslimit                   m_limit;
         pmanager                   m_pmanager;
     public:
         polynomial::manager & pm() { return m_pmanager.pm(); }
-
+        reslimit & poly_limit() { return m_limit; }
+        
         // ------------------------
         //
         // RCF manager

--- a/src/api/api_datalog.cpp
+++ b/src/api/api_datalog.cpp
@@ -130,12 +130,6 @@ namespace api {
             m_context.display_smt2(num_queries, queries, str);
             return str.str();
         }
-        void cancel() { 
-            m_context.cancel(); 
-        }
-        void reset_cancel() { 
-            m_context.reset_cancel(); 
-        }
         unsigned get_num_levels(func_decl* pred) {
             return m_context.get_num_levels(pred);
         }
@@ -285,13 +279,13 @@ extern "C" {
         LOG_Z3_fixedpoint_query(c, d, q);
         RESET_ERROR_CODE();
         lbool r = l_undef;
-        cancel_eh<api::fixedpoint_context> eh(*to_fixedpoint_ref(d));
         unsigned timeout = to_fixedpoint(d)->m_params.get_uint("timeout", mk_c(c)->get_timeout());
         unsigned rlimit  = to_fixedpoint(d)->m_params.get_uint("rlimit", mk_c(c)->get_rlimit());
-        api::context::set_interruptable si(*(mk_c(c)), eh);        
         {
-            scoped_timer timer(timeout, &eh);
             scoped_rlimit _rlimit(mk_c(c)->m().limit(), rlimit);
+            cancel_eh<reslimit> eh(mk_c(c)->m().limit());
+            api::context::set_interruptable si(*(mk_c(c)), eh);        
+            scoped_timer timer(timeout, &eh);
             try {
                 r = to_fixedpoint_ref(d)->ctx().query(to_expr(q));
             }
@@ -313,7 +307,7 @@ extern "C" {
         RESET_ERROR_CODE();
         lbool r = l_undef;
         unsigned timeout = to_fixedpoint(d)->m_params.get_uint("timeout", mk_c(c)->get_timeout());
-        cancel_eh<api::fixedpoint_context> eh(*to_fixedpoint_ref(d));
+        cancel_eh<reslimit> eh(mk_c(c)->m().limit());
         api::context::set_interruptable si(*(mk_c(c)), eh);
         {
             scoped_timer timer(timeout, &eh);

--- a/src/api/api_interp.cpp
+++ b/src/api/api_interp.cpp
@@ -260,7 +260,7 @@ extern "C" {
         unsigned timeout     =  to_params(p)->m_params.get_uint("timeout", mk_c(c)->get_timeout());
         unsigned rlimit      =  to_params(p)->m_params.get_uint("rlimit", mk_c(c)->get_rlimit());
         bool     use_ctrl_c  =  to_params(p)->m_params.get_bool("ctrl_c", false);
-        cancel_eh<solver> eh(*m_solver.get());
+        cancel_eh<reslimit> eh(mk_c(c)->m().limit());
         api::context::set_interruptable si(*(mk_c(c)), eh);
 
         ast *_pat = to_ast(pat);

--- a/src/api/api_opt.cpp
+++ b/src/api/api_opt.cpp
@@ -124,7 +124,7 @@ extern "C" {
         LOG_Z3_optimize_check(c, o);
         RESET_ERROR_CODE();
         lbool r = l_undef;
-        cancel_eh<opt::context> eh(*to_optimize_ptr(o));
+        cancel_eh<reslimit> eh(mk_c(c)->m().limit());
         unsigned timeout = to_optimize_ptr(o)->get_params().get_uint("timeout", mk_c(c)->get_timeout());
         unsigned rlimit = mk_c(c)->get_rlimit();
         api::context::set_interruptable si(*(mk_c(c)), eh);        

--- a/src/api/api_polynomial.cpp
+++ b/src/api/api_polynomial.cpp
@@ -66,7 +66,7 @@ extern "C" {
             polynomial_ref r(pm);
             expr_ref _r(mk_c(c)->m());
             {
-                cancel_eh<polynomial::manager> eh(pm);
+                cancel_eh<reslimit> eh(mk_c(c)->m().limit());
                 api::context::set_interruptable si(*(mk_c(c)), eh);
                 scoped_timer timer(mk_c(c)->params().m_timeout, &eh);
                 pm.psc_chain(_p, _q, v_x, rs);

--- a/src/api/api_polynomial.cpp
+++ b/src/api/api_polynomial.cpp
@@ -29,17 +29,13 @@ Notes:
 
 namespace api {
 
-    pmanager::pmanager():
-        m_pm(m_nm) {
+    pmanager::pmanager(reslimit& lim):
+        m_pm(lim, m_nm) {
     }
 
     pmanager::~pmanager() {
     }
     
-    void pmanager::set_cancel(bool f) {
-        m_pm.set_cancel(f);
-    }
-
 };
 
 extern "C" {
@@ -66,7 +62,7 @@ extern "C" {
             polynomial_ref r(pm);
             expr_ref _r(mk_c(c)->m());
             {
-                cancel_eh<reslimit> eh(mk_c(c)->m().limit());
+                cancel_eh<reslimit> eh(mk_c(c)->poly_limit());
                 api::context::set_interruptable si(*(mk_c(c)), eh);
                 scoped_timer timer(mk_c(c)->params().m_timeout, &eh);
                 pm.psc_chain(_p, _q, v_x, rs);

--- a/src/api/api_polynomial.cpp
+++ b/src/api/api_polynomial.cpp
@@ -61,6 +61,7 @@ extern "C" {
             polynomial_ref_vector rs(pm);
             polynomial_ref r(pm);
             expr_ref _r(mk_c(c)->m());
+
             {
                 cancel_eh<reslimit> eh(mk_c(c)->poly_limit());
                 api::context::set_interruptable si(*(mk_c(c)), eh);

--- a/src/api/api_polynomial.h
+++ b/src/api/api_polynomial.h
@@ -28,10 +28,9 @@ namespace api {
         polynomial::manager m_pm;
         // TODO: add support for caching expressions -> polynomial and back
     public:
-        pmanager();
+        pmanager(reslimit& limx);
         virtual ~pmanager();
         polynomial::manager & pm() { return m_pm; }
-        void set_cancel(bool f);
     };
 
 };

--- a/src/api/api_rcf.cpp
+++ b/src/api/api_rcf.cpp
@@ -30,7 +30,7 @@ static rcmanager & rcfm(Z3_context c) {
 }
 
 static void reset_rcf_cancel(Z3_context c) {
-    rcfm(c).reset_cancel();
+    // no-op
 }
 
 static Z3_rcf_num from_rcnumeral(rcnumeral a) { 

--- a/src/api/api_solver.cpp
+++ b/src/api/api_solver.cpp
@@ -271,7 +271,7 @@ extern "C" {
         unsigned timeout     = to_solver(s)->m_params.get_uint("timeout", mk_c(c)->get_timeout());
         unsigned rlimit      = to_solver(s)->m_params.get_uint("rlimit", mk_c(c)->get_rlimit());
         bool     use_ctrl_c  = to_solver(s)->m_params.get_bool("ctrl_c", false);
-        cancel_eh<solver> eh(*to_solver_ref(s));
+        cancel_eh<reslimit> eh(mk_c(c)->m().limit());
         api::context::set_interruptable si(*(mk_c(c)), eh);
         lbool result;
         {

--- a/src/api/api_tactic.cpp
+++ b/src/api/api_tactic.cpp
@@ -409,7 +409,7 @@ extern "C" {
 
         unsigned timeout     = p.get_uint("timeout", UINT_MAX);
         bool     use_ctrl_c  = p.get_bool("ctrl_c", false);
-        cancel_eh<tactic> eh(*to_tactic_ref(t));
+        cancel_eh<reslimit> eh(mk_c(c)->m().limit());
         
         to_tactic_ref(t)->updt_params(p);
 

--- a/src/ast/arith_decl_plugin.cpp
+++ b/src/ast/arith_decl_plugin.cpp
@@ -28,8 +28,8 @@ struct arith_decl_plugin::algebraic_numbers_wrapper {
     id_gen                        m_id_gen;
     scoped_anum_vector            m_nums;
 
-    algebraic_numbers_wrapper():
-        m_amanager(m_qmanager),
+    algebraic_numbers_wrapper(reslimit& lim):
+        m_amanager(lim, m_qmanager),
         m_nums(m_amanager) {
     }
 
@@ -66,7 +66,7 @@ struct arith_decl_plugin::algebraic_numbers_wrapper {
 
 arith_decl_plugin::algebraic_numbers_wrapper & arith_decl_plugin::aw() const {
     if (m_aw == 0)
-        const_cast<arith_decl_plugin*>(this)->m_aw = alloc(algebraic_numbers_wrapper);
+        const_cast<arith_decl_plugin*>(this)->m_aw = alloc(algebraic_numbers_wrapper, m_manager->limit());
     return *m_aw;
 }
 

--- a/src/ast/arith_decl_plugin.cpp
+++ b/src/ast/arith_decl_plugin.cpp
@@ -110,10 +110,6 @@ parameter arith_decl_plugin::translate(parameter const & p, decl_plugin & target
     return parameter(_target.aw().mk_id(aw().idx2anum(p.get_ext_id())), true);
 }
 
-void arith_decl_plugin::set_cancel(bool f) {
-    if (m_aw)
-        m_aw->m_amanager.set_cancel(f);
-}
 
 void arith_decl_plugin::set_manager(ast_manager * m, family_id id) {
     decl_plugin::set_manager(m, id);

--- a/src/ast/arith_decl_plugin.h
+++ b/src/ast/arith_decl_plugin.h
@@ -211,7 +211,6 @@ public:
 
     virtual expr * get_some_value(sort * s);
 
-    virtual void set_cancel(bool f);
 };
 
 /**
@@ -398,9 +397,6 @@ public:
         return m_manager.mk_eq(lhs, rhs);
     }
 
-    void set_cancel(bool f) {
-        plugin().set_cancel(f);
-    }
 };
 
 #endif /* ARITH_DECL_PLUGIN_H_ */

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -1433,12 +1433,6 @@ ast_manager::~ast_manager() {
     }
 }
 
-void ast_manager::set_cancel(bool f) {
-    for (unsigned i = 0; i < m_plugins.size(); i++) {
-        m_plugins[i]->set_cancel(f);
-    }
-}
-
 void ast_manager::compact_memory() {
     m_alloc.consolidate();
     unsigned capacity = m_ast_table.capacity();

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -932,7 +932,6 @@ public:
     virtual ~decl_plugin() {}
     virtual void finalize() {}
 
-    virtual void set_cancel(bool f) {}
 
     virtual decl_plugin * mk_fresh() = 0;
 
@@ -1472,9 +1471,6 @@ public:
     ~ast_manager();
 
     // propagate cancellation signal to decl_plugins
-    void set_cancel(bool f);
-    void cancel() { set_cancel(true); }
-    void reset_cancel() { set_cancel(false); }
 
     bool has_trace_stream() const { return m_trace_stream != 0; }
     std::ostream & trace_stream() { SASSERT(has_trace_stream()); return *m_trace_stream; }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1522,6 +1522,7 @@ public:
     }
 
     reslimit& limit() { return m_limit; }
+    bool canceled() { return !limit().inc(); }
 
     void register_plugin(symbol const & s, decl_plugin * plugin);
     

--- a/src/ast/normal_forms/name_exprs.cpp
+++ b/src/ast/normal_forms/name_exprs.cpp
@@ -87,9 +87,6 @@ public:
         TRACE("name_exprs", tout << mk_ismt2_pp(n, m_rw.m()) << "\n---->\n" << mk_ismt2_pp(r, m_rw.m()) << "\n";);
     }
     
-    virtual void set_cancel(bool f) {
-        m_rw.set_cancel(f);
-    }
 
     virtual void reset() {
         m_rw.reset();

--- a/src/ast/normal_forms/name_exprs.h
+++ b/src/ast/normal_forms/name_exprs.h
@@ -37,9 +37,6 @@ public:
                             proof_ref & p                      // [OUT] proof for (iff n p)
                             ) = 0;
     
-    virtual void set_cancel(bool f) = 0;
-    void cancel() { set_cancel(true); }
-    void reset_cancel() { set_cancel(false); }
     virtual void reset() = 0;
 };
 

--- a/src/ast/normal_forms/nnf.cpp
+++ b/src/ast/normal_forms/nnf.cpp
@@ -250,7 +250,6 @@ struct nnf::imp {
     name_exprs *           m_name_nested_formulas;
     name_exprs *           m_name_quant;
     
-    volatile bool          m_cancel;
     unsigned long long     m_max_memory; // in bytes
 
     imp(ast_manager & m, defined_names & n, params_ref const & p):
@@ -259,8 +258,7 @@ struct nnf::imp {
         m_todo_defs(m),
         m_todo_proofs(m),
         m_result_pr_stack(m),
-        m_skolemizer(m),
-        m_cancel(false) {
+        m_skolemizer(m) {
         updt_params(p);
         for (unsigned i = 0; i < 4; i++) {
             m_cache[i] = alloc(act_cache, m);
@@ -369,15 +367,12 @@ struct nnf::imp {
         return false;
     }
 
-    void set_cancel(bool f) {
-        m_cancel = f;
-    }
     
     void checkpoint() {
         cooperate("nnf");
         if (memory::get_allocation_size() > m_max_memory)
             throw nnf_exception(Z3_MAX_MEMORY_MSG);
-        if (m_cancel)
+        if (m().canceled()) 
             throw nnf_exception(Z3_CANCELED_MSG);
     }
 
@@ -916,9 +911,6 @@ void nnf::get_param_descrs(param_descrs & r) {
     imp::get_param_descrs(r);
 }
 
-void nnf::set_cancel(bool f) {
-    m_imp->set_cancel(f);
-}
 
 void nnf::reset() {
     m_imp->reset();

--- a/src/ast/normal_forms/nnf.h
+++ b/src/ast/normal_forms/nnf.h
@@ -44,10 +44,6 @@ public:
     */
     static void get_param_descrs(param_descrs & r);
 
-    void cancel() { set_cancel(true); }
-    void reset_cancel() { set_cancel(false); }
-    void set_cancel(bool f);
-
     void reset();
     void reset_cache();
 };

--- a/src/ast/rewriter/arith_rewriter.cpp
+++ b/src/ast/rewriter/arith_rewriter.cpp
@@ -1032,9 +1032,6 @@ br_status arith_rewriter::mk_abs_core(expr * arg, expr_ref & result) {
     return BR_REWRITE2;
 }
 
-void arith_rewriter::set_cancel(bool f) {
-    m_util.set_cancel(f);
-}
 
 // Return true if t is of the form  c*Pi where c is a numeral.
 // Store c into k

--- a/src/ast/rewriter/arith_rewriter.h
+++ b/src/ast/rewriter/arith_rewriter.h
@@ -167,8 +167,6 @@ public:
     }
     br_status mk_is_int(expr * arg, expr_ref & result);
 
-    void set_cancel(bool f);
-
     br_status mk_sin_core(expr * arg, expr_ref & result);
     br_status mk_cos_core(expr * arg, expr_ref & result);
     br_status mk_tan_core(expr * arg, expr_ref & result);

--- a/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.cpp
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.cpp
@@ -649,10 +649,6 @@ void bit_blaster_rewriter::updt_params(params_ref const& p) {
     m_imp->m_cfg.updt_params(p);
 }
 
-void bit_blaster_rewriter::set_cancel(bool f) {
-    m_imp->set_cancel(f);
-    m_imp->m_blaster.set_cancel(f);
-}
 
 void bit_blaster_rewriter::push() {
     m_imp->push();

--- a/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.h
@@ -30,7 +30,6 @@ public:
     bit_blaster_rewriter(ast_manager & m, params_ref const & p);
     ~bit_blaster_rewriter();
     void updt_params(params_ref const & p);
-    void set_cancel(bool f);
     ast_manager & m() const;
     unsigned get_num_steps() const;
     void cleanup();

--- a/src/ast/rewriter/bit_blaster/bit_blaster_tpl.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_tpl.h
@@ -36,7 +36,6 @@ protected:
     void mk_ext_rotate_left_right(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits);
 
     unsigned long long m_max_memory;
-    volatile bool      m_cancel;
     bool               m_use_wtm; /* Wallace Tree Multiplier */
     bool               m_use_bcm; /* Booth Multiplier for constants */
     void checkpoint();
@@ -45,7 +44,6 @@ public:
     bit_blaster_tpl(Cfg const & cfg = Cfg(), unsigned long long max_memory = UINT64_MAX, bool use_wtm = false, bool use_bcm=false):
         Cfg(cfg),
         m_max_memory(max_memory),
-        m_cancel(false),
         m_use_wtm(use_wtm),
         m_use_bcm(use_bcm) {
     }
@@ -54,9 +52,6 @@ public:
         m_max_memory = max_memory;
     }
 
-    void set_cancel(bool f) { m_cancel = f; }
-    void cancel() { set_cancel(true); }
-    void reset_cancel() { set_cancel(false); }
     
     // Cfg required API
     ast_manager & m() const { return Cfg::m(); }

--- a/src/ast/rewriter/bit_blaster/bit_blaster_tpl_def.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_tpl_def.h
@@ -27,7 +27,7 @@ template<typename Cfg>
 void bit_blaster_tpl<Cfg>::checkpoint() {
     if (memory::get_allocation_size() > m_max_memory)
         throw rewriter_exception(Z3_MAX_MEMORY_MSG);
-    if (m_cancel)
+    if (m().canceled())
         throw rewriter_exception(Z3_CANCELED_MSG);
     cooperate("bit-blaster");
 }

--- a/src/ast/rewriter/der.cpp
+++ b/src/ast/rewriter/der.cpp
@@ -444,12 +444,6 @@ void der_rewriter::operator()(expr * t, expr_ref & result, proof_ref & result_pr
     m_imp->operator()(t, result, result_pr);
 }
 
-void der_rewriter::set_cancel(bool f) {
-    #pragma omp critical (der_rewriter)
-    {
-        m_imp->set_cancel(f);
-    }
-}
 
 void der_rewriter::cleanup() {
     ast_manager & m = m_imp->m();

--- a/src/ast/rewriter/der.h
+++ b/src/ast/rewriter/der.h
@@ -174,9 +174,6 @@ public:
 
     void operator()(expr * t, expr_ref & result, proof_ref & result_pr);
 
-    void cancel() { set_cancel(true); }
-    void reset_cancel() { set_cancel(false); }
-    void set_cancel(bool f);
     void cleanup();
     void reset();
 };

--- a/src/ast/rewriter/expr_replacer.cpp
+++ b/src/ast/rewriter/expr_replacer.cpp
@@ -107,9 +107,6 @@ public:
         }
     }
 
-    virtual void set_cancel(bool f) {
-        m_replacer.set_cancel(f);
-    }
 
     virtual unsigned get_num_steps() const {
         return m_replacer.get_num_steps();
@@ -144,10 +141,6 @@ public:
         m_r(t, result, result_pr);
         result_dep = m_r.get_used_dependencies();
         m_r.reset_used_dependencies();
-    }
-
-    virtual void set_cancel(bool f) {
-        m_r.set_cancel(f);
     }
 
     virtual unsigned get_num_steps() const { 

--- a/src/ast/rewriter/expr_replacer.h
+++ b/src/ast/rewriter/expr_replacer.h
@@ -39,9 +39,6 @@ public:
     virtual void operator()(expr * t, expr_ref & result);
     virtual void operator()(expr_ref & t) { expr_ref s(t, m()); (*this)(s, t); }
 
-    void cancel() { set_cancel(true); }
-    void reset_cancel() { set_cancel(false); }
-    virtual void set_cancel(bool f) = 0;
     virtual unsigned get_num_steps() const { return 0; }
     virtual void reset() = 0;
     

--- a/src/ast/rewriter/rewriter.h
+++ b/src/ast/rewriter/rewriter.h
@@ -212,7 +212,6 @@ protected:
     };
     Config &                   m_cfg;
     unsigned                   m_num_steps;
-    volatile bool              m_cancel;
     ptr_vector<expr>           m_bindings;
     var_shifter                m_shifter;
     expr_ref                   m_r;
@@ -332,10 +331,6 @@ public:
     ast_manager & m() const { return this->m_manager; }
     Config & cfg() { return m_cfg; }
     Config const & cfg() const { return m_cfg; }
-
-    void set_cancel(bool f) { m_cancel = f; }
-    void cancel() { set_cancel(true); }
-    void reset_cancel() { set_cancel(false); }
 
     ~rewriter_tpl();
     

--- a/src/ast/rewriter/rewriter_def.h
+++ b/src/ast/rewriter/rewriter_def.h
@@ -578,8 +578,12 @@ void rewriter_tpl<Config>::resume_core(expr_ref & result, proof_ref & result_pr)
     while (!frame_stack().empty()) {
         if (m_cancel)
             throw rewriter_exception(Z3_CANCELED_MSG);
-        if (!m().limit().inc()) 
+        if (!m().canceled()) {
+            if (m().limit().cancel_flag_set()) {
+                throw rewriter_exception(Z3_CANCELED_MSG);
+            }
             throw rewriter_exception(Z3_MAX_RESOURCE_MSG);
+        }
         SASSERT(!ProofGen || result_stack().size() == result_pr_stack().size());
         frame & fr = frame_stack().back();
         expr * t   = fr.m_curr;

--- a/src/ast/rewriter/rewriter_def.h
+++ b/src/ast/rewriter/rewriter_def.h
@@ -576,10 +576,7 @@ void rewriter_tpl<Config>::resume_core(expr_ref & result, proof_ref & result_pr)
     SASSERT(!frame_stack().empty());
     while (!frame_stack().empty()) {
         if (m().canceled()) {
-            if (m().limit().cancel_flag_set()) {
-                throw rewriter_exception(Z3_CANCELED_MSG);
-            }
-            throw rewriter_exception(Z3_MAX_RESOURCE_MSG);
+            throw rewriter_exception(m().limit().get_cancel_msg());
         }
         SASSERT(!ProofGen || result_stack().size() == result_pr_stack().size());
         frame & fr = frame_stack().back();

--- a/src/ast/rewriter/rewriter_def.h
+++ b/src/ast/rewriter/rewriter_def.h
@@ -495,7 +495,6 @@ rewriter_tpl<Config>::rewriter_tpl(ast_manager & m, bool proof_gen, Config & cfg
     rewriter_core(m, proof_gen),
     m_cfg(cfg),
     m_num_steps(0),
-    m_cancel(false),
     m_shifter(m),
     m_r(m),
     m_pr(m),
@@ -576,8 +575,6 @@ template<bool ProofGen>
 void rewriter_tpl<Config>::resume_core(expr_ref & result, proof_ref & result_pr) {
     SASSERT(!frame_stack().empty());
     while (!frame_stack().empty()) {
-        if (m_cancel)
-            throw rewriter_exception(Z3_CANCELED_MSG);
         if (!m().canceled()) {
             if (m().limit().cancel_flag_set()) {
                 throw rewriter_exception(Z3_CANCELED_MSG);

--- a/src/ast/rewriter/rewriter_def.h
+++ b/src/ast/rewriter/rewriter_def.h
@@ -575,7 +575,7 @@ template<bool ProofGen>
 void rewriter_tpl<Config>::resume_core(expr_ref & result, proof_ref & result_pr) {
     SASSERT(!frame_stack().empty());
     while (!frame_stack().empty()) {
-        if (!m().canceled()) {
+        if (m().canceled()) {
             if (m().limit().cancel_flag_set()) {
                 throw rewriter_exception(Z3_CANCELED_MSG);
             }

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -214,7 +214,7 @@ br_status seq_rewriter::mk_seq_contains(expr* a, expr* b, expr_ref& result) {
     for (unsigned i = 0; !found && i < as.size(); ++i) {
         if (bs.size() > as.size() - i) break;
         unsigned j = 0;
-        for (; j < bs.size() && as[j] == bs[i+j]; ++j) {};
+        for (; j < bs.size() && as[j+i] == bs[j]; ++j) {};
         found = j == bs.size();
     }
     if (found) {

--- a/src/ast/rewriter/th_rewriter.cpp
+++ b/src/ast/rewriter/th_rewriter.cpp
@@ -734,11 +734,8 @@ unsigned th_rewriter::get_num_steps() const {
 
 void th_rewriter::cleanup() {
     ast_manager & m = m_imp->m();
-    #pragma omp critical (th_rewriter)
-    {
-        dealloc(m_imp);
-        m_imp = alloc(imp, m, m_params);
-    }
+    dealloc(m_imp);
+    m_imp = alloc(imp, m, m_params);    
 }
 
 void th_rewriter::reset() {

--- a/src/ast/rewriter/th_rewriter.cpp
+++ b/src/ast/rewriter/th_rewriter.cpp
@@ -685,9 +685,6 @@ struct th_rewriter_cfg : public default_rewriter_cfg {
         return false;
     }
 
-    void set_cancel(bool f) {
-        m_a_rw.set_cancel(f);
-    }
 };
 
 template class rewriter_tpl<th_rewriter_cfg>;
@@ -734,13 +731,6 @@ unsigned th_rewriter::get_num_steps() const {
     return m_imp->get_num_steps();
 }
 
-void th_rewriter::set_cancel(bool f) {
-    #pragma omp critical (th_rewriter)
-    {
-        m_imp->set_cancel(f);
-        m_imp->cfg().set_cancel(f);
-    }
-}
 
 void th_rewriter::cleanup() {
     ast_manager & m = m_imp->m();

--- a/src/ast/rewriter/th_rewriter.h
+++ b/src/ast/rewriter/th_rewriter.h
@@ -45,9 +45,6 @@ public:
     void operator()(expr * t, expr_ref & result, proof_ref & result_pr);
     void operator()(expr * n, unsigned num_bindings, expr * const * bindings, expr_ref & result);
 
-    void cancel() { set_cancel(true); }
-    void reset_cancel() { set_cancel(false); }
-    void set_cancel(bool f);
     void cleanup();
     void reset();
 

--- a/src/cmd_context/cmd_context.cpp
+++ b/src/cmd_context/cmd_context.cpp
@@ -352,16 +352,15 @@ cmd_context::~cmd_context() {
 }
 
 void cmd_context::set_cancel(bool f) {
-    if (m_solver) {
+    if (has_manager()) {
+        m().set_cancel(f);
         if (f) {
-            m_solver->cancel();
+            m().limit().cancel();
         }
         else {
-            m_solver->reset_cancel();
+            m().limit().reset_cancel();
         }
     }
-    if (has_manager())
-        m().set_cancel(f);
 }
 
 opt_wrapper* cmd_context::get_opt() {
@@ -1453,7 +1452,7 @@ void cmd_context::check_sat(unsigned num_assumptions, expr * const * assumptions
     else if (m_solver) {
         m_check_sat_result = m_solver.get(); // solver itself stores the result.
         m_solver->set_progress_callback(this);
-        cancel_eh<solver> eh(*m_solver);
+        cancel_eh<reslimit> eh(m().limit());
         scoped_ctrl_c ctrlc(eh);
         scoped_timer timer(timeout, &eh);
         scoped_rlimit _rlimit(m().limit(), rlimit);
@@ -1612,7 +1611,7 @@ void cmd_context::validate_model() {
     model_evaluator evaluator(*(md.get()), p);
     contains_array_op_proc contains_array(m());
     {
-        cancel_eh<model_evaluator> eh(evaluator);
+        cancel_eh<reslimit> eh(m().limit());
         expr_ref r(m());
         scoped_ctrl_c ctrlc(eh);
         ptr_vector<expr>::const_iterator it  = begin_assertions();

--- a/src/cmd_context/cmd_context.cpp
+++ b/src/cmd_context/cmd_context.cpp
@@ -353,7 +353,6 @@ cmd_context::~cmd_context() {
 
 void cmd_context::set_cancel(bool f) {
     if (has_manager()) {
-        m().set_cancel(f);
         if (f) {
             m().limit().cancel();
         }

--- a/src/cmd_context/cmd_context.cpp
+++ b/src/cmd_context/cmd_context.cpp
@@ -1610,6 +1610,7 @@ void cmd_context::validate_model() {
     model_evaluator evaluator(*(md.get()), p);
     contains_array_op_proc contains_array(m());
     {
+        scoped_rlimit _rlimit(m().limit(), 0);
         cancel_eh<reslimit> eh(m().limit());
         expr_ref r(m());
         scoped_ctrl_c ctrlc(eh);

--- a/src/cmd_context/cmd_context.cpp
+++ b/src/cmd_context/cmd_context.cpp
@@ -1418,7 +1418,7 @@ void cmd_context::check_sat(unsigned num_assumptions, expr * const * assumptions
     if (m_opt && !m_opt->empty()) {
         was_opt = true;
         m_check_sat_result = get_opt();
-        cancel_eh<opt_wrapper> eh(*get_opt());
+        cancel_eh<reslimit> eh(m().limit());
         scoped_ctrl_c ctrlc(eh);
         scoped_timer timer(timeout, &eh);
         scoped_rlimit _rlimit(m().limit(), rlimit);

--- a/src/cmd_context/cmd_context.h
+++ b/src/cmd_context/cmd_context.h
@@ -116,9 +116,6 @@ public:
     virtual bool empty() = 0;
     virtual void push() = 0;
     virtual void pop(unsigned n) = 0;
-    virtual void set_cancel(bool f) = 0;
-    virtual void reset_cancel() = 0;
-    virtual void cancel() = 0;
     virtual lbool optimize() = 0;
     virtual void set_hard_constraints(ptr_vector<expr> & hard) = 0;
     virtual void display_assignment(std::ostream& out) = 0;

--- a/src/cmd_context/context_params.cpp
+++ b/src/cmd_context/context_params.cpp
@@ -35,7 +35,7 @@ context_params::context_params() {
     m_smtlib2_compliant = false;
     m_well_sorted_check = false;
     m_timeout = UINT_MAX;
-    m_rlimit  = UINT_MAX;
+    m_rlimit  = 0;
     updt_params();
 }
 
@@ -153,7 +153,7 @@ void context_params::updt_params(params_ref const & p) {
 
 void context_params::collect_param_descrs(param_descrs & d) {
     d.insert("timeout", CPK_UINT, "default timeout (in milliseconds) used for solvers", "4294967295");
-    d.insert("rlimit", CPK_UINT, "default resource limit used for solvers", "4294967295");
+    d.insert("rlimit", CPK_UINT, "default resource limit used for solvers. Unrestricted when set to 0.", "0");
     d.insert("well_sorted_check", CPK_BOOL, "type checker", "false");
     d.insert("type_check", CPK_BOOL, "type checker (alias for well_sorted_check)", "true");
     d.insert("auto_config", CPK_BOOL, "use heuristics to automatically select solver and configure it", "true");

--- a/src/cmd_context/eval_cmd.cpp
+++ b/src/cmd_context/eval_cmd.cpp
@@ -63,11 +63,13 @@ public:
         last_result->get_model(md);
         expr_ref r(ctx.m());
         unsigned timeout = m_params.get_uint("timeout", UINT_MAX);
+        unsigned rlimit  = m_params.get_uint("rlimit", 0);
         model_evaluator ev(*(md.get()), m_params);
         cancel_eh<reslimit> eh(ctx.m().limit());
         { 
             scoped_ctrl_c ctrlc(eh);
             scoped_timer timer(timeout, &eh);
+            scoped_rlimit _rlimit(ctx.m().limit(), rlimit);
             cmd_context::scoped_watch sw(ctx);
             try {
                 ev(m_target, r);

--- a/src/cmd_context/eval_cmd.cpp
+++ b/src/cmd_context/eval_cmd.cpp
@@ -64,7 +64,7 @@ public:
         expr_ref r(ctx.m());
         unsigned timeout = m_params.get_uint("timeout", UINT_MAX);
         model_evaluator ev(*(md.get()), m_params);
-        cancel_eh<model_evaluator> eh(ev);
+        cancel_eh<reslimit> eh(ctx.m().limit());
         { 
             scoped_ctrl_c ctrlc(eh);
             scoped_timer timer(timeout, &eh);

--- a/src/cmd_context/extra_cmds/polynomial_cmds.cpp
+++ b/src/cmd_context/extra_cmds/polynomial_cmds.cpp
@@ -83,6 +83,7 @@ static void factor(cmd_context & ctx, expr * t, polynomial::factor_params const 
 class poly_isolate_roots_cmd : public cmd {
     struct context {
         arith_util                  m_util;
+        reslimit                    m_lim;
         unsynch_mpq_manager         m_qm;
         polynomial::manager         m_pm;
         algebraic_numbers::manager  m_am;
@@ -95,7 +96,7 @@ class poly_isolate_roots_cmd : public cmd {
         context(ast_manager & m):
             m_util(m),
             m_pm(m_qm),
-            m_am(m_qm),
+            m_am(m_lim, m_qm),
             m_p(m_pm),
             m_expr2poly(m, m_pm),
             m_var(polynomial::null_var),

--- a/src/cmd_context/extra_cmds/polynomial_cmds.cpp
+++ b/src/cmd_context/extra_cmds/polynomial_cmds.cpp
@@ -33,7 +33,7 @@ Notes:
 
 static void to_poly(cmd_context & ctx, expr * t) {
     polynomial::numeral_manager nm;
-    polynomial::manager pm(nm);
+    polynomial::manager pm(ctx.m().limit(), nm);
     default_expr2polynomial expr2poly(ctx.m(), pm);
     polynomial::polynomial_ref p(pm);
     polynomial::scoped_numeral d(nm);
@@ -52,7 +52,7 @@ static void to_poly(cmd_context & ctx, expr * t) {
 
 static void factor(cmd_context & ctx, expr * t, polynomial::factor_params const & ps) {
     polynomial::numeral_manager nm;
-    polynomial::manager pm(nm);
+    polynomial::manager pm(ctx.m().limit(), nm);
     default_expr2polynomial expr2poly(ctx.m(), pm);
     polynomial::polynomial_ref p(pm);
     polynomial::scoped_numeral d(nm);
@@ -95,7 +95,7 @@ class poly_isolate_roots_cmd : public cmd {
         
         context(ast_manager & m):
             m_util(m),
-            m_pm(m_qm),
+            m_pm(m.limit(), m_qm),
             m_am(m_lim, m_qm),
             m_p(m_pm),
             m_expr2poly(m, m_pm),

--- a/src/cmd_context/extra_cmds/subpaving_cmds.cpp
+++ b/src/cmd_context/extra_cmds/subpaving_cmds.cpp
@@ -27,7 +27,7 @@ static void to_subpaving(cmd_context & ctx, expr * t) {
     ast_manager & m = ctx.m();
     unsynch_mpq_manager qm;
     scoped_ptr<subpaving::context> s;
-    s = subpaving::mk_mpq_context(qm);
+    s = subpaving::mk_mpq_context(ctx.m().limit(), qm);
     expr2var e2v(m);
     expr2subpaving e2s(m, *s, &e2v);
     params_ref p;

--- a/src/cmd_context/simplify_cmd.cpp
+++ b/src/cmd_context/simplify_cmd.cpp
@@ -73,9 +73,11 @@ public:
         unsigned cache_sz;
         unsigned num_steps = 0;
         unsigned timeout   = m_params.get_uint("timeout", UINT_MAX);
+        unsigned rlimit    = m_params.get_uint("rlimit", UINT_MAX);
         bool failed = false;
         cancel_eh<reslimit> eh(ctx.m().limit());
         { 
+            scoped_rlimit _rlimit(ctx.m().limit(), rlimit);
             scoped_ctrl_c ctrlc(eh);
             scoped_timer timer(timeout, &eh);
             cmd_context::scoped_watch sw(ctx);

--- a/src/cmd_context/simplify_cmd.cpp
+++ b/src/cmd_context/simplify_cmd.cpp
@@ -74,7 +74,7 @@ public:
         unsigned num_steps = 0;
         unsigned timeout   = m_params.get_uint("timeout", UINT_MAX);
         bool failed = false;
-        cancel_eh<th_rewriter> eh(s);
+        cancel_eh<reslimit> eh(ctx.m().limit());
         { 
             scoped_ctrl_c ctrlc(eh);
             scoped_timer timer(timeout, &eh);

--- a/src/cmd_context/tactic_cmds.cpp
+++ b/src/cmd_context/tactic_cmds.cpp
@@ -188,6 +188,7 @@ public:
         tref->set_logic(ctx.get_logic());
         ast_manager & m = ctx.m();
         unsigned timeout   = p.get_uint("timeout", UINT_MAX);
+        unsigned rlimit  =   p.get_uint("rlimit", 0);
         goal_ref g = alloc(goal, m, ctx.produce_proofs(), ctx.produce_models(), ctx.produce_unsat_cores());
         assert_exprs_from(ctx, *g);
         TRACE("check_sat_using", g->display(tout););
@@ -201,6 +202,7 @@ public:
             tactic & t = *tref;
             cancel_eh<reslimit>  eh(m.limit());
             {
+                scoped_rlimit _rlimit(m.limit(), rlimit);
                 scoped_ctrl_c ctrlc(eh);
                 scoped_timer timer(timeout, &eh);
                 cmd_context::scoped_watch sw(ctx);
@@ -302,6 +304,7 @@ public:
             assert_exprs_from(ctx, *g);
 
             unsigned timeout   = p.get_uint("timeout", UINT_MAX);
+            unsigned rlimit  =   p.get_uint("rlimit", 0);
 
             goal_ref_buffer     result_goals;
             model_converter_ref mc;
@@ -312,6 +315,7 @@ public:
             bool failed = false;
             cancel_eh<reslimit>  eh(m.limit());
             {
+                scoped_rlimit _rlimit(m.limit(), rlimit);
                 scoped_ctrl_c ctrlc(eh);
                 scoped_timer timer(timeout, &eh);
                 cmd_context::scoped_watch sw(ctx);

--- a/src/cmd_context/tactic_cmds.cpp
+++ b/src/cmd_context/tactic_cmds.cpp
@@ -199,7 +199,7 @@ public:
         ctx.set_check_sat_result(result.get());
         {
             tactic & t = *tref;
-            cancel_eh<tactic>  eh(t);
+            cancel_eh<reslimit>  eh(m.limit());
             {
                 scoped_ctrl_c ctrlc(eh);
                 scoped_timer timer(timeout, &eh);
@@ -310,7 +310,7 @@ public:
 
             std::string reason_unknown;
             bool failed = false;
-            cancel_eh<tactic>  eh(t);
+            cancel_eh<reslimit>  eh(m.limit());
             {
                 scoped_ctrl_c ctrlc(eh);
                 scoped_timer timer(timeout, &eh);

--- a/src/duality/duality_wrapper.h
+++ b/src/duality/duality_wrapper.h
@@ -936,8 +936,7 @@ namespace Duality {
 	void cancel(){
             scoped_proof_mode spm(m(),m_mode); 
             canceled = true;
-            if(m_solver)
-                m_solver->cancel();
+            m().limit().cancel();
 	}
 
 	unsigned get_scope_level(){ scoped_proof_mode spm(m(),m_mode); return m_solver->get_scope_level();}

--- a/src/math/euclid/euclidean_solver.cpp
+++ b/src/math/euclid/euclidean_solver.cpp
@@ -98,7 +98,6 @@ struct euclidean_solver::imp {
 
     numeral_manager *  m_manager;
     bool               m_owns_m;
-    volatile bool      m_cancel;
 
     equations          m_equations;
     equations          m_solution;
@@ -517,7 +516,6 @@ struct euclidean_solver::imp {
         m_var_queue(16, elim_order_lt(m_solved)) {
         m_inconsistent       = null_eq_idx;
         m_next_justification = 0; 
-        m_cancel             = false;
         m_next_x             = null_var;
         m_next_eq            = null_eq_idx;
     }
@@ -779,9 +777,6 @@ struct euclidean_solver::imp {
         del_nums(m_norm_bs_vector);
     }
 
-    void set_cancel(bool f) {
-        m_cancel = f;
-    }
 
 };
 
@@ -842,12 +837,6 @@ void euclidean_solver::normalize(unsigned num, mpz const * as, var const * xs, m
     return m_imp->normalize(num, as, xs, c, a_prime, c_prime, js);
 }
 
-void euclidean_solver::set_cancel(bool f) {
-    #pragma omp critical (euclidean_solver)
-    {
-        m_imp->set_cancel(f);
-    }
-}
 
 void euclidean_solver::display(std::ostream & out) const {
     m_imp->display(out);

--- a/src/math/euclid/euclidean_solver.cpp
+++ b/src/math/euclid/euclidean_solver.cpp
@@ -796,12 +796,9 @@ void euclidean_solver::reset() {
     numeral_manager * m = m_imp->m_manager;
     bool owns_m         = m_imp->m_owns_m;
     m_imp->m_owns_m     = false;
-    #pragma omp critical (euclidean_solver)
-    {
-        dealloc(m_imp);
-        m_imp = alloc(imp, m);
-        m_imp->m_owns_m = owns_m;
-    }
+    dealloc(m_imp);
+    m_imp = alloc(imp, m);
+    m_imp->m_owns_m = owns_m;    
 }
 
 euclidean_solver::var euclidean_solver::mk_var() {

--- a/src/math/euclid/euclidean_solver.h
+++ b/src/math/euclid/euclidean_solver.h
@@ -95,10 +95,6 @@ public:
     */
     void normalize(unsigned num, mpz const * as, var const * xs, mpz const & c, mpz & a_prime, mpz & c_prime, justification_vector & js);
 
-    /**
-       \brief Set/Reset the cancel flag.
-    */
-    void set_cancel(bool f);
 
     void display(std::ostream & out) const;
 };

--- a/src/math/hilbert/hilbert_basis.h
+++ b/src/math/hilbert/hilbert_basis.h
@@ -32,6 +32,7 @@ Revision History:
 #include "lbool.h"
 #include "statistics.h"
 #include "checked_int64.h"
+#include "rlimit.h"
 
 typedef vector<rational> rational_vector;
 
@@ -85,6 +86,7 @@ class hilbert_basis {
         numeral const* operator()() const { return m_values; }
     };
 
+    reslimit&          m_limit;
     vector<num_vector> m_ineqs;      // set of asserted inequalities
     svector<bool>      m_iseq;       // inequalities that are equalities
     num_vector         m_store;      // store of vectors
@@ -95,7 +97,6 @@ class hilbert_basis {
     svector<offset_t>  m_zero;       // zeros
     passive*           m_passive;    // passive set
     passive2*          m_passive2;   // passive set
-    volatile bool      m_cancel;     
     stats              m_stats;
     index*             m_index;      // index of generated vectors
     unsigned_vector    m_ints;       // indices that can be both positive and negative
@@ -104,6 +105,7 @@ class hilbert_basis {
     bool               m_use_support;             // parameter: (associativity) resolve only against vectors that are initially in basis.
     bool               m_use_ordered_support;     // parameter: (commutativity) resolve in order
     bool               m_use_ordered_subsumption; // parameter
+
 
     class iterator {
         hilbert_basis const& hb;
@@ -138,6 +140,8 @@ class hilbert_basis {
     bool can_resolve(offset_t i, offset_t j, bool check_sign) const;
     sign_t get_sign(offset_t idx) const;
     bool add_goal(offset_t idx);
+    bool checkpoint();
+
     offset_t alloc_vector();
     void resolve(offset_t i, offset_t j, offset_t r);
     iterator begin() const { return iterator(*this,0); }
@@ -154,7 +158,7 @@ class hilbert_basis {
 
 public:
         
-    hilbert_basis();
+    hilbert_basis(reslimit& rl);
     ~hilbert_basis();
 
     void reset();
@@ -187,8 +191,6 @@ public:
 
     unsigned get_num_ineqs() const { return m_ineqs.size(); }
     void get_ge(unsigned i, rational_vector& v, rational& b, bool& is_eq);    
-
-    void set_cancel(bool f) { m_cancel = f; }
 
     void display(std::ostream& out) const;
 

--- a/src/math/interval/interval.h
+++ b/src/math/interval/interval.h
@@ -21,6 +21,7 @@ Revision History:
 
 #include"mpq.h"
 #include"ext_numeral.h"
+#include"rlimit.h"
 
 /**
    \brief Default configuration for interval manager.
@@ -110,6 +111,7 @@ public:
     typedef typename numeral_manager::numeral numeral;
     typedef typename C::interval              interval;
 private:
+    reslimit&  m_limit;
     C          m_c;
     numeral    m_result_lower;
     numeral    m_result_upper;
@@ -127,7 +129,6 @@ private:
     interval   m_3_pi_div_2;
     interval   m_2_pi;
 
-    volatile bool m_cancel;     
     
     void round_to_minus_inf() { m_c.round_to_minus_inf(); }
     void round_to_plus_inf() { m_c.round_to_plus_inf(); }
@@ -161,10 +162,8 @@ private:
     void checkpoint();
 
 public:    
-    interval_manager(C const & c);
+    interval_manager(reslimit& lim, C const & c);
     ~interval_manager();
-
-    void set_cancel(bool f) { m_cancel = f; }
 
     numeral_manager & m() const { return m_c.m(); }    
 

--- a/src/math/interval/interval_def.h
+++ b/src/math/interval/interval_def.h
@@ -62,7 +62,7 @@ void interval_manager<C>::del(interval & a) {
 
 template<typename C>
 void interval_manager<C>::checkpoint() {
-    if (m_limit.canceled())
+    if (!m_limit.inc())
         throw default_exception("canceled");
     cooperate("interval");
 }

--- a/src/math/interval/interval_def.h
+++ b/src/math/interval/interval_def.h
@@ -30,11 +30,10 @@ Revision History:
 // #define TRACE_NTH_ROOT
 
 template<typename C>
-interval_manager<C>::interval_manager(C const & c):m_c(c) { 
+interval_manager<C>::interval_manager(reslimit& lim, C const & c): m_limit(lim), m_c(c) { 
     m().set(m_minus_one, -1); 
     m().set(m_one, 1);
     m_pi_n = 0;
-    m_cancel = false;
 }
 
 template<typename C>
@@ -63,7 +62,7 @@ void interval_manager<C>::del(interval & a) {
 
 template<typename C>
 void interval_manager<C>::checkpoint() {
-    if (m_cancel)
+    if (m_limit.canceled())
         throw default_exception("canceled");
     cooperate("interval");
 }

--- a/src/math/polynomial/algebraic_numbers.cpp
+++ b/src/math/polynomial/algebraic_numbers.cpp
@@ -61,7 +61,8 @@ namespace algebraic_numbers {
         algebraic_params::collect_param_descrs(r);
     }
 
-    struct manager::imp {
+    struct manager::imp {        
+        reslimit&                m_limit;
         manager &                m_wrapper;
         small_object_allocator & m_allocator;
         unsynch_mpq_manager &    m_qmanager;
@@ -96,7 +97,8 @@ namespace algebraic_numbers {
         unsigned                 m_compare_refine;
         unsigned                 m_compare_poly_eq;
 
-        imp(manager & w, unsynch_mpq_manager & m, params_ref const & p, small_object_allocator & a):
+        imp(reslimit& lim, manager & w, unsynch_mpq_manager & m, params_ref const & p, small_object_allocator & a):
+            m_limit(lim),
             m_wrapper(w),
             m_allocator(a),
             m_qmanager(m),
@@ -2764,14 +2766,14 @@ namespace algebraic_numbers {
        
     };
 
-    manager::manager(unsynch_mpq_manager & m, params_ref const & p, small_object_allocator * a) {
+    manager::manager(reslimit& lim, unsynch_mpq_manager & m, params_ref const & p, small_object_allocator * a) {
         m_own_allocator = false;
         m_allocator     = a;
         if (m_allocator == 0) {
             m_own_allocator = true;
             m_allocator     = alloc(small_object_allocator, "algebraic");
         }
-        m_imp = alloc(imp, *this, m, p, *m_allocator);
+        m_imp = alloc(imp, lim, *this, m, p, *m_allocator);
     }
 
     manager::~manager() {

--- a/src/math/polynomial/algebraic_numbers.cpp
+++ b/src/math/polynomial/algebraic_numbers.cpp
@@ -83,7 +83,6 @@ namespace algebraic_numbers {
         scoped_upoly             m_add_tmp;
         polynomial::var          m_x;
         polynomial::var          m_y;
-        volatile bool            m_cancel;
         
         // configuration
         int                        m_min_magnitude;
@@ -104,8 +103,8 @@ namespace algebraic_numbers {
             m_qmanager(m),
             m_bqmanager(m),
             m_bqimanager(m_bqmanager),
-            m_pmanager(m, &a),
-            m_upmanager(m),
+            m_pmanager(lim, m, &a),
+            m_upmanager(lim, m),
             m_is_rational_tmp(m),
             m_isolate_tmp1(upm()),
             m_isolate_tmp2(upm()),
@@ -118,7 +117,6 @@ namespace algebraic_numbers {
             m_add_tmp(upm()) {
             updt_params(p);
             reset_statistics();
-            m_cancel = false;
             m_x = pm().mk_var();
             m_y = pm().mk_var();
         }
@@ -126,14 +124,8 @@ namespace algebraic_numbers {
         ~imp() {
         }
         
-        void set_cancel(bool f) {
-            m_cancel = f;
-            pm().set_cancel(f);
-            upm().set_cancel(f);
-        }
-
         void checkpoint() {
-            if (m_cancel)
+            if (!m_limit.inc())
                 throw algebraic_exception("canceled");
             cooperate("algebraic");
         }
@@ -2783,10 +2775,6 @@ namespace algebraic_numbers {
     }
 
     void manager::updt_params(params_ref const & p) {
-    }
-
-    void manager::set_cancel(bool f) {
-        m_imp->set_cancel(f);
     }
 
     unsynch_mpq_manager & manager::qm() const {

--- a/src/math/polynomial/algebraic_numbers.h
+++ b/src/math/polynomial/algebraic_numbers.h
@@ -64,10 +64,6 @@ namespace algebraic_numbers {
         static void get_param_descrs(param_descrs & r);
         static void collect_param_descrs(param_descrs & r) { get_param_descrs(r); }
 
-        void set_cancel(bool f);
-        void cancel() { set_cancel(true); }
-        void reset_cancel() { set_cancel(false); }
-
         void updt_params(params_ref const & p);
 
         unsynch_mpq_manager & qm() const;

--- a/src/math/polynomial/algebraic_numbers.h
+++ b/src/math/polynomial/algebraic_numbers.h
@@ -28,6 +28,7 @@ Notes:
 #include"tptr.h"
 #include"statistics.h"
 #include"params.h"
+#include"rlimit.h"
 
 class small_object_allocator;
 class mpbq_manager;
@@ -57,7 +58,7 @@ namespace algebraic_numbers {
         typedef _scoped_numeral<manager> scoped_numeral;
         typedef _scoped_numeral_vector<manager> scoped_numeral_vector;
 
-        manager(unsynch_mpq_manager & m, params_ref const & p = params_ref(), small_object_allocator * a = 0);
+        manager(reslimit& rl, unsynch_mpq_manager & m, params_ref const & p = params_ref(), small_object_allocator * a = 0);
         ~manager();
 
         static void get_param_descrs(param_descrs & r);

--- a/src/math/polynomial/polynomial.h
+++ b/src/math/polynomial/polynomial.h
@@ -28,6 +28,7 @@ Notes:
 #include"scoped_numeral_vector.h"
 #include"params.h"
 #include"mpbqi.h"
+#include"rlimit.h"
 
 class small_object_allocator;
 
@@ -190,8 +191,8 @@ namespace polynomial {
     private:
         imp * m_imp;
     public:
-        manager(numeral_manager & m, monomial_manager * mm = 0);
-        manager(numeral_manager & m, small_object_allocator * a);
+        manager(reslimit& lim, numeral_manager & m, monomial_manager * mm = 0);
+        manager(reslimit& lim, numeral_manager & m, small_object_allocator * a);
         ~manager();
 
         numeral_manager & m() const;
@@ -217,10 +218,6 @@ namespace polynomial {
         */
         void set_zp(numeral const & p);
         void set_zp(uint64 p);
-
-        void set_cancel(bool f);
-        void cancel() { set_cancel(true); }
-        void reset_cancel() { set_cancel(false); }
 
         /**
            \brief Abstract event handler.

--- a/src/math/polynomial/rpolynomial.cpp
+++ b/src/math/polynomial/rpolynomial.cpp
@@ -58,7 +58,6 @@ namespace rpolynomial {
         numeral_manager &                m_manager;
         small_object_allocator *         m_allocator;
         bool                             m_own_allocator;
-        volatile bool                    m_cancel;
         
         imp(manager & w, numeral_manager & m, small_object_allocator * a):
             m_wrapper(w),
@@ -67,7 +66,6 @@ namespace rpolynomial {
             m_own_allocator(a == 0) {
             if (a == 0)
                 m_allocator = alloc(small_object_allocator, "rpolynomial");
-            m_cancel = false;
         }
 
         ~imp() {

--- a/src/math/polynomial/rpolynomial.h
+++ b/src/math/polynomial/rpolynomial.h
@@ -57,8 +57,6 @@ namespace rpolynomial {
         numeral_manager & m() const;
         small_object_allocator & allocator() const;
 
-        void set_cancel(bool f);
-
         /**
            \brief Create a new variable.
         */

--- a/src/math/polynomial/upolynomial.cpp
+++ b/src/math/polynomial/upolynomial.cpp
@@ -134,9 +134,9 @@ namespace upolynomial {
         std::swap(m_total_degree, other.m_total_degree);
     }
 
-    core_manager::core_manager(unsynch_mpz_manager & m):
+    core_manager::core_manager(reslimit& lim, unsynch_mpz_manager & m):
+        m_limit(lim),
         m_manager(m) {
-        m_cancel = false;
     }
 
     core_manager::~core_manager() {
@@ -153,12 +153,8 @@ namespace upolynomial {
         reset(m_pw_tmp);
     }
 
-    void core_manager::set_cancel(bool f) {
-        m_cancel = f;
-    }
-
     void core_manager::checkpoint() {
-        if (m_cancel)
+        if (!m_limit.inc()) 
             throw upolynomial_exception("canceled");
         cooperate("upolynomial");
     }

--- a/src/math/polynomial/upolynomial.h
+++ b/src/math/polynomial/upolynomial.h
@@ -29,6 +29,7 @@ Notes:
 #include"polynomial.h"
 #include"z3_exception.h"
 #include"mpbq.h"
+#include"rlimit.h"
 #define FACTOR_VERBOSE_LVL 1000
 
 namespace upolynomial {
@@ -101,6 +102,7 @@ namespace upolynomial {
         };
 
     protected:
+        reslimit&         m_limit;
         numeral_manager   m_manager;
         numeral_vector    m_basic_tmp;
         numeral_vector    m_div_tmp1;
@@ -114,7 +116,6 @@ namespace upolynomial {
         numeral_vector    m_sqf_tmp1;
         numeral_vector    m_sqf_tmp2;
         numeral_vector    m_pw_tmp;
-        volatile bool     m_cancel;
 
         static bool is_alias(numeral const * p, numeral_vector & buffer) { return buffer.c_ptr() != 0 && buffer.c_ptr() == p; }
         void neg_core(unsigned sz1, numeral const * p1, numeral_vector & buffer);
@@ -128,12 +129,12 @@ namespace upolynomial {
         void CRA_combine_images(numeral_vector const & q, numeral const & p, numeral_vector & C, numeral & bound);
 
     public:
-        core_manager(z_numeral_manager & m);
+        core_manager(reslimit& lim, z_numeral_manager & m);
         ~core_manager();
 
         z_numeral_manager & zm() const { return m_manager.m(); }
         numeral_manager & m() const { return const_cast<core_manager*>(this)->m_manager; }
-
+        reslimit& lim() const { return m_limit; }
         /**
            \brief Return true if Z_p[X]
         */
@@ -156,7 +157,6 @@ namespace upolynomial {
 
         void checkpoint();
 
-        void set_cancel(bool f);
 
         /**
            \brief set p size to 0. That is, p is the zero polynomial after this operation.
@@ -576,7 +576,7 @@ namespace upolynomial {
         bool factor_core(unsigned sz, numeral const * p, factors & r, factor_params const & params);
 
     public:
-        manager(z_numeral_manager & m):core_manager(m) {}
+        manager(reslimit& lim, z_numeral_manager & m):core_manager(lim, m) {}
         ~manager();
 
         void reset(numeral_vector & p) { core_manager::reset(p); }

--- a/src/math/polynomial/upolynomial_factorization.cpp
+++ b/src/math/polynomial/upolynomial_factorization.cpp
@@ -518,7 +518,7 @@ bool check_hansel_lift(z_manager & upm, numeral_vector const & C,
     scoped_mpz br(nm);
     nm.mul(b, r, br);
     
-    zp_manager br_upm(upm.zm());
+    zp_manager br_upm(upm.lim(), upm.zm());
     br_upm.set_zp(br);
 
     if (A_lifted.size() != A.size()) return false;
@@ -543,7 +543,7 @@ bool check_hansel_lift(z_manager & upm, numeral_vector const & C,
         return false;
     }
 
-    zp_manager b_upm(nm);
+    zp_manager b_upm(upm.lim(), nm);
     b_upm.set_zp(b);
 
     // test2: A_lifted = A (mod b)
@@ -596,7 +596,7 @@ void hensel_lift(z_manager & upm, numeral const & a, numeral const & b, numeral 
         tout << "C = "; upm.display(tout, C); tout << ")" << endl;
     );
 
-    zp_manager r_upm(nm);
+    zp_manager r_upm(upm.lim(), nm);
     r_upm.set_zp(r);
 
     SASSERT(upm.degree(C) == upm.degree(A) + upm.degree(B));
@@ -717,7 +717,7 @@ void hensel_lift_quadratic(z_manager& upm, numeral_vector const & C,
     );
 
     // we create a new Z_p manager, since we'll be changing the input one
-    zp_manager zp_upm(nm);
+    zp_manager zp_upm(upm.lim(), nm);
     zp_upm.set_zp(zpe_upm.m().p());
 
     // get the U, V, such that A*U + B*V = 1 (mod p)
@@ -1055,7 +1055,7 @@ bool factor_square_free(z_manager & upm, numeral_vector const & f, factors & fs,
     // the variables we'll be using and updating in Z_p
     scoped_numeral p(nm); 
     nm.set(p, 2);
-    zp_manager zp_upm(nm.m());
+    zp_manager zp_upm(upm.lim(), nm.m());
     zp_upm.set_zp(p);
     zp_factors zp_fs(zp_upm);
     scoped_numeral zp_fs_p(nm); nm.set(zp_fs_p, 2);
@@ -1163,7 +1163,7 @@ bool factor_square_free(z_manager & upm, numeral_vector const & f, factors & fs,
           );
     
     // we got a prime factoring, so we do the lifting now
-    zp_manager zpe_upm(nm.m());
+    zp_manager zpe_upm(upm.lim(), nm.m());
     zpe_upm.set_zp(zp_fs_p);
     zp_numeral_manager & zpe_nm = zpe_upm.m();
     

--- a/src/math/realclosure/realclosure.cpp
+++ b/src/math/realclosure/realclosure.cpp
@@ -501,8 +501,8 @@ namespace realclosure {
             m_qm(qm),
             m_mm(m_qm, *m_allocator),
             m_bqm(m_qm),
-            m_qim(m_qm),
-            m_bqim(m_bqm),
+            m_qim(lim, m_qm),
+            m_bqim(lim, m_bqm),
             m_plus_inf_approx(m_bqm),
             m_minus_inf_approx(m_bqm) {
             mpq one(1);

--- a/src/math/realclosure/realclosure.cpp
+++ b/src/math/realclosure/realclosure.cpp
@@ -369,6 +369,7 @@ namespace realclosure {
         typedef sbuffer<int, REALCLOSURE_INI_BUFFER_SIZE> int_buffer;
         typedef sbuffer<unsigned, REALCLOSURE_INI_BUFFER_SIZE> unsigned_buffer;
         
+        reslimit&                      m_limit;
         small_object_allocator *       m_allocator;
         bool                           m_own_allocator;
         unsynch_mpq_manager &          m_qm;
@@ -400,7 +401,6 @@ namespace realclosure {
 
         bool                           m_in_aux_values; // True if we are computing SquareFree polynomials or Sturm sequences. That is, the values being computed will be discarded.
 
-        volatile bool                  m_cancel;
 
         struct scoped_polynomial_seq {
             typedef ref_buffer<value, imp, REALCLOSURE_INI_SEQ_SIZE> value_seq;
@@ -494,7 +494,8 @@ namespace realclosure {
         #define INC_DEPTH() ((void) 0)
         #endif
 
-        imp(unsynch_mpq_manager & qm, params_ref const & p, small_object_allocator * a):
+        imp(reslimit& lim, unsynch_mpq_manager & qm, params_ref const & p, small_object_allocator * a):
+            m_limit(lim),
             m_allocator(a == 0 ? alloc(small_object_allocator, "realclosure") : a),
             m_own_allocator(a == 0),
             m_qm(qm),
@@ -514,7 +515,6 @@ namespace realclosure {
 
             m_in_aux_values = false;
 
-            m_cancel = false;
             
             updt_params(p);
         }
@@ -547,7 +547,7 @@ namespace realclosure {
         small_object_allocator & allocator() { return *m_allocator; }
 
         void checkpoint() {
-            if (m_cancel)
+            if (!m_limit.inc())
                 throw exception("canceled");
             cooperate("rcf");
         }
@@ -730,9 +730,6 @@ namespace realclosure {
             return m_extensions[extension::ALGEBRAIC].size();
         }
         
-        void set_cancel(bool f) {
-            m_cancel = f;
-        }
         
         void updt_params(params_ref const & _p) {
             rcf_params p(_p);
@@ -6033,8 +6030,8 @@ namespace realclosure {
         ~save_interval_ctx() { m->restore_saved_intervals(); }
     };
 
-    manager::manager(unsynch_mpq_manager & m, params_ref const & p, small_object_allocator * a) {
-        m_imp = alloc(imp, m, p, a);
+    manager::manager(reslimit& lim, unsynch_mpq_manager & m, params_ref const & p, small_object_allocator * a) {
+        m_imp = alloc(imp, lim, m, p, a);
     }
         
     manager::~manager() {
@@ -6043,10 +6040,6 @@ namespace realclosure {
 
     void manager::get_param_descrs(param_descrs & r) {
         rcf_params::collect_param_descrs(r);
-    }
-
-    void manager::set_cancel(bool f) {
-        m_imp->set_cancel(f);
     }
 
     void manager::updt_params(params_ref const & p) {

--- a/src/math/realclosure/realclosure.h
+++ b/src/math/realclosure/realclosure.h
@@ -28,6 +28,7 @@ Notes:
 #include"scoped_numeral_vector.h"
 #include"interval.h"
 #include"z3_exception.h"
+#include"rlimit.h"
 
 namespace realclosure {
     class num;
@@ -47,7 +48,7 @@ namespace realclosure {
         friend class save_interval_ctx;
         imp * m_imp;
     public:
-        manager(unsynch_mpq_manager & m, params_ref const & p = params_ref(), small_object_allocator * a = 0);
+        manager(reslimit& lim, unsynch_mpq_manager & m, params_ref const & p = params_ref(), small_object_allocator * a = 0);
         ~manager();
         typedef num                             numeral;
         typedef svector<numeral>                numeral_vector;
@@ -57,9 +58,6 @@ namespace realclosure {
         static void get_param_descrs(param_descrs & r);
         static void collect_param_descrs(param_descrs & r) { get_param_descrs(r); }
 
-        void set_cancel(bool f);
-        void cancel() { set_cancel(true); }
-        void reset_cancel() { set_cancel(false); }
 
         void updt_params(params_ref const & p);
 

--- a/src/math/simplex/simplex.h
+++ b/src/math/simplex/simplex.h
@@ -92,6 +92,7 @@ namespace simplex {
         };
 
         static const var_t null_var;
+        reslimit&                   m_limit;
         mutable manager             m;
         mutable eps_manager         em;
         mutable matrix              M;
@@ -109,10 +110,10 @@ namespace simplex {
         stats                       m_stats;
 
     public:
-        simplex():
+        simplex(reslimit& lim):
+            m_limit(lim),
             M(m),
             m_max_iterations(UINT_MAX),
-            m_cancel(false),
             m_to_patch(1024),
             m_bland(false),
             m_blands_rule_threshold(1000) {}
@@ -140,7 +141,6 @@ namespace simplex {
         void  unset_lower(var_t var);
         void  unset_upper(var_t var); 
         void  set_value(var_t var, eps_numeral const& b);        
-        void  set_cancel(bool f) { m_cancel = f; }
         void  set_max_iterations(unsigned n) { m_max_iterations = n; }
         void  reset();
         lbool make_feasible();

--- a/src/math/simplex/simplex.h
+++ b/src/math/simplex/simplex.h
@@ -97,7 +97,6 @@ namespace simplex {
         mutable eps_manager         em;
         mutable matrix              M;
         unsigned                    m_max_iterations;
-        volatile bool               m_cancel;
         var_heap                    m_to_patch;
         vector<var_info>            m_vars;
         svector<var_t>              m_row2base;

--- a/src/math/simplex/simplex_def.h
+++ b/src/math/simplex/simplex_def.h
@@ -332,7 +332,7 @@ namespace simplex {
         SASSERT(well_formed());
         while ((v = select_var_to_fix()) != null_var) {
             TRACE("simplex", display(tout << "v" << v << "\n"););
-            if (m_cancel || num_iterations > m_max_iterations) {
+            if (!m_limit.inc() || num_iterations > m_max_iterations) {
                 return l_undef;
             }
             check_blands_rule(v, num_repeated);
@@ -670,7 +670,7 @@ namespace simplex {
         bool inc_x_i, inc_x_j;
 
         while (true) {
-            if (m_cancel) {
+            if (!m_limit.inc()) {
                 return l_undef;
             }
             select_pivot_primal(v, x_i, x_j, a_ij, inc_x_i, inc_x_j);

--- a/src/math/subpaving/subpaving.cpp
+++ b/src/math/subpaving/subpaving.cpp
@@ -37,7 +37,7 @@ namespace subpaving {
     protected:
         CTX m_ctx;
     public:
-        context_wrapper(typename CTX::numeral_manager & m, params_ref const & p, small_object_allocator * a):m_ctx(m, p, a) {}
+        context_wrapper(reslimit& lim, typename CTX::numeral_manager & m, params_ref const & p, small_object_allocator * a):m_ctx(lim, m, p, a) {}
         virtual ~context_wrapper() {}
         virtual unsigned num_vars() const { return m_ctx.num_vars(); }
         virtual var mk_var(bool is_int) { return m_ctx.mk_var(is_int); }
@@ -47,7 +47,6 @@ namespace subpaving {
         virtual void dec_ref(ineq * a) { m_ctx.dec_ref(reinterpret_cast<typename CTX::ineq*>(a)); }
         virtual void add_clause(unsigned sz, ineq * const * atoms) { m_ctx.add_clause(sz, reinterpret_cast<typename CTX::ineq * const *>(atoms)); }
         virtual void display_constraints(std::ostream & out, bool use_star) const { m_ctx.display_constraints(out, use_star); }
-        virtual void set_cancel(bool f) { m_ctx.set_cancel(f); }
         virtual void set_display_proc(display_var_proc * p) { m_ctx.set_display_proc(p); }
         virtual void reset_statistics() { m_ctx.reset_statistics(); }
         virtual void collect_statistics(statistics & st) const { m_ctx.collect_statistics(st); }
@@ -61,8 +60,8 @@ namespace subpaving {
         scoped_mpq        m_c;
         scoped_mpq_vector m_as;
     public:
-        context_mpq_wrapper(unsynch_mpq_manager & m, params_ref const & p, small_object_allocator * a):
-            context_wrapper<context_mpq>(m, p, a), 
+        context_mpq_wrapper(reslimit& lim, unsynch_mpq_manager & m, params_ref const & p, small_object_allocator * a):
+            context_wrapper<context_mpq>(lim, m, p, a), 
             m_c(m), 
             m_as(m) 
         {}
@@ -100,8 +99,8 @@ namespace subpaving {
         }
         
     public:
-        context_mpf_wrapper(f2n<mpf_manager> & fm, params_ref const & p, small_object_allocator * a):
-            context_wrapper<context_mpf>(fm, p, a),
+        context_mpf_wrapper(reslimit& lim, f2n<mpf_manager> & fm, params_ref const & p, small_object_allocator * a):
+            context_wrapper<context_mpf>(lim, fm, p, a),
             m_qm(fm.m().mpq_manager()),
             m_c(fm.m()),
             m_as(fm.m()),
@@ -161,8 +160,8 @@ namespace subpaving {
         }
         
     public:
-        context_hwf_wrapper(f2n<hwf_manager> & fm, unsynch_mpq_manager & qm, params_ref const & p, small_object_allocator * a):
-            context_wrapper<context_hwf>(fm, p, a),
+        context_hwf_wrapper(reslimit& lim,f2n<hwf_manager> & fm, unsynch_mpq_manager & qm, params_ref const & p, small_object_allocator * a):
+            context_wrapper<context_hwf>(lim, fm, p, a),
             m_qm(qm) {
         }
 
@@ -215,8 +214,8 @@ namespace subpaving {
         }
         
     public:
-        context_fpoint_wrapper(typename context_fpoint::numeral_manager & m, unsynch_mpq_manager & qm, params_ref const & p, small_object_allocator * a):
-            context_wrapper<context_fpoint>(m, p, a),
+        context_fpoint_wrapper(reslimit& lim, typename context_fpoint::numeral_manager & m, unsynch_mpq_manager & qm, params_ref const & p, small_object_allocator * a):
+            context_wrapper<context_fpoint>(lim, m, p, a),
             m_qm(qm), 
             m_c(m),
             m_as(m),
@@ -261,24 +260,24 @@ namespace subpaving {
     typedef context_fpoint_wrapper<context_mpff> context_mpff_wrapper;
     typedef context_fpoint_wrapper<context_mpfx> context_mpfx_wrapper;
 
-    context * mk_mpq_context(unsynch_mpq_manager & m, params_ref const & p, small_object_allocator * a) {
-        return alloc(context_mpq_wrapper, m, p, a);
+    context * mk_mpq_context(reslimit& lim, unsynch_mpq_manager & m, params_ref const & p, small_object_allocator * a) {
+        return alloc(context_mpq_wrapper, lim, m, p, a);
     }
 
-    context * mk_mpf_context(f2n<mpf_manager> & m, params_ref const & p, small_object_allocator * a) {
-        return alloc(context_mpf_wrapper, m, p, a);
+    context * mk_mpf_context(reslimit& lim, f2n<mpf_manager> & m, params_ref const & p, small_object_allocator * a) {
+        return alloc(context_mpf_wrapper, lim, m, p, a);
     }
 
-    context * mk_hwf_context(f2n<hwf_manager> & m, unsynch_mpq_manager & qm, params_ref const & p, small_object_allocator * a) {
-        return alloc(context_hwf_wrapper, m, qm, p, a);
+    context * mk_hwf_context(reslimit& lim, f2n<hwf_manager> & m, unsynch_mpq_manager & qm, params_ref const & p, small_object_allocator * a) {
+        return alloc(context_hwf_wrapper, lim, m, qm, p, a);
     }
 
-    context * mk_mpff_context(mpff_manager & m, unsynch_mpq_manager & qm, params_ref const & p, small_object_allocator * a) {
-        return alloc(context_mpff_wrapper, m, qm, p, a);
+    context * mk_mpff_context(reslimit& lim, mpff_manager & m, unsynch_mpq_manager & qm, params_ref const & p, small_object_allocator * a) {
+        return alloc(context_mpff_wrapper, lim, m, qm, p, a);
     }
 
-    context * mk_mpfx_context(mpfx_manager & m, unsynch_mpq_manager & qm, params_ref const & p, small_object_allocator * a) {
-        return alloc(context_mpfx_wrapper, m, qm, p, a);
+    context * mk_mpfx_context(reslimit& lim, mpfx_manager & m, unsynch_mpq_manager & qm, params_ref const & p, small_object_allocator * a) {
+        return alloc(context_mpfx_wrapper, lim, m, qm, p, a);
     }
 
 };

--- a/src/math/subpaving/subpaving.h
+++ b/src/math/subpaving/subpaving.h
@@ -95,7 +95,6 @@ public:
     */
     virtual void display_constraints(std::ostream & out, bool use_star = false) const = 0;
 
-    virtual void set_cancel(bool f) = 0;
 
     virtual void collect_param_descrs(param_descrs & r) = 0;
 
@@ -112,11 +111,11 @@ public:
     virtual void display_bounds(std::ostream & out) const = 0;
 };
 
-context * mk_mpq_context(unsynch_mpq_manager & m, params_ref const & p = params_ref(), small_object_allocator * a = 0);
-context * mk_mpf_context(f2n<mpf_manager> & m, params_ref const & p = params_ref(), small_object_allocator * a = 0);
-context * mk_hwf_context(f2n<hwf_manager> & m, unsynch_mpq_manager & qm, params_ref const & p = params_ref(), small_object_allocator * a = 0);
-context * mk_mpff_context(mpff_manager & m, unsynch_mpq_manager & qm, params_ref const & p = params_ref(), small_object_allocator * a = 0);
-context * mk_mpfx_context(mpfx_manager & m, unsynch_mpq_manager & qm, params_ref const & p = params_ref(), small_object_allocator * a = 0);
+ context * mk_mpq_context(reslimit& lim, unsynch_mpq_manager & m, params_ref const & p = params_ref(), small_object_allocator * a = 0);
+context * mk_mpf_context(reslimit& lim, f2n<mpf_manager> & m, params_ref const & p = params_ref(), small_object_allocator * a = 0);
+context * mk_hwf_context(reslimit& lim, f2n<hwf_manager> & m, unsynch_mpq_manager & qm, params_ref const & p = params_ref(), small_object_allocator * a = 0);
+context * mk_mpff_context(reslimit& lim, mpff_manager & m, unsynch_mpq_manager & qm, params_ref const & p = params_ref(), small_object_allocator * a = 0);
+context * mk_mpfx_context(reslimit& lim, mpfx_manager & m, unsynch_mpq_manager & qm, params_ref const & p = params_ref(), small_object_allocator * a = 0);
 
 };
 

--- a/src/math/subpaving/subpaving_hwf.h
+++ b/src/math/subpaving/subpaving_hwf.h
@@ -40,7 +40,7 @@ public:
 
 class context_hwf : public context_t<config_hwf> {
 public:
-    context_hwf(f2n<hwf_manager> & m, params_ref const & p, small_object_allocator * a):context_t<config_hwf>(config_hwf(m), p, a) {}
+ context_hwf(reslimit& lim, f2n<hwf_manager> & m, params_ref const & p, small_object_allocator * a):context_t<config_hwf>(lim, config_hwf(m), p, a) {}
 };
 
 };

--- a/src/math/subpaving/subpaving_mpf.h
+++ b/src/math/subpaving/subpaving_mpf.h
@@ -41,7 +41,7 @@ public:
 
 class context_mpf : public context_t<config_mpf> {
 public:
-    context_mpf(f2n<mpf_manager> & m, params_ref const & p, small_object_allocator * a):context_t<config_mpf>(config_mpf(m), p, a) {}
+ context_mpf(reslimit& lim, f2n<mpf_manager> & m, params_ref const & p, small_object_allocator * a):context_t<config_mpf>(lim, config_mpf(m), p, a) {}
 };
 
 };

--- a/src/math/subpaving/subpaving_t.h
+++ b/src/math/subpaving/subpaving_t.h
@@ -31,6 +31,7 @@ Revision History:
 #include"statistics.h"
 #include"lbool.h"
 #include"id_gen.h"
+#include"rlimit.h"
 #ifdef _MSC_VER
 #pragma warning(disable : 4200)
 #pragma warning(disable : 4355)
@@ -526,8 +527,6 @@ private:
     numeral                   m_tmp1, m_tmp2, m_tmp3;
     interval                  m_i_tmp1, m_i_tmp2, m_i_tmp3;
 
-    // Cancel flag
-    volatile bool             m_cancel;
 
     friend class node;
 
@@ -759,7 +758,7 @@ private:
     bool check_invariant() const;
 
 public:
-    context_t(C const & c, params_ref const & p, small_object_allocator * a);
+    context_t(reslimit& lim, C const & c, params_ref const & p, small_object_allocator * a);
     ~context_t();
 
     /**
@@ -834,8 +833,6 @@ public:
     void display_bounds(std::ostream & out, node * n) const;
 
     void set_display_proc(display_var_proc * p) { m_display_proc = p; }
-
-    void set_cancel(bool f) { m_cancel = f; im().set_cancel(f); }
 
     void updt_params(params_ref const & p);
 

--- a/src/math/subpaving/subpaving_t.h
+++ b/src/math/subpaving/subpaving_t.h
@@ -467,6 +467,7 @@ public:
     typedef _scoped_numeral_vector<numeral_manager> scoped_numeral_vector;
 
 private:
+    reslimit&                 m_limit;
     C                         m_c;
     bool                      m_arith_failed; //!< True if the arithmetic module produced an exception.
     bool                      m_own_allocator;

--- a/src/math/subpaving/subpaving_t_def.h
+++ b/src/math/subpaving/subpaving_t_def.h
@@ -431,7 +431,6 @@ context_t<C>::context_t(C const & c, params_ref const & p, small_object_allocato
     m_node_selector = alloc(breadth_first_node_selector<C>, this);
     m_var_selector  = alloc(round_robing_var_selector<C>, this);
     m_node_splitter = alloc(midpoint_node_splitter<C>, this);
-    m_cancel        = false;
     m_num_nodes     = 0;
     updt_params(p);
     reset_statistics();
@@ -459,7 +458,7 @@ context_t<C>::~context_t() {
 
 template<typename C>
 void context_t<C>::checkpoint() {
-    if (m_cancel)
+    if (m_limit.canceled())
         throw default_exception("canceled");
     if (memory::get_allocation_size() > m_max_memory)
         throw default_exception(Z3_MAX_MEMORY_MSG);

--- a/src/math/subpaving/subpaving_t_def.h
+++ b/src/math/subpaving/subpaving_t_def.h
@@ -413,12 +413,13 @@ void context_t<C>::polynomial::display(std::ostream & out, numeral_manager & nm,
 }
 
 template<typename C>
-context_t<C>::context_t(C const & c, params_ref const & p, small_object_allocator * a):
+context_t<C>::context_t(reslimit& lim, C const & c, params_ref const & p, small_object_allocator * a):
+    m_limit(lim),
     m_c(c),
     m_own_allocator(a == 0),
     m_allocator(a == 0 ? alloc(small_object_allocator, "subpaving") : a),
     m_bm(*this, *m_allocator),
-    m_im(interval_config(m_c.m())),
+    m_im(lim, interval_config(m_c.m())),
     m_num_buffer(nm()) {
     m_arith_failed  = false;
     m_timestamp     = 0;
@@ -458,7 +459,7 @@ context_t<C>::~context_t() {
 
 template<typename C>
 void context_t<C>::checkpoint() {
-    if (m_limit.canceled())
+    if (!m_limit.inc())
         throw default_exception("canceled");
     if (memory::get_allocation_size() > m_max_memory)
         throw default_exception(Z3_MAX_MEMORY_MSG);

--- a/src/math/subpaving/tactic/expr2subpaving.cpp
+++ b/src/math/subpaving/tactic/expr2subpaving.cpp
@@ -51,7 +51,6 @@ struct expr2subpaving::imp {
 
     obj_map<expr, subpaving::ineq*>    m_lit_cache;
 
-    volatile bool                      m_cancel;
 
     imp(ast_manager & m, subpaving::context & s, expr2var * e2v):
         m_manager(m),
@@ -71,7 +70,6 @@ struct expr2subpaving::imp {
             m_expr2var_owner = false;
         }
         
-        m_cancel = false;
     }
     
     ~imp() {
@@ -95,7 +93,7 @@ struct expr2subpaving::imp {
     }
 
     void checkpoint() {
-        if (m_cancel)
+        if (m().canceled())
             throw default_exception("canceled");
         cooperate("expr2subpaving");
     }
@@ -357,9 +355,6 @@ struct expr2subpaving::imp {
         return m_expr2var->is_var(t); 
     }
 
-    void set_cancel(bool f) {
-        m_cancel = f;
-    }
     
     subpaving::var internalize_term(expr * t, mpz & n, mpz & d) {
         return process(t, 0, n, d);
@@ -386,9 +381,6 @@ bool expr2subpaving::is_var(expr * t) const {
     return m_imp->is_var(t);
 }
     
-void expr2subpaving::set_cancel(bool f) {
-    m_imp->set_cancel(f);
-}
 
 subpaving::var expr2subpaving::internalize_term(expr * t, mpz & n, mpz & d) {
     return m_imp->internalize_term(t, n, d);

--- a/src/math/subpaving/tactic/expr2subpaving.h
+++ b/src/math/subpaving/tactic/expr2subpaving.h
@@ -40,12 +40,7 @@ public:
        \brief Return true if t was encoded as a variable by the translator.
     */
     bool is_var(expr * t) const;
-    
-    /**
-       \brief Cancel/Interrupt execution.
-    */
-    void set_cancel(bool f);
-    
+       
     /**
        \brief Internalize a Z3 arithmetical expression into the subpaving data-structure.
 

--- a/src/math/subpaving/tactic/subpaving_tactic.cpp
+++ b/src/math/subpaving/tactic/subpaving_tactic.cpp
@@ -124,7 +124,6 @@ class subpaving_tactic : public tactic {
         }
 
         void set_cancel(bool f) {
-            m_e2s->set_cancel(f);
             m_ctx->set_cancel(f);
         }
 
@@ -279,11 +278,6 @@ public:
         }
     }
 
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 

--- a/src/math/subpaving/tactic/subpaving_tactic.cpp
+++ b/src/math/subpaving/tactic/subpaving_tactic.cpp
@@ -103,11 +103,11 @@ class subpaving_tactic : public tactic {
             if (m_kind != new_kind) {
                 m_kind = new_kind;
                 switch (m_kind) {
-                case MPQ:  m_ctx = subpaving::mk_mpq_context(m_qm); break;
-                case MPF:  m_ctx = subpaving::mk_mpf_context(m_fm); break;
-                case HWF:  m_ctx = subpaving::mk_hwf_context(m_hm, m_qm); break;
-                case MPFF: m_ctx = subpaving::mk_mpff_context(m_ffm, m_qm); break;
-                case MPFX: m_ctx = subpaving::mk_mpfx_context(m_fxm, m_qm); break;
+                case MPQ:  m_ctx = subpaving::mk_mpq_context(m().limit(), m_qm); break;
+                case MPF:  m_ctx = subpaving::mk_mpf_context(m().limit(), m_fm); break;
+                case HWF:  m_ctx = subpaving::mk_hwf_context(m().limit(), m_hm, m_qm); break;
+                case MPFF: m_ctx = subpaving::mk_mpff_context(m().limit(), m_ffm, m_qm); break;
+                case MPFX: m_ctx = subpaving::mk_mpfx_context(m().limit(), m_fxm, m_qm); break;
                 default: UNREACHABLE(); break;
                 }
                 m_e2s = alloc(expr2subpaving, m_manager, *m_ctx, &m_e2v);
@@ -121,10 +121,6 @@ class subpaving_tactic : public tactic {
 
         void reset_statistics() {
             m_ctx->reset_statistics();
-        }
-
-        void set_cancel(bool f) {
-            m_ctx->set_cancel(f);
         }
 
         subpaving::ineq * mk_ineq(expr * a) {

--- a/src/math/subpaving/tactic/subpaving_tactic.cpp
+++ b/src/math/subpaving/tactic/subpaving_tactic.cpp
@@ -261,17 +261,8 @@ public:
     
     virtual void cleanup() {
         ast_manager & m = m_imp->m();
-        imp * d = m_imp;
-        #pragma omp critical (tactic_cancel)
-        {
-            d = m_imp;
-        }
-        dealloc(d);
-        d = alloc(imp, m, m_params);
-        #pragma omp critical (tactic_cancel) 
-        {
-            m_imp = d;
-        }
+        dealloc(m_imp);
+        m_imp = alloc(imp, m, m_params);
     }
 
 };

--- a/src/model/model_evaluator.cpp
+++ b/src/model/model_evaluator.cpp
@@ -256,12 +256,6 @@ unsigned model_evaluator::get_num_steps() const {
     return m_imp->get_num_steps();
 }
 
-void model_evaluator::set_cancel(bool f) {
-    #pragma omp critical (model_evaluator)
-    {
-        m_imp->set_cancel(f);
-    }
-}
 
 void model_evaluator::cleanup(params_ref const & p) {
     model & md = m_imp->cfg().m_model;

--- a/src/model/model_evaluator.h
+++ b/src/model/model_evaluator.h
@@ -41,9 +41,6 @@ public:
 
     void operator()(expr * t, expr_ref & r);
 
-    void set_cancel(bool f);
-    void cancel() { set_cancel(true); }
-    void reset_cancel() { set_cancel(false); }
     void cleanup(params_ref const & p = params_ref());
     void reset(params_ref const & p = params_ref());
     

--- a/src/muz/base/dl_context.cpp
+++ b/src/muz/base/dl_context.cpp
@@ -230,8 +230,7 @@ namespace datalog {
         m_enable_bind_variables(true),
         m_last_status(OK),
         m_last_answer(m),
-        m_engine_type(LAST_ENGINE),
-        m_cancel(false) {
+        m_engine_type(LAST_ENGINE) {
         re.set_context(this);
         updt_params(pa);
     }
@@ -751,15 +750,16 @@ namespace datalog {
     }
 
 
+#if 0
     void context::cancel() {
         m_cancel = true;
         m_last_status = CANCELED;
         m_transf.cancel();
         if (m_engine) m_engine->cancel();
     }
+#endif
 
     void context::cleanup() {
-        m_cancel = false;
         m_last_status = OK;
         if (m_engine) m_engine->cleanup();
     }

--- a/src/muz/base/dl_context.cpp
+++ b/src/muz/base/dl_context.cpp
@@ -749,16 +749,6 @@ namespace datalog {
         m_background.push_back(e); 
     }
 
-
-#if 0
-    void context::cancel() {
-        m_cancel = true;
-        m_last_status = CANCELED;
-        m_transf.cancel();
-        if (m_engine) m_engine->cancel();
-    }
-#endif
-
     void context::cleanup() {
         m_last_status = OK;
         if (m_engine) m_engine->cleanup();

--- a/src/muz/base/dl_context.h
+++ b/src/muz/base/dl_context.h
@@ -209,7 +209,6 @@ namespace datalog {
         execution_result   m_last_status;
         expr_ref           m_last_answer;
         DL_ENGINE          m_engine_type;
-        volatile bool      m_cancel;
 
 
 

--- a/src/muz/base/dl_context.h
+++ b/src/muz/base/dl_context.h
@@ -487,11 +487,13 @@ namespace datalog {
         //
         // -----------------------------------
 
-        void cancel();
-        bool canceled() const { return m_cancel; }
+        bool canceled() {
+            if (m.limit().inc()) return true;
+            m_last_status = CANCELED;
+            return false;
+        }
 
         void cleanup();
-        void reset_cancel() { cleanup(); }
 
         /**
            \brief check if query 'q' is satisfied under asserted rules and background.

--- a/src/muz/base/hnf.cpp
+++ b/src/muz/base/hnf.cpp
@@ -74,7 +74,6 @@ class hnf::imp {
 
     ast_manager&          m;
     bool                  m_produce_proofs;
-    volatile bool         m_cancel;
     expr_ref_vector       m_todo;
     proof_ref_vector      m_proofs;
     expr_ref_vector       m_refs;
@@ -96,7 +95,6 @@ public:
     imp(ast_manager & m):
         m(m),
         m_produce_proofs(false),
-        m_cancel(false),
         m_todo(m),
         m_proofs(m),
         m_refs(m), 
@@ -156,7 +154,7 @@ public:
         m_todo.push_back(n);
         m_proofs.push_back(p);
         m_produce_proofs = p != 0;
-        while (!m_todo.empty() && !m_cancel) {
+        while (!m_todo.empty() && checkpoint()) {
             fml = m_todo.back();
             pr = m_proofs.back();
             m_todo.pop_back();
@@ -174,8 +172,8 @@ public:
               });
     }
 
-    void set_cancel(bool f) {
-        m_cancel = f;
+    bool checkpoint() {
+        return m.limit().inc();
     }
 
     void set_name(symbol const& n) {
@@ -192,7 +190,6 @@ public:
     }
 
     void reset() {
-        m_cancel = false;
         m_todo.reset();
         m_proofs.reset();
         m_refs.reset();
@@ -524,9 +521,6 @@ void hnf::operator()(expr * n, proof* p, expr_ref_vector & rs, proof_ref_vector&
           );
 }
 
-void hnf::set_cancel(bool f) {
-    m_imp->set_cancel(f);
-}
 
 void hnf::set_name(symbol const& n) {
     m_imp->set_name(n);

--- a/src/muz/base/hnf.cpp
+++ b/src/muz/base/hnf.cpp
@@ -173,7 +173,7 @@ public:
     }
 
     bool checkpoint() {
-        return m.limit().inc();
+        return !m.canceled();
     }
 
     void set_name(symbol const& n) {

--- a/src/muz/base/hnf.h
+++ b/src/muz/base/hnf.h
@@ -43,9 +43,6 @@ class hnf {
                     proof_ref_vector& ps               // [OUT] proofs of rs
                     );
 
-    void cancel() { set_cancel(true); }
-    void reset_cancel() { set_cancel(false); }
-    void set_cancel(bool f);
     void set_name(symbol const& name);    
     void reset();
     func_decl_ref_vector const& get_fresh_predicates();

--- a/src/muz/bmc/dl_bmc_engine.cpp
+++ b/src/muz/bmc/dl_bmc_engine.cpp
@@ -483,7 +483,7 @@ namespace datalog {
         }
 
         proof_ref get_proof(model_ref& md, func_decl* pred, app* prop, unsigned level) {
-            if (b.m_cancel) {
+            if (!m.limit().inc()) {
                 return proof_ref(0, m);
             }
             TRACE("bmc", tout << "Predicate: " << pred->get_name() << "\n";);
@@ -1172,7 +1172,7 @@ namespace datalog {
     private:
 
         void get_model(unsigned level) {
-            if (b.m_cancel) {
+            if (!m.limit().inc()) {
                 return;
             }
             rule_manager& rm = b.m_ctx.get_rule_manager();
@@ -1426,8 +1426,7 @@ namespace datalog {
         m_solver(m, m_fparams),
         m_rules(ctx),
         m_query_pred(m),
-        m_answer(m),
-        m_cancel(false) {
+        m_answer(m) {
     }
 
     bmc::~bmc() {}
@@ -1510,19 +1509,9 @@ namespace datalog {
     }
 
     void bmc::checkpoint() {
-        if (m_cancel) {
+        if (!m.limit().inc()) {
             throw default_exception("bmc canceled");
         }
-    }
-
-    void bmc::cancel() {
-        m_cancel = true;
-        m_solver.cancel();
-    }
-
-    void bmc::cleanup() {
-        m_cancel = false;
-        m_solver.reset();
     }
 
     void bmc::display_certificate(std::ostream& out) const {

--- a/src/muz/bmc/dl_bmc_engine.cpp
+++ b/src/muz/bmc/dl_bmc_engine.cpp
@@ -483,7 +483,7 @@ namespace datalog {
         }
 
         proof_ref get_proof(model_ref& md, func_decl* pred, app* prop, unsigned level) {
-            if (!m.limit().inc()) {
+            if (m.canceled()) {
                 return proof_ref(0, m);
             }
             TRACE("bmc", tout << "Predicate: " << pred->get_name() << "\n";);
@@ -1172,7 +1172,7 @@ namespace datalog {
     private:
 
         void get_model(unsigned level) {
-            if (!m.limit().inc()) {
+            if (m.canceled()) {
                 return;
             }
             rule_manager& rm = b.m_ctx.get_rule_manager();
@@ -1509,7 +1509,7 @@ namespace datalog {
     }
 
     void bmc::checkpoint() {
-        if (!m.limit().inc()) {
+        if (m.canceled()) {
             throw default_exception("bmc canceled");
         }
     }

--- a/src/muz/bmc/dl_bmc_engine.h
+++ b/src/muz/bmc/dl_bmc_engine.h
@@ -38,7 +38,6 @@ namespace datalog {
         rule_set         m_rules;
         func_decl_ref    m_query_pred;
         expr_ref         m_answer;
-        volatile bool    m_cancel;
 
         void checkpoint();
 
@@ -58,10 +57,6 @@ namespace datalog {
         ~bmc();
 
         lbool query(expr* query);
-
-        void cancel();
-
-        void cleanup();
 
         void display_certificate(std::ostream& out) const;
 

--- a/src/muz/clp/clp_context.cpp
+++ b/src/muz/clp/clp_context.cpp
@@ -44,7 +44,6 @@ namespace datalog {
         var_subst              m_var_subst;
         expr_ref_vector        m_ground;
         app_ref_vector         m_goals;
-        volatile bool          m_cancel;
         stats                  m_stats;
     public:
         imp(context& ctx):
@@ -54,8 +53,7 @@ namespace datalog {
             m_solver(m, m_fparams),      // TBD: can be replaced by efficient BV solver.
             m_var_subst(m, false),
             m_ground(m),
-            m_goals(m),
-            m_cancel(false)
+            m_goals(m)
         {
             // m_fparams.m_relevancy_lvl = 0;
             m_fparams.m_mbqi = false;

--- a/src/muz/clp/clp_context.cpp
+++ b/src/muz/clp/clp_context.cpp
@@ -84,17 +84,7 @@ namespace datalog {
             m_goals.push_back(to_app(head));
             return search(20, 0);
         }
-    
-        void cancel() {
-            m_cancel = true;
-            m_solver.cancel();
-        }
-        
-        void cleanup() {
-            m_cancel = false;
-            m_goals.reset();
-            m_solver.reset_cancel();
-        }
+            
 
         void reset_statistics() {
             m_stats.reset();
@@ -223,12 +213,7 @@ namespace datalog {
     lbool clp::query(expr* query) {
         return m_imp->query(query);
     }
-    void clp::cancel() {
-        m_imp->cancel();
-    }
-    void clp::cleanup() {
-        m_imp->cleanup();
-    }
+
     void clp::reset_statistics() {
         m_imp->reset_statistics();
     }

--- a/src/muz/clp/clp_context.h
+++ b/src/muz/clp/clp_context.h
@@ -34,8 +34,6 @@ namespace datalog {
         clp(context& ctx);
         ~clp();
         virtual lbool query(expr* query);
-        virtual void cancel();
-        virtual void cleanup();
         virtual void reset_statistics();
         virtual void collect_statistics(statistics& st) const;
         virtual void display_certificate(std::ostream& out) const;        

--- a/src/muz/ddnf/ddnf.cpp
+++ b/src/muz/ddnf/ddnf.cpp
@@ -470,7 +470,6 @@ namespace datalog {
         ast_manager&           m;
         rule_manager&          rm;
         bv_util                bv;
-        volatile bool          m_cancel;
         ptr_vector<expr>       m_todo;
         ast_mark               m_visited1, m_visited2;
         ddnfs                  m_ddnfs;
@@ -486,7 +485,6 @@ namespace datalog {
             m(ctx.get_manager()),
             rm(ctx.get_rule_manager()),
             bv(m),
-            m_cancel(false),
             m_trail(m),
             m_inner_ctx(m, m_ctx.get_register_engine(), m_ctx.get_fparams())
         {
@@ -518,15 +516,7 @@ namespace datalog {
             // return execute_rules(new_rules);
         }
     
-        void cancel() {
-            m_cancel = true;
-            m_inner_ctx.cancel();
-        }
-        
-        void cleanup() {
-            m_cancel = false;
-        }
-
+       
         void reset_statistics() {
             m_stats.reset();
         }
@@ -883,12 +873,6 @@ namespace datalog {
     }    
     lbool ddnf::query(expr* query) {
         return m_imp->query(query);
-    }
-    void ddnf::cancel() {
-        m_imp->cancel();
-    }
-    void ddnf::cleanup() {
-        m_imp->cleanup();
     }
     void ddnf::reset_statistics() {
         m_imp->reset_statistics();

--- a/src/muz/ddnf/ddnf.h
+++ b/src/muz/ddnf/ddnf.h
@@ -37,8 +37,6 @@ namespace datalog {
         ddnf(context& ctx);
         ~ddnf();
         virtual lbool query(expr* query);
-        virtual void cancel();
-        virtual void cleanup();
         virtual void reset_statistics();
         virtual void collect_statistics(statistics& st) const;
         virtual void display_certificate(std::ostream& out) const;        

--- a/src/muz/fp/dl_cmds.cpp
+++ b/src/muz/fp/dl_cmds.cpp
@@ -230,7 +230,7 @@ public:
         set_background(ctx);        
         dlctx.updt_params(m_params);
         unsigned timeout   = m_dl_ctx->get_params().timeout(); 
-        cancel_eh<datalog::context> eh(dlctx);
+        cancel_eh<reslimit> eh(ctx.m().limit());
         bool query_exn = false;
         lbool status = l_undef;
         {

--- a/src/muz/fp/horn_tactic.cpp
+++ b/src/muz/fp/horn_tactic.cpp
@@ -403,18 +403,10 @@ public:
     
     virtual void cleanup() {
         ast_manager & m = m_imp->m;
-        imp * d = m_imp;
-        d->collect_statistics(m_stats);
-        #pragma omp critical (tactic_cancel)
-        {
-            m_imp = 0;
-        }
-        dealloc(d);
-        d = alloc(imp, m_is_simplify, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            m_imp = d;
-        }
+        m_imp->collect_statistics(m_stats);
+        dealloc(m_imp);
+        m_imp = alloc(imp, m_is_simplify, m, m_params);
+        
     }
     
 

--- a/src/muz/fp/horn_tactic.cpp
+++ b/src/muz/fp/horn_tactic.cpp
@@ -63,9 +63,6 @@ class horn_tactic : public tactic {
             m_ctx.collect_statistics(st);
         }
 
-        void set_cancel(bool f) {
-        }
-
         void normalize(expr_ref& f) {
             bool is_positive = true;
             expr* e = 0;
@@ -420,11 +417,7 @@ public:
         }
     }
     
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
+
 };
 
 tactic * mk_horn_tactic(ast_manager & m, params_ref const & p) {

--- a/src/muz/fp/horn_tactic.cpp
+++ b/src/muz/fp/horn_tactic.cpp
@@ -64,9 +64,6 @@ class horn_tactic : public tactic {
         }
 
         void set_cancel(bool f) {
-            if (f) {
-                m_ctx.cancel();
-            }
         }
 
         void normalize(expr_ref& f) {

--- a/src/muz/pdr/pdr_context.cpp
+++ b/src/muz/pdr/pdr_context.cpp
@@ -1453,8 +1453,7 @@ namespace pdr {
           m_search(m_params.pdr_bfs_model_search()),
           m_last_result(l_undef),
           m_inductive_lvl(0),
-          m_expanded_lvl(0),
-          m_cancel(false)
+          m_expanded_lvl(0)
     {
     }
 
@@ -1465,7 +1464,6 @@ namespace pdr {
 
     void context::reset() {
         TRACE("pdr", tout << "\n";);
-        cleanup();
         decl2rel::iterator it = m_rels.begin(), end = m_rels.end();
         for (; it != end; ++it) {
             dealloc(it->m_value);
@@ -1912,16 +1910,8 @@ namespace pdr {
         return l_undef;
     }
 
-    void context::cancel() {
-        m_cancel = true;
-    }
-
-    void context::cleanup() {
-        m_cancel = false;
-    }
-
     void context::checkpoint() {
-        if (m_cancel) {
+        if (!m.limit().inc()) {
             throw default_exception("pdr canceled");
         }
     }

--- a/src/muz/pdr/pdr_context.cpp
+++ b/src/muz/pdr/pdr_context.cpp
@@ -1911,7 +1911,7 @@ namespace pdr {
     }
 
     void context::checkpoint() {
-        if (!m.limit().inc()) {
+        if (m.canceled()) {
             throw default_exception("pdr canceled");
         }
     }

--- a/src/muz/pdr/pdr_context.h
+++ b/src/muz/pdr/pdr_context.h
@@ -336,7 +336,6 @@ namespace pdr {
         unsigned             m_expanded_lvl;
         ptr_vector<core_generalizer>  m_core_generalizers;
         stats                m_stats;
-        volatile bool        m_cancel;
         model_converter_ref  m_mc;
         proof_converter_ref  m_pc;
         
@@ -411,9 +410,6 @@ namespace pdr {
 
         lbool solve();
 
-        void cancel();
-
-        void cleanup();
 
         void reset();
 

--- a/src/muz/pdr/pdr_dl_interface.cpp
+++ b/src/muz/pdr/pdr_dl_interface.cpp
@@ -206,13 +206,7 @@ expr_ref dl_interface::get_answer() {
     return m_context->get_answer();
 }
 
-void dl_interface::cancel() {
-    m_context->cancel();
-}
 
-void dl_interface::cleanup() {
-    m_context->cleanup();
-}
 
 void dl_interface::updt_params() {
     dealloc(m_context);

--- a/src/muz/pdr/pdr_dl_interface.h
+++ b/src/muz/pdr/pdr_dl_interface.h
@@ -51,10 +51,6 @@ namespace pdr {
         
         virtual lbool query(expr* query);
 
-        virtual void cancel();
-
-        virtual void cleanup();
-
         virtual void display_certificate(std::ostream& out) const;
 
         virtual void collect_statistics(statistics& st) const;

--- a/src/muz/rel/dl_base.h
+++ b/src/muz/rel/dl_base.h
@@ -270,8 +270,6 @@ namespace datalog {
 
             symbol const& get_name() const { return m_name; }
 
-            virtual void set_cancel(bool f) {}
-
             relation_manager & get_manager() const { return m_manager; }
             ast_manager& get_ast_manager() const { return datalog::get_ast_manager_from_rel_manager(m_manager); }
             context& get_context() const { return datalog::get_context_from_rel_manager(m_manager); }

--- a/src/muz/rel/dl_lazy_table.h
+++ b/src/muz/rel/dl_lazy_table.h
@@ -54,8 +54,6 @@ namespace datalog {
         
         virtual table_base * mk_empty(const table_signature & s);
                 
-        virtual void set_cancel(bool f) { m_plugin.set_cancel(f); }
-
         static table_plugin* mk_sparse(relation_manager& rm);
         
     protected:

--- a/src/muz/rel/dl_relation_manager.cpp
+++ b/src/muz/rel/dl_relation_manager.cpp
@@ -463,12 +463,6 @@ namespace datalog {
             }
     }
 
-    void relation_manager::set_cancel(bool f) {
-        for (unsigned i = 0; i < m_relation_plugins.size(); ++i) {
-            m_relation_plugins[i]->set_cancel(f);
-        }
-    }
-
     std::string relation_manager::to_nice_string(const relation_element & el) const {
         uint64 val;
         std::stringstream stm;

--- a/src/muz/rel/dl_relation_manager.h
+++ b/src/muz/rel/dl_relation_manager.h
@@ -225,8 +225,6 @@ namespace datalog {
             relation_fact & to);
 
 
-        void set_cancel(bool f);
-
 
         // -----------------------------------
         //

--- a/src/muz/rel/karr_relation.cpp
+++ b/src/muz/rel/karr_relation.cpp
@@ -498,9 +498,6 @@ namespace datalog {
         return dynamic_cast<karr_relation const&>(r);
     }  
 
-    void karr_relation_plugin::set_cancel(bool f) {
-    }
-
     relation_base * karr_relation_plugin::mk_empty(const relation_signature & s) {
         return alloc(karr_relation, *this, 0, s, true);
     }

--- a/src/muz/rel/karr_relation.cpp
+++ b/src/muz/rel/karr_relation.cpp
@@ -499,7 +499,6 @@ namespace datalog {
     }  
 
     void karr_relation_plugin::set_cancel(bool f) {
-        m_hb.set_cancel(f);
     }
 
     relation_base * karr_relation_plugin::mk_empty(const relation_signature & s) {

--- a/src/muz/rel/karr_relation.h
+++ b/src/muz/rel/karr_relation.h
@@ -51,8 +51,6 @@ namespace datalog {
 
         static symbol get_name() { return symbol("karr_relation"); }
 
-        virtual void set_cancel(bool f);
-
         virtual relation_base * mk_empty(const relation_signature & s);
 
         virtual relation_base * mk_full(func_decl* p, const relation_signature & s);

--- a/src/muz/rel/karr_relation.h
+++ b/src/muz/rel/karr_relation.h
@@ -41,6 +41,7 @@ namespace datalog {
     public:
         karr_relation_plugin(relation_manager& rm):
             relation_plugin(karr_relation_plugin::get_name(), rm),
+            m_hb(get_ast_manager().limit()),
             a(get_ast_manager())
         {}            
         

--- a/src/muz/rel/rel_context.cpp
+++ b/src/muz/rel/rel_context.cpp
@@ -512,9 +512,6 @@ namespace datalog {
         get_rmanager().set_predicate_kind(pred, target_kind);
     }
 
-    void rel_context::set_cancel(bool f) {
-        get_rmanager().set_cancel(f);        
-    }
 
     void rel_context::setup_default_relation() {
         if (m_context.default_relation() == symbol("doc")) {

--- a/src/muz/rel/rel_context.h
+++ b/src/muz/rel/rel_context.h
@@ -51,8 +51,6 @@ namespace datalog {
         
         lbool saturate(scoped_query& sq);
 
-        void set_cancel(bool f);
-
         void setup_default_relation();
 
     public:
@@ -82,8 +80,6 @@ namespace datalog {
 
         virtual void collect_statistics(statistics& st) const;
 
-        virtual void cancel() { set_cancel(true); }
-        virtual void cleanup() { set_cancel(false);}
         virtual void updt_params();
 
         /**

--- a/src/muz/tab/tab_context.cpp
+++ b/src/muz/tab/tab_context.cpp
@@ -581,7 +581,7 @@ namespace tb {
 
         // extract pre_cond => post_cond validation obligation from match.
         bool find_match(unsigned& subsumer) {
-            for (unsigned i = 0; m.limit().inc() && i < m_index.size(); ++i) {
+            for (unsigned i = 0; !m.canceled() && i < m_index.size(); ++i) {
                 if (match_rule(i)) {
                     subsumer = m_index[i]->get_seqno();
                     return true;
@@ -618,7 +618,7 @@ namespace tb {
 
             app* q = g.get_predicate(predicate_index);
 
-            for (unsigned i = 0; m.limit().inc() && i < m_preds.size(); ++i) {
+            for (unsigned i = 0; !m.canceled() && i < m_preds.size(); ++i) {
                 app* p = m_preds[i].get();
                 m_subst.push_scope();
                 unsigned limit = m_sideconds.size();
@@ -647,7 +647,7 @@ namespace tb {
             expr_ref_vector fmls(m_sideconds);
             m_subst.reset_cache();
             
-            for (unsigned i = 0; m.limit().inc() && i < fmls.size(); ++i) {
+            for (unsigned i = 0; !m.canceled() && i < fmls.size(); ++i) {
                 m_subst.apply(2, deltas, expr_offset(fmls[i].get(), 0), q);
                 fmls[i] = q;
             }
@@ -664,7 +664,7 @@ namespace tb {
                 }
             }
             m_rw.mk_and(fmls.size(), fmls.c_ptr(), postcond);
-            if (!m.limit().inc()) {
+            if (m.canceled()) {
                 return false;
             }
             if (m.is_false(postcond)) {
@@ -1495,7 +1495,7 @@ namespace datalog {
             m_status      = l_undef;
             while (true) {
                 IF_VERBOSE(2, verbose_stream() << m_instruction << "\n";);
-                if (!m.limit().inc()) {
+                if (m.canceled()) {
                     cleanup();
                     return l_undef;
                 }

--- a/src/muz/tab/tab_context.cpp
+++ b/src/muz/tab/tab_context.cpp
@@ -509,7 +509,6 @@ namespace tb {
         bool_rewriter          m_rw;
         smt_params             m_fparams;
         smt::kernel            m_solver;
-        volatile bool          m_cancel;
         
     public:
         index(ast_manager& m):
@@ -523,8 +522,7 @@ namespace tb {
             m_subst(m),
             m_qe(m),
             m_rw(m),
-            m_solver(m, m_fparams),
-            m_cancel(false) {}
+            m_solver(m, m_fparams) {}
 
         void insert(ref<clause>& g) {
             m_index.push_back(g);
@@ -540,17 +538,6 @@ namespace tb {
             return found;
         }
 
-        void cancel() {
-            m_cancel = true;
-            m_solver.cancel();
-            m_qe.set_cancel(true);
-        }
-
-        void cleanup() {
-            m_solver.reset_cancel();
-            m_qe.set_cancel(false);
-            m_cancel = false;
-        }
 
         void reset() {
             m_index.reset();
@@ -594,7 +581,7 @@ namespace tb {
 
         // extract pre_cond => post_cond validation obligation from match.
         bool find_match(unsigned& subsumer) {
-            for (unsigned i = 0; !m_cancel && i < m_index.size(); ++i) {
+            for (unsigned i = 0; m.limit().inc() && i < m_index.size(); ++i) {
                 if (match_rule(i)) {
                     subsumer = m_index[i]->get_seqno();
                     return true;
@@ -631,7 +618,7 @@ namespace tb {
 
             app* q = g.get_predicate(predicate_index);
 
-            for (unsigned i = 0; !m_cancel && i < m_preds.size(); ++i) {
+            for (unsigned i = 0; m.limit().inc() && i < m_preds.size(); ++i) {
                 app* p = m_preds[i].get();
                 m_subst.push_scope();
                 unsigned limit = m_sideconds.size();
@@ -660,7 +647,7 @@ namespace tb {
             expr_ref_vector fmls(m_sideconds);
             m_subst.reset_cache();
             
-            for (unsigned i = 0; !m_cancel && i < fmls.size(); ++i) {
+            for (unsigned i = 0; m.limit().inc() && i < fmls.size(); ++i) {
                 m_subst.apply(2, deltas, expr_offset(fmls[i].get(), 0), q);
                 fmls[i] = q;
             }
@@ -677,7 +664,7 @@ namespace tb {
                 }
             }
             m_rw.mk_and(fmls.size(), fmls.c_ptr(), postcond);
-            if (m_cancel) {
+            if (!m.limit().inc()) {
                 return false;
             }
             if (m.is_false(postcond)) {
@@ -1350,7 +1337,6 @@ namespace datalog {
         unsigned               m_seqno;
         tb::instruction        m_instruction;
         lbool                  m_status;
-        volatile bool          m_cancel;
         stats                  m_stats;
         uint_set               m_displayed_rules;
     public:
@@ -1365,8 +1351,7 @@ namespace datalog {
             m_rules(),
             m_seqno(0),
             m_instruction(tb::SELECT_PREDICATE),
-            m_status(l_undef),
-            m_cancel(false)
+            m_status(l_undef)
         {
             // m_fparams.m_relevancy_lvl = 0;
             m_fparams.m_mbqi = false;
@@ -1393,18 +1378,9 @@ namespace datalog {
             IF_VERBOSE(1, display_clause(*get_clause(), verbose_stream() << "g" << get_clause()->get_seqno() << " "););
             return run();
         }
-    
-        void cancel() {
-            m_cancel = true;
-            m_index.cleanup();
-            m_solver.cancel();
-        }
-        
+            
         void cleanup() {
-            m_cancel = false;
             m_clauses.reset();
-            m_index.cleanup();
-            m_solver.reset_cancel();
         }
 
         void reset_statistics() {
@@ -1519,7 +1495,7 @@ namespace datalog {
             m_status      = l_undef;
             while (true) {
                 IF_VERBOSE(2, verbose_stream() << m_instruction << "\n";);
-                if (m_cancel) {
+                if (!m.limit().inc()) {
                     cleanup();
                     return l_undef;
                 }
@@ -1670,9 +1646,6 @@ namespace datalog {
     }    
     lbool tab::query(expr* query) {
         return m_imp->query(query);
-    }
-    void tab::cancel() {
-        m_imp->cancel();
     }
     void tab::cleanup() {
         m_imp->cleanup();

--- a/src/muz/tab/tab_context.h
+++ b/src/muz/tab/tab_context.h
@@ -34,7 +34,6 @@ namespace datalog {
         tab(context& ctx);
         ~tab();
         virtual lbool query(expr* query);
-        virtual void cancel();
         virtual void cleanup();
         virtual void reset_statistics();
         virtual void collect_statistics(statistics& st) const;

--- a/src/muz/transforms/dl_mk_karr_invariants.cpp
+++ b/src/muz/transforms/dl_mk_karr_invariants.cpp
@@ -208,7 +208,7 @@ namespace datalog {
 
         get_invariants(*src_loop);
 
-        if (!m.limit().inc()) {
+        if (m.canceled()) {
             return 0;
         }
 

--- a/src/muz/transforms/dl_mk_karr_invariants.cpp
+++ b/src/muz/transforms/dl_mk_karr_invariants.cpp
@@ -50,8 +50,7 @@ namespace datalog {
         rm(ctx.get_rule_manager()),
         m_inner_ctx(m, ctx.get_register_engine(), ctx.get_fparams()),
         a(m),
-        m_pinned(m),
-        m_cancel(false) {
+        m_pinned(m) {
             params_ref params;
             params.set_sym("default_relation", symbol("karr_relation"));
             params.set_sym("engine", symbol("datalog"));
@@ -189,11 +188,6 @@ namespace datalog {
             }
         }
     };
-
-    void mk_karr_invariants::cancel() {
-        m_cancel = true;
-        m_inner_ctx.cancel();
-    }
     
     rule_set * mk_karr_invariants::operator()(rule_set const & source) {
         if (!m_ctx.karr()) {
@@ -214,7 +208,7 @@ namespace datalog {
 
         get_invariants(*src_loop);
 
-        if (m_cancel) {
+        if (!m.limit().inc()) {
             return 0;
         }
 

--- a/src/muz/transforms/dl_mk_karr_invariants.h
+++ b/src/muz/transforms/dl_mk_karr_invariants.h
@@ -57,7 +57,6 @@ namespace datalog {
         arith_util      a;
         obj_map<func_decl, expr*>      m_fun2inv;
         ast_ref_vector m_pinned;
-        volatile bool  m_cancel;
 
         void get_invariants(rule_set const& src);
 
@@ -67,8 +66,6 @@ namespace datalog {
         mk_karr_invariants(context & ctx, unsigned priority);
 
         virtual ~mk_karr_invariants();
-
-        virtual void cancel();
         
         rule_set * operator()(rule_set const & source);
 

--- a/src/nlsat/nlsat_solver.cpp
+++ b/src/nlsat/nlsat_solver.cpp
@@ -166,7 +166,7 @@ namespace nlsat {
             m_allocator("nlsat"),
             m_pm(m_qm, &m_allocator),
             m_cache(m_pm),
-            m_am(m_qm, p, &m_allocator),
+            m_am(rlim, m_qm, p, &m_allocator),
             m_asm(*this, m_allocator),
             m_assignment(m_am),
             m_evaluator(m_assignment, m_pm, m_allocator), 

--- a/src/nlsat/nlsat_solver.cpp
+++ b/src/nlsat/nlsat_solver.cpp
@@ -217,10 +217,7 @@ namespace nlsat {
         }
 
         void checkpoint() {
-            if (!m_rlimit.inc()) {
-                if (m_rlimit.cancel_flag_set()) throw solver_exception(Z3_CANCELED_MSG);
-                throw solver_exception(Z3_MAX_RESOURCE_MSG);
-            }
+            if (!m_rlimit.inc()) throw solver_exception(m_rlimit.get_cancel_msg());
             if (memory::get_allocation_size() > m_max_memory) throw solver_exception(Z3_MAX_MEMORY_MSG);
         }
 

--- a/src/nlsat/nlsat_solver.h
+++ b/src/nlsat/nlsat_solver.h
@@ -154,7 +154,6 @@ namespace nlsat {
         void updt_params(params_ref const & p);
         static void collect_param_descrs(param_descrs & d);
 
-        void set_cancel(bool f);
         void collect_statistics(statistics & st);
         void reset_statistics();
         void display_status(std::ostream & out) const;

--- a/src/nlsat/tactic/goal2nlsat.cpp
+++ b/src/nlsat/tactic/goal2nlsat.cpp
@@ -61,7 +61,6 @@ struct goal2nlsat::imp {
     unsigned long long        m_max_memory;
     bool                      m_factor;
 
-    volatile bool             m_cancel;
 
     imp(ast_manager & _m, params_ref const & p, nlsat::solver & s, expr2var & a2b, expr2var & t2x):
         m(_m),
@@ -73,18 +72,12 @@ struct goal2nlsat::imp {
         m_t2x(t2x),
         m_expr2poly(m_solver, m, m_solver.pm(), &m_t2x) {
         updt_params(p);
-        m_cancel = false;
     }
 
     void updt_params(params_ref const & p) {
         m_max_memory   = megabytes_to_bytes(p.get_uint("max_memory", UINT_MAX));
         m_factor       = p.get_bool("factor", true);  
         m_fparams.updt_params(p);
-    }
-
-    void set_cancel(bool f) {
-        m_cancel = f;
-        m_pm.set_cancel(f);
     }
 
     nlsat::atom::kind flip(nlsat::atom::kind k) {
@@ -303,7 +296,3 @@ void goal2nlsat::operator()(goal const & g, params_ref const & p, nlsat::solver 
     local_imp(g);
 }
     
-void goal2nlsat::set_cancel(bool f) {
-    if (m_imp)
-        m_imp->set_cancel(f);
-}

--- a/src/nlsat/tactic/goal2nlsat.cpp
+++ b/src/nlsat/tactic/goal2nlsat.cpp
@@ -262,17 +262,11 @@ struct goal2nlsat::imp {
 struct goal2nlsat::scoped_set_imp {
     goal2nlsat & m_owner; 
     scoped_set_imp(goal2nlsat & o, imp & i):m_owner(o) {
-        #pragma omp critical (tactic_cancel)
-        {
-            m_owner.m_imp = &i;
-        }
+        m_owner.m_imp = &i;        
     }
     
     ~scoped_set_imp() {
-        #pragma omp critical (tactic_cancel)
-        {
-            m_owner.m_imp = 0;
-        }
+        m_owner.m_imp = 0;        
     }
 };
 

--- a/src/nlsat/tactic/goal2nlsat.h
+++ b/src/nlsat/tactic/goal2nlsat.h
@@ -51,7 +51,6 @@ public:
     */
     void operator()(goal const & g, params_ref const & p, nlsat::solver & s, expr2var & a2b, expr2var & t2x);
     
-    void set_cancel(bool f);
 };
 
 class nlsat2goal {
@@ -69,7 +68,6 @@ public:
     void operator()(nlsat::solver const & s, expr2var const & a2b, expr2var const & t2x,
                     params_ref const & p, goal & g, model_converter_ref & mc);
     
-    void set_cancel(bool f);
 };
 
 #endif

--- a/src/nlsat/tactic/nlsat_tactic.cpp
+++ b/src/nlsat/tactic/nlsat_tactic.cpp
@@ -57,11 +57,6 @@ class nlsat_tactic : public tactic {
             m_params = p;
             m_solver.updt_params(p);
         }
-
-        void set_cancel(bool f) {
-            m_solver.set_cancel(f);
-            m_g2nl.set_cancel(f);
-        }
         
         bool contains_unsupported(expr_ref_vector & b2a, expr_ref_vector & x2t) {
             for (unsigned x = 0; x < x2t.size(); x++) {
@@ -240,11 +235,6 @@ public:
     
     virtual void cleanup() {}
     
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
-
     virtual void collect_statistics(statistics & st) const {
         st.copy(m_stats);
     }

--- a/src/nlsat/tactic/nlsat_tactic.cpp
+++ b/src/nlsat/tactic/nlsat_tactic.cpp
@@ -175,18 +175,12 @@ class nlsat_tactic : public tactic {
     struct scoped_set_imp {
         nlsat_tactic & m_owner; 
         scoped_set_imp(nlsat_tactic & o, imp & i):m_owner(o) {
-            #pragma omp critical (tactic_cancel)
-            {
-                m_owner.m_imp = &i;
-            }
+            m_owner.m_imp = &i;            
         }
 
         ~scoped_set_imp() {
             m_owner.m_imp->m_solver.collect_statistics(m_owner.m_stats);
-            #pragma omp critical (tactic_cancel)
-            {
-                m_owner.m_imp = 0;
-            }
+            m_owner.m_imp = 0;
         }
     };
 

--- a/src/opt/bcd2.cpp
+++ b/src/opt/bcd2.cpp
@@ -118,7 +118,7 @@ namespace opt {
             expr_ref_vector asms(m);
             init();
             init_bcd();
-            if (m_cancel) {
+            if (m.canceled()) {
                 normalize_bounds();
                 return l_undef;
             }
@@ -130,7 +130,7 @@ namespace opt {
                 TRACE("opt", display(tout););
                 assert_cores();
                 set2asms(m_asm_set, asms);                
-                if (m_cancel) {
+                if (m.canceled()) {
                     normalize_bounds();
                     return l_undef;
                 }

--- a/src/opt/hitting_sets.h
+++ b/src/opt/hitting_sets.h
@@ -22,6 +22,7 @@ Notes:
 #include "rational.h"
 #include "statistics.h"
 #include "lbool.h"
+#include "rlimit.h"
 
 namespace opt {
 
@@ -29,7 +30,7 @@ namespace opt {
         struct imp;
         imp* m_imp;
     public:        
-        hitting_sets();
+        hitting_sets(reslimit& lim);
         ~hitting_sets();
         void add_weight(rational const& w);
         void add_exists_true(unsigned sz, unsigned const* elems);

--- a/src/opt/maxhs.cpp
+++ b/src/opt/maxhs.cpp
@@ -83,10 +83,6 @@ namespace opt {
         }
         virtual ~maxhs() {}
 
-        virtual void set_cancel(bool f) { 
-            maxsmt_solver_base::set_cancel(f); 
-        }
-
         virtual void collect_statistics(statistics& st) const {
             maxsmt_solver_base::collect_statistics(st);
             m_hs.collect_statistics(st);
@@ -113,7 +109,7 @@ namespace opt {
                 ++m_stats.m_num_iterations;
                 trace_bounds("maxhs");
                 TRACE("opt", tout << "(maxhs [" << m_lower << ":" << m_upper << "])\n";);
-                if (m_cancel) {
+                if (m.canceled()) {
                     return l_undef;
                 }
                 

--- a/src/opt/maxhs.cpp
+++ b/src/opt/maxhs.cpp
@@ -77,6 +77,7 @@ namespace opt {
     public:
         maxhs(maxsat_context& c, weights_t& ws, expr_ref_vector const& soft):
             maxsmt_solver_base(c, ws, soft), 
+            m_hs(m.limit()), 
             m_aux(m), 
             m_at_lower_bound(false) {
         }
@@ -84,7 +85,6 @@ namespace opt {
 
         virtual void set_cancel(bool f) { 
             maxsmt_solver_base::set_cancel(f); 
-            m_hs.set_cancel(f);
         }
 
         virtual void collect_statistics(statistics& st) const {

--- a/src/opt/maxres.cpp
+++ b/src/opt/maxres.cpp
@@ -200,7 +200,7 @@ public:
                   display(tout);
                   );
             is_sat = check_sat_hill_climb(m_asms);
-            if (m_cancel) {
+            if (m.canceled()) {
                 return l_undef;
             }
             switch (is_sat) {
@@ -233,7 +233,7 @@ public:
         exprs cs;
         while (m_lower < m_upper) {
             lbool is_sat = check_sat_hill_climb(m_asms);
-            if (m_cancel) {
+            if (m.canceled()) {
                 return l_undef;
             }
             switch (is_sat) {
@@ -784,11 +784,6 @@ public:
 
     void remove_core(exprs const& core) {
         remove_soft(core, m_asms);
-    }
-
-    virtual void set_cancel(bool f) {
-        maxsmt_solver_base::set_cancel(f);
-        m_mus.set_cancel(f);
     }
 
     virtual void updt_params(params_ref& p) {

--- a/src/opt/maxsmt.cpp
+++ b/src/opt/maxsmt.cpp
@@ -39,7 +39,6 @@ namespace opt {
         maxsat_context& c, vector<rational> const& ws, expr_ref_vector const& soft):
         m(c.get_manager()), 
         m_c(c),
-        m_cancel(false), 
         m_soft(soft),
         m_weights(ws),
         m_assertions(m) {
@@ -150,7 +149,7 @@ namespace opt {
 
 
     maxsmt::maxsmt(maxsat_context& c):
-        m(c.get_manager()), m_c(c), m_cancel(false), 
+        m(c.get_manager()), m_c(c), 
         m_soft_constraints(m), m_answer(m) {}
 
     lbool maxsmt::operator()() {
@@ -274,13 +273,6 @@ namespace opt {
         }
     }
     
-    void maxsmt::set_cancel(bool f) {
-        m_cancel = f;
-        
-        if (m_msolver) {
-            m_msolver->set_cancel(f);
-        }
-    }
     
     bool maxsmt::is_maxsat_problem(vector<rational> const& ws) const {
         for (unsigned i = 0; i < ws.size(); ++i) {

--- a/src/opt/maxsmt.h
+++ b/src/opt/maxsmt.h
@@ -44,7 +44,6 @@ namespace opt {
         virtual rational get_lower() const = 0;
         virtual rational get_upper() const = 0;
         virtual bool get_assignment(unsigned index) const = 0;
-        virtual void set_cancel(bool f) = 0;
         virtual void collect_statistics(statistics& st) const = 0;
         virtual void get_model(model_ref& mdl, svector<symbol>& labels) = 0;
         virtual void updt_params(params_ref& p) = 0;
@@ -60,7 +59,6 @@ namespace opt {
     protected:
         ast_manager&     m;
         maxsat_context&  m_c;
-        volatile bool    m_cancel;
         const expr_ref_vector  m_soft;
         vector<rational> m_weights;
         expr_ref_vector  m_assertions;
@@ -78,7 +76,6 @@ namespace opt {
         virtual rational get_lower() const { return m_lower; }
         virtual rational get_upper() const { return m_upper; }
         virtual bool get_assignment(unsigned index) const { return m_assignment[index]; }
-        virtual void set_cancel(bool f) { m_cancel = f; if (f) s().cancel(); else s().reset_cancel(); }
         virtual void collect_statistics(statistics& st) const { }
         virtual void get_model(model_ref& mdl, svector<symbol>& labels) { mdl = m_model.get(); labels = m_labels;}
         virtual void commit_assignment();
@@ -115,7 +112,6 @@ namespace opt {
         ast_manager&              m;
         maxsat_context&           m_c;
         scoped_ptr<maxsmt_solver_base> m_msolver;
-        volatile bool    m_cancel;
         expr_ref_vector  m_soft_constraints;
         expr_ref_vector  m_answer;
         vector<rational> m_weights;
@@ -128,7 +124,6 @@ namespace opt {
     public:
         maxsmt(maxsat_context& c);
         lbool operator()();
-        void set_cancel(bool f);
         void updt_params(params_ref& p);
         void add(expr* f, rational const& w); 
         void set_adjust_value(adjust_value& adj) { m_adjust_value = adj; }

--- a/src/opt/mss.cpp
+++ b/src/opt/mss.cpp
@@ -26,7 +26,7 @@ Notes:
 namespace opt {
 
 
-    mss::mss(solver& s, ast_manager& m): m_s(s), m(m), m_cancel(false) {
+    mss::mss(solver& s, ast_manager& m): m_s(s), m(m) {
     }
     
     mss::~mss() {
@@ -191,7 +191,7 @@ namespace opt {
         if (core.empty()) {
             return l_true;
         }
-        if (m_cancel) {
+        if (m.canceled()) {
             return l_undef;
         }
         if (sz == 1 && core.size() == 1 && is_last && !has_mcs) {

--- a/src/opt/mss.h
+++ b/src/opt/mss.h
@@ -23,7 +23,6 @@ namespace opt {
     class mss {
         solver&       m_s;
         ast_manager&  m;
-        volatile bool m_cancel;
         typedef ptr_vector<expr> exprs;
         typedef obj_hashtable<expr>  expr_set;
         exprs         m_mss;
@@ -38,7 +37,6 @@ namespace opt {
         
         lbool operator()(model* initial_model, vector<exprs> const& cores, exprs& literals, exprs& mcs);
                 
-        void set_cancel(bool f) { m_cancel = f; }
 
         void get_model(model_ref& mdl) { mdl = m_model; }
 

--- a/src/opt/mus.cpp
+++ b/src/opt/mus.cpp
@@ -33,25 +33,20 @@ struct mus::imp {
     ast_manager&             m;
     expr_ref_vector          m_cls2expr;
     obj_map<expr, unsigned>  m_expr2cls;
-    volatile bool            m_cancel;
     model_ref                m_model;
     expr_ref_vector          m_soft;
     vector<rational>         m_weights;
     rational                 m_weight;
 
     imp(solver& s, ast_manager& m): 
-        m_s(s), m(m), m_cls2expr(m),  m_cancel(false), m_soft(m)
+        m_s(s), m(m), m_cls2expr(m),  m_soft(m)
     {}
 
     void reset() {
         m_cls2expr.reset();
         m_expr2cls.reset();
     }
-        
-    void set_cancel(bool f) {
-        m_cancel = f;
-    }
-    
+            
     
     unsigned add_soft(expr* cls) {
         SASSERT(is_uninterp_const(cls) || 
@@ -216,9 +211,6 @@ lbool mus::get_mus(unsigned_vector& mus) {
     return m_imp->get_mus(mus);
 }
 
-void mus::set_cancel(bool f) {
-    m_imp->set_cancel(f);
-}
 
 void mus::reset() {
     m_imp->reset();

--- a/src/opt/mus.h
+++ b/src/opt/mus.h
@@ -39,8 +39,6 @@ namespace opt {
         
         void reset();
         
-        void set_cancel(bool f);
-
         /**
            Instrument MUS extraction to also provide the minimal
            penalty model, if any is found.

--- a/src/opt/opt_cmds.cpp
+++ b/src/opt/opt_cmds.cpp
@@ -195,7 +195,7 @@ public:
             opt.add_hard_constraint(*it);
         }
         lbool r = l_undef;
-        cancel_eh<opt::context> eh(opt);        
+        cancel_eh<reslimit> eh(m.limit());
         {
             scoped_ctrl_c ctrlc(eh);
             scoped_timer timer(timeout, &eh);

--- a/src/opt/opt_context.cpp
+++ b/src/opt/opt_context.cpp
@@ -1259,26 +1259,6 @@ namespace opt {
         }
     }
 
-    void context::set_cancel(bool f) {
-        #pragma omp critical (opt_context)
-        {
-            if (m_solver) {
-                if (f) m_solver->cancel(); else m_solver->reset_cancel();
-            }
-            if (m_pareto) {
-                m_pareto->set_cancel(f);
-            }
-            if (m_simplify) {
-                if (f) m_simplify->cancel(); else m_solver->reset_cancel();
-            }
-            map_t::iterator it = m_maxsmts.begin(), end = m_maxsmts.end();
-            for (; it != end; ++it) {
-                it->m_value->set_cancel(f);
-            }            
-        }
-        m_optsmt.set_cancel(f);
-    }
-
     void context::collect_statistics(statistics& stats) const {
         if (m_solver) {
             m_solver->collect_statistics(stats);

--- a/src/opt/opt_context.h
+++ b/src/opt/opt_context.h
@@ -174,9 +174,6 @@ namespace opt {
         virtual void push();
         virtual void pop(unsigned n);
         virtual bool empty() { return m_scoped_state.m_objectives.empty(); }
-        virtual void set_cancel(bool f);
-        virtual void reset_cancel() { set_cancel(false); }
-        virtual void cancel() { set_cancel(true); }
         virtual void set_hard_constraints(ptr_vector<expr> & hard);
         virtual lbool optimize();
         virtual bool print_model() const;

--- a/src/opt/opt_pareto.cpp
+++ b/src/opt/opt_pareto.cpp
@@ -34,7 +34,7 @@ namespace opt {
             {
                 solver::scoped_push _s(*m_solver.get());
                 while (is_sat == l_true) {
-                    if (m_cancel) {
+                    if (m.canceled()) {
                         return l_undef;
                     }
                     m_solver->get_model(m_model);
@@ -92,7 +92,7 @@ namespace opt {
     lbool oia_pareto::operator()() {
         solver::scoped_push _s(*m_solver.get());
         lbool is_sat = m_solver->check_sat(0, 0);
-        if (m_cancel) {
+        if (m.canceled()) {
             is_sat = l_undef;
         }
         if (is_sat == l_true) {

--- a/src/opt/opt_pareto.h
+++ b/src/opt/opt_pareto.h
@@ -37,7 +37,6 @@ namespace opt {
     protected:
         ast_manager&     m;
         pareto_callback& cb;
-        volatile bool    m_cancel;
         ref<solver>      m_solver;
         params_ref       m_params;
         model_ref        m_model;
@@ -50,7 +49,6 @@ namespace opt {
             params_ref & p):
             m(m),
             cb(cb),            
-            m_cancel(false),
             m_solver(s),
             m_params(p) {
         }
@@ -64,13 +62,6 @@ namespace opt {
         }
         virtual void collect_statistics(statistics & st) const {
             m_solver->collect_statistics(st);
-        }
-        virtual void set_cancel(bool f) {
-            if (f) 
-                m_solver->cancel();
-            else 
-                m_solver->reset_cancel();
-            m_cancel = f;
         }
         virtual void display(std::ostream & out) const {
             m_solver->display(out);

--- a/src/opt/opt_solver.cpp
+++ b/src/opt/opt_solver.cpp
@@ -297,11 +297,7 @@ namespace opt {
         m_context.get_relevant_labels(0, tmp);
         r.append(tmp.size(), tmp.c_ptr());
     }
-    
-    void opt_solver::set_cancel(bool f) {
-        m_context.set_cancel(f);
-    }
-    
+        
     void opt_solver::set_progress_callback(progress_callback * callback) {
         m_callback = callback;
         m_context.set_progress_callback(callback);

--- a/src/opt/opt_solver.h
+++ b/src/opt/opt_solver.h
@@ -100,11 +100,11 @@ namespace opt {
         virtual proof * get_proof();
         virtual std::string reason_unknown() const;
         virtual void get_labels(svector<symbol> & r);
-        virtual void set_cancel(bool f);
         virtual void set_progress_callback(progress_callback * callback);
         virtual unsigned get_num_assertions() const;
         virtual expr * get_assertion(unsigned idx) const;
         virtual void display(std::ostream & out) const;
+        virtual ast_manager& get_manager() { return m; } 
         void set_logic(symbol const& logic);
 
         smt::theory_var add_objective(app* term);

--- a/src/opt/optsmt.h
+++ b/src/opt/optsmt.h
@@ -30,7 +30,6 @@ namespace opt {
     class optsmt {
         ast_manager&     m;
         opt_solver*      m_s;
-        volatile bool    m_cancel;
         vector<inf_eps>  m_lower;
         vector<inf_eps>  m_upper;
         app_ref_vector   m_objs;
@@ -42,7 +41,7 @@ namespace opt {
         sref_vector<model> m_models;
     public:
         optsmt(ast_manager& m): 
-            m(m), m_s(0), m_cancel(false), m_objs(m), m_lower_fmls(m) {}
+            m(m), m_s(0), m_objs(m), m_lower_fmls(m) {}
 
         void setup(opt_solver& solver);
 
@@ -51,8 +50,6 @@ namespace opt {
         lbool lex(unsigned obj_index, bool is_maximize);
 
         unsigned add(app* t);
-
-        void set_cancel(bool f);
 
         void updt_params(params_ref& p);
 

--- a/src/opt/pb_sls.cpp
+++ b/src/opt/pb_sls.cpp
@@ -60,7 +60,6 @@ namespace smt {
         pb_util          pb;
         unsynch_mpz_manager mgr;
         th_rewriter      m_rewrite;
-        volatile bool    m_cancel;
         vector<clause>   m_clauses;      // clauses to be satisfied        
         expr_ref_vector  m_orig_clauses; // for debugging
         model_ref        m_orig_model;   // for debugging
@@ -86,7 +85,6 @@ namespace smt {
             m(m),
             pb(m),
             m_rewrite(m),
-            m_cancel(false),
             m_orig_clauses(m),
             m_trail(m),
             one(mgr)
@@ -157,7 +155,7 @@ namespace smt {
                 while (m_max_flips > 0) {
                     --m_max_flips;
                     literal lit = flip();
-                    if (m_cancel) {
+                    if (m.canceled()) {
                         return l_undef;
                     }
                     IF_VERBOSE(3, verbose_stream() 
@@ -202,9 +200,6 @@ namespace smt {
 
         bool get_value(literal l) {
             return l.sign() ^ m_assignment[l.var()];
-        }
-        void set_cancel(bool f) {
-            m_cancel = f;
         }
         void get_model(model_ref& mdl) {
             mdl = alloc(model, m);
@@ -718,9 +713,6 @@ namespace smt {
     }
     lbool pb_sls::operator()() {
         return (*m_imp)();
-    }
-    void pb_sls::set_cancel(bool f) {
-        m_imp->set_cancel(f);
     }
     void pb_sls::collect_statistics(statistics& st) const {
         m_imp->collect_statistics(st);

--- a/src/opt/pb_sls.h
+++ b/src/opt/pb_sls.h
@@ -38,7 +38,6 @@ namespace smt {
         bool soft_holds(unsigned index);
         void set_model(model_ref& mdl);
         lbool operator()();
-        void set_cancel(bool f);
         void collect_statistics(::statistics& st) const;
         void get_model(model_ref& mdl);
         void updt_params(params_ref& p);

--- a/src/opt/wmax.cpp
+++ b/src/opt/wmax.cpp
@@ -47,7 +47,7 @@ namespace opt {
             }
             while (l_true == is_sat) {
                 is_sat = s().check_sat(0,0);
-                if (m_cancel) {
+                if (m.canceled()) {
                     is_sat = l_undef;
                 }
                 if (is_sat == l_true) {

--- a/src/qe/qe.cpp
+++ b/src/qe/qe.cpp
@@ -898,7 +898,6 @@ namespace qe {
 
         virtual void eliminate(bool is_forall, unsigned num_vars, app* const* vars, expr_ref& fml) = 0;      
 
-        virtual void set_cancel(bool f) = 0;
 
         virtual void updt_params(params_ref const& p) {}
         
@@ -1408,10 +1407,6 @@ namespace qe {
             m_conjs.add_plugin(p);
         }
 
-        void set_cancel(bool f) {
-            m_solver.set_cancel(f);
-            m_rewriter.set_cancel(f);
-        }
 
         void check(unsigned num_vars, app* const* vars, 
                    expr* assumption, expr_ref& fml, bool get_first,
@@ -2032,7 +2027,6 @@ namespace qe {
         expr_ref                m_assumption;
         bool                    m_produce_models;
         ptr_vector<quant_elim_plugin> m_plugins;
-        volatile bool            m_cancel;
         bool                     m_eliminate_variables_as_block;
 
     public:
@@ -2041,7 +2035,6 @@ namespace qe {
             m_fparams(p),
             m_assumption(m),
             m_produce_models(m_fparams.m_model),
-            m_cancel(false),
             m_eliminate_variables_as_block(true)
           {
           }
@@ -2055,16 +2048,9 @@ namespace qe {
                 dealloc(m_plugins[i]);
             }
         }
-        
-        void set_cancel(bool f) {
-            for (unsigned i = 0; i < m_plugins.size(); ++i) {
-                m_plugins[i]->set_cancel(f);
-            }
-            m_cancel = f;
-        }
-        
+                
         void checkpoint() {
-            if (m_cancel)
+            if (m.canceled()) 
                 throw tactic_exception(TACTIC_CANCELED_MSG);
             cooperate("qe");
         }
@@ -2409,11 +2395,6 @@ namespace qe {
         return is_sat != l_undef;
     }
 
-    void expr_quant_elim::set_cancel(bool f) {
-        if (m_qe) {
-            m_qe->set_cancel(f);
-        }
-    }
 
 
 

--- a/src/qe/qe.h
+++ b/src/qe/qe.h
@@ -313,8 +313,6 @@ namespace qe {
         bool solve_for_vars(unsigned num_vars, app* const* vars, expr* fml, guarded_defs& defs);
 
 
-        void set_cancel(bool f);
-
     private:
         void instantiate_expr(expr_ref_vector& bound, expr_ref& fml);
         void abstract_expr(unsigned sz, expr* const* bound, expr_ref& fml);
@@ -343,7 +341,6 @@ namespace qe {
             return m_quant_elim.first_elim(num_vars, vars, fml, defs);
         }
 
-        void set_cancel(bool f) {} // TBD: replace simplifier by rewriter
 
     };
 

--- a/src/qe/qe_lite.cpp
+++ b/src/qe/qe_lite.cpp
@@ -93,7 +93,6 @@ namespace eq {
         expr_ref_vector  m_subst_map;
         expr_ref_buffer  m_new_args;
         th_rewriter      m_rewriter;
-        volatile bool    m_cancel;
         
         void der_sort_vars(ptr_vector<var> & vars, ptr_vector<expr> & definitions, unsigned_vector & order) {
             order.reset();
@@ -738,7 +737,7 @@ namespace eq {
 
         void checkpoint() {
             cooperate("der");
-            if (m_cancel)
+            if (m.canceled()) 
                 throw tactic_exception(TACTIC_CANCELED_MSG);
         }
 
@@ -752,8 +751,7 @@ namespace eq {
             m_new_exprs(m), 
             m_subst_map(m), 
             m_new_args(m), 
-            m_rewriter(m), 
-            m_cancel(false) {}
+            m_rewriter(m) {}
         
         void set_is_variable_proc(is_variable_proc& proc) { m_is_variable = &proc;}
         
@@ -790,10 +788,6 @@ namespace eq {
         
         ast_manager& get_manager() const { return m; }
 
-        void set_cancel(bool f) {
-            m_rewriter.set_cancel(f);
-            m_cancel = f;
-        }
 
     };
 }; // namespace eq
@@ -808,7 +802,6 @@ namespace ar {
         is_variable_proc*        m_is_variable;
         ptr_vector<expr>         m_todo;
         expr_mark                m_visited;
-        volatile bool            m_cancel;
         
         bool is_variable(expr * e) const {
             return (*m_is_variable)(e);
@@ -923,13 +916,13 @@ namespace ar {
 
         void checkpoint() {
             cooperate("der");
-            if (m_cancel)
+            if (m.canceled())
                 throw tactic_exception(TACTIC_CANCELED_MSG);
         }
 
     public:
 
-        der(ast_manager& m): m(m), a(m), m_is_variable(0), m_cancel(false) {}
+        der(ast_manager& m): m(m), a(m), m_is_variable(0) {}
 
         void operator()(expr_ref_vector& fmls) {
             for (unsigned i = 0; i < fmls.size(); ++i) {
@@ -942,10 +935,6 @@ namespace ar {
         void operator()(expr* e) {}
 
         void set_is_variable_proc(is_variable_proc& proc) { m_is_variable = &proc;}
-
-        void set_cancel(bool f) {
-            m_cancel = f;
-        }
         
     };
 }; // namespace ar
@@ -1066,7 +1055,6 @@ namespace fm {
         vector<constraints>      m_uppers;
         uint_set                 m_forbidden_set; // variables that cannot be eliminated because occur in non OCC ineq part
         expr_ref_vector          m_new_fmls;
-        volatile bool            m_cancel;
         id_gen                   m_id_gen;
         bool                     m_fm_real_only;
         unsigned                 m_fm_limit;
@@ -1459,7 +1447,6 @@ namespace fm {
             m_var2expr(m),
             m_new_fmls(m),
             m_inconsistent_core(m) {
-            m_cancel = false;
             updt_params();
             m_counter = 0;
             m_inconsistent = false;
@@ -1478,9 +1465,6 @@ namespace fm {
             m_fm_occ         = true;
         }
         
-        void set_cancel(bool f) {
-            m_cancel = f;
-        }
     private:
         
         struct forbidden_proc {
@@ -2222,7 +2206,7 @@ namespace fm {
         
         void checkpoint() {
             cooperate("fm");
-            if (m_cancel)
+            if (m.canceled())
                 throw tactic_exception(TACTIC_CANCELED_MSG);
         }
     public:
@@ -2453,14 +2437,6 @@ public:
         TRACE("qe_lite", for (unsigned i = 0; i < fmls.size(); ++i) tout << mk_pp(fmls[i].get(), m) << "\n";);
     }
 
-    void set_cancel(bool f) {
-        m_der.set_cancel(f);
-        m_array_der.set_cancel(f);
-        m_fm.set_cancel(f);
-        m_elim_star.set_cancel(f);
-        m_rewriter.set_cancel(f);
-    }
-
 };
 
 qe_lite::qe_lite(ast_manager& m) {
@@ -2475,9 +2451,6 @@ void qe_lite::operator()(app_ref_vector& vars, expr_ref& fml) {
     (*m_impl)(vars, fml);
 }
 
-void qe_lite::set_cancel(bool f) {
-    m_impl->set_cancel(f);
-}
 
 void qe_lite::operator()(expr_ref& fml, proof_ref& pr) {
     (*m_impl)(fml, pr);
@@ -2496,21 +2469,14 @@ class qe_lite_tactic : public tactic {
     struct imp {
         ast_manager&             m;
         qe_lite                  m_qe;
-        volatile bool            m_cancel;
 
         imp(ast_manager& m, params_ref const& p): 
             m(m),
-            m_qe(m),
-            m_cancel(false)
+            m_qe(m)
         {}
 
-        void set_cancel(bool f) {
-            m_cancel = f;
-            m_qe.set_cancel(f);
-        }
-
         void checkpoint() {
-            if (m_cancel)
+            if (m.canceled())
                 throw tactic_exception(TACTIC_CANCELED_MSG);
             cooperate("qe-lite");
         }

--- a/src/qe/qe_lite.cpp
+++ b/src/qe/qe_lite.cpp
@@ -2569,17 +2569,8 @@ public:
     
     virtual void cleanup() {
         ast_manager & m = m_imp->m;
-        imp * d = m_imp;
-        #pragma omp critical (tactic_cancel)
-        {
-            m_imp = 0;
-        }
-        dealloc(d);
-        d = alloc(imp, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            m_imp = d;
-        }
+        dealloc(m_imp);
+        m_imp = alloc(imp, m, m_params);
     }
     
 };

--- a/src/qe/qe_lite.h
+++ b/src/qe/qe_lite.h
@@ -59,8 +59,6 @@ public:
         \brief full rewriting based light-weight quantifier elimination round.
     */
     void operator()(expr_ref& fml, proof_ref& pr);
-
-    void set_cancel(bool f);
 };
 
 tactic * mk_qe_lite_tactic(ast_manager & m, params_ref const & p = params_ref());

--- a/src/qe/qe_tactic.cpp
+++ b/src/qe/qe_tactic.cpp
@@ -25,14 +25,12 @@ class qe_tactic : public tactic {
     struct     imp {
         ast_manager &            m;
         smt_params               m_fparams;
-        volatile bool            m_cancel;
         qe::expr_quant_elim      m_qe;
 
         imp(ast_manager & _m, params_ref const & p):
             m(_m),
             m_qe(m, m_fparams) {
             updt_params(p);
-            m_cancel = false;
         }
 
         void updt_params(params_ref const & p) {
@@ -45,13 +43,8 @@ class qe_tactic : public tactic {
             m_qe.collect_param_descrs(r);
         }
 
-        void set_cancel(bool f) {
-            m_cancel = f;
-            m_qe.set_cancel(f);
-        }
-
         void checkpoint() {
-            if (m_cancel)
+            if (m.canceled()) 
                 throw tactic_exception(TACTIC_CANCELED_MSG);
             cooperate("qe");
         }
@@ -141,11 +134,6 @@ public:
         }
     }
     
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_qe_tactic(ast_manager & m, params_ref const & p) {

--- a/src/qe/qe_tactic.cpp
+++ b/src/qe/qe_tactic.cpp
@@ -121,17 +121,8 @@ public:
     
     virtual void cleanup() {
         ast_manager & m = m_imp->m;
-        imp * d = m_imp;
-        #pragma omp critical (tactic_cancel)
-        {
-            m_imp = 0;
-        }
-        dealloc(d);
-        d = alloc(imp, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            m_imp = d;
-        }
+        dealloc(m_imp);
+        m_imp = alloc(imp, m, m_params);
     }
     
 };

--- a/src/sat/sat_mus.cpp
+++ b/src/sat/sat_mus.cpp
@@ -84,7 +84,7 @@ namespace sat {
                   tout << "core: " << core << "\n";
                   tout << "mus:  " << mus  << "\n";);
 
-            if (s.m_cancel) {
+            if (s.canceled()) {
                 set_core();
                 return l_undef;
             }

--- a/src/sat/sat_sls.cpp
+++ b/src/sat/sat_sls.cpp
@@ -50,7 +50,7 @@ namespace sat {
         return m_elems[rnd(num_elems())];
     }
 
-    sls::sls(solver& s): s(s), m_cancel(false) {
+    sls::sls(solver& s): s(s) {
         m_prob_choose_min_var = 43;
         m_clause_generation = 0;
     }
@@ -64,7 +64,7 @@ namespace sat {
     lbool sls::operator()(unsigned sz, literal const* tabu, bool reuse_model) {
         init(sz, tabu, reuse_model);
         unsigned i;
-        for (i = 0; !m_false.empty() && !m_cancel && i < m_max_tries; ++i) {
+        for (i = 0; !m_false.empty() && !s.canceled() && i < m_max_tries; ++i) {
             flip();
         }
         IF_VERBOSE(2, verbose_stream() << "tries " << i << "\n";);
@@ -378,7 +378,7 @@ namespace sat {
         }
         DEBUG_CODE(check_invariant(););
         unsigned i = 0;
-        for (; !m_cancel && m_best_value > 0 && i < m_max_tries; ++i) {
+        for (; !s.canceled() && m_best_value > 0 && i < m_max_tries; ++i) {
             wflip();
             if (m_false.empty()) {
                 double val = evaluate_model(m_model);

--- a/src/sat/sat_sls.h
+++ b/src/sat/sat_sls.h
@@ -54,12 +54,10 @@ namespace sat {
         clause_allocator m_alloc;              // clause allocator
         clause_vector    m_bin_clauses;        // binary clauses
         svector<bool>    m_tabu;               // variables that cannot be swapped
-        volatile bool    m_cancel;
     public:
         sls(solver& s);
         virtual ~sls();        
         lbool operator()(unsigned sz, literal const* tabu, bool reuse_model);
-        void set_cancel(bool f) { m_cancel = f; }
         void set_max_tries(unsigned mx) { m_max_tries = mx; }
         virtual void display(std::ostream& out) const;
     protected:

--- a/src/sat/sat_solver.cpp
+++ b/src/sat/sat_solver.cpp
@@ -32,7 +32,6 @@ Revision History:
 namespace sat {
 
     solver::solver(params_ref const & p, reslimit& l, extension * ext):
-        m_cancel(false),
         m_rlimit(l),
         m_config(p),
         m_ext(ext),
@@ -2714,11 +2713,6 @@ namespace sat {
         scc::collect_param_descrs(d);
     }
 
-    void solver::set_cancel(bool f) {
-        m_cancel = f;
-        m_wsls.set_cancel(f);
-    }
-
     void solver::collect_statistics(statistics & st) const {
         m_stats.collect_statistics(st);
         m_cleaner.collect_statistics(st);
@@ -2784,7 +2778,7 @@ namespace sat {
     //
     // -----------------------
     bool solver::check_invariant() const {
-        if (m_cancel) return true;
+        if (!m_rlimit.inc()) return true;
         integrity_checker checker(*this);
         SASSERT(checker());
         return true;

--- a/src/sat/sat_solver.h
+++ b/src/sat/sat_solver.h
@@ -71,7 +71,6 @@ namespace sat {
     public:
         struct abort_solver {};
     protected:
-        volatile bool           m_cancel;
         reslimit&               m_rlimit;
         config                  m_config;
         stats                   m_stats;
@@ -158,7 +157,6 @@ namespace sat {
         void updt_params(params_ref const & p);
         static void collect_param_descrs(param_descrs & d);
 
-        void set_cancel(bool f);
         void collect_statistics(statistics & st) const;
         void reset_statistics();
         void display_status(std::ostream & out) const;
@@ -239,13 +237,13 @@ namespace sat {
         lbool status(clause const & c) const;        
         clause_offset get_offset(clause const & c) const { return m_cls_allocator.get_offset(&c); }
         void checkpoint() {
-            if (m_cancel) throw solver_exception(Z3_CANCELED_MSG);
-            if (!m_rlimit.inc()) { m_cancel = true; throw solver_exception(Z3_CANCELED_MSG); }
+            if (!m_rlimit.inc()) { throw solver_exception(Z3_CANCELED_MSG); }
             ++m_num_checkpoints;
             if (m_num_checkpoints < 10) return;
             m_num_checkpoints = 0;
             if (memory::get_allocation_size() > m_config.m_max_memory) throw solver_exception(Z3_MAX_MEMORY_MSG);
         }
+        bool canceled() { return !m_rlimit.inc(); }
         typedef std::pair<literal, literal> bin_clause;
     protected:
         watch_list & get_wlist(literal l) { return m_watches[l.index()]; }

--- a/src/sat/sat_solver/inc_sat_solver.cpp
+++ b/src/sat/sat_solver/inc_sat_solver.cpp
@@ -85,7 +85,6 @@ public:
         simp2_p.set_bool("flat", true); // required by som
         simp2_p.set_bool("hoist_mul", false); // required by som
         simp2_p.set_bool("elim_and", true);
-
         m_preprocess = 
             and_then(mk_card2bv_tactic(m, m_params),
                      using_params(mk_simplify_tactic(m), simp2_p),
@@ -169,11 +168,6 @@ public:
         }
         return r;
     }
-    virtual void set_cancel(bool f) {
-        m_goal2sat.set_cancel(f);
-        m_solver.set_cancel(f);
-        if (f) m_preprocess->cancel(); else m_preprocess->reset_cancel();
-    }
     virtual void push() {
         internalize_formulas();
         m_solver.user_push();
@@ -215,6 +209,7 @@ public:
             assert_expr(t);
         }
     }
+    virtual ast_manager& get_manager() { return m; }
     virtual void assert_expr(expr * t) {
         TRACE("sat", tout << mk_pp(t, m) << "\n";);
         m_fmls.push_back(t);

--- a/src/sat/tactic/goal2sat.cpp
+++ b/src/sat/tactic/goal2sat.cpp
@@ -58,7 +58,6 @@ struct goal2sat::imp {
     sat::bool_var               m_true;
     bool                        m_ite_extra;
     unsigned long long          m_max_memory;
-    volatile bool               m_cancel;
     expr_ref_vector             m_trail;
     bool                        m_default_external;
     
@@ -70,7 +69,6 @@ struct goal2sat::imp {
         m_trail(m),
         m_default_external(default_external) {
         updt_params(p);
-        m_cancel = false;
         m_true = sat::null_bool_var;
     }
         
@@ -334,7 +332,7 @@ struct goal2sat::imp {
         while (!m_frame_stack.empty()) {
         loop:
             cooperate("goal2sat");
-            if (m_cancel)
+            if (m.canceled())
                 throw tactic_exception(TACTIC_CANCELED_MSG);
             if (memory::get_allocation_size() > m_max_memory)
                 throw tactic_exception(TACTIC_MAX_MEMORY_MSG);
@@ -442,7 +440,6 @@ struct goal2sat::imp {
             process(fs[i]);
     }
 
-    void set_cancel(bool f) { m_cancel = f; }
 };
 
 struct unsupported_bool_proc {
@@ -505,14 +502,6 @@ void goal2sat::operator()(goal const & g, params_ref const & p, sat::solver & t,
     imp proc(g.m(), p, t, m, dep2asm, default_external);
     scoped_set_imp set(this, &proc);
     proc(g);
-}
-
-void goal2sat::set_cancel(bool f) {
-    #pragma omp critical (goal2sat)
-    {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 }
 
 
@@ -631,9 +620,8 @@ struct sat2goal::imp {
     expr_ref_vector         m_lit2expr;
     unsigned long long      m_max_memory;
     bool                    m_learned;
-    volatile bool           m_cancel;
     
-    imp(ast_manager & _m, params_ref const & p):m(_m), m_lit2expr(m), m_cancel(false) {
+    imp(ast_manager & _m, params_ref const & p):m(_m), m_lit2expr(m) {
         updt_params(p);
     }
 
@@ -643,7 +631,7 @@ struct sat2goal::imp {
     }
 
     void checkpoint() {
-        if (m_cancel)
+        if (m.canceled())
             throw tactic_exception(TACTIC_CANCELED_MSG);
         if (memory::get_allocation_size() > m_max_memory)
             throw tactic_exception(TACTIC_MAX_MEMORY_MSG);
@@ -731,7 +719,6 @@ struct sat2goal::imp {
             assert_clauses(s.begin_learned(), s.end_learned(), r);
     }
 
-    void set_cancel(bool f) { m_cancel = f; }
 };
 
 sat2goal::sat2goal():m_imp(0) {
@@ -765,10 +752,3 @@ void sat2goal::operator()(sat::solver const & t, atom2bool_var const & m, params
     proc(t, m, g, mc);
 }
 
-void sat2goal::set_cancel(bool f) {
-    #pragma omp critical (sat2goal)
-    {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
-}

--- a/src/sat/tactic/goal2sat.cpp
+++ b/src/sat/tactic/goal2sat.cpp
@@ -485,16 +485,10 @@ void goal2sat::collect_param_descrs(param_descrs & r) {
 struct goal2sat::scoped_set_imp {
     goal2sat * m_owner; 
     scoped_set_imp(goal2sat * o, goal2sat::imp * i):m_owner(o) {
-        #pragma omp critical (goal2sat)
-        {
-            m_owner->m_imp = i;
-        }
+        m_owner->m_imp = i;        
     }
     ~scoped_set_imp() {
-        #pragma omp critical (goal2sat)
-        {
-            m_owner->m_imp = 0;
-        }
+        m_owner->m_imp = 0;        
     }
 };
 
@@ -732,16 +726,10 @@ void sat2goal::collect_param_descrs(param_descrs & r) {
 struct sat2goal::scoped_set_imp {
     sat2goal * m_owner; 
     scoped_set_imp(sat2goal * o, sat2goal::imp * i):m_owner(o) {
-        #pragma omp critical (sat2goal)
-        {
-            m_owner->m_imp = i;
-        }
+        m_owner->m_imp = i;        
     }
     ~scoped_set_imp() {
-        #pragma omp critical (sat2goal)
-        {
-            m_owner->m_imp = 0;
-        }
+        m_owner->m_imp = 0;        
     }
 };
 

--- a/src/sat/tactic/goal2sat.h
+++ b/src/sat/tactic/goal2sat.h
@@ -59,7 +59,6 @@ public:
     */
     void operator()(goal const & g, params_ref const & p, sat::solver & t, atom2bool_var & m, dep2asm_map& dep2asm, bool default_external = false);
 
-    void set_cancel(bool f);
 
 };
 
@@ -83,7 +82,6 @@ public:
     */
     void operator()(sat::solver const & t, atom2bool_var const & m, params_ref const & p, goal & s, model_converter_ref & mc);
     
-    void set_cancel(bool f);
 };
 
 #endif

--- a/src/sat/tactic/sat_tactic.cpp
+++ b/src/sat/tactic/sat_tactic.cpp
@@ -145,17 +145,11 @@ class sat_tactic : public tactic {
         sat_tactic * m_owner; 
 
         scoped_set_imp(sat_tactic * o, imp * i):m_owner(o) {
-            #pragma omp critical (sat_tactic)
-            {
-                m_owner->m_imp = i;
-            }
+            m_owner->m_imp = i;            
         }
         
         ~scoped_set_imp() {
-            #pragma omp critical (sat_tactic)
-            {
-                m_owner->m_imp = 0;
-            }
+            m_owner->m_imp = 0;        
         }
     };
 

--- a/src/sat/tactic/sat_tactic.cpp
+++ b/src/sat/tactic/sat_tactic.cpp
@@ -123,11 +123,6 @@ class sat_tactic : public tactic {
             result.push_back(g.get());
         }
         
-        void set_cancel(bool f) {
-            m_goal2sat.set_cancel(f);
-            m_sat2goal.set_cancel(f);
-            m_solver.set_cancel(f);
-        }
 
         void dep2assumptions(obj_map<expr, sat::literal>& dep2asm, 
                              sat::literal_vector& assumptions) {
@@ -223,13 +218,6 @@ public:
     }
 
 protected:
-    virtual void set_cancel(bool f) {
-        #pragma omp critical (sat_tactic)
-        {
-            if (m_imp)
-                m_imp->set_cancel(f);
-        }
-    }
 
 };
 

--- a/src/shell/opt_frontend.cpp
+++ b/src/shell/opt_frontend.cpp
@@ -307,7 +307,7 @@ static void display_statistics() {
 
 static void on_ctrl_c(int) {
     if (g_opt && g_first_interrupt) {
-        g_opt->set_cancel(true);
+        g_opt->get_manager().limit().cancel();
         g_first_interrupt = false;
     }
     else {

--- a/src/smt/asserted_formulas.cpp
+++ b/src/smt/asserted_formulas.cpp
@@ -54,8 +54,7 @@ asserted_formulas::asserted_formulas(ast_manager & m, smt_params & p):
     m_macro_manager(m, m_simplifier),
     m_bit2int(m),
     m_bv_sharing(m),
-    m_inconsistent(false),
-    m_cancel_flag(false) {
+    m_inconsistent(false){
 
     m_bsimp = 0;
     m_bvsimp = 0;
@@ -223,9 +222,6 @@ void asserted_formulas::reset() {
     m_inconsistent = false;
 }
 
-void asserted_formulas::set_cancel_flag(bool f) {
-    m_cancel_flag = f; 
-}
 
 #ifdef Z3DEBUG
 bool asserted_formulas::check_well_sorted() const {

--- a/src/smt/asserted_formulas.h
+++ b/src/smt/asserted_formulas.h
@@ -62,7 +62,6 @@ class asserted_formulas {
         bool                    m_inconsistent_old;
     };
     svector<scope>              m_scopes;
-    volatile bool               m_cancel_flag;
 
     void setup_simplifier_plugins(simplifier & s, basic_simplifier_plugin * & bsimp, arith_simplifier_plugin * & asimp, bv_simplifier_plugin * & bvsimp);
     void reduce_asserted_formulas();
@@ -97,7 +96,7 @@ class asserted_formulas {
     unsigned get_total_size() const;
     bool has_bv() const;
     void max_bv_sharing();
-    bool canceled() { return m_cancel_flag; }
+    bool canceled() { return m_manager.canceled(); }
 
 public:
     asserted_formulas(ast_manager & m, smt_params & p);

--- a/src/smt/expr_context_simplifier.h
+++ b/src/smt/expr_context_simplifier.h
@@ -77,7 +77,6 @@ public:
     
     void collect_statistics(statistics & st) const { m_solver.collect_statistics(st); }
     void reset_statistics() { m_solver.reset_statistics(); }
-    void set_cancel(bool f) { m_solver.set_cancel(f); }
 };
 
 #endif /* EXPR_CONTEXT_SIMPLIFIER_H_ */

--- a/src/smt/smt_context.cpp
+++ b/src/smt/smt_context.cpp
@@ -45,7 +45,6 @@ namespace smt {
         m_fparams(p),
         m_params(_p),
         m_setup(*this, p),
-        m_cancel_flag(false),
         m_asserted_formulas(m, p),
         m_qmanager(alloc(quantifier_manager, *this, p, _p)),
         m_model_generator(alloc(model_generator, m)),
@@ -3069,11 +3068,6 @@ namespace smt {
         if (m_manager.has_trace_stream())
             m_manager.trace_stream() << "[begin-check] " << m_scope_lvl << "\n";
 
-        if (reset_cancel) {
-            m_cancel_flag = false;
-            m_asserted_formulas.set_cancel_flag(false);
-        }
-
         if (memory::above_high_watermark()) {
             m_last_search_failure = MEMOUT;
             return false;
@@ -4152,11 +4146,6 @@ namespace smt {
 
     failure context::get_last_search_failure() const { 
         return m_last_search_failure; 
-    }
-
-    void context::set_cancel_flag(bool f) {
-        m_cancel_flag = f;
-        m_asserted_formulas.set_cancel_flag(f);
     }
 
 };

--- a/src/smt/smt_context.h
+++ b/src/smt/smt_context.h
@@ -79,7 +79,6 @@ namespace smt {
         smt_params &                m_fparams;
         params_ref                  m_params;
         setup                       m_setup;
-        volatile bool               m_cancel_flag;
         timer                       m_timer;
         asserted_formulas           m_asserted_formulas;
         scoped_ptr<quantifier_manager>   m_qmanager;
@@ -233,9 +232,8 @@ namespace smt {
             return m_params;
         }
 
-        virtual void set_cancel_flag(bool f = true);
 
-        bool get_cancel_flag() { return m_cancel_flag || !m_manager.limit().inc(); }
+        bool get_cancel_flag() { return !m_manager.limit().inc(); }
 
         region & get_region() {
             return m_region;

--- a/src/smt/smt_kernel.cpp
+++ b/src/smt/smt_kernel.cpp
@@ -169,10 +169,6 @@ namespace smt {
         void display_istatistics(std::ostream & out) const {
             m_kernel.display_istatistics(out);
         }
-
-        void set_cancel(bool f) {
-            m_kernel.set_cancel_flag(f);
-        }
         
         bool canceled() {
             return m_kernel.get_cancel_flag();
@@ -326,14 +322,6 @@ namespace smt {
 
     void kernel::display_istatistics(std::ostream & out) const {
         m_imp->display_istatistics(out);
-    }
-
-    void kernel::set_cancel(bool f) {
-        #pragma omp critical (smt_kernel)
-        {
-            if (m_imp)
-                m_imp->set_cancel(f);
-        }
     }
 
     bool kernel::canceled() const {

--- a/src/smt/smt_kernel.h
+++ b/src/smt/smt_kernel.h
@@ -204,18 +204,7 @@ namespace smt {
            \brief Display statistics in low level format.
         */
         void display_istatistics(std::ostream & out) const;
-        
-        /**
-           \brief Interrupt the kernel. 
-        */
-        void set_cancel(bool f = true);
-        void cancel() { set_cancel(true); }
-
-        /**
-           \brief Reset interruption.
-        */
-        void reset_cancel() { set_cancel(false); }
-        
+                
         /**
            \brief Return true if the kernel was interrupted.
         */

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -101,9 +101,8 @@ namespace smt {
             r.append(tmp.size(), tmp.c_ptr());
         }
 
-        virtual void set_cancel(bool f) {
-            m_context.set_cancel(f);
-        }
+        virtual ast_manager& get_manager() { return m_context.m(); }
+
 
         virtual void set_progress_callback(progress_callback * callback) {
             m_callback = callback;

--- a/src/smt/tactic/ctx_solver_simplify_tactic.cpp
+++ b/src/smt/tactic/ctx_solver_simplify_tactic.cpp
@@ -35,12 +35,10 @@ class ctx_solver_simplify_tactic : public tactic {
     func_decl_ref         m_fn;
     obj_map<sort, func_decl*> m_fns;
     unsigned              m_num_steps;
-    volatile bool         m_cancel;
 public:
     ctx_solver_simplify_tactic(ast_manager & m, params_ref const & p = params_ref()):
         m(m), m_params(p), m_solver(m, m_front_p),  
-        m_arith(m), m_mk_app(m), m_fn(m), m_num_steps(0), 
-        m_cancel(false) {
+        m_arith(m), m_mk_app(m), m_fn(m), m_num_steps(0) {
         sort* i_sort = m_arith.mk_int();
         m_fn = m.mk_func_decl(symbol(0xbeef101), i_sort, m.mk_bool_sort());
     }
@@ -86,15 +84,10 @@ public:
     virtual void cleanup() {
         reset_statistics();
         m_solver.reset();
-        m_cancel = false;
     }
 
 protected:
 
-    virtual void set_cancel(bool f) {
-        m_solver.set_cancel(f);
-        m_cancel = false;
-    }
 
     void reduce(goal& g) {
         SASSERT(g.is_well_sorted());
@@ -177,7 +170,7 @@ protected:
         names.push_back(n);
         m_solver.push();
 
-        while (!todo.empty() && !m_cancel) {            
+        while (!todo.empty() && !m.canceled()) {            
             expr_ref res(m);
             args.reset();
             expr* e    = todo.back().m_expr;
@@ -249,7 +242,7 @@ protected:
             names.pop_back();
             m_solver.pop(1);
         }
-        if (!m_cancel) {
+        if (!m.canceled()) {
             VERIFY(cache.find(fml, path_r));
             result = path_r.m_expr;
         }

--- a/src/smt/tactic/smt_tactic.cpp
+++ b/src/smt/tactic/smt_tactic.cpp
@@ -132,10 +132,6 @@ public:
         smt_params_helper::collect_param_descrs(r);
     }
     
-    virtual void set_cancel(bool f) {
-        if (m_ctx)
-            m_ctx->set_cancel(f);
-    }
 
     virtual void collect_statistics(statistics & st) const {
         if (m_ctx)

--- a/src/smt/tactic/smt_tactic.cpp
+++ b/src/smt/tactic/smt_tactic.cpp
@@ -167,18 +167,14 @@ public:
             if (o.m_callback) {
                 new_ctx->set_progress_callback(o.m_callback);
             }
-            #pragma omp critical (as_st_solver) 
-            {
-                o.m_ctx = new_ctx;
-            }
+            o.m_ctx = new_ctx;
+            
         }
 
         ~scoped_init_ctx() {
             smt::kernel * d = m_owner.m_ctx;
-            #pragma omp critical (as_st_cancel)
-            {
-                m_owner.m_ctx = 0;
-            }
+            m_owner.m_ctx = 0;
+            
             if (d)
                 dealloc(d);
         }

--- a/src/smt/tactic/unit_subsumption_tactic.cpp
+++ b/src/smt/tactic/unit_subsumption_tactic.cpp
@@ -22,7 +22,6 @@ struct unit_subsumption_tactic : public tactic {
     ast_manager&    m;
     params_ref      m_params;
     smt_params      m_fparams;
-    volatile bool   m_cancel;
     smt::context    m_context;
     expr_ref_vector m_clauses;
     unsigned        m_clause_count;
@@ -34,19 +33,11 @@ struct unit_subsumption_tactic : public tactic {
         params_ref const& p):
         m(m), 
         m_params(p), 
-        m_cancel(false), 
         m_context(m, m_fparams, p),
         m_clauses(m) {
     }
-           
-    void set_cancel(bool f) {
-        m_cancel = f;
-        m_context.set_cancel_flag(f);
-    }
 
-    virtual void cleanup() {
-        set_cancel(false);
-    }
+    void cleanup() {}
 
     virtual void operator()(/* in */  goal_ref const & in, 
                             /* out */ goal_ref_buffer & result, 
@@ -66,7 +57,7 @@ struct unit_subsumption_tactic : public tactic {
     }
     
     void checkpoint() {
-        if (m_cancel) {
+        if (m.canceled()) {
             throw tactic_exception(TACTIC_CANCELED_MSG);
         }
     }

--- a/src/smt/theory_dense_diff_logic_def.h
+++ b/src/smt/theory_dense_diff_logic_def.h
@@ -896,8 +896,8 @@ namespace smt {
     template<typename Ext>
     inf_eps_rational<inf_rational> theory_dense_diff_logic<Ext>::maximize(theory_var v, expr_ref& blocker, bool& has_shared) {
         typedef simplex::simplex<simplex::mpq_ext> Simplex;
-        Simplex S;
         ast_manager& m = get_manager();
+        Simplex S(m.limit());
         objective_term const& objective = m_objectives[v];
         has_shared = false;
         

--- a/src/smt/theory_diff_logic.h
+++ b/src/smt/theory_diff_logic.h
@@ -236,6 +236,7 @@ namespace smt {
             m_non_diff_logic_exprs(false),
             m_factory(0),
             m_nc_functor(*this),
+            m_S(m.limit()),
             m_num_simplex_edges(0) {
         }            
 

--- a/src/smt/theory_pb.cpp
+++ b/src/smt/theory_pb.cpp
@@ -231,6 +231,7 @@ namespace smt {
     theory_pb::theory_pb(ast_manager& m, theory_pb_params& p):
         theory(m.mk_family_id("pb")),
         m_params(p),
+        m_simplex(m.limit()),
         m_util(m),
         m_max_compiled_coeff(rational(8))
     {        

--- a/src/solver/check_sat_result.h
+++ b/src/solver/check_sat_result.h
@@ -52,6 +52,7 @@ public:
     virtual proof * get_proof() = 0;
     virtual std::string reason_unknown() const = 0;
     virtual void get_labels(svector<symbol> & r) = 0;
+    virtual ast_manager& get_manager() = 0;
 };
 
 /**
@@ -63,9 +64,11 @@ struct simple_check_sat_result : public check_sat_result {
     expr_ref_vector m_core;
     proof_ref       m_proof;
     std::string     m_unknown;
+    
 
     simple_check_sat_result(ast_manager & m);
     virtual ~simple_check_sat_result();
+    virtual ast_manager& get_manager() { return m_proof.get_manager(); }
     virtual void collect_statistics(statistics & st) const;
     virtual void get_unsat_core(ptr_vector<expr> & r);
     virtual void get_model(model_ref & m);

--- a/src/solver/combined_solver.cpp
+++ b/src/solver/combined_solver.cpp
@@ -84,7 +84,7 @@ private:
         volatile bool   m_canceled;
         aux_timeout_eh(solver * s):m_solver(s), m_canceled(false) {}
         virtual void operator()() {
-            m_solver->get_manager().cancel();
+            m_solver->get_manager().limit().cancel();
             m_canceled = true;
         }
     };

--- a/src/solver/combined_solver.cpp
+++ b/src/solver/combined_solver.cpp
@@ -84,7 +84,7 @@ private:
         volatile bool   m_canceled;
         aux_timeout_eh(solver * s):m_solver(s), m_canceled(false) {}
         virtual void operator()() {
-            m_solver->cancel();
+            m_solver->get_manager().cancel();
             m_canceled = true;
         }
     };
@@ -95,6 +95,8 @@ private:
         m_ignore_solver1 = p.ignore_solver1();
         m_inc_unknown_behavior = static_cast<inc_unknown_behavior>(p.solver2_unknown());
     }
+
+    virtual ast_manager& get_manager() { return m_solver1->get_manager(); }
 
     bool has_quantifiers() const {
         unsigned sz = get_num_assertions();
@@ -220,24 +222,17 @@ public:
                     m_use_solver1_results = false;
                     return r;
                 }
+                if (eh.m_canceled) {
+                    m_solver1->get_manager().limit().reset_cancel();
+                }
             }
-            IF_VERBOSE(PS_VB_LVL, verbose_stream() << "(combined-solver \"solver 2 failed, trying solver1\")\n";);                        
+            IF_VERBOSE(PS_VB_LVL, verbose_stream() << "(combined-solver \"solver 2 failed, trying solver1\")\n";);
+
         }
         
         IF_VERBOSE(PS_VB_LVL, verbose_stream() << "(combined-solver \"using solver 1\")\n";);
         m_use_solver1_results = true;
         return m_solver1->check_sat(0, 0);
-    }
-
-    virtual void set_cancel(bool f) {
-        if (f) {
-            m_solver1->cancel();
-            m_solver2->cancel();
-        }
-        else {
-            m_solver1->reset_cancel();
-            m_solver2->reset_cancel();
-        }
     }
     
     virtual void set_progress_callback(progress_callback * callback) {

--- a/src/solver/solver.h
+++ b/src/solver/solver.h
@@ -41,7 +41,6 @@ public:
      - parameter setting (updt_params)
      - statistics
      - results based on check_sat_result API
-     - interruption (set_cancel)
 */
 class solver : public check_sat_result {
 public:
@@ -105,14 +104,6 @@ public:
     */
     virtual lbool check_sat(unsigned num_assumptions, expr * const * assumptions) = 0;
 
-    /**
-       \brief Interrupt this solver.
-    */
-    //void cancel() { set_cancel(true); }
-    /**
-       \brief Reset the interruption.
-    */
-    //void reset_cancel() { set_cancel(false); }
 
     /**
        \brief Set a progress callback procedure that is invoked by this solver during check_sat.
@@ -156,9 +147,6 @@ public:
         ~scoped_push() { if (!m_nopop) s.pop(1); }
         void disable_pop() { m_nopop = true; }
     };
-
-protected:
-    //virtual void set_cancel(bool f) = 0;
 };
 
 #endif

--- a/src/solver/solver.h
+++ b/src/solver/solver.h
@@ -108,11 +108,11 @@ public:
     /**
        \brief Interrupt this solver.
     */
-    void cancel() { set_cancel(true); }
+    //void cancel() { set_cancel(true); }
     /**
        \brief Reset the interruption.
     */
-    void reset_cancel() { set_cancel(false); }
+    //void reset_cancel() { set_cancel(false); }
 
     /**
        \brief Set a progress callback procedure that is invoked by this solver during check_sat.
@@ -158,7 +158,7 @@ public:
     };
 
 protected:
-    virtual void set_cancel(bool f) = 0;
+    //virtual void set_cancel(bool f) = 0;
 };
 
 #endif

--- a/src/solver/tactic2solver.cpp
+++ b/src/solver/tactic2solver.cpp
@@ -59,7 +59,6 @@ public:
     virtual void pop_core(unsigned n);
     virtual lbool check_sat_core(unsigned num_assumptions, expr * const * assumptions);
 
-    virtual void set_cancel(bool f);
 
     virtual void collect_statistics(statistics & st) const;
     virtual void get_unsat_core(ptr_vector<expr> & r);
@@ -74,7 +73,10 @@ public:
     virtual expr * get_assertion(unsigned idx) const;
 
     virtual void display(std::ostream & out) const;
+    virtual ast_manager& get_manager(); 
 };
+
+ast_manager& tactic2solver::get_manager() { return m_assertions.get_manager(); }
 
 tactic2solver::tactic2solver(ast_manager & m, tactic * t, params_ref const & p, bool produce_proofs, bool produce_models, bool produce_unsat_cores, symbol const & logic):
     solver_na2as(m),
@@ -177,14 +179,6 @@ lbool tactic2solver::check_sat_core(unsigned num_assumptions, expr * const * ass
     return m_result->status();
 }
 
-void tactic2solver::set_cancel(bool f) {
-    if (m_tactic.get()) {
-        if (f) 
-            m_tactic->cancel();
-        else
-            m_tactic->reset_cancel();
-    }
-}
 
 solver* tactic2solver::translate(ast_manager& m, params_ref const& p) {
     tactic* t = m_tactic->translate(m);

--- a/src/solver/tactic2solver.h
+++ b/src/solver/tactic2solver.h
@@ -37,6 +37,7 @@ solver * mk_tactic2solver(ast_manager & m,
                           bool produce_unsat_cores = false, 
                           symbol const & logic = symbol::null);
 
+
 solver_factory * mk_tactic2solver_factory(tactic * t);
 solver_factory * mk_tactic_factory2solver_factory(tactic_factory * f);
 

--- a/src/tactic/aig/aig.cpp
+++ b/src/tactic/aig/aig.cpp
@@ -119,7 +119,6 @@ struct aig_manager::imp {
     aig_lit                  m_false;
     bool                     m_default_gate_encoding;
     unsigned long long       m_max_memory;
-    volatile bool            m_cancel;
 
     void dec_ref_core(aig * n) {
         SASSERT(n->m_ref_count > 0);
@@ -131,7 +130,7 @@ struct aig_manager::imp {
     void checkpoint() {
         if (memory::get_allocation_size() > m_max_memory)
             throw aig_exception(TACTIC_MAX_MEMORY_MSG);
-        if (m_cancel)
+        if (m().canceled())
             throw aig_exception(TACTIC_CANCELED_MSG);
         cooperate("aig");
     }
@@ -1309,8 +1308,7 @@ public:
         m_num_aigs(0),
         m_var2exprs(m),
         m_allocator("aig"),
-        m_true(mk_var(m.mk_true())),
-        m_cancel(false) {
+        m_true(mk_var(m.mk_true())) {
         SASSERT(is_true(m_true));
         m_false = m_true;
         m_false.invert();
@@ -1328,7 +1326,6 @@ public:
 
     ast_manager & m() const { return m_var2exprs.get_manager(); }
 
-    void set_cancel(bool f) { m_cancel = f; }
 
     void inc_ref(aig * n) { n->m_ref_count++; }
     void inc_ref(aig_lit const & r) { inc_ref(r.ptr()); }
@@ -1754,8 +1751,5 @@ unsigned aig_manager::get_num_aigs() const {
     return m_imp->get_num_aigs();
 }
 
-void aig_manager::set_cancel(bool f) {
-    m_imp->set_cancel(f);
-}
 
 

--- a/src/tactic/aig/aig.h
+++ b/src/tactic/aig/aig.h
@@ -73,7 +73,6 @@ public:
     void display(std::ostream & out, aig_ref const & r) const;
     void display_smt2(std::ostream & out, aig_ref const & r) const;
     unsigned get_num_aigs() const;
-    void set_cancel(bool f);
 };
 
 #endif

--- a/src/tactic/aig/aig_tactic.cpp
+++ b/src/tactic/aig/aig_tactic.cpp
@@ -37,6 +37,7 @@ class aig_tactic : public tactic {
         
         ~mk_aig_manager() {
             dealloc(m_owner.m_aig_manager);
+            m_owner.m_aig_manager = 0;
         }
     };
 

--- a/src/tactic/aig/aig_tactic.cpp
+++ b/src/tactic/aig/aig_tactic.cpp
@@ -111,14 +111,6 @@ public:
 
     virtual void cleanup() {}
 
-protected:
-    virtual void set_cancel(bool f) {
-        #pragma omp critical (aig_tactic)
-        {
-            if (m_aig_manager)
-                m_aig_manager->set_cancel(f);
-        }
-    }
 };
 
 tactic * mk_aig_tactic(params_ref const & p) {

--- a/src/tactic/aig/aig_tactic.cpp
+++ b/src/tactic/aig/aig_tactic.cpp
@@ -32,19 +32,11 @@ class aig_tactic : public tactic {
 
         mk_aig_manager(aig_tactic & o, ast_manager & m):m_owner(o) {
             aig_manager * mng = alloc(aig_manager, m, o.m_max_memory, o.m_aig_gate_encoding);
-            #pragma omp critical (aig_tactic)
-            {
-                m_owner.m_aig_manager = mng;
-            }
+            m_owner.m_aig_manager = mng;            
         }
         
         ~mk_aig_manager() {
-            aig_manager * mng = m_owner.m_aig_manager;
-            #pragma omp critical (aig_tactic)
-            {
-                m_owner.m_aig_manager = 0;
-            }
-            dealloc(mng);
+            dealloc(m_owner.m_aig_manager);
         }
     };
 

--- a/src/tactic/arith/add_bounds_tactic.cpp
+++ b/src/tactic/arith/add_bounds_tactic.cpp
@@ -62,7 +62,6 @@ class add_bounds_tactic : public tactic {
         ast_manager & m;
         rational      m_lower;
         rational      m_upper;
-        volatile bool m_cancel;
         
         imp(ast_manager & _m, params_ref const & p):
             m(_m) {
@@ -74,9 +73,6 @@ class add_bounds_tactic : public tactic {
             m_upper  = p.get_rat("add_bound_upper", rational(2));
         }
         
-        void set_cancel(bool f) {
-            m_cancel = f;
-        }
         
         struct add_bound_proc {
             arith_util       m_util;
@@ -180,11 +176,6 @@ public:
         dealloc(d);
     }
 
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_add_bounds_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/arith/add_bounds_tactic.cpp
+++ b/src/tactic/arith/add_bounds_tactic.cpp
@@ -169,10 +169,7 @@ public:
     
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);
         dealloc(d);
     }
 

--- a/src/tactic/arith/arith_bounds_tactic.cpp
+++ b/src/tactic/arith/arith_bounds_tactic.cpp
@@ -13,24 +13,15 @@ struct arith_bounds_tactic : public tactic {
 
     ast_manager& m;
     arith_util   a;
-    volatile bool m_cancel;
 
     arith_bounds_tactic(ast_manager& m):
         m(m),
-        a(m),
-        m_cancel(false)
+        a(m)
     {
     }        
 
     ast_manager& get_manager() { return m; }
 
-    void set_cancel(bool f) {
-        m_cancel = f;
-    }
-
-    virtual void cleanup() {
-        m_cancel = false;
-    }
 
     virtual void operator()(/* in */  goal_ref const & in, 
                             /* out */ goal_ref_buffer & result, 
@@ -45,7 +36,7 @@ struct arith_bounds_tactic : public tactic {
     }
     
     void checkpoint() {
-        if (m_cancel) {
+        if (m.canceled()) {
             throw tactic_exception(TACTIC_CANCELED_MSG);
         }
     }
@@ -155,6 +146,7 @@ struct arith_bounds_tactic : public tactic {
         TRACE("arith_subsumption", s->display(tout); );
     }
 
+    virtual void cleanup() {}
 
 };
 

--- a/src/tactic/arith/card2bv_tactic.cpp
+++ b/src/tactic/arith/card2bv_tactic.cpp
@@ -462,10 +462,6 @@ public:
     virtual void collect_param_descrs(param_descrs & r) {  
     }
 
-    void set_cancel(bool f) {
-        m_rw1.set_cancel(f);
-        m_rw2.set_cancel(f);
-    }
     
     virtual void operator()(goal_ref const & g, 
                             goal_ref_buffer & result, 

--- a/src/tactic/arith/degree_shift_tactic.cpp
+++ b/src/tactic/arith/degree_shift_tactic.cpp
@@ -315,10 +315,7 @@ public:
     
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/arith/degree_shift_tactic.cpp
+++ b/src/tactic/arith/degree_shift_tactic.cpp
@@ -40,7 +40,6 @@ class degree_shift_tactic : public tactic {
         rational                 m_one;
         bool                     m_produce_models;
         bool                     m_produce_proofs;
-        volatile bool            m_cancel;
 
         expr * mk_power(expr * t, rational const & k) {
             if (k.is_one())
@@ -96,15 +95,11 @@ class degree_shift_tactic : public tactic {
             m_pinned(_m),
             m_one(1),
             m_rw(0) {
-            m_cancel = false;
         }
 
-        void set_cancel(bool f) {
-            m_cancel = f;
-        }
 
         void checkpoint() {
-            if (m_cancel)
+            if (m.canceled())
                 throw tactic_exception(TACTIC_CANCELED_MSG);
             cooperate("degree_shift");
         }
@@ -326,12 +321,7 @@ public:
         }
         dealloc(d);
     }
-    
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
+
 };
 
 tactic * mk_degree_shift_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/arith/diff_neq_tactic.cpp
+++ b/src/tactic/arith/diff_neq_tactic.cpp
@@ -45,7 +45,6 @@ class diff_neq_tactic : public tactic {
         vector<diseqs>      m_var_diseqs;
         typedef svector<int> decision_stack;
         decision_stack       m_stack;
-        volatile bool        m_cancel;
         
         bool                m_produce_models;
         rational            m_max_k;
@@ -58,7 +57,6 @@ class diff_neq_tactic : public tactic {
             u(m),
             m_var2expr(m) {
             updt_params(p);
-            m_cancel = false;
         }
         
         void updt_params(params_ref const & p) {
@@ -67,11 +65,7 @@ class diff_neq_tactic : public tactic {
             if (m_max_k >= rational(INT_MAX/2)) 
                 m_max_k = rational(INT_MAX/2);
         }
-        
-        void set_cancel(bool f) {
-            m_cancel = f;
-        }
-        
+                
         void throw_not_supported() {
             throw tactic_exception("goal is not diff neq");
         }
@@ -294,7 +288,7 @@ class diff_neq_tactic : public tactic {
             init_forbidden();
             unsigned nvars = num_vars();
             while (m_stack.size() < nvars) {
-                if (m_cancel)
+                if (m.canceled())
                     throw tactic_exception(TACTIC_CANCELED_MSG);
                 TRACE("diff_neq_tactic", display_model(tout););
                 var x = m_stack.size();
@@ -407,11 +401,6 @@ public:
         dealloc(d);
     }
 
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_diff_neq_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/arith/diff_neq_tactic.cpp
+++ b/src/tactic/arith/diff_neq_tactic.cpp
@@ -394,10 +394,7 @@ public:
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m, m_params);
         d->m_num_conflicts = m_imp->m_num_conflicts;
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/arith/elim01_tactic.cpp
+++ b/src/tactic/arith/elim01_tactic.cpp
@@ -136,10 +136,7 @@ public:
 
     virtual ~elim01_tactic() {
     }
-        
-    void set_cancel(bool f) {
-    }
-        
+                
     virtual void updt_params(params_ref const & p) {
         m_max_hi = rational(p.get_uint("max_coefficient", m_max_hi_default));
         m_params = p;

--- a/src/tactic/arith/eq2bv_tactic.cpp
+++ b/src/tactic/arith/eq2bv_tactic.cpp
@@ -139,9 +139,6 @@ public:
     virtual ~eq2bv_tactic() {
     }
         
-    void set_cancel(bool f) {
-        m_rw.set_cancel(f);
-    }
         
     void updt_params(params_ref const & p) {
     }

--- a/src/tactic/arith/factor_tactic.cpp
+++ b/src/tactic/arith/factor_tactic.cpp
@@ -34,7 +34,7 @@ class factor_tactic : public tactic {
         rw_cfg(ast_manager & _m, params_ref const & p):
             m(_m),
             m_util(_m),
-            m_pm(m_qm),
+            m_pm(m.limit(), m_qm),
             m_expr2poly(m, m_pm) {
             updt_params(p);
         }
@@ -251,10 +251,6 @@ class factor_tactic : public tactic {
             m_rw(m, p) {
         }
 
-        void set_cancel(bool f) {
-            m_rw.set_cancel(f);
-            m_rw.cfg().m_pm.set_cancel(f);
-        }
 
         void updt_params(params_ref const & p) {
             m_rw.cfg().updt_params(p);
@@ -341,10 +337,7 @@ public:
         dealloc(d);
     }
 
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
+
 };
 
 tactic * mk_factor_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/arith/factor_tactic.cpp
+++ b/src/tactic/arith/factor_tactic.cpp
@@ -330,10 +330,7 @@ public:
 
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/arith/fix_dl_var_tactic.cpp
+++ b/src/tactic/arith/fix_dl_var_tactic.cpp
@@ -335,10 +335,7 @@ public:
     
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 };

--- a/src/tactic/arith/fix_dl_var_tactic.cpp
+++ b/src/tactic/arith/fix_dl_var_tactic.cpp
@@ -247,11 +247,7 @@ class fix_dl_var_tactic : public tactic {
         void updt_params(params_ref const & p) {
             m_rw.updt_params(p);
         }
-        
-        void set_cancel(bool f) {
-            m_rw.set_cancel(f);
-        }
-        
+                
         void operator()(goal_ref const & g, 
                         goal_ref_buffer & result, 
                         model_converter_ref & mc, 
@@ -344,11 +340,6 @@ public:
             std::swap(d, m_imp);
         }
         dealloc(d);
-    }
-
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
     }
 };
 

--- a/src/tactic/arith/fm_tactic.cpp
+++ b/src/tactic/arith/fm_tactic.cpp
@@ -1669,10 +1669,7 @@ public:
 
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/arith/fm_tactic.cpp
+++ b/src/tactic/arith/fm_tactic.cpp
@@ -44,7 +44,6 @@ class fm_tactic : public tactic {
         ast_manager &         m;
         ptr_vector<func_decl> m_xs;
         vector<clauses>       m_clauses;
-        volatile bool         m_cancel;
 
         enum r_kind {
             NONE,
@@ -182,7 +181,6 @@ class fm_tactic : public tactic {
 
         virtual void operator()(model_ref & md, unsigned goal_idx) {
             TRACE("fm_mc", model_v2_pp(tout, *md); display(tout););
-            m_cancel = false;
             model_evaluator ev(*(md.get()));
             ev.set_model_completion(true);
             arith_util u(m);
@@ -199,7 +197,7 @@ class fm_tactic : public tactic {
                 clauses::iterator it  = m_clauses[i].begin();
                 clauses::iterator end = m_clauses[i].end();
                 for (; it != end; ++it) {
-                    if (m_cancel) throw tactic_exception(TACTIC_CANCELED_MSG);
+                    if (m.canceled()) throw tactic_exception(TACTIC_CANCELED_MSG);
                     switch (process(x, *it, u, ev, val)) {
                     case NONE: 
                         TRACE("fm_mc", tout << "no bound for:\n" << mk_ismt2_pp(*it, m) << "\n";);
@@ -244,9 +242,6 @@ class fm_tactic : public tactic {
             TRACE("fm_mc", model_v2_pp(tout, *md););
         }
 
-        virtual void cancel() {
-            m_cancel = true;
-        }
 
         virtual void display(std::ostream & out) {
             out << "(fm-model-converter";
@@ -394,7 +389,6 @@ class fm_tactic : public tactic {
         obj_hashtable<func_decl> m_forbidden_set; // variables that cannot be eliminated because occur in non OCC ineq part
         goal_ref                 m_new_goal;
         ref<fm_model_converter>  m_mc;
-        volatile bool            m_cancel;
         id_gen                   m_id_gen;
         bool                     m_produce_models;
         bool                     m_fm_real_only;
@@ -784,7 +778,6 @@ class fm_tactic : public tactic {
             m_var2expr(m),
             m_inconsistent_core(m) {
             updt_params(p);
-            m_cancel = false;
         }
         
         ~imp() {
@@ -801,9 +794,6 @@ class fm_tactic : public tactic {
             m_fm_occ         = p.get_bool("fm_occ", false);
         }
         
-        void set_cancel(bool f) {
-            m_cancel = f;
-        }
         
         struct forbidden_proc {
             imp & m_owner;
@@ -1552,7 +1542,7 @@ class fm_tactic : public tactic {
         
         void checkpoint() {
             cooperate("fm");
-            if (m_cancel)
+            if (m.canceled())
                 throw tactic_exception(TACTIC_CANCELED_MSG);
             if (memory::get_allocation_size() > m_max_memory)
                 throw tactic_exception(TACTIC_MAX_MEMORY_MSG);
@@ -1676,10 +1666,6 @@ public:
         r.insert("fm_extra", CPK_UINT, "(default: 0) max. increase on the number of inequalities for each FM variable elimination step.");
     }
 
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m, m_params);

--- a/src/tactic/arith/lia2card_tactic.cpp
+++ b/src/tactic/arith/lia2card_tactic.cpp
@@ -152,11 +152,7 @@ public:
         dealloc(m_todo);
         dealloc(m_01s);
     }
-        
-    void set_cancel(bool f) {
-        m_rw.set_cancel(f);
-    }
-        
+                
     void updt_params(params_ref const & p) {
         m_params = p;
         m_compile_equality = p.get_bool("compile_equality", false);

--- a/src/tactic/arith/lia2card_tactic.cpp
+++ b/src/tactic/arith/lia2card_tactic.cpp
@@ -400,11 +400,8 @@ public:
     virtual void cleanup() {        
         expr_set* d = alloc(expr_set);
         ptr_vector<expr>* todo = alloc(ptr_vector<expr>);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(m_01s, d);
-            std::swap(m_todo, todo);
-        }
+        std::swap(m_01s, d);
+        std::swap(m_todo, todo);        
         dealloc(d);
         dealloc(todo);
     }

--- a/src/tactic/arith/lia2pb_tactic.cpp
+++ b/src/tactic/arith/lia2pb_tactic.cpp
@@ -346,10 +346,7 @@ public:
     
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/arith/lia2pb_tactic.cpp
+++ b/src/tactic/arith/lia2pb_tactic.cpp
@@ -60,9 +60,6 @@ class lia2pb_tactic : public tactic {
             updt_params_core(p);
         }
         
-        void set_cancel(bool f) {
-            m_rw.set_cancel(f);
-        }
         
         bool is_target_core(expr * n, rational & u) {
             if (!is_uninterp_const(n))
@@ -356,11 +353,6 @@ public:
         dealloc(d);
     }
 
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_lia2pb_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/arith/nla2bv_tactic.cpp
+++ b/src/tactic/arith/nla2bv_tactic.cpp
@@ -404,17 +404,11 @@ class nla2bv_tactic : public tactic {
         nla2bv_tactic & m_owner; 
         scoped_set_imp(nla2bv_tactic & o, imp & i):
             m_owner(o) {
-            #pragma omp critical (tactic_cancel)
-            {
-                m_owner.m_imp = &i;
-            }
+            m_owner.m_imp = &i;            
         }
 
         ~scoped_set_imp() {
-            #pragma omp critical (tactic_cancel)
-            {
-                m_owner.m_imp = 0;
-            }
+            m_owner.m_imp = 0;            
         }
     };
     

--- a/src/tactic/arith/normalize_bounds_tactic.cpp
+++ b/src/tactic/arith/normalize_bounds_tactic.cpp
@@ -189,10 +189,7 @@ public:
     virtual void cleanup() {
         ast_manager & m = m_imp->m;
         imp * d = alloc(imp, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 };

--- a/src/tactic/arith/normalize_bounds_tactic.cpp
+++ b/src/tactic/arith/normalize_bounds_tactic.cpp
@@ -52,9 +52,6 @@ class normalize_bounds_tactic : public tactic {
             updt_params_core(p);
         }
         
-        void set_cancel(bool f) {
-            m_rw.set_cancel(f);
-        }
         
         bool is_target(expr * var, rational & val) {
             bool strict;
@@ -197,12 +194,6 @@ public:
             std::swap(d, m_imp);
         }
         dealloc(d);
-    }
-
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
     }
 };
 

--- a/src/tactic/arith/pb2bv_tactic.cpp
+++ b/src/tactic/arith/pb2bv_tactic.cpp
@@ -1004,10 +1004,7 @@ public:
     virtual void cleanup() {
         ast_manager & m = m_imp->m;
         imp * d = alloc(imp, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/arith/pb2bv_tactic.cpp
+++ b/src/tactic/arith/pb2bv_tactic.cpp
@@ -884,10 +884,6 @@ private:
             r.erase("elim_and");            
         }
         
-        void set_cancel(bool f) {
-            m_rw.set_cancel(f);
-        }
-
         virtual void operator()(goal_ref const & g, 
                                 goal_ref_buffer & result, 
                                 model_converter_ref & mc, 
@@ -1015,11 +1011,7 @@ public:
         dealloc(d);
     }
 
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
+
 };
 
 tactic * mk_pb2bv_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/arith/probe_arith.cpp
+++ b/src/tactic/arith/probe_arith.cpp
@@ -33,7 +33,7 @@ class arith_degree_probe : public probe {
         unsigned long long       m_acc_degree;
         unsigned                 m_counter;
 
-        proc(ast_manager & _m):m(_m), m_pm(m_qm), m_expr2poly(m, m_pm), m_util(m) {
+        proc(ast_manager & _m):m(_m), m_pm(m.limit(), m_qm), m_expr2poly(m, m_pm), m_util(m) {
             m_max_degree = 0;
             m_acc_degree = 0;
             m_counter    = 0;

--- a/src/tactic/arith/propagate_ineqs_tactic.cpp
+++ b/src/tactic/arith/propagate_ineqs_tactic.cpp
@@ -55,8 +55,6 @@ public:
     virtual void operator()(goal_ref const & g, goal_ref_buffer & result, model_converter_ref & mc, proof_converter_ref & pc, expr_dependency_ref & core);
     
     virtual void cleanup();
-protected:
-    virtual void set_cancel(bool f);
 };
 
 tactic * mk_propagate_ineqs_tactic(ast_manager & m, params_ref const & p) {
@@ -512,9 +510,6 @@ struct propagate_ineqs_tactic::imp {
         TRACE("propagate_ineqs_tactic", r->display(tout););
     }
 
-    void set_cancel(bool f) {
-        // TODO
-    }
 };
 
 propagate_ineqs_tactic::propagate_ineqs_tactic(ast_manager & m, params_ref const & p):
@@ -546,10 +541,6 @@ void propagate_ineqs_tactic::operator()(goal_ref const & g,
     SASSERT(r->is_well_sorted());
 }
 
-void propagate_ineqs_tactic::set_cancel(bool f) {
-    if (m_imp)
-        m_imp->set_cancel(f);
-}
  
 void propagate_ineqs_tactic::cleanup() {
     imp * d = alloc(imp, m_imp->m, m_params);

--- a/src/tactic/arith/propagate_ineqs_tactic.cpp
+++ b/src/tactic/arith/propagate_ineqs_tactic.cpp
@@ -544,9 +544,6 @@ void propagate_ineqs_tactic::operator()(goal_ref const & g,
  
 void propagate_ineqs_tactic::cleanup() {
     imp * d = alloc(imp, m_imp->m, m_params);
-    #pragma omp critical (tactic_cancel)
-    {
-        std::swap(d, m_imp);
-    }
+    std::swap(d, m_imp);    
     dealloc(d);
 }

--- a/src/tactic/arith/purify_arith_tactic.cpp
+++ b/src/tactic/arith/purify_arith_tactic.cpp
@@ -748,8 +748,6 @@ public:
     virtual void cleanup() {
     }
 
-    virtual void set_cancel(bool f) {
-    }
 };
 
 tactic * mk_purify_arith_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/arith/recover_01_tactic.cpp
+++ b/src/tactic/arith/recover_01_tactic.cpp
@@ -66,9 +66,6 @@ class recover_01_tactic : public tactic {
             updt_params_core(p);
         }
         
-        void set_cancel(bool f) {
-            m_rw.set_cancel(f);
-        }
 
         bool save_clause(expr * c) {
             if (!m.is_or(c))
@@ -431,12 +428,6 @@ public:
             std::swap(d, m_imp);
         }
         dealloc(d);
-    }
-
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
     }
 };
 

--- a/src/tactic/arith/recover_01_tactic.cpp
+++ b/src/tactic/arith/recover_01_tactic.cpp
@@ -423,10 +423,7 @@ public:
     
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 };

--- a/src/tactic/bv/bit_blaster_tactic.cpp
+++ b/src/tactic/bv/bit_blaster_tactic.cpp
@@ -149,10 +149,7 @@ public:
 
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m(), m_rewriter, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
     

--- a/src/tactic/bv/bit_blaster_tactic.cpp
+++ b/src/tactic/bv/bit_blaster_tactic.cpp
@@ -49,9 +49,6 @@ class bit_blaster_tactic : public tactic {
         
         ast_manager & m() const { return m_rewriter->m(); }
         
-        void set_cancel(bool f) {
-            m_rewriter->set_cancel(f);
-        }
 
         void operator()(goal_ref const & g, 
                         goal_ref_buffer & result, 
@@ -163,11 +160,6 @@ public:
         return m_imp->get_num_steps();
     }
 
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 

--- a/src/tactic/bv/bv1_blaster_tactic.cpp
+++ b/src/tactic/bv/bv1_blaster_tactic.cpp
@@ -377,9 +377,6 @@ class bv1_blaster_tactic : public tactic {
         
         ast_manager & m() const { return m_rw.m(); }
         
-        void set_cancel(bool f) {
-            m_rw.set_cancel(f);
-        }
         
         void operator()(goal_ref const & g, 
                         goal_ref_buffer & result, 
@@ -478,11 +475,6 @@ public:
         return m_imp->get_num_steps();
     }
     
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_bv1_blaster_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/bv/bv1_blaster_tactic.cpp
+++ b/src/tactic/bv/bv1_blaster_tactic.cpp
@@ -464,10 +464,7 @@ public:
     
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m(), m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
     

--- a/src/tactic/bv/bv_size_reduction_tactic.cpp
+++ b/src/tactic/bv/bv_size_reduction_tactic.cpp
@@ -43,7 +43,6 @@ public:
     virtual void operator()(goal_ref const & g, goal_ref_buffer & result, model_converter_ref & mc, proof_converter_ref & pc, expr_dependency_ref & core);
 
     virtual void cleanup();
-    virtual void set_cancel(bool f);
 };
 
 tactic * mk_bv_size_reduction_tactic(ast_manager & m, params_ref const & p) {
@@ -64,13 +63,11 @@ struct bv_size_reduction_tactic::imp {
     ref<filter_model_converter> m_fmc;
     scoped_ptr<expr_replacer> m_replacer;
     bool                      m_produce_models;
-    volatile bool             m_cancel;
 
     imp(ast_manager & _m):
         m(_m),
         m_util(m),
-        m_replacer(mk_default_expr_replacer(m)),
-        m_cancel(false) {
+        m_replacer(mk_default_expr_replacer(m)) {
     }
 
     void update_signed_lower(app * v, numeral const & k) {
@@ -178,7 +175,7 @@ struct bv_size_reduction_tactic::imp {
     }
     
     void checkpoint() {
-        if (m_cancel)
+        if (m.canceled())
             throw tactic_exception(TACTIC_CANCELED_MSG);
     }
     
@@ -375,10 +372,6 @@ struct bv_size_reduction_tactic::imp {
         TRACE("after_bv_size_reduction", g.display(tout); if (m_mc) m_mc->display(tout););
     }
 
-    void set_cancel(bool f) {
-        m_replacer->set_cancel(f);
-        m_cancel = f;
-    }
 };
 
 bv_size_reduction_tactic::bv_size_reduction_tactic(ast_manager & m) {
@@ -404,10 +397,6 @@ void bv_size_reduction_tactic::operator()(goal_ref const & g,
     SASSERT(g->is_well_sorted());
 }
 
-void bv_size_reduction_tactic::set_cancel(bool f) {
-    if (m_imp)
-        m_imp->set_cancel(f);
-}
  
 void bv_size_reduction_tactic::cleanup() {
     imp * d = alloc(imp, m_imp->m);

--- a/src/tactic/bv/bv_size_reduction_tactic.cpp
+++ b/src/tactic/bv/bv_size_reduction_tactic.cpp
@@ -400,10 +400,7 @@ void bv_size_reduction_tactic::operator()(goal_ref const & g,
  
 void bv_size_reduction_tactic::cleanup() {
     imp * d = alloc(imp, m_imp->m);
-    #pragma omp critical (tactic_cancel)
-    {
-        std::swap(d, m_imp);
-    }
+    std::swap(d, m_imp);    
     dealloc(d);
 }
 

--- a/src/tactic/bv/bvarray2uf_tactic.cpp
+++ b/src/tactic/bv/bvarray2uf_tactic.cpp
@@ -34,7 +34,6 @@ class bvarray2uf_tactic : public tactic {
         bool                m_produce_models;
         bool                m_produce_proofs;
         bool                m_produce_cores;
-        volatile bool       m_cancel;
         bvarray2uf_rewriter m_rw;
 
         ast_manager & m() { return m_manager; }
@@ -44,17 +43,13 @@ class bvarray2uf_tactic : public tactic {
             m_produce_models(false),
             m_produce_proofs(false),
             m_produce_cores(false),
-            m_cancel(false),
             m_rw(m, p) {
             updt_params(p);
         }
 
-        void set_cancel(bool f) {
-            m_cancel = f;
-        }
 
         void checkpoint() {
-            if (m_cancel)
+            if (m_manager.canceled())
                 throw tactic_exception(TACTIC_CANCELED_MSG);
         }
 
@@ -153,11 +148,6 @@ public:
             std::swap(d, m_imp);
         }
         dealloc(d);
-    }
-
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
     }
 
 };

--- a/src/tactic/bv/bvarray2uf_tactic.cpp
+++ b/src/tactic/bv/bvarray2uf_tactic.cpp
@@ -143,10 +143,7 @@ public:
     virtual void cleanup() {
         ast_manager & m = m_imp->m();
         imp * d = alloc(imp, m, m_params);
-    #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/bv/elim_small_bv_tactic.cpp
+++ b/src/tactic/bv/elim_small_bv_tactic.cpp
@@ -229,10 +229,6 @@ class elim_small_bv_tactic : public tactic {
             m_rw(m, p) {
         }
 
-        void set_cancel(bool f) {
-            m_rw.set_cancel(f);
-        }
-
         void updt_params(params_ref const & p) {
             m_rw.cfg().updt_params(p);
         }
@@ -318,10 +314,6 @@ public:
         dealloc(d);
     }
 
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_elim_small_bv_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/bv/elim_small_bv_tactic.cpp
+++ b/src/tactic/bv/elim_small_bv_tactic.cpp
@@ -307,10 +307,7 @@ public:
     virtual void cleanup() {
         ast_manager & m = m_imp->m;
         imp * d = alloc(imp, m, m_params);
-#pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);    
         dealloc(d);
     }
 

--- a/src/tactic/bv/max_bv_sharing_tactic.cpp
+++ b/src/tactic/bv/max_bv_sharing_tactic.cpp
@@ -308,10 +308,7 @@ public:
     
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m(), m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 };

--- a/src/tactic/bv/max_bv_sharing_tactic.cpp
+++ b/src/tactic/bv/max_bv_sharing_tactic.cpp
@@ -235,11 +235,7 @@ class max_bv_sharing_tactic : public tactic {
         }
         
         ast_manager & m() const { return m_rw.m(); }
-        
-        void set_cancel(bool f) {
-            m_rw.set_cancel(f);
-        }
-        
+                
         void operator()(goal_ref const & g, 
                         goal_ref_buffer & result, 
                         model_converter_ref & mc, 
@@ -317,11 +313,6 @@ public:
             std::swap(d, m_imp);
         }
         dealloc(d);
-    }
-
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
     }
 };
 

--- a/src/tactic/core/blast_term_ite_tactic.cpp
+++ b/src/tactic/core/blast_term_ite_tactic.cpp
@@ -182,12 +182,8 @@ public:
     
     virtual void cleanup() {
         ast_manager & m = m_imp->m;
-        imp * d = m_imp;
-        m_imp = 0;
-        
-        dealloc(d);
-        d = alloc(imp, m, m_params);
-        m_imp = d;        
+        dealloc(m_imp);
+        m_imp = alloc(imp, m, m_params);
     }
 
     static void blast_term_ite(expr_ref& fml) {

--- a/src/tactic/core/blast_term_ite_tactic.cpp
+++ b/src/tactic/core/blast_term_ite_tactic.cpp
@@ -183,16 +183,11 @@ public:
     virtual void cleanup() {
         ast_manager & m = m_imp->m;
         imp * d = m_imp;
-        #pragma omp critical (tactic_cancel)
-        {
-            m_imp = 0;
-        }
+        m_imp = 0;
+        
         dealloc(d);
         d = alloc(imp, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            m_imp = d;
-        }
+        m_imp = d;        
     }
 
     static void blast_term_ite(expr_ref& fml) {

--- a/src/tactic/core/blast_term_ite_tactic.cpp
+++ b/src/tactic/core/blast_term_ite_tactic.cpp
@@ -109,9 +109,6 @@ class blast_term_ite_tactic : public tactic {
             m_rw(m, p) {
         }
         
-        void set_cancel(bool f) {
-            m_rw.set_cancel(f);
-        }
         
         void updt_params(params_ref const & p) {
             m_rw.cfg().updt_params(p);
@@ -196,11 +193,6 @@ public:
         {
             m_imp = d;
         }
-    }
-
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
     }
 
     static void blast_term_ite(expr_ref& fml) {

--- a/src/tactic/core/cofactor_elim_term_ite.cpp
+++ b/src/tactic/core/cofactor_elim_term_ite.cpp
@@ -30,13 +30,12 @@ struct cofactor_elim_term_ite::imp {
     params_ref         m_params;
     unsigned long long m_max_memory;
     bool               m_cofactor_equalities;
-    volatile bool      m_cancel;
 
     void checkpoint() { 
         cooperate("cofactor ite");
         if (memory::get_allocation_size() > m_max_memory)
             throw tactic_exception(TACTIC_MAX_MEMORY_MSG);
-        if (m_cancel)
+        if (m.canceled())
             throw tactic_exception(TACTIC_CANCELED_MSG);
     }
 
@@ -315,9 +314,6 @@ struct cofactor_elim_term_ite::imp {
         r.insert("cofactor_equalities", CPK_BOOL, "(default: true) use equalities to rewrite bodies of ite-expressions. This is potentially expensive.");
     }
 
-    void set_cancel(bool f) {
-        m_cancel = f;
-    }
 
     struct cofactor_rw_cfg : public default_rewriter_cfg {
         ast_manager &         m;
@@ -659,7 +655,6 @@ struct cofactor_elim_term_ite::imp {
         m(_m),
         m_params(p),
         m_cofactor_equalities(true) {
-        m_cancel = false;
         updt_params(p);
     }
 
@@ -698,10 +693,6 @@ void cofactor_elim_term_ite::operator()(expr * t, expr_ref & r) {
     m_imp->operator()(t, r);
 }
     
-void cofactor_elim_term_ite::set_cancel(bool f) {
-    if (m_imp)
-        m_imp->set_cancel(f);
-}
 
 void cofactor_elim_term_ite::cleanup() {
     ast_manager & m = m_imp->m;    

--- a/src/tactic/core/cofactor_elim_term_ite.cpp
+++ b/src/tactic/core/cofactor_elim_term_ite.cpp
@@ -697,10 +697,7 @@ void cofactor_elim_term_ite::operator()(expr * t, expr_ref & r) {
 void cofactor_elim_term_ite::cleanup() {
     ast_manager & m = m_imp->m;    
     imp * d = alloc(imp, m, m_params);
-    #pragma omp critical (tactic_cancel)
-    {
-        std::swap(d, m_imp);
-    }
+    std::swap(d, m_imp);    
     dealloc(d);
 }
 

--- a/src/tactic/core/cofactor_elim_term_ite.h
+++ b/src/tactic/core/cofactor_elim_term_ite.h
@@ -35,10 +35,7 @@ public:
 
     void operator()(expr * t, expr_ref & r);
     
-    void cancel() { set_cancel(true); }
-    void reset_cancel() { set_cancel(false); }
     void cleanup();
-    void set_cancel(bool f);
 
 };
 

--- a/src/tactic/core/cofactor_term_ite_tactic.cpp
+++ b/src/tactic/core/cofactor_term_ite_tactic.cpp
@@ -73,7 +73,6 @@ public:
     
     virtual void cleanup() { return m_elim_ite.cleanup(); }
 
-    virtual void set_cancel(bool f) { m_elim_ite.set_cancel(f); }
 };
 
 tactic * mk_cofactor_term_ite_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/core/ctx_simplify_tactic.cpp
+++ b/src/tactic/core/ctx_simplify_tactic.cpp
@@ -540,10 +540,7 @@ void ctx_simplify_tactic::operator()(goal_ref const & in,
 void ctx_simplify_tactic::cleanup() {
     ast_manager & m   = m_imp->m;
     imp * d = alloc(imp, m, m_params);
-    #pragma omp critical (tactic_cancel)
-    {
-        std::swap(d, m_imp);
-    }
+    std::swap(d, m_imp);    
     dealloc(d);
 }
 

--- a/src/tactic/core/ctx_simplify_tactic.cpp
+++ b/src/tactic/core/ctx_simplify_tactic.cpp
@@ -57,21 +57,16 @@ struct ctx_simplify_tactic::imp {
     unsigned                    m_max_depth;
     unsigned                    m_max_steps;
     bool                        m_bail_on_blowup;
-    volatile bool               m_cancel;
 
     imp(ast_manager & _m, params_ref const & p):
         m(_m),
         m_allocator("context-simplifier"),
         m_occs(true, true),
         m_mk_app(m, p) {
-        m_cancel = false;
         m_scope_lvl = 0;
         updt_params(p);
     }
 
-    void set_cancel(bool f) {
-        m_cancel = f;
-    }
 
     ~imp() {
         pop(m_scope_lvl);
@@ -100,7 +95,7 @@ struct ctx_simplify_tactic::imp {
         cooperate("ctx_simplify_tactic");
         if (memory::get_allocation_size() > m_max_memory)
             throw tactic_exception(TACTIC_MAX_MEMORY_MSG);
-        if (m_cancel)
+        if (m.canceled())
             throw tactic_exception(TACTIC_CANCELED_MSG);
     }
 
@@ -541,10 +536,6 @@ void ctx_simplify_tactic::operator()(goal_ref const & in,
     result.push_back(in.get());
 }
     
-void ctx_simplify_tactic::set_cancel(bool f) {
-    if (m_imp)
-        m_imp->set_cancel(f);
-}
 
 void ctx_simplify_tactic::cleanup() {
     ast_manager & m   = m_imp->m;

--- a/src/tactic/core/ctx_simplify_tactic.h
+++ b/src/tactic/core/ctx_simplify_tactic.h
@@ -45,8 +45,6 @@ public:
                             expr_dependency_ref & core);
 
     virtual void cleanup();
-protected:
-    virtual void set_cancel(bool f);
 };
 
 inline tactic * mk_ctx_simplify_tactic(ast_manager & m, params_ref const & p = params_ref()) {

--- a/src/tactic/core/der_tactic.cpp
+++ b/src/tactic/core/der_tactic.cpp
@@ -87,10 +87,7 @@ public:
     virtual void cleanup() {
         ast_manager & m = m_imp->m();
         imp * d = alloc(imp, m);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
     

--- a/src/tactic/core/der_tactic.cpp
+++ b/src/tactic/core/der_tactic.cpp
@@ -28,11 +28,7 @@ class der_tactic : public tactic {
         }
         
         ast_manager & m() const { return m_manager; }
-        
-        void set_cancel(bool f) {
-            m_r.set_cancel(f);
-        }
-        
+                
         void reset() {
             m_r.reset();
         }
@@ -98,10 +94,6 @@ public:
         dealloc(d);
     }
     
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_der_tactic(ast_manager & m) {

--- a/src/tactic/core/distribute_forall_tactic.cpp
+++ b/src/tactic/core/distribute_forall_tactic.cpp
@@ -140,11 +140,6 @@ public:
         }
     }
 
-    virtual void set_cancel(bool f) {
-        if (m_rw)
-            m_rw->set_cancel(f);
-    }
-
     virtual void cleanup() {}
 };
 

--- a/src/tactic/core/distribute_forall_tactic.cpp
+++ b/src/tactic/core/distribute_forall_tactic.cpp
@@ -108,10 +108,7 @@ public:
         ast_manager & m = g->m();
         bool produce_proofs = g->proofs_enabled();
         rw r(m, produce_proofs);
-        #pragma omp critical (tactic_cancel)
-        {
-            m_rw = &r;
-        }
+        m_rw = &r;        
         mc = 0; pc = 0; core = 0; result.reset();
         tactic_report report("distribute-forall", *g);
         
@@ -134,10 +131,7 @@ public:
         result.push_back(g.get());
         TRACE("distribute-forall", g->display(tout););
         SASSERT(g->is_well_sorted());
-        #pragma omp critical (tactic_cancel)
-        {
-            m_rw = 0;
-        }
+        m_rw = 0;        
     }
 
     virtual void cleanup() {}

--- a/src/tactic/core/elim_term_ite_tactic.cpp
+++ b/src/tactic/core/elim_term_ite_tactic.cpp
@@ -172,10 +172,7 @@ public:
     virtual void cleanup() {
         ast_manager & m = m_imp->m;
         imp * d = alloc(imp, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/core/elim_term_ite_tactic.cpp
+++ b/src/tactic/core/elim_term_ite_tactic.cpp
@@ -94,9 +94,6 @@ class elim_term_ite_tactic : public tactic {
             m_rw(m, p) {
         }
         
-        void set_cancel(bool f) {
-            m_rw.set_cancel(f);
-        }
         
         void updt_params(params_ref const & p) {
             m_rw.cfg().updt_params(p);
@@ -182,10 +179,6 @@ public:
         dealloc(d);
     }
 
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_elim_term_ite_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/core/elim_uncnstr_tactic.cpp
+++ b/src/tactic/core/elim_uncnstr_tactic.cpp
@@ -895,10 +895,7 @@ class elim_uncnstr_tactic : public tactic {
         }
         
         void init_rw(bool produce_proofs) {
-            #pragma omp critical (tactic_cancel)
-            {
-                m_rw = alloc(rw, m(), produce_proofs, m_vars, m_mc.get(), m_max_memory, m_max_steps);
-            }
+            m_rw = alloc(rw, m(), produce_proofs, m_vars, m_mc.get(), m_max_memory, m_max_steps);            
         }
 
         virtual void operator()(goal_ref const & g, 
@@ -968,10 +965,7 @@ class elim_uncnstr_tactic : public tactic {
                         }
                     }
                     m_mc = 0;
-                    #pragma omp critical (tactic_cancel)
-                    {
-                        m_rw  = 0;
-                    }
+                    m_rw  = 0;                    
                     TRACE("elim_uncnstr", if (mc) mc->display(tout););
                     result.push_back(g.get());
                     g->inc_depth();
@@ -1034,10 +1028,7 @@ public:
         unsigned num_elim_apps = get_num_elim_apps();
         ast_manager & m = m_imp->m_manager;        
         imp * d = alloc(imp, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
         m_imp->m_num_elim_apps = num_elim_apps;
     }

--- a/src/tactic/core/elim_uncnstr_tactic.cpp
+++ b/src/tactic/core/elim_uncnstr_tactic.cpp
@@ -993,10 +993,6 @@ class elim_uncnstr_tactic : public tactic {
             }
         }
         
-        void set_cancel(bool f) {
-            if (m_rw)
-                m_rw->set_cancel(f);
-        }
     };
     
     imp *      m_imp;
@@ -1058,11 +1054,6 @@ public:
         m_imp->m_num_elim_apps = 0;
     }
 
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_elim_uncnstr_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/core/nnf_tactic.cpp
+++ b/src/tactic/core/nnf_tactic.cpp
@@ -113,13 +113,6 @@ public:
     }
     
     virtual void cleanup() {}
-    virtual void set_cancel(bool f) {
-        #pragma omp critical (nnf_tactic)
-        {
-            if (m_nnf)
-                m_nnf->set_cancel(f);
-        }
-    }
 };
 
 tactic * mk_snf_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/core/nnf_tactic.cpp
+++ b/src/tactic/core/nnf_tactic.cpp
@@ -29,17 +29,11 @@ class nnf_tactic : public tactic {
         
         set_nnf(nnf_tactic & owner, nnf & n):
             m_owner(owner) {
-            #pragma omp critical (nnf_tactic)
-            {
-                m_owner.m_nnf = &n;
-            }
+            m_owner.m_nnf = &n;            
         }
         
         ~set_nnf() {
-            #pragma omp critical (nnf_tactic)
-            {
-                m_owner.m_nnf = 0;
-            }
+            m_owner.m_nnf = 0;            
         }
     };
 public:

--- a/src/tactic/core/occf_tactic.cpp
+++ b/src/tactic/core/occf_tactic.cpp
@@ -29,20 +29,14 @@ Revision History:
 class occf_tactic : public tactic {
     struct     imp {
         ast_manager &            m;
-        volatile bool            m_cancel;
         filter_model_converter * m_mc;
         
         imp(ast_manager & _m):
             m(_m) {
-            m_cancel = false;
-        }
-
-        void set_cancel(bool f) {
-            m_cancel = f;
         }
 
         void checkpoint() {
-            if (m_cancel)
+            if (m.canceled())
                 throw tactic_exception(TACTIC_CANCELED_MSG);
             cooperate("occf");
         }
@@ -233,11 +227,6 @@ public:
         dealloc(d);
     }
     
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_occf_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/core/occf_tactic.cpp
+++ b/src/tactic/core/occf_tactic.cpp
@@ -220,10 +220,7 @@ public:
     
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
     

--- a/src/tactic/core/pb_preprocess_tactic.cpp
+++ b/src/tactic/core/pb_preprocess_tactic.cpp
@@ -264,9 +264,6 @@ public:
         return m_progress;
     }
 
-    virtual void set_cancel(bool f) {
-    }
-
     virtual void updt_params(params_ref const & p) {
     }
 

--- a/src/tactic/core/propagate_values_tactic.cpp
+++ b/src/tactic/core/propagate_values_tactic.cpp
@@ -54,9 +54,6 @@ class propagate_values_tactic : public tactic {
 
         ast_manager & m() const { return m_manager; }
         
-        void set_cancel(bool f) {
-            m_r.set_cancel(f);
-        }
         
         bool is_shared(expr * t) {
             return m_occs.is_shared(t);
@@ -267,11 +264,6 @@ public:
         dealloc(d);
     }
     
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_propagate_values_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/core/propagate_values_tactic.cpp
+++ b/src/tactic/core/propagate_values_tactic.cpp
@@ -257,10 +257,7 @@ public:
     virtual void cleanup() {
         ast_manager & m = m_imp->m();
         imp * d = alloc(imp, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
     

--- a/src/tactic/core/reduce_args_tactic.cpp
+++ b/src/tactic/core/reduce_args_tactic.cpp
@@ -532,10 +532,7 @@ void reduce_args_tactic::operator()(goal_ref const & g,
 void reduce_args_tactic::cleanup() {
     ast_manager & m   = m_imp->m();    
     imp * d = alloc(imp, m);
-    #pragma omp critical (tactic_cancel)
-    {
-        std::swap(d, m_imp);
-    }
+    std::swap(d, m_imp);    
     dealloc(d);
 }
 

--- a/src/tactic/core/simplify_tactic.cpp
+++ b/src/tactic/core/simplify_tactic.cpp
@@ -112,10 +112,7 @@ void simplify_tactic::operator()(goal_ref const & in,
 void simplify_tactic::cleanup() {
     ast_manager & m = m_imp->m();
     imp * d = alloc(imp, m, m_params);
-    #pragma omp critical (tactic_cancel)
-    {
-        std::swap(d, m_imp);
-    }
+    std::swap(d, m_imp);    
     dealloc(d);
 }
 

--- a/src/tactic/core/simplify_tactic.cpp
+++ b/src/tactic/core/simplify_tactic.cpp
@@ -36,9 +36,6 @@ struct simplify_tactic::imp {
 
     ast_manager & m() const { return m_manager; }
 
-    void set_cancel(bool f) {
-        m_r.set_cancel(f);
-    }
 
     void reset() {
         m_r.reset();
@@ -111,10 +108,6 @@ void simplify_tactic::operator()(goal_ref const & in,
     }
 }
 
-void simplify_tactic::set_cancel(bool f) {
-    if (m_imp)
-        m_imp->set_cancel(f);
-}
 
 void simplify_tactic::cleanup() {
     ast_manager & m = m_imp->m();

--- a/src/tactic/core/simplify_tactic.h
+++ b/src/tactic/core/simplify_tactic.h
@@ -45,8 +45,6 @@ public:
     unsigned get_num_steps() const;
 
     virtual tactic * translate(ast_manager & m) { return alloc(simplify_tactic, m, m_params); }
-protected:
-    virtual void set_cancel(bool f);
 
 };
 

--- a/src/tactic/core/solve_eqs_tactic.cpp
+++ b/src/tactic/core/solve_eqs_tactic.cpp
@@ -751,10 +751,7 @@ public:
 
         imp * d = alloc(imp, m, m_params, r, owner);
         d->m_num_eliminated_vars = num_elim_vars;
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/core/solve_eqs_tactic.cpp
+++ b/src/tactic/core/solve_eqs_tactic.cpp
@@ -48,7 +48,6 @@ class solve_eqs_tactic : public tactic {
         bool                          m_produce_proofs;
         bool                          m_produce_unsat_cores;
         bool                          m_produce_models;
-        volatile bool                 m_cancel;
         
         imp(ast_manager & m, params_ref const & p, expr_replacer * r, bool owner):
             m_manager(m),
@@ -56,8 +55,8 @@ class solve_eqs_tactic : public tactic {
             m_r_owner(r == 0 || owner),
             m_a_util(m),
             m_num_steps(0),
-            m_num_eliminated_vars(0),
-            m_cancel(false) {
+            m_num_eliminated_vars(0)
+             {
             updt_params(p);
             if (m_r == 0)
                 m_r       = mk_default_expr_replacer(m);
@@ -75,14 +74,9 @@ class solve_eqs_tactic : public tactic {
             m_theory_solver  = p.get_bool("theory_solver", true);
             m_max_occs       = p.get_uint("solve_eqs_max_occs", UINT_MAX);
         }
-        
-        void set_cancel(bool f) {
-            m_cancel = f;
-            m_r->set_cancel(f);
-        }
-        
+                
         void checkpoint() {
-            if (m_cancel)
+            if (m().canceled())
                 throw tactic_exception(TACTIC_CANCELED_MSG);
             cooperate("solve-eqs");
         }
@@ -772,10 +766,6 @@ public:
         m_imp->m_num_eliminated_vars = 0;
     }
     
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_solve_eqs_tactic(ast_manager & m, params_ref const & p, expr_replacer * r) {

--- a/src/tactic/core/tseitin_cnf_tactic.cpp
+++ b/src/tactic/core/tseitin_cnf_tactic.cpp
@@ -105,7 +105,6 @@ class tseitin_cnf_tactic : public tactic {
         unsigned long long   m_max_memory;
 
         unsigned             m_num_aux_vars;
-        volatile bool        m_cancel;
 
         imp(ast_manager & _m, params_ref const & p):
             m(_m),
@@ -115,8 +114,7 @@ class tseitin_cnf_tactic : public tactic {
             m_clauses(_m),
             m_deps(_m),
             m_rw(_m),
-            m_num_aux_vars(0),
-            m_cancel(false) {
+            m_num_aux_vars(0) {
             updt_params(p);
             m_rw.set_flat(false);
         }
@@ -756,13 +754,10 @@ class tseitin_cnf_tactic : public tactic {
     if (r == CONT) goto loop;                                   \
     if (r == DONE) { m_frame_stack.pop_back(); continue; }
         
-        void set_cancel(bool f) {
-            m_cancel = f;
-        }
         
         void checkpoint() {
             cooperate("tseitin cnf");
-            if (m_cancel)
+            if (m.canceled())
                 throw tactic_exception(TACTIC_CANCELED_MSG);
             if (memory::get_allocation_size() > m_max_memory)
                 throw tactic_exception(TACTIC_MAX_MEMORY_MSG);
@@ -906,11 +901,6 @@ public:
             std::swap(d, m_imp);
         }
         dealloc(d);
-    }
-
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
     }
 
     virtual void collect_statistics(statistics & st) const {

--- a/src/tactic/core/tseitin_cnf_tactic.cpp
+++ b/src/tactic/core/tseitin_cnf_tactic.cpp
@@ -896,10 +896,7 @@ public:
         ast_manager & m = m_imp->m;
         imp * d = alloc(imp, m, m_params);
         d->m_num_aux_vars = m_imp->m_num_aux_vars;
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/extension_model_converter.cpp
+++ b/src/tactic/extension_model_converter.cpp
@@ -91,14 +91,6 @@ void extension_model_converter::operator()(model_ref & md, unsigned goal_idx) {
     TRACE("extension_mc", model_v2_pp(tout, *md); display_decls_info(tout, md););
 }
 
-void extension_model_converter::cancel() {
-    #pragma omp critical (extension_model_converter) 
-    {
-        if (m_eval)
-            m_eval->cancel();
-    }
-}
-
 void extension_model_converter::display(std::ostream & out) {
     ast_manager & m = m_vars.get_manager();
     out << "(extension-model-converter";

--- a/src/tactic/extension_model_converter.h
+++ b/src/tactic/extension_model_converter.h
@@ -40,8 +40,6 @@ public:
     
     virtual void operator()(model_ref & md, unsigned goal_idx);
 
-    virtual void cancel();
-
     virtual void display(std::ostream & out);
 
     // register a variable that was eliminated

--- a/src/tactic/fpa/fpa2bv_tactic.cpp
+++ b/src/tactic/fpa/fpa2bv_tactic.cpp
@@ -46,10 +46,6 @@ class fpa2bv_tactic : public tactic {
             m_rw.cfg().updt_params(p);
         }
 
-        void set_cancel(bool f) {
-            m_rw.set_cancel(f);
-        }
-
         virtual void operator()(goal_ref const & g,
                                 goal_ref_buffer & result,
                                 model_converter_ref & mc,
@@ -166,11 +162,6 @@ public:
         dealloc(d);
     }
 
-protected:
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_fpa2bv_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/fpa/fpa2bv_tactic.cpp
+++ b/src/tactic/fpa/fpa2bv_tactic.cpp
@@ -155,10 +155,7 @@ public:
 
     virtual void cleanup() {
         imp * d = alloc(imp, m_imp->m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/nlsat_smt/nl_purify_tactic.cpp
+++ b/src/tactic/nlsat_smt/nl_purify_tactic.cpp
@@ -73,7 +73,6 @@ class nl_purify_tactic : public tactic {
     params_ref      m_params;
     bool            m_produce_proofs;
     ref<filter_model_converter> m_fmc;
-    bool            m_cancel;       
     tactic_ref      m_nl_tac;       // nlsat tactic
     goal_ref        m_nl_g;         // nlsat goal
     ref<solver>     m_solver;       // SMT solver
@@ -289,7 +288,7 @@ private:
     arith_util & u() { return m_util; }
 
     void check_point() {
-        if (m_cancel) {
+        if (m.canceled()) {
             throw tactic_exception("canceled");
         }
     }
@@ -701,7 +700,6 @@ public:
         m_util(m),
         m_params(p),
         m_fmc(0),
-        m_cancel(false),
         m_nl_tac(mk_nlsat_tactic(m, p)),
         m_nl_g(0),
         m_solver(mk_smt_solver(m, p, symbol::null)),
@@ -719,17 +717,6 @@ public:
 
     virtual tactic * translate(ast_manager& m) {
         return alloc(nl_purify_tactic, m, m_params);
-    }
-
-    virtual void set_cancel(bool f) {
-        m_nl_tac->set_cancel(f);
-        if (f) {
-            m_solver->cancel();
-        }
-        else {
-            m_solver->reset_cancel();
-        }
-        m_cancel = f;
     }
 
     virtual void collect_statistics(statistics & st) const {

--- a/src/tactic/sls/sls_engine.cpp
+++ b/src/tactic/sls/sls_engine.cpp
@@ -37,7 +37,6 @@ sls_engine::sls_engine(ast_manager & m, params_ref const & p) :
     m_zero(m_mpz_manager.mk_z(0)),
     m_one(m_mpz_manager.mk_z(1)),
     m_two(m_mpz_manager.mk_z(2)),
-    m_cancel(false),
     m_bv_util(m),
     m_tracker(m, m_bv_util, m_mpz_manager, m_powers),
     m_evaluator(m, m_bv_util, m_tracker, m_mpz_manager, m_powers)
@@ -95,7 +94,7 @@ void sls_engine::collect_statistics(statistics& st) const {
 }
 
 void sls_engine::checkpoint() {
-    if (m_cancel)
+    if (m_manager.canceled())
         throw tactic_exception(TACTIC_CANCELED_MSG);
     cooperate("sls");
 }

--- a/src/tactic/sls/sls_engine.h
+++ b/src/tactic/sls/sls_engine.h
@@ -64,7 +64,6 @@ protected:
     powers          m_powers;
     mpz             m_zero, m_one, m_two;
     bool            m_produce_models;
-    volatile bool   m_cancel;
     bv_util         m_bv_util;
     sls_tracker     m_tracker;
     sls_evaluator   m_evaluator;
@@ -93,9 +92,6 @@ public:
 
     ast_manager & m() const { return m_manager; }
 
-    void set_cancel(bool f) { m_cancel = f; }
-    void cancel() { set_cancel(true); }
-    void reset_cancel() { set_cancel(false); }
 
     void updt_params(params_ref const & _p);
 

--- a/src/tactic/sls/sls_tactic.cpp
+++ b/src/tactic/sls/sls_tactic.cpp
@@ -95,10 +95,6 @@ public:
         m_engine->reset_statistics();
     }
 
-    virtual void set_cancel(bool f) {
-        if (m_engine)
-            m_engine->set_cancel(f);
-    }
 };
 
 tactic * mk_sls_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/sls/sls_tactic.cpp
+++ b/src/tactic/sls/sls_tactic.cpp
@@ -80,10 +80,7 @@ public:
 
     virtual void cleanup() {        
         sls_engine * d = alloc(sls_engine, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_engine);
-        }
+        std::swap(d, m_engine);            
         dealloc(d);
     }
     

--- a/src/tactic/tactic.cpp
+++ b/src/tactic/tactic.cpp
@@ -22,19 +22,7 @@ Notes:
 #include"stopwatch.h"
 #include"model_v2_pp.h"
 
-void tactic::cancel() {
-    #pragma omp critical (tactic_cancel)
-    {
-        set_cancel(true);
-    }
-}
 
-void tactic::reset_cancel() {
-    #pragma omp critical (tactic_cancel)
-    {
-        set_cancel(false);
-    }
-}
 
 struct tactic_report::imp {
     char const *    m_id;

--- a/src/tactic/tactic.h
+++ b/src/tactic/tactic.h
@@ -44,9 +44,6 @@ public:
 
     virtual void updt_params(params_ref const & p) {}
     virtual void collect_param_descrs(param_descrs & r) {}
-
-    void cancel();
-    void reset_cancel();
     
     /**
        \brief Apply tactic to goal \c in.
@@ -100,8 +97,6 @@ protected:
     friend class binary_tactical;
     friend class unary_tactical;
     friend class nl_purify_tactic;
-
-    virtual void set_cancel(bool f) {}
 
 };
 

--- a/src/tactic/tactical.cpp
+++ b/src/tactic/tactical.cpp
@@ -40,15 +40,8 @@ public:
     }
     
     virtual ~binary_tactical() {
-        tactic * t1 = m_t1;
-        tactic * t2 = m_t2;
-        #pragma omp critical (tactic_cancel)
-        {
-            m_t1 = 0;
-            m_t2 = 0;
-        }
-        t1->dec_ref();
-        t2->dec_ref();
+        m_t1->dec_ref();
+        m_t2->dec_ref();
     }
     
     virtual void updt_params(params_ref const & p) {
@@ -291,17 +284,9 @@ public:
     }
 
     virtual ~nary_tactical() {
-        ptr_buffer<tactic> old_ts;
         unsigned sz = m_ts.size();
-        old_ts.append(sz, m_ts.c_ptr());
-        #pragma omp critical (tactic_cancel)
-        {
-            for (unsigned i = 0; i < sz; i++) {
-                m_ts[i] = 0;
-            }
-        }
         for (unsigned i = 0; i < sz; i++) {
-            old_ts[i]->dec_ref();
+            m_ts[i]->dec_ref();
         }
     }
 
@@ -906,12 +891,7 @@ public:
     }    
 
     virtual ~unary_tactical() { 
-        tactic * t = m_t;
-        #pragma omp critical (tactic_cancel)
-        {
-            m_t = 0;
-        }
-        t->dec_ref();
+        m_t->dec_ref();
     }
 
     virtual void operator()(goal_ref const & in, 

--- a/src/tactic/tactical.cpp
+++ b/src/tactic/tactical.cpp
@@ -98,14 +98,6 @@ public:
     }
 
 protected:
-    /**
-       \brief Reset cancel flag of t if this was not canceled.
-    */
-    void parent_reset_cancel(tactic & t) {
-        if (!m_cancel) {
-            t.reset_cancel();
-        }
-    }
 
     virtual void set_cancel(bool f) {
         m_cancel = f;
@@ -390,14 +382,6 @@ public:
     }
 
 protected:
-    /**
-       \brief Reset cancel flag of st if this was not canceled.
-    */
-    void parent_reset_cancel(tactic & t) {
-        if (!m_cancel) {
-            t.reset_cancel();
-        }
-    }
 
     virtual void set_cancel(bool f) {
         m_cancel = f;
@@ -583,8 +567,10 @@ public:
                 }                
                 if (first) {
                     for (unsigned j = 0; j < sz; j++) {
-                        if (static_cast<unsigned>(i) != j)
+                        if (static_cast<unsigned>(i) != j) {
                             ts.get(j)->cancel();
+                            managers[j]->limit().cancel();
+                        }
                     }
                     ast_translation translator(*(managers[i]), m, false);
                     for (unsigned k = 0; k < _result.size(); k++) {
@@ -784,8 +770,10 @@ public:
 
                 if (curr_failed) {
                     for (unsigned j = 0; j < r1_size; j++) {
-                        if (static_cast<unsigned>(i) != j)
+                        if (static_cast<unsigned>(i) != j) {
                             ts2.get(j)->cancel();
+                            managers[j]->limit().cancel();
+                        }
                     }
                 }
                 else {
@@ -804,8 +792,10 @@ public:
                             }
                             if (first) {
                                 for (unsigned j = 0; j < r1_size; j++) {
-                                    if (static_cast<unsigned>(i) != j)
+                                    if (static_cast<unsigned>(i) != j) {
                                         ts2.get(j)->cancel();
+                                        managers[j]->limit().cancel();
+                                    }
                                 }
                                 ast_translation translator(new_m, m, false);
                                 SASSERT(r2.size() == 1);

--- a/src/tactic/ufbv/macro_finder_tactic.cpp
+++ b/src/tactic/ufbv/macro_finder_tactic.cpp
@@ -30,21 +30,16 @@ class macro_finder_tactic : public tactic {
 
     struct imp {
         ast_manager & m_manager;
-        bool m_cancel;
         bool m_elim_and;
 
         imp(ast_manager & m, params_ref const & p) : 
             m_manager(m),
-            m_cancel(false),
             m_elim_and(false) {
             updt_params(p);
         }
         
         ast_manager & m() const { return m_manager; }
         
-        void set_cancel(bool f) {
-            m_cancel = f;
-        }
         
         void operator()(goal_ref const & g, 
                         goal_ref_buffer & result, 
@@ -152,10 +147,7 @@ public:
         dealloc(d);
     }
 
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
+
 };
 
 tactic * mk_macro_finder_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/ufbv/macro_finder_tactic.cpp
+++ b/src/tactic/ufbv/macro_finder_tactic.cpp
@@ -140,10 +140,7 @@ public:
     virtual void cleanup() {
         ast_manager & m = m_imp->m();
         imp * d = alloc(imp, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/ufbv/quasi_macros_tactic.cpp
+++ b/src/tactic/ufbv/quasi_macros_tactic.cpp
@@ -31,17 +31,13 @@ class quasi_macros_tactic : public tactic {
 
     struct imp {
         ast_manager & m_manager;
-        bool m_cancel;
 
-        imp(ast_manager & m, params_ref const & p) : m_manager(m),m_cancel(false) {
+        imp(ast_manager & m, params_ref const & p) : m_manager(m) {
             updt_params(p);
         }
         
         ast_manager & m() const { return m_manager; }
         
-        void set_cancel(bool f) {
-            m_cancel = f;
-        }
         
         void operator()(goal_ref const & g, 
                         goal_ref_buffer & result, 
@@ -80,7 +76,7 @@ class quasi_macros_tactic : public tactic {
             }
         
             while (more) { // CMW: use repeat(...) ?
-                if (m_cancel) 
+                if (m().canceled())
                   throw tactic_exception(TACTIC_CANCELED_MSG);
 
                 new_forms.reset();
@@ -159,10 +155,6 @@ public:
         dealloc(d);
     }
 
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_quasi_macros_tactic(ast_manager & m, params_ref const & p) {

--- a/src/tactic/ufbv/quasi_macros_tactic.cpp
+++ b/src/tactic/ufbv/quasi_macros_tactic.cpp
@@ -148,10 +148,7 @@ public:
     virtual void cleanup() {
         ast_manager & m = m_imp->m();
         imp * d = alloc(imp, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/ufbv/ufbv_rewriter_tactic.cpp
+++ b/src/tactic/ufbv/ufbv_rewriter_tactic.cpp
@@ -115,10 +115,7 @@ public:
     virtual void cleanup() {
         ast_manager & m = m_imp->m();
         imp * d = alloc(imp, m, m_params);
-        #pragma omp critical (tactic_cancel)
-        {
-            std::swap(d, m_imp);
-        }
+        std::swap(d, m_imp);        
         dealloc(d);
     }
 

--- a/src/tactic/ufbv/ufbv_rewriter_tactic.cpp
+++ b/src/tactic/ufbv/ufbv_rewriter_tactic.cpp
@@ -26,18 +26,13 @@ class ufbv_rewriter_tactic : public tactic {
 
     struct imp {
         ast_manager & m_manager;
-        bool m_cancel;
 
-        imp(ast_manager & m, params_ref const & p) : m_manager(m),m_cancel(false) {
+        imp(ast_manager & m, params_ref const & p) : m_manager(m) {
             updt_params(p);
         }
         
         ast_manager & m() const { return m_manager; }
-        
-        void set_cancel(bool f) {
-            m_cancel = f;
-        }
-        
+                
         void operator()(goal_ref const & g, 
                         goal_ref_buffer & result, 
                         model_converter_ref & mc, 
@@ -127,10 +122,6 @@ public:
         dealloc(d);
     }
 
-    virtual void set_cancel(bool f) {
-        if (m_imp)
-            m_imp->set_cancel(f);
-    }
 };
 
 tactic * mk_ufbv_rewriter_tactic(ast_manager & m, params_ref const & p) {

--- a/src/util/rlimit.cpp
+++ b/src/util/rlimit.cpp
@@ -84,7 +84,7 @@ void reslimit::pop_child() {
 void reslimit::cancel() {
     #pragma omp critical (reslimit_cancel)
     {
-        set_cancel(false);
+        set_cancel(true);
     }
 }
 

--- a/src/util/rlimit.cpp
+++ b/src/util/rlimit.cpp
@@ -56,3 +56,16 @@ void reslimit::pop() {
     m_limits.pop_back();
     m_cancel = false;
 }
+
+void reslimit::cancel() { 
+    m_cancel = true; 
+    for (unsigned i = 0; i < m_children.size(); ++i) {
+        m_children[i]->cancel();
+    }
+}
+void reslimit::reset_cancel() { 
+    m_cancel = false; 
+    for (unsigned i = 0; i < m_children.size(); ++i) {
+        m_children[i]->reset_cancel();
+    }
+}

--- a/src/util/rlimit.cpp
+++ b/src/util/rlimit.cpp
@@ -45,6 +45,7 @@ void reslimit::push(unsigned delta_limit) {
     }
     m_limits.push_back(m_limit);
     m_limit = m_limit==0?new_limit:std::min(new_limit, m_limit);
+    m_cancel = false;
 }
 
 void reslimit::pop() {
@@ -53,4 +54,5 @@ void reslimit::pop() {
     }
     m_limit = m_limits.back();
     m_limits.pop_back();
+    m_cancel = false;
 }

--- a/src/util/rlimit.cpp
+++ b/src/util/rlimit.cpp
@@ -17,6 +17,7 @@ Revision History:
 
 --*/
 #include "rlimit.h"
+#include "common_msgs.h"
 
 reslimit::reslimit():
     m_cancel(false),
@@ -57,7 +58,7 @@ void reslimit::pop() {
     m_cancel = false;
 }
 
-char const* get_cancel_msg() const {
+char const* reslimit::get_cancel_msg() const {
     if (m_cancel) {
         return Z3_CANCELED_MSG;
     }

--- a/src/util/rlimit.h
+++ b/src/util/rlimit.h
@@ -26,19 +26,22 @@ class reslimit {
     uint64          m_count;
     uint64          m_limit;
     svector<uint64> m_limits;
-
+    ptr_vector<reslimit> m_children;
 public:    
     reslimit();
     void push(unsigned delta_limit);
     void pop();
+    void push_child(reslimit* r) { m_children.push_back(r); }
+    void pop_child() { m_children.pop_back(); }
+
     bool inc();
     bool inc(unsigned offset);
     uint64 count() const; 
 
 
     bool cancel_flag_set() { return m_cancel; }
-    void cancel() { m_cancel = true; }
-    void reset_cancel() { m_cancel = false; }
+    void cancel();
+    void reset_cancel();
 };
 
 class scoped_rlimit {

--- a/src/util/rlimit.h
+++ b/src/util/rlimit.h
@@ -22,16 +22,21 @@ Revision History:
 #include "vector.h"
 
 class reslimit {
-    unsigned        m_count;
-    unsigned        m_limit;
-    unsigned_vector m_limits;
+    volatile bool   m_cancel;
+    uint64          m_count;
+    uint64          m_limit;
+    svector<uint64> m_limits;
+
 public:    
     reslimit();
-    bool inc();
-    bool inc(unsigned offset);
     void push(unsigned delta_limit);
     void pop();
-    unsigned count() const; 
+    bool inc();
+    bool inc(unsigned offset);
+    uint64 count() const; 
+
+    void cancel() { m_cancel = true; }
+    void reset_cancel() { m_cancel = false; }
 };
 
 class scoped_rlimit {

--- a/src/util/rlimit.h
+++ b/src/util/rlimit.h
@@ -27,19 +27,23 @@ class reslimit {
     uint64          m_limit;
     svector<uint64> m_limits;
     ptr_vector<reslimit> m_children;
+
+    void set_cancel(bool f);
+    
 public:    
     reslimit();
     void push(unsigned delta_limit);
     void pop();
-    void push_child(reslimit* r) { m_children.push_back(r); }
-    void pop_child() { m_children.pop_back(); }
+    void push_child(reslimit* r);
+    void pop_child();
 
     bool inc();
     bool inc(unsigned offset);
     uint64 count() const; 
 
 
-    bool cancel_flag_set() { return m_cancel; }
+    bool get_cancel_flag() const { return m_cancel; }
+    char const* get_cancel_msg() const;
     void cancel();
     void reset_cancel();
 };

--- a/src/util/rlimit.h
+++ b/src/util/rlimit.h
@@ -35,6 +35,8 @@ public:
     bool inc(unsigned offset);
     uint64 count() const; 
 
+
+    bool cancel_flag_set() { return m_cancel; }
     void cancel() { m_cancel = true; }
     void reset_cancel() { m_cancel = false; }
 };

--- a/src/util/statistics.cpp
+++ b/src/util/statistics.cpp
@@ -238,5 +238,5 @@ void get_memory_statistics(statistics& st) {
 }
 
 void get_rlimit_statistics(reslimit& l, statistics& st) {
-    st.update("rlimit count",     l.count());
+    st.update("rlimit count",     static_cast<double>(l.count()));
 }

--- a/src/util/statistics.cpp
+++ b/src/util/statistics.cpp
@@ -227,16 +227,25 @@ double statistics::get_double_value(unsigned idx) const {
     return m_d_stats[idx - m_stats.size()].second;
 }
 
+static void get_uint64_stats(statistics& st, char const* name, unsigned long long value) {
+    if (value <= UINT_MAX) {
+        st.update(name, static_cast<unsigned>(value));
+    }
+    else {
+        st.update(name, static_cast<double>(value));
+    }
+}
+
 void get_memory_statistics(statistics& st) {
     unsigned long long max_mem = memory::get_max_used_memory();
     unsigned long long mem = memory::get_allocation_size();
     max_mem = (100*max_mem)/(1024*1024);
     mem = (100*mem)/(1024*1024);
-    st.update("max memory",  static_cast<double>(max_mem)/100.0);
-    st.update("memory",      static_cast<double>(mem)/100.0);
-    st.update("num allocs",  static_cast<double>(memory::get_allocation_count()));
+    st.update("max memory", static_cast<double>(max_mem)/100.0);    
+    st.update("memory", static_cast<double>(mem)/100.0);
+    get_uint64_stats(st, "num allocs",  memory::get_allocation_count());
 }
 
 void get_rlimit_statistics(reslimit& l, statistics& st) {
-    st.update("rlimit count",     static_cast<double>(l.count()));
+    get_uint64_stats(st, "rlimit count", l.count());
 }


### PR DESCRIPTION
instead of exposing cancel methods on all objects, we pass in a resource limit tracker to these objects. The life-time of the resource tracker exceeds the objects, so cancellation is safe for interrupts that only depend on the life-time of the resource tracker (and not the tactics/solvers). This also deprecates set_cancel methods in tactics/rewriters.
