### PR TITLE
Export default tactic for use via the SMT-LIB 2 interface.

### DIFF
--- a/src/tactic/portfolio/default_tactic.h
+++ b/src/tactic/portfolio/default_tactic.h
@@ -25,4 +25,8 @@ class tactic;
 
 tactic * mk_default_tactic(ast_manager & m, params_ref const & p = params_ref());
 
+/*
+ADD_TACTIC("default", "default strategy used when no logic is specified.", "mk_default_tactic(m, p)")
+*/
+
 #endif


### PR DESCRIPTION
This suggestion is in response to [this Stack Overflow discussion](https://stackoverflow.com/questions/37443308/check-sat-using-default-or-similar).  The purpose of this change is to permit combining the Z3 default tactic with other tactics in a custom strategy.  For example `(check-sat-using (or-else default qfnra-nlsat))`.