### PR TITLE
adding flag to build Z3 without direct loading of the Z3-library with Java-Bindings.

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2724,6 +2724,7 @@ def mk_bindings(api_files):
           dotnet_output_dir=dotnet_output_dir,
           java_output_dir=java_output_dir,
           java_package_name=java_package_name,
+          java_load_library_directly=not use_java_external_library_loading(),
           ml_output_dir=ml_output_dir
         )
         cp_z3py_to_build()

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -81,7 +81,7 @@ VS_PROJ = False
 TRACE = False
 DOTNET_ENABLED=False
 JAVA_ENABLED=False
-JAVA_EXTERNAL_LIBRARY_LOADING=False
+JAVA_LOAD_LIBRARY=True
 ML_ENABLED=False
 PYTHON_INSTALL_ENABLED=False
 STATIC_LIB=False
@@ -620,7 +620,7 @@ def display_help(exit_code):
         print("  --optimize                    generate optimized code during linking.")
     print("  --dotnet                      generate .NET bindings.")
     print("  --java                        generate Java bindings.")
-    print("  --javaExternalLibraryLoading  the user has to load the Z3-library himself.")
+    print("  --disable-java-load           the user has to load the Z3-library himself.")
     print("  --ml                          generate OCaml bindings.")
     print("  --python                      generate Python bindings.")
     print("  --staticlib                   build Z3 static library.")
@@ -655,13 +655,13 @@ def display_help(exit_code):
 # Parse configuration option for mk_make script
 def parse_options():
     global VERBOSE, DEBUG_MODE, IS_WINDOWS, VS_X64, ONLY_MAKEFILES, SHOW_CPPS, VS_PROJ, TRACE, VS_PAR, VS_PAR_NUM
-    global DOTNET_ENABLED, JAVA_ENABLED, JAVA_EXTERNAL_LIBRARY_LOADING, ML_ENABLED, STATIC_LIB, STATIC_BIN, PREFIX, GMP, FOCI2, FOCI2LIB, PYTHON_PACKAGE_DIR, GPROF, GIT_HASH, PYTHON_INSTALL_ENABLED
+    global DOTNET_ENABLED, JAVA_ENABLED, JAVA_LOAD_LIBRARY, ML_ENABLED, STATIC_LIB, STATIC_BIN, PREFIX, GMP, FOCI2, FOCI2LIB, PYTHON_PACKAGE_DIR, GPROF, GIT_HASH, PYTHON_INSTALL_ENABLED
     global LINUX_X64, SLOW_OPTIMIZE, USE_OMP
     try:
         options, remainder = getopt.gnu_getopt(sys.argv[1:],
                                                'b:df:sxhmcvtnp:gj',
                                                ['build=', 'debug', 'silent', 'x64', 'help', 'makefiles', 'showcpp', 'vsproj',
-                                                'trace', 'dotnet', 'staticlib', 'prefix=', 'gmp', 'foci2=', 'java', 'javaExternalLibraryLoading', 'parallel=', 'gprof',
+                                                'trace', 'dotnet', 'staticlib', 'prefix=', 'gmp', 'foci2=', 'java', 'disable-java-load', 'parallel=', 'gprof',
                                                 'githash=', 'x86', 'ml', 'optimize', 'noomp', 'pypkgdir=', 'python', 'staticbin'])
     except:
         print("ERROR: Invalid command line option")
@@ -715,8 +715,8 @@ def parse_options():
             FOCI2LIB = arg
         elif opt in ('-j', '--java'):
             JAVA_ENABLED = True
-        elif opt in ("--javaExternalLibraryLoading"):
-            JAVA_EXTERNAL_LIBRARY_LOADING = True
+        elif opt in ("--disable-java-load"):
+            JAVA_LOAD_LIBRARY = False
         elif opt == '--gprof':
             GPROF = True
         elif opt == '--githash':
@@ -816,8 +816,8 @@ def is_verbose():
 def is_java_enabled():
     return JAVA_ENABLED
 
-def use_java_external_library_loading():
-    return JAVA_EXTERNAL_LIBRARY_LOADING
+def is_java_load_library():
+    return JAVA_LOAD_LIBRARY
 
 def is_ml_enabled():
     return ML_ENABLED
@@ -1705,7 +1705,7 @@ class JavaDLLComponent(Component):
                 out.write('\t$(SLINK) $(SLINK_OUT_FLAG)libz3java$(SO_EXT) $(SLINK_FLAGS) %s$(OBJ_EXT) libz3$(LIB_EXT)\n' %
                           os.path.join('api', 'java', 'Native'))
             else:
