### PR TITLE
[CMake] Fix install of libz3.dll on Windows

### DIFF
--- a/contrib/cmake/src/CMakeLists.txt
+++ b/contrib/cmake/src/CMakeLists.txt
@@ -166,7 +166,8 @@ endforeach()
 
 install(TARGETS libz3
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" # On Windows this installs ``libz3.lib`` which CMake calls the "corresponding import library". Do we want this installed?
+  RUNTIME DESTINATION "${CMAKE_INSTALL_LIBDIR}" # For Windows. DLLs are runtime targets for CMake
   PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 


### PR DESCRIPTION
[CMake] On Windows fix the ``install`` target so that it installs ``libz3.dll``.

I've left a comment about the installation of ``libz3.lib``. I'm not
sure if we want that installed or not.