### PR TITLE
alternate str.at semantics check in seq_rewriter

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -598,14 +598,25 @@ br_status seq_rewriter::mk_seq_contains(expr* a, expr* b, expr_ref& result) {
     return BR_FAILED;
 }
 
+/*
+ * (str.at s i), constants s/i, i < 0 or i >= |s| ==> (str.at s i) = ""
+ */
 br_status seq_rewriter::mk_seq_at(expr* a, expr* b, expr_ref& result) {
     zstring c;
     rational r;
-    if (m_util.str.is_string(a, c) && m_autil.is_numeral(b, r) && r.is_unsigned()) {
-        unsigned j = r.get_unsigned();
-        if (j < c.length()) {
-            result = m_util.str.mk_string(c.extract(j, 1));
+    if (m_util.str.is_string(a, c) && m_autil.is_numeral(b, r)) {
+        if (r.is_neg()) {
+            result = m_util.str.mk_string(symbol(""));
             return BR_DONE;
+        } else if (r.is_unsigned()) {
+            unsigned j = r.get_unsigned();
+            if (j < c.length()) {
+                result = m_util.str.mk_string(c.extract(j, 1));
+                return BR_DONE;
+            } else {
+                result = m_util.str.mk_string(symbol(""));
+                return BR_DONE;
+            }
         }
     }
     return BR_FAILED;


### PR DESCRIPTION
In order to be consistent with other solvers and to be able to validate certain models, we need to handle the case where the integer term in `str.at` is negative or a value beyond the length of the string. This adds a case in `seq_rewriter` to check for this and rewrite to the empty string. This is the same interpretation used in CVC4.