### PR TITLE
Fix VisualStudio 2010 compiler warning C4100

### DIFF
--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -127,7 +127,7 @@ namespace z3 {
     */
     class context {
         Z3_context m_ctx;
-        static void error_handler(Z3_context c, Z3_error_code e) { /* do nothing */ }
+        static void error_handler(Z3_context /*c*/, Z3_error_code /*e*/) { /* do nothing */ }
         void init(config & c) {
             m_ctx = Z3_mk_context_rc(c);
             Z3_set_error_handler(m_ctx, error_handler);


### PR DESCRIPTION
When compiling with Visual Studio 2010 the buildlog warns of the following:

- `z3++.h: warning C4100: 'e' : unreferenced formal parameter` and
- `z3++.h: warning C4100: 'c' : unreferenced formal parameter`.

This merge request removes the warnings.