### PR TITLE
Make clause offset conversion safe for debug mode AMD64.

### DIFF
--- a/src/api/python/z3.py
+++ b/src/api/python/z3.py
@@ -1547,6 +1547,9 @@ def And(*args):
     if isinstance(last_arg, Context):
         ctx = args[len(args)-1]
         args = args[:len(args)-1]
+    elif len(args) == 1 and isinstance(args[0], AstVector):
+        ctx = args[0].ctx
+        args = [a for a in args[0]]
     else:
         ctx = main_ctx()
     args = _get_args(args)
@@ -6773,7 +6776,7 @@ class Optimize(Z3PPObject):
         return Z3_optimize_to_string(self.ctx.ref(), self.optimize)
 
     def statistics(self):
-        """Return statistics for the last `query()`.
+        """Return statistics for the last check`.
         """
         return Statistics(Z3_optimize_get_statistics(self.ctx.ref(), self.optimize), self.ctx)
 

--- a/src/sat/sat_clause.cpp
+++ b/src/sat/sat_clause.cpp
@@ -125,7 +125,9 @@ namespace sat {
         m_allocator("clause-allocator") {
 #if defined(_AMD64_) 
         m_num_segments = 0;
+#if defined(Z3DEBUG)
         m_overflow_valid = false;
+#endif
 #endif
     }
 

--- a/src/sat/sat_clause.h
+++ b/src/sat/sat_clause.h
@@ -132,9 +132,11 @@ namespace sat {
         static const size_t    c_aligment_mask = (1ull << c_cls_alignment) - 1ull;
         unsigned               m_num_segments;
         size_t                 m_segments[c_max_segments];
+#if defined(Z3DEBUG)
         bool                   m_overflow_valid;
         size_t_map<unsigned>   m_ptr2cls_offset;
         u_map<clause const*>   m_cls_offset2ptr;
+#endif
 #endif
     public:
         clause_allocator();

--- a/src/sat/sat_clause.h
+++ b/src/sat/sat_clause.h
@@ -22,6 +22,7 @@ Revision History:
 #include"sat_types.h"
 #include"small_object_allocator.h"
 #include"id_gen.h"
+#include"map.h"
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4200)
@@ -124,13 +125,16 @@ namespace sat {
     class clause_allocator {
         small_object_allocator m_allocator;
         id_gen                 m_id_gen;
-#ifdef _AMD64_
-        unsigned get_segment(size_t ptr);
+#if defined(_AMD64_) 
+        unsigned get_segment(clause const* cls);
         static const unsigned  c_cls_alignment = 3; 
         static const unsigned  c_max_segments  = 1 << c_cls_alignment;
         static const size_t    c_aligment_mask = (1ull << c_cls_alignment) - 1ull;
         unsigned               m_num_segments;
         size_t                 m_segments[c_max_segments];
+        bool                   m_overflow_valid;
+        size_t_map<unsigned>   m_ptr2cls_offset;
+        u_map<clause const*>   m_cls_offset2ptr;
 #endif
     public:
         clause_allocator();


### PR DESCRIPTION
The following is a proposed change to address problems running with 64bit systems whose allocators use random high-order bits of the virtual address space. The compression of 64 bit address spaces into 32 bits (available in clause_offset type), relies on an assumption that addresses are allocated within a limited range of high-order bits. Address sanitizer systems will not follow this pattern as reported in #436. Furthermore, issue #712, reports the same problem, also under debug mode. 
On non-debug mode, the small object allocator uses chunks, so more clauses are required to fall back to an allocator that potentially uses different high-order virtual address ranges. In non-debug mode, the code now throws instead of falling back to hash-tables. 