### PR TITLE
[Z3py] Fix conversion of float -0.0

### DIFF
--- a/src/api/python/z3.py
+++ b/src/api/python/z3.py
@@ -8409,11 +8409,16 @@ def FPSort(ebits, sbits, ctx=None):
 
 def _to_float_str(val, exp=0):
     if isinstance(val, float):
-        v = val.as_integer_ratio()
-        num = v[0]
-        den = v[1]
-        rvs = str(num) + '/' + str(den)
-        res = rvs + 'p' + _to_int_str(exp)
+        # float.as_integer_ratio() cannot return an accurate representation of
+        # -0.0 because the denominator it returns is always positive.
+        if str(val) == "-0.0":
+          res = "-0.0"
+        else:
+          v = val.as_integer_ratio()
+          num = v[0]
+          den = v[1]
+          rvs = str(num) + '/' + str(den)
+          res = rvs + 'p' + _to_int_str(exp)
     elif isinstance(val, bool):
         if val:
             res = "1.0"


### PR DESCRIPTION
Issue #464 was partially fixed by c171170 but there was still a problem
when creating an FPVal from the float -0.0 (from string '-0.0' worked
fine). Reason for the problem was the use of
float.as_integer_ratio() which does not return an accurate
representation of -0.0 because the denominator is always positive. This
fix explicitly handles -0.0.