### PR TITLE
[Z3py] Fix error in FPRef.__neg__()

### DIFF
--- a/src/api/python/z3.py
+++ b/src/api/python/z3.py
@@ -8178,8 +8178,13 @@ class FPRef(ExprRef):
         return self
 
     def __neg__(self):
-        """Create the Z3 expression `-self`."""
-        return FPRef(fpNeg(self))
+        """Create the Z3 expression `-self`.
+        
+        >>> x = FP('x', Float32())
+        >>> -x
+        -x
+        """
+        return fpNeg(self)
 
     def __div__(self, other):
         """Create the Z3 expression `self / other`.


### PR DESCRIPTION
`FPRef.__neg__()` did not work previously because it tried to construct an FPRef from an FPRef (`fpNeg()` already returns an FPRef).