### PR TITLE
Fix typo in examples/*/README

### DIFF
--- a/examples/c/README
+++ b/examples/c/README
@@ -1,4 +1,4 @@
-Small example using the c++ bindings.
+Small example using the C bindings.
 To build the example execute
    make examples
 in the build directory.

--- a/examples/maxsat/README
+++ b/examples/maxsat/README
@@ -1,4 +1,4 @@
-Small example using the c++ bindings.
+Small example using the C bindings.
 To build the example execute
    make examples
 in the build directory.


### PR DESCRIPTION
They are using the Z3 C binding, rather than C++.