### PR TITLE
[CMake] Bump the version number in the CMake build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,9 @@ project(Z3 C CXX)
 # Project version
 ################################################################################
 set(Z3_VERSION_MAJOR 4)
-set(Z3_VERSION_MINOR 4)
-set(Z3_VERSION_PATCH 2)
-set(Z3_VERSION_TWEAK 1)
+set(Z3_VERSION_MINOR 5)
+set(Z3_VERSION_PATCH 1)
+set(Z3_VERSION_TWEAK 0)
 set(Z3_FULL_VERSION 0)
 set(Z3_VERSION "${Z3_VERSION_MAJOR}.${Z3_VERSION_MINOR}.${Z3_VERSION_PATCH}.${Z3_VERSION_TWEAK}")
 message(STATUS "Z3 version ${Z3_VERSION}")


### PR DESCRIPTION
@wintersteiger It's great to see another Z3 release was made but in the future it would be nice if you could either bump the version in the `CMakeLists.txt` file or give me a heads up so I can make the change before making the release. The tagged `4.5.0` release has the wrong version in the CMake build.