### PR TITLE
Convert stream to bool explicitly

### DIFF
--- a/src/util/debug.cpp
+++ b/src/util/debug.cpp
@@ -76,7 +76,7 @@ void invoke_gdb() {
     for (;;) {
         std::cerr << "(C)ontinue, (A)bort, (S)top, (T)hrow exception, Invoke (G)DB\n";
         char result;
-        bool ok = (std::cin >> result);
+        bool ok = bool(std::cin >> result);
         if (!ok) exit(ERR_INTERNAL_FATAL); // happens if std::cin is eof or unattached.
         switch(result) {
         case 'C':


### PR DESCRIPTION
In C++11 there is no implicit conversion from iostream classes to `void*`, just an explicit conversion to bool.