### PR TITLE
Fix issue 939, use customized checkpoint() for sat_simplifier

### DIFF
--- a/src/sat/sat_simplifier.h
+++ b/src/sat/sat_simplifier.h
@@ -173,13 +173,7 @@ namespace sat {
         struct subsumption_report;
         struct elim_var_report;
 
-        class scoped_finalize {
-            simplifier& s;
-        public:
-            scoped_finalize(simplifier& s) : s(s) {}
-            ~scoped_finalize() { s.scoped_finalize_fn(); }
-        };
-        void scoped_finalize_fn();
+
 
     public:
         simplifier(solver & s, params_ref const & p);


### PR DESCRIPTION
Fix a potential double free bug in the sat engine https://github.com/Z3Prover/z3/issues/939 

Use customized `checkpoint()` function for sat_simplifier.cpp:  If z3 times out here, first call `simplifier::finalize()`, then reset the model converter(with `s.m_mc.reset()`).  