### PR TITLE
Bugfix: character not in ascii range if output contains german characters

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -852,7 +852,7 @@ def is_CXX_gpp():
 
 def is_clang_in_gpp_form(cc):
     version_string = check_output([cc, '--version'])
-    return str(version_string).find('clang') != -1
+    return str(version_string.encode('utf_8')).find('clang') != -1
 
 def is_CXX_clangpp():
     if is_compiler(CXX, 'g++'):


### PR DESCRIPTION
Hi,

the mk_util.py script crashs in function is_clang_in_gpp_form because of a character which is not in ascii range.

`gcc (GCC) 6.1.1 20160501
Copyright (C) 2016 Free Software Foundation, Inc.
Dies ist freie Software; die Kopierbedingungen stehen in den Quellen. Es
gibt KEINE Garantie; auch nicht für MARKTGÄNGIGKEIT oder FÜR SPEZIELLE ZWECKE.`

regards
Sascha