### PR TITLE
Add init file to Python bindings

### DIFF
--- a/contrib/cmake/src/api/python/CMakeLists.txt
+++ b/contrib/cmake/src/api/python/CMakeLists.txt
@@ -4,6 +4,7 @@ message(STATUS "Emitting rules to build Z3 python bindings")
 ###############################################################################
 # This allows the python bindings to be used directly from the build directory
 set(z3py_files
+  __init__.py
   z3.py
   z3num.py
   z3poly.py

--- a/src/api/python/__init__.py
+++ b/src/api/python/__init__.py
@@ -1,0 +1,1 @@
+from z3 import *


### PR DESCRIPTION
I wondered why the Python bindings come without an `__init__.py` file, so I just created one. I think this would help package maintainers to provide z3 Python packages which work out of the box. For example, in Fedora 23 the lack of an init file (or the presence of an empty init file created by the maintainer) renders the module unusable (unless your CWD is `/usr/lib64/python2.7/site-packages/z3`):

```
$ python -c 'import z3; print(z3.get_version_string())'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named z3
```

Merging this PR should provide the expected functionality (once it arrives in the distros):

```
$ python -c 'import z3; print(z3.get_version_string())'
4.4.1
```

What do you think?