### PR TITLE
Add missing source file declarations to CMake build that were

### DIFF
--- a/contrib/cmake/src/ast/fpa/CMakeLists.txt
+++ b/contrib/cmake/src/ast/fpa/CMakeLists.txt
@@ -1,6 +1,7 @@
 z3_add_component(fpa
   SOURCES
     fpa2bv_converter.cpp
+    fpa2bv_rewriter.cpp
   COMPONENT_DEPENDENCIES
     ast
     simplifier

--- a/contrib/cmake/src/test/CMakeLists.txt
+++ b/contrib/cmake/src/test/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(test-z3
   "${CMAKE_CURRENT_BINARY_DIR}/mem_initializer.cpp"
   memory.cpp
   model2expr.cpp
+  model_evaluator.cpp
   model_retrieval.cpp
   mpbq.cpp
   mpf.cpp


### PR DESCRIPTION
Add missing source file declarations to CMake build that were
added by 70f13ced3393cea570970b24d3d932d112183b9a