### PR TITLE
Set soname version correctly in cmake build

### DIFF
--- a/contrib/cmake/src/CMakeLists.txt
+++ b/contrib/cmake/src/CMakeLists.txt
@@ -121,9 +121,12 @@ set_target_properties(libz3 PROPERTIES
   # VERSION determines the version in the filename of the shared library.
   # SOVERSION determines the value of the DT_SONAME field on ELF platforms.
   # On ELF platforms the final compiled filename will be libz3.so.W.X.Y.Z
-  # but symlinks will be made to this file from libz3.so and also from libz3.so.W
+  # but symlinks will be made to this file from libz3.so and also from
+  # libz3.so.W.X.
+  # This indicates that no breaking API changes will be made within a single
+  # minor version.
   VERSION ${Z3_VERSION}
-  SOVERSION ${Z3_VERSION_MAJOR})
+  SOVERSION ${Z3_VERSION_MAJOR}.${Z3_VERSION_MINOR})
 
 if (NOT MSVC)
   # On UNIX like platforms if we don't change the OUTPUT_NAME

--- a/contrib/cmake/src/CMakeLists.txt
+++ b/contrib/cmake/src/CMakeLists.txt
@@ -117,14 +117,13 @@ else()
   set(lib_type "STATIC")
 endif()
 add_library(libz3 ${lib_type} ${object_files})
-# FIXME: Set "VERSION" and "SOVERSION" properly
 set_target_properties(libz3 PROPERTIES
-  # FIXME: Should we be using ${Z3_VERSION} here?
-  # VERSION: Sets up symlinks, does it do anything else?
+  # VERSION determines the version in the filename of the shared library.
+  # SOVERSION determines the value of the DT_SONAME field on ELF platforms.
+  # On ELF platforms the final compiled filename will be libz3.so.W.X.Y.Z
+  # but symlinks will be made to this file from libz3.so and also from libz3.so.W
   VERSION ${Z3_VERSION}
-  # SOVERSION: On platforms that use ELF this sets the API version
-  # and should be incremented everytime the API changes
-  SOVERSION ${Z3_VERSION})
+  SOVERSION ${Z3_VERSION_MAJOR})
 
 if (NOT MSVC)
   # On UNIX like platforms if we don't change the OUTPUT_NAME


### PR DESCRIPTION
Resolves a FIXME in the cmake build. See diff.

Previously, the DT_SONAME of libz3.so was libz3.so.4.4.2.1, which was kind of horrifying to me? This means that if any package maintainer distributes a binary that depends on the z3 shared library, they are forced to redo their distribution any time z3 publishes a _tweak_ update.

Note that this is only if the z3 distributor uses the cmake build, and it looks like the libz3.so in the ubuntu xenial archives was not built this way. This... confuses me, since the python build system produces a libz3.so that doesn't have a DT_SONAME and it's not clear if there's supposed to be a flag to enable this behavior, so I have no idea how the ubuntu distribution was built? The ubuntu distribution currently has a soname of libz3.so.4, which is what this pull request changes the soname to.

All this, of course, operates under the assumption that z3 only breaks its APIs on major version increments. If this is not the case we can change the soname to major.minor.
