### PR TITLE
CMake/CLion support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,10 @@ src/api/ml/z3.mllib
 *.bak
 doc/api
 doc/code
+.idea/
+/CMakeLists.txt
+/cmake/bin/*
+/cmake/lib/*
+/cmake/include-dirs.txt
+/cmake/sources-libz3.txt
+/cmake/sources-z3.txt

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.3)
+
+project(z3)
+
+set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/cmake/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/cmake/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/cmake/bin)
+set(CMAKE_CXX_FLAGS "-O0 -std=c++11 -D_NO_OMP_ -D_MP_GMP -Wno-deprecated-register -Wno-implicit-function-declaration")
+
+find_package(JNI)
+
+add_definitions(-D_AMD64_ -D_TRACE)
+
+link_libraries(gmp)
+
+file(STRINGS cmake/include-dirs.txt INCLUDE_DIRS)
+file(STRINGS cmake/sources-z3.txt EXE_SOURCE_FILES)
+file(STRINGS cmake/sources-libz3.txt LIB_SOURCE_FILES)
+
+include_directories(${JNI_INCLUDE_DIRS} ${INCLUDE_DIRS})
+
+add_library(z3 SHARED ${LIB_SOURCE_FILES})
+
+add_executable(z3-command ${EXE_SOURCE_FILES})
+set_target_properties(z3-command PROPERTIES OUTPUT_NAME z3)
+target_link_libraries(z3-command z3)
+
+add_executable(example examples/c++/example.cpp)
+target_link_libraries(example z3)
+
+add_library(z3java SHARED src/api/java/Native.cpp)
+target_link_libraries(z3java z3)

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -1,0 +1,12 @@
+To use CLion as an IDE, you need to build Z3 with CMake.
+
+* First build Z3 using the normal method.  We need the python build
+  system to generate files in src/
+
+  $ ./configure [--java]
+  $ cd build; make
+
+* Then run mk-cmake.sh.  This will generate the file lists that will
+  be consumed by CMake.
+
+* Build, run, debug the code from CLion.

--- a/cmake/mk-cmake.sh
+++ b/cmake/mk-cmake.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e -u -o pipefail
+trap "kill 0" SIGINT SIGTERM
+
+# brew installs of binutils put gnu readlink as greadlink
+READLINK=readlink
+if which greadlink &>/dev/null; then
+  READLINK=greadlink
+fi
+
+cmake_dir=$($READLINK -f $(dirname $0))
+z3_dir=$($READLINK -f $cmake_dir/..)
+
+ln -fs $cmake_dir/CMakeLists.txt $z3_dir
+
+find $z3_dir/src -type d > $cmake_dir/include-dirs.txt
+find $z3_dir/src -name '*.cpp' | grep -v Native.cpp | grep -v src/shell | grep -v src/test > $cmake_dir/sources-libz3.txt
+find $z3_dir/src/shell -name '*.cpp' > $cmake_dir/sources-z3.txt

--- a/src/util/debug.cpp
+++ b/src/util/debug.cpp
@@ -76,7 +76,7 @@ void invoke_gdb() {
     for (;;) {
         std::cerr << "(C)ontinue, (A)bort, (S)top, (T)hrow exception, Invoke (G)DB\n";
         char result;
-        bool ok = (std::cin >> result);
+        bool ok = static_cast<bool>(std::cin >> result);
         if (!ok) exit(ERR_INTERNAL_FATAL); // happens if std::cin is eof or unattached.
         switch(result) {
         case 'C':


### PR DESCRIPTION
To use the CLion IDE from Jetbrains, we need to build
Z3 with CMake.  This change adds CMake support to Z3
and allows developement with CLion with minimal effort.

I'm not sure if the Z3 team is interested in having this on the master branch.  But it took enough time to figure out that I figured others may benefit.