-                out.write('\t$(SLINK) $(SLINK_OUT_FLAG)libz3java$(SO_EXT) $(SLINK_FLAGS) $(JAVA_EXTERNAL_LIBRARY_LOADING_FLAG) %s$(OBJ_EXT) libz3$(SO_EXT)\n' %
+                out.write('\t$(SLINK) $(SLINK_OUT_FLAG)libz3java$(SO_EXT) $(SLINK_FLAGS) $(JAVA_LOAD_LIBRARY_FLAG) %s$(OBJ_EXT) libz3$(SO_EXT)\n' %
                           os.path.join('api', 'java', 'Native'))
             out.write('%s.jar: libz3java$(SO_EXT) ' % self.package_name)
             deps = ''
@@ -2366,7 +2366,7 @@ def mk_config():
         if TRACE or DEBUG_MODE:
             CPPFLAGS     = '%s -D_TRACE' % CPPFLAGS
         # '$$' is needed to escape '$' in the makefile, the result should be '$ORIGIN'
-        JAVA_EXTERNAL_LIBRARY_LOADING_FLAG = '-Wl,-rpath,\'$$ORIGIN\' ' if use_java_external_library_loading() else ''
+        JAVA_LOAD_LIBRARY_FLAG = '' if is_java_load_library() else '-Wl,-rpath,\'$$ORIGIN\' '
         config.write('PREFIX=%s\n' % PREFIX)
         config.write('CC=%s\n' % CC)
         config.write('CXX=%s\n' % CXX)
@@ -2379,7 +2379,7 @@ def mk_config():
         config.write('AR_FLAGS=rcs\n')
         config.write('AR_OUTFLAG=\n')
         config.write('EXE_EXT=\n')
-        config.write('JAVA_EXTERNAL_LIBRARY_LOADING_FLAG=%s\n' % JAVA_EXTERNAL_LIBRARY_LOADING_FLAG) 
+        config.write('JAVA_LOAD_LIBRARY_FLAG=%s\n' % JAVA_LOAD_LIBRARY_FLAG) 
         config.write('LINK=%s\n' % CXX)
         if STATIC_BIN:
             config.write('LINK_FLAGS=-static\n')
@@ -2724,7 +2724,7 @@ def mk_bindings(api_files):
           dotnet_output_dir=dotnet_output_dir,
           java_output_dir=java_output_dir,
           java_package_name=java_package_name,
-          java_load_library_directly=not use_java_external_library_loading(),
+          java_load_library_directly=is_java_load_library(),
           ml_output_dir=ml_output_dir
         )
         cp_z3py_to_build()

--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -474,7 +474,7 @@ def java_array_element_type(p):
     else:
         return 'jlong'
 
-def mk_java(java_dir, package_name):
+def mk_java(java_dir, package_name, load_library_directly):
     java_nativef  = os.path.join(java_dir, 'Native.java')
     java_wrapperf = os.path.join(java_dir, 'Native.cpp')
     java_native   = open(java_nativef, 'w')
@@ -489,7 +489,7 @@ def mk_java(java_dir, package_name):
     java_native.write('  public static class UIntArrayPtr { public int[] value; }\n')
     java_native.write('  public static native void setInternalErrorHandler(long ctx);\n\n')
 
-    if not mk_util.use_java_external_library_loading():
+    if load_library_directly:
         java_native.write('  static {\n')
         java_native.write('    try { System.loadLibrary("z3java"); }\n')
         java_native.write('    catch (UnsatisfiedLinkError ex) { System.loadLibrary("libz3java"); }\n')
@@ -1564,6 +1564,7 @@ def generate_files(api_files,
                    dotnet_output_dir=None,
                    java_output_dir=None,
                    java_package_name=None,
+                   java_load_library_directly=True,
                    ml_output_dir=None):
   """
     Scan the api files in ``api_files`` and emit the relevant API files into
@@ -1636,7 +1637,7 @@ def generate_files(api_files,
         print("Generated '{}'".format(dotnet_file.name))
 
   if java_output_dir:
-    mk_java(java_output_dir, java_package_name)
+    mk_java(java_output_dir, java_package_name, java_load_library_directly)
   if ml_output_dir:
     mk_ml(ml_output_dir)
 

--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -489,10 +489,11 @@ def mk_java(java_dir, package_name):
     java_native.write('  public static class UIntArrayPtr { public int[] value; }\n')
     java_native.write('  public static native void setInternalErrorHandler(long ctx);\n\n')
 
-    java_native.write('  static {\n')
-    java_native.write('    try { System.loadLibrary("z3java"); }\n')
-    java_native.write('    catch (UnsatisfiedLinkError ex) { System.loadLibrary("libz3java"); }\n')
-    java_native.write('  }\n')
+    if not mk_util.use_java_external_library_loading():
+        java_native.write('  static {\n')
+        java_native.write('    try { System.loadLibrary("z3java"); }\n')
+        java_native.write('    catch (UnsatisfiedLinkError ex) { System.loadLibrary("libz3java"); }\n')
+        java_native.write('  }\n')
 
     java_native.write('\n')
     for name, result, params in _dotnet_decls:


### PR DESCRIPTION
This allows the user to choose other loading mechanisms, for example with a different path for the Z3-library.
This flag is needed, if no static linking is used for the binary and also no LD_LIBRARY_PATH or other searching mechanisms.
For example, in combination with our project, we know that libz3.so and libz3java.so are in the same directory.
The flag JAVA_EXTERNAL_LIBRARY_LOADING_FLAG allows to load libz3.so directly from the same directory than other libraries that access it.