### PR TITLE
Fix gcc build failure on ARM caused by including <emmintrin.h>

### DIFF
--- a/src/util/hwf.cpp
+++ b/src/util/hwf.cpp
@@ -29,7 +29,8 @@ Revision History:
 #include<fenv.h>
 #endif
 
-#ifndef _M_IA64
+#if defined(__x86_64__) || defined(_M_X64) ||	\
+    defined(__i386) || defined(_M_IX86)
 #define USE_INTRINSICS
 #endif
 
@@ -47,7 +48,9 @@ Revision History:
 // Luckily, these are kind of standardized, at least for Windows/Linux/OSX.
 #ifdef __clang__
 #undef USE_INTRINSICS
-#else
+#endif
+
+#ifdef USE_INTRINSICS
 #include <emmintrin.h>
 #endif
 


### PR DESCRIPTION
src/util/hwf.cpp tries to use <emmintrin.h> to directly use SSE
intrinsics. Make sure to only use those when actually on x86 or
x86_64.