### PR TITLE
Clean up README

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -1,7 +1,7 @@
 API documentation
 -----------------
 
-To generate the API documentation for the C, .NET and Python APIs, we must execute
+To generate the API documentation for the C, C++, .NET, Java and Python APIs, we must execute
 
    python mk_api_doc.py
 


### PR DESCRIPTION
k_api_doc.py also generates API documentation for Java and C++, which are not mentioned in this README file.