### PR TITLE
Unbreak the CMake build broken by 009af4455d60e0affb376e36f48e3ab42fcf67d0

### DIFF
--- a/contrib/cmake/src/ast/fpa/CMakeLists.txt
+++ b/contrib/cmake/src/ast/fpa/CMakeLists.txt
@@ -1,10 +1,12 @@
 z3_add_component(fpa
   SOURCES
+    bv2fpa_converter.cpp
     fpa2bv_converter.cpp
     fpa2bv_rewriter.cpp
   COMPONENT_DEPENDENCIES
     ast
     simplifier
+    model
     util
   PYG_FILES
     fpa2bv_rewriter_params.pyg


### PR DESCRIPTION
Unbreak the CMake build broken by 009af4455d60e0affb376e36f48e3ab42fcf67d0

The commit added an additional source file and dependency but the
corresponding changes weren't added to the CMake build.