### PR TITLE
In ``small_object_allocator`` remove early return for Debug builds

### DIFF
--- a/src/util/small_object_allocator.cpp
+++ b/src/util/small_object_allocator.cpp
@@ -69,11 +69,6 @@ void small_object_allocator::reset() {
 #define MASK ((1 << PTR_ALIGNMENT) - 1)
 
 void small_object_allocator::deallocate(size_t size, void * p) {
-#if defined(Z3DEBUG) && !defined(_WINDOWS)
-    // Valgrind friendly
-    memory::deallocate(p);
-    return;
-#endif
     SASSERT(m_alloc_size >= size);
     SASSERT(p);
     m_alloc_size -= size;
@@ -91,10 +86,6 @@ void small_object_allocator::deallocate(size_t size, void * p) {
 }
 
 void * small_object_allocator::allocate(size_t size) {
-#if defined(Z3DEBUG) && !defined(_WINDOWS)
-    // Valgrind friendly
-    return memory::allocate(size);
-#endif
     m_alloc_size += size;
     if (size >= SMALL_OBJ_SIZE - (1 << PTR_ALIGNMENT))
         return memory::allocate(size);


### PR DESCRIPTION
In ``small_object_allocator`` remove early return for Debug builds on non-windows platforms.

The existing code meant that the ``SASSERT()`` calls were never checked
on non-windows platforms because they were only "syntactically"
reachable in Release builds (in which they are no-ops). The comments
suggest that this early return was for Valgrind but this doesn't seem
like a good idea. If false positives occur when running Z3 under
valgrind then a suppression file should be used rather than trying to
change Z3's behaviour. This is related to #477 .