### PR TITLE
Fix UTF-8 Error

### DIFF
--- a/scripts/mk_make.py
+++ b/scripts/mk_make.py
@@ -6,6 +6,11 @@
 #
 # Author: Leonardo de Moura (leonardo)
 ############################################
+#Fix the utf8 error
+import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
 from mk_util import *
 from mk_project import *
 


### PR DESCRIPTION
Some scripts use utf8.
That cause the following error : 
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa9' in position 35: ordinal not in range(128)

This little code is here to fix that. 