### PR TITLE
Fix issue with bd1f07f864a7f1790cec08a306ccc17507f7e5a8

### DIFF
--- a/src/util/scoped_timer.cpp
+++ b/src/util/scoped_timer.cpp
@@ -230,8 +230,9 @@ struct scoped_timer::imp {
         }
         pthread_mutex_lock(&m_mutex);
         m_signal_sent = true;
-        pthread_cond_signal(&m_cond);
         pthread_mutex_unlock(&m_mutex);
+        // Perform signal outside of lock to avoid waking timing thread twice.
+        pthread_cond_signal(&m_cond);
 
         pthread_join(m_thread_id, NULL);
         pthread_cond_destroy(&m_cond);


### PR DESCRIPTION
Fix issue with bd1f07f864a7f1790cec08a306ccc17507f7e5a8 pointed out by @nunolopes .

If `pthread_cond_signal()` is called while `m_mutex` is held then the
timing thread might be woken up twice due to waking up from
`pthread_cond_timeout()` (due to being signaled) but then being forced
to sleep again because the thread calling `~imp()` is still holding
`m_mutex` (which the timing thread needs to acquire).