### PR TITLE
Fix off-by-one bug in computing the maximal and minimal exponents in …

### DIFF
--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -264,7 +264,7 @@ void fpa2bv_converter::mk_function(func_decl * f, unsigned num, expr * const * a
     rng = f->get_range();
     fapp = m.mk_app(f, num, args);
     if (m_util.is_float(rng)) {
-        sort_ref bv_rng(m);        
+        sort_ref bv_rng(m);
         expr_ref new_eq(m);
         unsigned ebits = m_util.get_ebits(rng);
         unsigned sbits = m_util.get_sbits(rng);
@@ -290,7 +290,7 @@ void fpa2bv_converter::mk_function(func_decl * f, unsigned num, expr * const * a
         m_extra_assertions.push_back(new_eq);
         result = flt_app;
     }
-    else 
+    else
         result = fapp;
 
     TRACE("fpa2bv", tout << "UF result: " << mk_ismt2_pp(result, m) << std::endl; );
@@ -1057,7 +1057,7 @@ void fpa2bv_converter::mk_rem(sort * s, expr_ref & x, expr_ref & y, expr_ref & r
     // (x is 0) -> x
     c5 = x_is_zero;
     v5 = pzero;
-   
+
     // exp(x) < exp(y) -> x
     unsigned ebits = m_util.get_ebits(s);
     unsigned sbits = m_util.get_sbits(s);
@@ -1117,15 +1117,15 @@ void fpa2bv_converter::mk_rem(sort * s, expr_ref & x, expr_ref & y, expr_ref & r
     dbg_decouple("fpa2bv_rem_exp_diff", exp_diff);
 
     // CMW: This creates _huge_ bit-vectors, which is potentially sub-optimal,
-    // but calculating this via rem = x - y * nearest(x/y) creates huge 
+    // but calculating this via rem = x - y * nearest(x/y) creates huge
     // circuits, too. Lazy instantiation seems the way to go in the long run
-    // (using the lazy bit-blaster helps on simple instances).    
+    // (using the lazy bit-blaster helps on simple instances).
     expr_ref a_sig_ext(m), b_sig_ext(m), lshift(m), rshift(m), shifted(m), huge_rem(m);
     a_sig_ext = m_bv_util.mk_concat(m_bv_util.mk_zero_extend(max_exp_diff_ui, a_sig), m_bv_util.mk_numeral(0, 3));
     b_sig_ext = m_bv_util.mk_concat(m_bv_util.mk_zero_extend(max_exp_diff_ui, b_sig), m_bv_util.mk_numeral(0, 3));
     lshift = m_bv_util.mk_zero_extend(max_exp_diff_ui + sbits - (ebits+2) + 3, exp_diff);
     rshift = m_bv_util.mk_zero_extend(max_exp_diff_ui + sbits - (ebits+2) + 3, neg_exp_diff);
-    shifted = m.mk_ite(exp_diff_is_neg, m_bv_util.mk_bv_ashr(a_sig_ext, rshift), 
+    shifted = m.mk_ite(exp_diff_is_neg, m_bv_util.mk_bv_ashr(a_sig_ext, rshift),
                                         m_bv_util.mk_bv_shl(a_sig_ext, lshift));
     huge_rem = m_bv_util.mk_bv_urem(shifted, b_sig_ext);
     dbg_decouple("fpa2bv_rem_huge_rem", huge_rem);
@@ -1142,7 +1142,7 @@ void fpa2bv_converter::mk_rem(sort * s, expr_ref & x, expr_ref & y, expr_ref & r
     expr_ref r_ge_y_half(m), r_gt_ny_half(m), r_le_y_half(m), r_lt_ny_half(m);
     expr_ref r_ge_zero(m), r_le_zero(m);
     expr_ref rounded_sub_y(m), rounded_add_y(m);
-    mpf zero, two;    
+    mpf zero, two;
     m_mpf_manager.set(two, ebits, sbits, 2);
     m_mpf_manager.set(zero, ebits, sbits, 0);
     mk_numeral(s, two, two_e);
@@ -1151,7 +1151,7 @@ void fpa2bv_converter::mk_rem(sort * s, expr_ref & x, expr_ref & y, expr_ref & r
     mk_neg(s, y_half, ny_half);
     mk_is_zero(y_half, y_half_is_zero);
     y_half_is_nz = m.mk_not(y_half_is_zero);
-    
+
     mk_float_ge(s, rndd, y_half, r_ge_y_half);
     mk_float_gt(s, rndd, ny_half, r_gt_ny_half);
     mk_float_le(s, rndd, y_half, r_le_y_half);
@@ -1161,8 +1161,8 @@ void fpa2bv_converter::mk_rem(sort * s, expr_ref & x, expr_ref & y, expr_ref & r
     mk_add(s, rne_bv, rndd, y, rounded_add_y);
 
     expr_ref sub_cnd(m), add_cnd(m);
-    sub_cnd = m.mk_and(y_half_is_nz, 
-                m.mk_or(m.mk_and(y_is_pos, r_ge_y_half), 
+    sub_cnd = m.mk_and(y_half_is_nz,
+                m.mk_or(m.mk_and(y_is_pos, r_ge_y_half),
                         m.mk_and(y_is_neg, r_le_y_half)));
     add_cnd = m.mk_and(y_half_is_nz,
                 m.mk_or(m.mk_and(y_is_pos, r_lt_ny_half),
@@ -1170,7 +1170,7 @@ void fpa2bv_converter::mk_rem(sort * s, expr_ref & x, expr_ref & y, expr_ref & r
 
     mk_ite(add_cnd, rounded_add_y, rndd, v7);
     mk_ite(sub_cnd, rounded_sub_y, v7, v7);
-        
+
     // And finally, we tie them together.
     mk_ite(c6, v6, v7, result);
     mk_ite(c5, v5, result, result);
@@ -3507,13 +3507,17 @@ void fpa2bv_converter::mk_bot_exp(unsigned sz, expr_ref & result) {
 
 void fpa2bv_converter::mk_min_exp(unsigned ebits, expr_ref & result) {
     SASSERT(ebits >= 2);
+    // smallest two's complement with ebits is -2^(ebits - 1)
     const mpz & z = m_mpf_manager.m_powers2.m1(ebits-1, true);
+    // add 1, as the bit pattern 0xFFF..FFF designates NaN
     result = m_bv_util.mk_numeral(z + mpz(1), ebits);
 }
 
 void fpa2bv_converter::mk_max_exp(unsigned ebits, expr_ref & result) {
     SASSERT(ebits >= 2);
-    result = m_bv_util.mk_numeral(m_mpf_manager.m_powers2.m1(ebits-1, false), ebits);
+    // largest two's complement with ebits is 2^(ebits - 1) - 1
+    const mpz & z = m_mpf_manager.m_powers2.m1(ebits-1, false);
+    result = m_bv_util.mk_numeral(z - mpz(1), ebits);
 }
 
 void fpa2bv_converter::mk_leading_zeros(expr * e, unsigned max_bits, expr_ref & result) {
@@ -3698,7 +3702,7 @@ void fpa2bv_converter::dbg_decouple(const char * prefix, expr_ref & e) {
     // CMW: This works only for quantifier-free formulas.
     if (m_util.is_fp(e)) {
         expr_ref new_bv(m);
-        expr *e_sgn, *e_sig, *e_exp; 
+        expr *e_sgn, *e_sig, *e_exp;
         split_fp(e, e_sgn, e_exp, e_sig);
         unsigned ebits = m_bv_util.get_bv_size(e_exp);
         unsigned sbits = m_bv_util.get_bv_size(e_sig) + 1;

--- a/src/util/mpf.cpp
+++ b/src/util/mpf.cpp
@@ -1224,7 +1224,7 @@ void mpf_manager::renormalize(unsigned ebits, unsigned sbits, mpf_exp_t & exp, m
         m_mpz_manager.machine_div2k(sig, 1);
         exp++;
     }
-    
+
     const mpz & pl = m_powers2(sbits-1);
     while (m_mpz_manager.lt(sig, pl)) {
         m_mpz_manager.mul2k(sig, 1);
@@ -1235,7 +1235,7 @@ void mpf_manager::renormalize(unsigned ebits, unsigned sbits, mpf_exp_t & exp, m
 void mpf_manager::partial_remainder(mpf & x, mpf const & y, mpf_exp_t const & exp_diff, bool partial) {
     unsigned ebits = x.ebits;
     unsigned sbits = x.sbits;
-    
+
     SASSERT(-1 <= exp_diff && exp_diff < INT64_MAX);
     SASSERT(exp_diff < ebits+sbits || partial);
 
@@ -1252,7 +1252,7 @@ void mpf_manager::partial_remainder(mpf & x, mpf const & y, mpf_exp_t const & ex
     SASSERT(m_mpz_manager.lt(y.significand, m_powers2(sbits)));
     SASSERT(m_mpz_manager.ge(y.significand, m_powers2(sbits - 1)));
 
-    // 1. Compute a/b        
+    // 1. Compute a/b
     bool x_div_y_sgn = x.sign != y.sign;
     mpf_exp_t x_div_y_exp = D;
     scoped_mpz x_sig_shifted(m_mpz_manager), x_div_y_sig_lrg(m_mpz_manager), x_div_y_rem(m_mpz_manager);
@@ -1271,7 +1271,7 @@ void mpf_manager::partial_remainder(mpf & x, mpf const & y, mpf_exp_t const & ex
     mpf_exp_t Q_exp = x_div_y_exp;
     scoped_mpz Q_sig(m_mpz_manager), Q_rem(m_mpz_manager);
     unsigned Q_shft = (sbits-1) + (sbits+3) -  (unsigned) (partial ? N :Q_exp);
-    if (partial) {        
+    if (partial) {
         // Round according to MPF_ROUND_TOWARD_ZERO
         SASSERT(0 < N && N < Q_exp && Q_exp < INT_MAX);
         m_mpz_manager.machine_div2k(x_div_y_sig_lrg, Q_shft, Q_sig);
@@ -1294,7 +1294,7 @@ void mpf_manager::partial_remainder(mpf & x, mpf const & y, mpf_exp_t const & ex
     TRACE("mpf_dbg_rem", tout << "Q_exp=" << Q_exp << std::endl;
                          tout << "Q_sig=" << m_mpz_manager.to_string(Q_sig) << std::endl;
                          tout << "Q=" << to_string_hexfloat(Q_sgn, Q_exp, Q_sig, ebits, sbits, 0) << std::endl;);
-        
+
     if ((D == -1 || partial) && m_mpz_manager.is_zero(Q_sig))
         return; // This means x % y = x.
 
@@ -1308,7 +1308,7 @@ void mpf_manager::partial_remainder(mpf & x, mpf const & y, mpf_exp_t const & ex
     bool YQ_sgn = x.sign;
     scoped_mpz YQ_sig(m_mpz_manager);
     mpf_exp_t YQ_exp = Q_exp + y.exponent;
-    m_mpz_manager.mul(y.significand, Q_sig, YQ_sig);    
+    m_mpz_manager.mul(y.significand, Q_sig, YQ_sig);
     renormalize(ebits, 2*sbits-1, YQ_exp, YQ_sig); // YQ_sig has `sbits-1' extra bits.
 
     (void)YQ_sgn;
@@ -1317,11 +1317,11 @@ void mpf_manager::partial_remainder(mpf & x, mpf const & y, mpf_exp_t const & ex
                          tout << "YQ_sig=" << m_mpz_manager.to_string(YQ_sig) << std::endl;
                          tout << "YQ=" << to_string_hexfloat(YQ_sgn, YQ_exp, YQ_sig, ebits, sbits, sbits-1) << std::endl;);
 
-    // `sbits-1' extra bits in YQ_sig.    
+    // `sbits-1' extra bits in YQ_sig.
     SASSERT(m_mpz_manager.lt(YQ_sig, m_powers2(2*sbits-1)));
     SASSERT(m_mpz_manager.ge(YQ_sig, m_powers2(2*sbits-2)) || YQ_exp <= mk_bot_exp(ebits));
 
-    // 4. Compute X-Y*Q    
+    // 4. Compute X-Y*Q
     mpf_exp_t X_YQ_exp = x.exponent;
     scoped_mpz X_YQ_sig(m_mpz_manager);
     mpf_exp_t exp_delta = exp(x) - YQ_exp;
@@ -1339,14 +1339,14 @@ void mpf_manager::partial_remainder(mpf & x, mpf const & y, mpf_exp_t const & ex
     SASSERT(m_mpz_manager.ge(minuend, m_powers2(2*sbits-2)));
     SASSERT(m_mpz_manager.lt(subtrahend, m_powers2(2*sbits-1)));
     SASSERT(m_mpz_manager.ge(subtrahend, m_powers2(2*sbits-2)));
-    
+
     if (exp_delta != 0) {
         scoped_mpz sticky_rem(m_mpz_manager);
         m_mpz_manager.set(sticky_rem, 0);
         if (exp_delta > sbits+5)
-            sticky_rem.swap(subtrahend);        
+            sticky_rem.swap(subtrahend);
         else if (exp_delta > 0)
-            m_mpz_manager.machine_div_rem(subtrahend, m_powers2((unsigned)exp_delta), subtrahend, sticky_rem);        
+            m_mpz_manager.machine_div_rem(subtrahend, m_powers2((unsigned)exp_delta), subtrahend, sticky_rem);
         else {
             SASSERT(exp_delta < 0);
             exp_delta = -exp_delta;
@@ -1356,7 +1356,7 @@ void mpf_manager::partial_remainder(mpf & x, mpf const & y, mpf_exp_t const & ex
             m_mpz_manager.inc(subtrahend);
         TRACE("mpf_dbg_rem", tout << "aligned subtrahend=" << m_mpz_manager.to_string(subtrahend) << std::endl;);
     }
-           
+
     m_mpz_manager.sub(minuend, subtrahend, X_YQ_sig);
     TRACE("mpf_dbg_rem", tout << "X_YQ_sig'=" << m_mpz_manager.to_string(X_YQ_sig) << std::endl;);
 
@@ -1374,7 +1374,7 @@ void mpf_manager::partial_remainder(mpf & x, mpf const & y, mpf_exp_t const & ex
                              tout << "subtrahend=" << m_mpz_manager.to_string(subtrahend) << std::endl;
                              tout << "X_YQ_sgn=" << X_YQ_sgn << std::endl;
                              tout << "X_YQ_exp=" << X_YQ_exp << std::endl;
-                             tout << "X_YQ_sig=" << m_mpz_manager.to_string(X_YQ_sig) << std::endl;        
+                             tout << "X_YQ_sig=" << m_mpz_manager.to_string(X_YQ_sig) << std::endl;
                              tout << "X-YQ=" << to_string_hexfloat(X_YQ_sgn, X_YQ_exp, X_YQ_sig, ebits, sbits, sbits-1) << std::endl;);
 
         // `sbits-1' extra bits in X_YQ_sig
@@ -1384,7 +1384,7 @@ void mpf_manager::partial_remainder(mpf & x, mpf const & y, mpf_exp_t const & ex
         TRACE("mpf_dbg_rem", tout << "final sticky=" << m_mpz_manager.to_string(rnd_bits) << std::endl; );
 
         // Round to nearest, ties to even.
-        if (m_mpz_manager.eq(rnd_bits, mpz(32))) { // tie. 
+        if (m_mpz_manager.eq(rnd_bits, mpz(32))) { // tie.
             if (m_mpz_manager.is_odd(X_YQ_sig)) {
                 m_mpz_manager.inc(X_YQ_sig);
             }
@@ -1430,7 +1430,7 @@ void mpf_manager::rem(mpf const & x, mpf const & y, mpf & o) {
         mpf_exp_t D;
         do {
             if (ST0.exponent() < ST1.exponent() - 1) {
-                D = 0;                    
+                D = 0;
             }
             else {
                 D = ST0.exponent() - ST1.exponent();
@@ -1741,13 +1741,17 @@ mpf_exp_t mpf_manager::mk_top_exp(unsigned ebits) {
 
 mpf_exp_t mpf_manager::mk_min_exp(unsigned ebits) {
     SASSERT(ebits > 0);
+    // smallest two's complement with ebits is -2^(ebits - 1)
     mpf_exp_t r = m_mpz_manager.get_int64(m_powers2.m1(ebits-1, true));
-    return r+1;
+    // add 1, as the bit pattern 0xFFF..FFF designates NaN
+    return r + 1;
 }
 
 mpf_exp_t mpf_manager::mk_max_exp(unsigned ebits) {
     SASSERT(ebits > 0);
-    return m_mpz_manager.get_int64(m_powers2.m1(ebits-1, false));
+    // largest two's complement with ebits is 2^(ebits - 1) - 1
+    mpf_exp_t r = m_mpz_manager.get_int64(m_powers2.m1(ebits-1, false));
+    return r - 1;
 }
 
 mpf_exp_t mpf_manager::bias_exp(unsigned ebits, mpf_exp_t unbiased_exponent) {
@@ -1889,7 +1893,7 @@ void mpf_manager::round(mpf_rounding_mode rm, mpf & o) {
 
     const mpz & p_m1 = m_powers2(o.sbits+2);
     const mpz & p_m2 = m_powers2(o.sbits+3);
-    (void)p_m1;    
+    (void)p_m1;
 
     TRACE("mpf_dbg", tout << "p_m1 = " << m_mpz_manager.to_string(p_m1) << std::endl <<
                              "p_m2 = " << m_mpz_manager.to_string(p_m2) << std::endl;);


### PR DESCRIPTION
…FPA.

The range of admissible exponent values in FPA was too large by one both in the mpf utils and in the fpa2bv converter. This patch fixes #699 and makes mk_max_exp return the correct bound of 2^(ebits-1)-1 and adds some comments to mk_min_exp to explain why it returns -2^(ebits-1)+1.