### PR TITLE
Potential fixes for #836

### DIFF
--- a/src/muz/rel/dl_sieve_relation.h
+++ b/src/muz/rel/dl_sieve_relation.h
@@ -104,6 +104,9 @@ namespace datalog {
         sieve_relation * mk_empty(const relation_signature & s, relation_plugin & inner_plugin);
 
         virtual relation_base * mk_full(func_decl* p, const relation_signature & s);
+        // Explicitly use `mk_full` from parent class so
+        // `mk_full(func_decl*, const relation_signature&, family_id)` is not hidden.
+        using relation_plugin::mk_full;
         sieve_relation * mk_full(func_decl* p, const relation_signature & s, relation_plugin & inner_plugin);
 
 

--- a/src/smt/proto_model/numeral_factory.h
+++ b/src/smt/proto_model/numeral_factory.h
@@ -50,6 +50,9 @@ public:
     bv_factory(ast_manager & m);
     virtual ~bv_factory();
 
+    // Explicitly use `mk_value` from parent class so
+    // `mk_value(rational const&, sort*)` is not hidden.
+    using numeral_factory::mk_value;
     app * mk_value(rational const & val, unsigned bv_size);
 };
 


### PR DESCRIPTION
Here are some potential fixes for #836 .

@NikolajBjorner 
Please think carefully about whether these fixes actually make sense because I don't know this code.

I think the the change to `src/smt/proto_model/numeral_factory.h` is potentially dangerous because now there are two very similar methods

```
bv_factory::mk_value(rational const&, unsigned)
bv_factory::mk_value(rational const&, sort*)
```

Which could easily be confused. Especially if you call `mk_value(some_rational, NULL)` which will actually call `bv_factory::mk_value(rational const&, unsigned)` not `bv_factory::mk_value(rational const&, sort*)`.

A few alternative ideas

* Rename `bv_factory::mk_value` to avoid hiding the method from the parent class.
* Suppress the Clang warning here using `#pragma` (I'm not a big fan of this idea).

There are a probably other ways of fixing this too. I just haven't thought of them.