### PR TITLE
Thread labels through tactic system

### DIFF
--- a/src/cmd_context/tactic_cmds.cpp
+++ b/src/cmd_context/tactic_cmds.cpp
@@ -167,7 +167,7 @@ public:
 
 struct check_sat_tactic_result : public simple_check_sat_result {
 public:
-  svector<symbol> labels;
+  labels_vec labels;
 
   check_sat_tactic_result(ast_manager & m) : simple_check_sat_result(m) {
   }
@@ -180,8 +180,6 @@ public:
     labels.append(r);
   }
 };
-
-typedef svector<symbol> & labels_ref;
 
 class check_sat_using_tactict_cmd : public exec_given_tactic_cmd {
 public:
@@ -205,7 +203,7 @@ public:
         ast_manager & m = ctx.m();
         unsigned timeout   = p.get_uint("timeout", ctx.params().m_timeout);
         unsigned rlimit  =   p.get_uint("rlimit", ctx.params().m_rlimit);
-        svector<symbol> labels;
+        labels_vec labels;
         goal_ref g = alloc(goal, m, ctx.produce_proofs(), ctx.produce_models(), ctx.produce_unsat_cores());
         assert_exprs_from(ctx, *g);
         TRACE("check_sat_using", g->display(tout););

--- a/src/smt/tactic/smt_tactic.cpp
+++ b/src/smt/tactic/smt_tactic.cpp
@@ -256,7 +256,9 @@ public:
                 if (in->models_enabled()) {
                     model_ref md;
                     m_ctx->get_model(md);
-                    mc = model2model_converter(md.get());
+                    buffer<symbol> r;
+                    m_ctx->get_relevant_labels(0, r);
+                    mc = model_and_labels2model_converter(md.get(), r);
                     mc = concat(fmc.get(), mc.get());
                 }
                 pc = 0;
@@ -308,7 +310,9 @@ public:
                         if (in->models_enabled()) {
                             model_ref md;
                             m_ctx->get_model(md);
-                            mc = model2model_converter(md.get());
+                            buffer<symbol> r;
+                            m_ctx->get_relevant_labels(0, r);
+                            mc = model_and_labels2model_converter(md.get(), r);
                         }
                         pc   = 0;
                         core = 0;

--- a/src/solver/tactic2solver.cpp
+++ b/src/solver/tactic2solver.cpp
@@ -144,8 +144,9 @@ lbool tactic2solver::check_sat_core(unsigned num_assumptions, expr * const * ass
     proof_ref           pr(m);
     expr_dependency_ref core(m);
     std::string         reason_unknown = "unknown";
+    svector<symbol> labels;
     try {
-        switch (::check_sat(*m_tactic, g, md, pr, core, reason_unknown)) {
+        switch (::check_sat(*m_tactic, g, md, labels, pr, core, reason_unknown)) {
         case l_true: 
             m_result->set_status(l_true);
             break;

--- a/src/solver/tactic2solver.cpp
+++ b/src/solver/tactic2solver.cpp
@@ -144,7 +144,7 @@ lbool tactic2solver::check_sat_core(unsigned num_assumptions, expr * const * ass
     proof_ref           pr(m);
     expr_dependency_ref core(m);
     std::string         reason_unknown = "unknown";
-    svector<symbol> labels;
+    labels_vec labels;
     try {
         switch (::check_sat(*m_tactic, g, md, labels, pr, core, reason_unknown)) {
         case l_true: 

--- a/src/tactic/filter_model_converter.cpp
+++ b/src/tactic/filter_model_converter.cpp
@@ -51,6 +51,9 @@ void filter_model_converter::operator()(model_ref & old_model, unsigned goal_idx
     TRACE("filter_mc", tout << "after filter_model_converter\n"; model_v2_pp(tout, *old_model););
 }
 
+void filter_model_converter::operator()(svector<symbol> & labels, unsigned goal_idx) {
+}
+
 void filter_model_converter::display(std::ostream & out) {
     out << "(filter-model-converter";
     for (unsigned i = 0; i < m_decls.size(); i++) {

--- a/src/tactic/filter_model_converter.h
+++ b/src/tactic/filter_model_converter.h
@@ -32,6 +32,8 @@ public:
     
     virtual void operator()(model_ref & md, unsigned goal_idx);
 
+    virtual void operator()(svector<symbol> & labels, unsigned goal_idx);
+    
     virtual void operator()(model_ref & md) { operator()(md, 0); } // TODO: delete
 
     virtual void cancel() {}

--- a/src/tactic/model_converter.cpp
+++ b/src/tactic/model_converter.cpp
@@ -33,6 +33,12 @@ public:
         this->m_c1->operator()(m, 0);
     }
 
+    virtual void operator()(svector<symbol> & r, unsigned goal_idx) {
+        this->m_c2->operator()(r, goal_idx);
+        this->m_c1->operator()(r, 0);
+    }
+
+  
     virtual char const * get_name() const { return "concat-model-converter"; }
 
     virtual model_converter * translate(ast_translation & translator) {
@@ -76,6 +82,24 @@ public:
         }
         UNREACHABLE();
     }
+
+    virtual void operator()(svector<symbol> & r, unsigned goal_idx) {
+        unsigned num = this->m_c2s.size();
+        for (unsigned i = 0; i < num; i++) {
+            if (goal_idx < this->m_szs[i]) {
+                // found the model converter that should be used
+                model_converter * c2 = this->m_c2s[i];
+                if (c2)
+                  c2->operator()(r, goal_idx);
+                if (m_c1)
+                  this->m_c1->operator()(r, i);
+                return;
+            }
+            // invalid goal
+            goal_idx -= this->m_szs[i];
+        }
+        UNREACHABLE();
+    }
     
     virtual char const * get_name() const { return "concat-star-model-converter"; }
 
@@ -102,8 +126,12 @@ model_converter * concat(model_converter * mc1, unsigned num, model_converter * 
 
 class model2mc : public model_converter {
     model_ref m_model;
+    buffer<symbol> m_labels;
 public:
     model2mc(model * m):m_model(m) {}
+
+    model2mc(model * m, buffer<symbol> r):m_model(m), m_labels(r) {}
+
     virtual ~model2mc() {}
 
     virtual void operator()(model_ref & m) {
@@ -114,7 +142,11 @@ public:
         m = m_model;
     }
 
-    virtual void cancel() {
+    virtual void operator()(svector<symbol> & r, unsigned goal_idx) {
+      r.append(m_labels.size(), m_labels.c_ptr());
+    }
+
+  virtual void cancel() {
     }
     
     virtual void display(std::ostream & out) {
@@ -133,6 +165,12 @@ model_converter * model2model_converter(model * m) {
     if (m == 0)
         return 0;
     return alloc(model2mc, m);
+}
+
+model_converter * model_and_labels2model_converter(model * m, buffer<symbol> & r) {
+    if (m == 0)
+        return 0;
+    return alloc(model2mc, m, r);
 }
 
 void model_converter2model(ast_manager & mng, model_converter * mc, model_ref & m) {

--- a/src/tactic/model_converter.cpp
+++ b/src/tactic/model_converter.cpp
@@ -33,7 +33,7 @@ public:
         this->m_c1->operator()(m, 0);
     }
 
-    virtual void operator()(svector<symbol> & r, unsigned goal_idx) {
+    virtual void operator()(labels_vec & r, unsigned goal_idx) {
         this->m_c2->operator()(r, goal_idx);
         this->m_c1->operator()(r, 0);
     }
@@ -83,7 +83,7 @@ public:
         UNREACHABLE();
     }
 
-    virtual void operator()(svector<symbol> & r, unsigned goal_idx) {
+    virtual void operator()(labels_vec & r, unsigned goal_idx) {
         unsigned num = this->m_c2s.size();
         for (unsigned i = 0; i < num; i++) {
             if (goal_idx < this->m_szs[i]) {
@@ -142,7 +142,7 @@ public:
         m = m_model;
     }
 
-    virtual void operator()(svector<symbol> & r, unsigned goal_idx) {
+    virtual void operator()(labels_vec & r, unsigned goal_idx) {
       r.append(m_labels.size(), m_labels.c_ptr());
     }
 

--- a/src/tactic/model_converter.cpp
+++ b/src/tactic/model_converter.cpp
@@ -130,7 +130,7 @@ class model2mc : public model_converter {
 public:
     model2mc(model * m):m_model(m) {}
 
-    model2mc(model * m, buffer<symbol> r):m_model(m), m_labels(r) {}
+    model2mc(model * m, buffer<symbol> const & r):m_model(m), m_labels(r) {}
 
     virtual ~model2mc() {}
 

--- a/src/tactic/model_converter.h
+++ b/src/tactic/model_converter.h
@@ -32,6 +32,8 @@ public:
         SASSERT(goal_idx == 0);
         operator()(m);
     }
+
+    virtual void operator()(svector<symbol> & r, unsigned goal_idx) {}
     
     virtual model_converter * translate(ast_translation & translator) = 0;
 };
@@ -48,6 +50,8 @@ model_converter * concat(model_converter * mc1, model_converter * mc2);
 model_converter * concat(model_converter * mc1, unsigned num, model_converter * const * mc2s, unsigned * num_subgoals);
 
 model_converter * model2model_converter(model * m);
+
+model_converter * model_and_labels2model_converter(model * m, buffer<symbol> &r);
 
 void model_converter2model(ast_manager & mng, model_converter * mc, model_ref & m);
 

--- a/src/tactic/model_converter.h
+++ b/src/tactic/model_converter.h
@@ -23,6 +23,8 @@ Notes:
 #include"converter.h"
 #include"ref.h"
 
+class labels_vec : public svector<symbol> {};
+
 class model_converter : public converter {
 public:
     virtual void operator()(model_ref & m) {}  // TODO: delete
@@ -33,7 +35,7 @@ public:
         operator()(m);
     }
 
-    virtual void operator()(svector<symbol> & r, unsigned goal_idx) {}
+    virtual void operator()(labels_vec & r, unsigned goal_idx) {}
     
     virtual model_converter * translate(ast_translation & translator) = 0;
 };

--- a/src/tactic/tactic.cpp
+++ b/src/tactic/tactic.cpp
@@ -174,7 +174,7 @@ void exec(tactic & t, goal_ref const & in, goal_ref_buffer & result, model_conve
     }
 }
 
-lbool check_sat(tactic & t, goal_ref & g, model_ref & md, proof_ref & pr, expr_dependency_ref & core, std::string & reason_unknown) {
+lbool check_sat(tactic & t, goal_ref & g, model_ref & md, svector<symbol> & labels, proof_ref & pr, expr_dependency_ref & core, std::string & reason_unknown) {
     bool models_enabled = g->models_enabled();
     bool proofs_enabled = g->proofs_enabled();
     bool cores_enabled  = g->unsat_core_enabled();
@@ -199,6 +199,7 @@ lbool check_sat(tactic & t, goal_ref & g, model_ref & md, proof_ref & pr, expr_d
 
     if (is_decided_sat(r)) {
         if (models_enabled) {
+            (*mc)(labels, 0);
             model_converter2model(m, mc.get(), md);
             if (!md) {
                 // create empty model.
@@ -215,7 +216,10 @@ lbool check_sat(tactic & t, goal_ref & g, model_ref & md, proof_ref & pr, expr_d
         return l_false;
     }
     else {
-        if (models_enabled) model_converter2model(m, mc.get(), md);
+        if (models_enabled) {
+          model_converter2model(m, mc.get(), md);
+          (*mc)(labels, 0);
+        }
         reason_unknown = "incomplete";
         return l_undef;
     }

--- a/src/tactic/tactic.cpp
+++ b/src/tactic/tactic.cpp
@@ -174,7 +174,7 @@ void exec(tactic & t, goal_ref const & in, goal_ref_buffer & result, model_conve
     }
 }
 
-lbool check_sat(tactic & t, goal_ref & g, model_ref & md, svector<symbol> & labels, proof_ref & pr, expr_dependency_ref & core, std::string & reason_unknown) {
+lbool check_sat(tactic & t, goal_ref & g, model_ref & md, labels_vec & labels, proof_ref & pr, expr_dependency_ref & core, std::string & reason_unknown) {
     bool models_enabled = g->models_enabled();
     bool proofs_enabled = g->proofs_enabled();
     bool cores_enabled  = g->unsat_core_enabled();

--- a/src/tactic/tactic.h
+++ b/src/tactic/tactic.h
@@ -153,7 +153,7 @@ public:                                                                         
 #define MK_SIMPLE_TACTIC_FACTORY(NAME, ST)  MK_TACTIC_FACTORY(NAME, return ST;)
 
 void exec(tactic & t, goal_ref const & in, goal_ref_buffer & result, model_converter_ref & mc, proof_converter_ref & pc, expr_dependency_ref & core);
-lbool check_sat(tactic & t, goal_ref & g, model_ref & md, proof_ref & pr, expr_dependency_ref & core, std::string & reason_unknown);
+lbool check_sat(tactic & t, goal_ref & g, model_ref & md, svector<symbol> & labels, proof_ref & pr, expr_dependency_ref & core, std::string & reason_unknown);
 
 // Throws an exception if goal \c in requires proof generation.
 void fail_if_proof_generation(char const * tactic_name, goal_ref const & in);

--- a/src/tactic/tactic.h
+++ b/src/tactic/tactic.h
@@ -153,7 +153,7 @@ public:                                                                         
 #define MK_SIMPLE_TACTIC_FACTORY(NAME, ST)  MK_TACTIC_FACTORY(NAME, return ST;)
 
 void exec(tactic & t, goal_ref const & in, goal_ref_buffer & result, model_converter_ref & mc, proof_converter_ref & pc, expr_dependency_ref & core);
-lbool check_sat(tactic & t, goal_ref & g, model_ref & md, svector<symbol> & labels, proof_ref & pr, expr_dependency_ref & core, std::string & reason_unknown);
+lbool check_sat(tactic & t, goal_ref & g, model_ref & md, labels_vec & labels, proof_ref & pr, expr_dependency_ref & core, std::string & reason_unknown);
 
 // Throws an exception if goal \c in requires proof generation.
 void fail_if_proof_generation(char const * tactic_name, goal_ref const & in);


### PR DESCRIPTION
This adds support for Simplify-style labels to the tactic system. Previously, `(labels)` calls would return no labels after `(check-sat-using smt)`; now they should return the same labels as if `(check-sat)` was called instead.

Model converters now convert both models and labels; another option would be to add a separate `label_converter` class.