### PR TITLE
Fix .NET Core bindings

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -365,7 +365,7 @@ def mk_dotnet(dotnet):
     dotnet.write('        public delegate void Z3_error_handler(Z3_context c, Z3_error_code e);\n\n')
     dotnet.write('        public class LIB\n')
     dotnet.write('        {\n')
-    dotnet.write('            const string Z3_DLL_NAME = \"libz3.dll\";\n'
+    dotnet.write('            const string Z3_DLL_NAME = \"libz3\";\n'
                  '            \n')
     dotnet.write('            [DllImport(Z3_DLL_NAME, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]\n')
     dotnet.write('            public extern static void Z3_set_error_handler(Z3_context a0, Z3_error_handler a1);\n\n')

--- a/src/api/dotnet/core/DummyContracts.cs
+++ b/src/api/dotnet/core/DummyContracts.cs
@@ -44,15 +44,21 @@ namespace System.Diagnostics.Contracts
 
     public static class Contract
     {
+        [Conditional("false")]
         public static void Ensures(bool b) { }
+        [Conditional("false")]
         public static void Requires(bool b) { }
+        [Conditional("false")]
         public static void Assume(bool b, string msg) { }
+        [Conditional("false")]
         public static void Assert(bool b) { }
         public static bool ForAll(bool b) { return true; }
         public static bool ForAll(Object c, Func<Object, bool> p) { return true; }
         public static bool ForAll(int from, int to, Predicate<int> p) { return true; }
+        [Conditional("false")]
         public static void Invariant(bool b) { }
         public static T[] Result<T>() { return new T[1]; }
+        [Conditional("false")]
         public static void EndContractBlock() { }
         public static T ValueAtReturn<T>(out T v) { T[] t = new T[1]; v = t[0]; return v; }
     }


### PR DESCRIPTION
Fix two separate issues making the Z3 .NET bindings not work on .NET Core:
1. While `DummyContracts` made the code compile, the expressions of some of the contracts threw exceptions at runtime. This adds `[Conditional]` attributes to the `void` `DummyContracts` methods to make those method calls (and therefore their arguments which throw exceptions) not get included in the compiled code.
2. Unlike Mono, .NET Core will not remove the `.dll` from the end of a native library name in attempt to find the correct filename on non-Windows platforms. This is fixed by not including any extension at all.

Note the build script still does not actually build the .NET Core bindings, but they can be built manually following the instructions already in the `README` in the `src/api/dotnet/core` directory.