### PR TITLE
Fix GCC/Clang compilation.

### DIFF
--- a/src/util/max_cliques.h
+++ b/src/util/max_cliques.h
@@ -24,6 +24,8 @@ Notes:
 
 template<class T>
 class max_cliques : public T {
+    using T::negate;
+
     vector<unsigned_vector> m_next, m_tc;
     uint_set                m_reachable[2];
     uint_set                m_seen1, m_seen2;


### PR DESCRIPTION
The calls to negate use a non-dependent name, so GCC and Clang do not
examine dependent base classes when looking up the name. Adds a using
declaration as suggested at
https://isocpp.org/wiki/faq/templates#nondependent-name-lookup-members.