### PR TITLE
Do not request time stamp if not needed

### DIFF
--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -31,8 +31,8 @@ public:
     ~timer();
     void start();
     double get_seconds();
-    bool timeout(unsigned secs) { return secs > 0 && get_seconds() > secs; }
-    bool ms_timeout(unsigned ms) { return ms > 0 && get_seconds() * 1000 > ms; }
+    bool timeout(unsigned secs) { return secs > 0 && secs != UINT_MAX && get_seconds() > secs; }
+    bool ms_timeout(unsigned ms) { return ms > 0 && ms != UINT_MAX && get_seconds() * 1000 > ms; }
 };
 
 #endif /* TIMER_H_ */


### PR DESCRIPTION
If no timeout is needed for solving queries, time stamps do not
need to be acquired.

My personal experiments show that measuring the time in the context of symbolic execution (KLEE) can take up to 25% of the execution time.