### PR TITLE
Fix gcc build broken by f175f864ec7ac91fd89c6b1fb3914d4b752faa71.

### DIFF
--- a/src/nlsat/nlsat_types.h
+++ b/src/nlsat/nlsat_types.h
@@ -113,13 +113,13 @@ namespace nlsat {
 
     inline std::ostream& operator<<(std::ostream& out, atom::kind k) {
         switch (k) {
-        case atom::kind::EQ: return out << "=";
-        case atom::kind::LT: return out << "<";
-        case atom::kind::ROOT_EQ: return out << "= root";
-        case atom::kind::ROOT_LT: return out << "< root";
-        case atom::kind::ROOT_LE: return out << "<= root";
-        case atom::kind::ROOT_GT: return out << "> root";
-        case atom::kind::ROOT_GE: return out << ">= root";
+        case atom::EQ: return out << "=";
+        case atom::LT: return out << "<";
+        case atom::ROOT_EQ: return out << "= root";
+        case atom::ROOT_LT: return out << "< root";
+        case atom::ROOT_LE: return out << "<= root";
+        case atom::ROOT_GT: return out << "> root";
+        case atom::ROOT_GE: return out << ">= root";
         default: UNREACHABLE();
         }
         return out;


### PR DESCRIPTION
Fix gcc build broken by f175f864ec7ac91fd89c6b1fb3914d4b752faa71.
C++ enums (unless they are class enums) don't define their own
namespace.