### PR TITLE
z3py: With tactical should not try to use context as a parameter

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -7204,7 +7204,7 @@ def With(t, *args, **keys):
     >>> t((x + 1)*(y + 2) == 0)
     [[2*x + y + x*y == -2]]
     """
-    ctx = keys.get('ctx', None)
+    ctx = keys.pop('ctx', None)
     t = _to_tactic(t, ctx)
     p = args2params(args, keys, t.ctx)
     return Tactic(Z3_tactic_using_params(t.ctx.ref(), t.tactic, p.params), t.ctx)


### PR DESCRIPTION
This program:

```python
from z3 import *

c = Context()

t = With('smt', random_seed=1, ctx=c)
```

fails with the error:

```
Traceback (most recent call last):
  File "/home/james/Desktop/fail.py", line 5, in <module>
    t = With('smt', random_seed=1, ctx=c)
  File "/usr/lib/python2.7/dist-packages/z3/z3.py", line 7138, in With
    p = args2params(args, keys, t.ctx)
  File "/usr/lib/python2.7/dist-packages/z3/z3.py", line 4663, in args2params
    r.set(k, v)
  File "/usr/lib/python2.7/dist-packages/z3/z3.py", line 4635, in set
    _z3_assert(False, "invalid parameter value")
  File "/usr/lib/python2.7/dist-packages/z3/z3.py", line 90, in _z3_assert
    raise Z3Exception(msg)
z3.z3types.Z3Exception: invalid parameter value
```

because it tries to use the context argument as a parameter for the tactic.