### PR TITLE
allow python to load libz3 using loader's default search

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1611,7 +1611,7 @@ _lib = None
 def lib():
   global _lib
   if _lib is None:
-    _dirs = ['.', pkg_resources.resource_filename('z3', 'lib'), os.path.join(sys.prefix, 'lib'), '']
+    _dirs = ['.', pkg_resources.resource_filename('z3', 'lib'), os.path.join(sys.prefix, 'lib'), None]
     for _dir in _dirs:
       try:
         init(_dir)
@@ -1641,9 +1641,12 @@ else:
         return ""
 
 def init(PATH):
-  PATH = os.path.realpath(PATH)
-  if os.path.isdir(PATH):
-    PATH = os.path.join(PATH, 'libz3.%s' % _ext)
+  if PATH:
+    PATH = os.path.realpath(PATH)
+    if os.path.isdir(PATH):
+      PATH = os.path.join(PATH, 'libz3.%s' % _ext)
+  else:
+    PATH = 'libz3.%s' % _ext
 
   global _lib
   _lib = ctypes.CDLL(PATH)


### PR DESCRIPTION
This should fix the regression tests. I think at some point I added the `realpath` call to fix some other issue, and this broke the last search case, which was meant to search globally. This adds an explicit path for that case.