### PR TITLE
[CMake][Doxygen] Support building/installing API documentation and fix lots of bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,13 @@ message(STATUS "Z3 version ${Z3_VERSION}")
 # Set various useful variables depending on CMake version
 ################################################################################
 if (("${CMAKE_VERSION}" VERSION_EQUAL "3.2") OR ("${CMAKE_VERSION}" VERSION_GREATER "3.2"))
-  # In CMake >= 3.2 add_custom_command() supports a ``USES_TERMINAL`` argument
+  # In CMake >= 3.2 add_custom_command() and add_custom_target()
+  # supports a ``USES_TERMINAL`` argument
   set(ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG "USES_TERMINAL")
+  set(ADD_CUSTOM_TARGET_USES_TERMINAL_ARG "USES_TERMINAL")
 else()
   set(ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG "")
+  set(ADD_CUSTOM_TARGET_USES_TERMINAL_ARG "")
 endif()
 
 ################################################################################
@@ -527,4 +530,15 @@ install(
 option(ENABLE_EXAMPLE_TARGETS "Build Z3 api examples" ON)
 if (ENABLE_EXAMPLE_TARGETS)
   add_subdirectory(examples)
+endif()
+
+################################################################################
+# Documentation
+################################################################################
+option(BUILD_DOCUMENTATION "Build API documentation" OFF)
+if (BUILD_DOCUMENTATION)
+  message(STATUS "Building documentation enabled")
+  add_subdirectory(doc)
+else()
+  message(STATUS "Building documentation disabled")
 endif()

--- a/README-CMake.md
+++ b/README-CMake.md
@@ -268,6 +268,7 @@ The following useful options can be passed to CMake whilst configuring.
 * ``CMAKE_INSTALL_PKGCONFIGDIR`` - STRING. The path to install pkgconfig files.
 * ``CMAKE_INSTALL_PYTHON_PKG_DIR`` - STRING. The path to install the z3 python bindings. This can be relative (to ``CMAKE_INSTALL_PREFIX``) or absolute.
 * ``CMAKE_INSTALL_Z3_CMAKE_PACKAGE_DIR`` - STRING. The path to install CMake package files (e.g. ``/usr/lib/cmake/z3``).
+* ``CMAKE_INSTALL_API_BINDINGS_DOC`` - STRING. The path to install documentation for API bindings.
 * ``ENABLE_TRACING_FOR_NON_DEBUG`` - BOOL. If set to ``TRUE`` enable tracing in non-debug builds, if set to ``FALSE`` disable tracing in non-debug builds. Note in debug builds tracing is always enabled.
 * ``BUILD_LIBZ3_SHARED`` - BOOL. If set to ``TRUE`` build libz3 as a shared library otherwise build as a static library.
 * ``ENABLE_EXAMPLE_TARGETS`` - BOOL. If set to ``TRUE`` add the build targets for building the API examples.
@@ -286,6 +287,11 @@ The following useful options can be passed to CMake whilst configuring.
 * ``Z3_JAVA_JNI_LIB_INSTALLDIRR`` - STRING. The path to directory to install the Z3 Java JNI bridge library. This path should be relative to ``CMAKE_INSTALL_PREFIX``.
 * ``INCLUDE_GIT_DESCRIBE`` - BOOL. If set to ``TRUE`` and the source tree of Z3 is a git repository then the output of ``git describe`` will be included in the build.
 * ``INCLUDE_GIT_HASH`` - BOOL. If set to ``TRUE`` and the source tree of Z3 is a git repository then the git hash will be included in the build.
+* ``BUILD_DOCUMENTATION`` - BOOL. If set to ``TRUE`` then documentation for the API bindings can be built by invoking the ``api_docs`` target.
+* ``INSTALL_API_BINDINGS_DOCUMENTATION`` - BOOL. If set to ``TRUE`` and ``BUILD_DOCUMENTATION` is ``TRUE`` then documentation for API bindings will be installed
+    when running the ``install`` target.
+* ``ALWAYS_BUILD_DOCS`` - BOOL. If set to ``TRUE`` and ``BUILD_DOCUMENTATION`` is ``TRUE`` then documentation for API bindings will always be built.
+    Disabling this is useful for faster incremental builds. The documentation can be manually built by invoking the ``api_docs`` target.
 
 On the command line these can be passed to ``cmake`` using the ``-D`` option. In ``ccmake`` and ``cmake-gui`` these can be set in the user interface.
 
@@ -417,6 +423,7 @@ There are a few special targets:
 * ``clean`` all the built targets in the current directory and below
 * ``edit_cache`` will invoke one of the CMake tools (depending on which is available) to let you change configuration options.
 * ``rebuild_cache`` will reinvoke ``cmake`` for the project.
+* ``api_docs`` will build the documentation for the API bindings.
 
 ### Setting build type specific flags
 

--- a/contrib/cmake/doc/CMakeLists.txt
+++ b/contrib/cmake/doc/CMakeLists.txt
@@ -1,0 +1,93 @@
+find_package(Doxygen REQUIRED)
+message(STATUS "DOXYGEN_EXECUTABLE: \"${DOXYGEN_EXECUTABLE}\"")
+message(STATUS "DOXYGEN_VERSION: \"${DOXYGEN_VERSION}\"")
+
+set(DOC_DEST_DIR "${CMAKE_CURRENT_BINARY_DIR}/api")
+set(DOC_TEMP_DIR "${CMAKE_CURRENT_BINARY_DIR}/temp")
+set(MK_API_DOC_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/mk_api_doc.py")
+
+set(PYTHON_API_OPTIONS "")
+set(DOTNET_API_OPTIONS "")
+set(JAVA_API_OPTIONS "")
+SET(DOC_EXTRA_DEPENDS "")
+
+if (BUILD_PYTHON_BINDINGS)
+  # FIXME: Don't hard code this path
+  list(APPEND PYTHON_API_OPTIONS "--z3py-package-path" "${CMAKE_BINARY_DIR}/python/z3")
+  list(APPEND DOC_EXTRA_DEPENDS "build_z3_python_bindings")
+else()
+  list(APPEND PYTHON_API_OPTIONS "--no-z3py")
+endif()
+
+if (BUILD_DOTNET_BINDINGS)
+  # FIXME: Don't hard code these paths
+  list(APPEND DOTNET_API_OPTIONS "--dotnet-search-paths"
+    "${CMAKE_SOURCE_DIR}/src/api/dotnet"
+    "${CMAKE_BINARY_DIR}/src/api/dotnet"
+  )
+  list(APPEND DOC_EXTRA_DEPENDS "build_z3_dotnet_bindings")
+else()
+  list(APPEND DOTNET_API_OPTIONS "--no-dotnet")
+endif()
+
+if (BUILD_JAVA_BINDINGS)
+  # FIXME: Don't hard code these paths
+  list(APPEND JAVA_API_OPTIONS "--java-search-paths"
+    "${CMAKE_SOURCE_DIR}/src/api/java"
+    "${CMAKE_BINARY_DIR}/src/api/java"
+  )
+  list(APPEND DOC_EXTRA_DEPENDS "build_z3_java_bindings")
+else()
+  list(APPEND JAVA_API_OPTIONS "--no-java")
+endif()
+
+option(ALWAYS_BUILD_DOCS "Always build documentation for API bindings" ON)
+if (ALWAYS_BUILD_DOCS)
+  set(ALWAYS_BUILD_DOCS_ARG "ALL")
+else()
+  set(ALWAYS_BUILD_DOCS_ARG "")
+  # FIXME: This sucks but there doesn't seem to be a way to make the top level
+  # install target depend on the `api_docs` target.
+  message(WARNING "Building documentation for API bindings is not part of the"
+    " all target. This may result in stale files being installed when running"
+    " the install target. You should run the api_docs target before running"
+    " the install target. Alternatively Set ALWAYS_BUILD_DOCS to ON to"
+    " automatically build documentation when running the install target."
+  )
+endif()
+
+add_custom_target(api_docs ${ALWAYS_BUILD_DOCS_ARG}
+  COMMAND
+  "${PYTHON_EXECUTABLE}" "${MK_API_DOC_SCRIPT}"
+  --doxygen-executable "${DOXYGEN_EXECUTABLE}"
+  --output-dir "${DOC_DEST_DIR}"
+  --temp-dir "${DOC_TEMP_DIR}"
+  ${PYTHON_API_OPTIONS}
+  ${DOTNET_API_OPTIONS}
+  ${JAVA_API_OPTIONS}
+  DEPENDS
+    ${DOC_EXTRA_DEPENDS}
+  BYPRODUCTS "${DOC_DEST_DIR}"
+  COMMENT "Generating documentation"
+  ${ADD_CUSTOM_TARGET_USES_TERMINAL_ARG}
+)
+
+# Remove generated documentation when running `clean` target.
+set_property(DIRECTORY APPEND PROPERTY
+  ADDITIONAL_MAKE_CLEAN_FILES
+  "${DOC_DEST_DIR}"
+)
+
+option(INSTALL_API_BINDINGS_DOCUMENTATION "Install documentation for API bindings" ON)
+set(CMAKE_INSTALL_API_BINDINGS_DOC
+  "${CMAKE_INSTALL_DOCDIR}"
+  CACHE
+  PATH
+  "Path to install documentation for API bindings"
+)
+if (INSTALL_API_BINDINGS_DOCUMENTATION)
+  install(
+    DIRECTORY "${DOC_DEST_DIR}"
+    DESTINATION "${CMAKE_INSTALL_API_BINDINGS_DOC}"
+  )
+endif()

--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -123,17 +123,12 @@ try:
     doxygen_config_file = temp_path('z3api.cfg')
     configure_file('z3api.cfg.in', doxygen_config_file, doxygen_config_substitutions)
 
-    fi = open('website.dox', 'r')
-    fo = open(temp_path('website.dox'), 'w')
-
-    for line in fi:
-        if (line != '[ML]\n'):
-            fo.write(line)
-        elif (ML_ENABLED):
-            fo.write('   - <a class="el" href="ml/index.html">ML/OCaml API</a>\n')
-    fi.close()
-    fo.close()
-
+    website_dox_substitutions = {}
+    if ML_ENABLED:
+        website_dox_substitutions['OCAML_API'] = '\n   - <a class="el" href="ml/index.html">ML/OCaml API</a>\n'
+    else:
+        website_dox_substitutions['OCAML_API'] = ''
+    configure_file('website.dox.in', temp_path('website.dox'), website_dox_substitutions)
 
     mk_dir(os.path.join(OUTPUT_DIRECTORY, 'html'))
     shutil.copyfile('../src/api/python/z3/z3.py', temp_path('z3py.py'))

--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -1,5 +1,9 @@
 # Copyright (c) Microsoft Corporation 2015
+"""
+Z3 API documentation generator script
+"""
 
+import argparse
 import os
 import shutil
 import re
@@ -12,39 +16,23 @@ import shutil
 ML_ENABLED=False
 BUILD_DIR='../build'
 
-def display_help(exit_code):
-    assert isinstance(exit_code, int)
-    print("mk_api_doc.py: Z3 documentation generator\n")
-    print("\nOptions:")
-    print("  -h, --help                    display this message.")
-    print("  -b <subdir>, --build=<subdir> subdirectory where Z3 is built (default: ../build).")
-    print("  --ml                          include ML/OCaml API documentation.")
-    sys.exit(exit_code)
-
 def parse_options():
     global ML_ENABLED, BUILD_DIR
-
-    try:
-        options, remainder = getopt.gnu_getopt(sys.argv[1:],
-                                               'b:h',
-                                               ['build=', 'help', 'ml'])
-    except:
-        print("ERROR: Invalid command line option")
-        display_help(1)
-
-    for opt, arg in options:
-        if opt in ('-b', '--build'):
-            BUILD_DIR = mk_util.norm_path(arg)
-        elif opt in ('h', '--help'):
-            display_help(0)
-        elif opt in ('--ml'):
-            ML_ENABLED=True
-        else:
-            print("ERROR: Invalid command line option: %s" % opt)
-            display_help(1)
-
-
-
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-b',
+        '--build',
+        default=BUILD_DIR,
+        help='Directory where Z3 is built (default: %(default)s)',
+    )
+    parser.add_argument('--ml',
+        action='store_true',
+        default=False,
+        help='Include ML/OCaml API documentation'
+    )
+    pargs = parser.parse_args()
+    ML_ENABLED = pargs.ml
+    BUILD_DIR = pargs.build
+    return
 
 def mk_dir(d):
     if not os.path.exists(d):

--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -22,10 +22,13 @@ Z3PY_PACKAGE_PATH='../src/api/python/z3'
 Z3PY_ENABLED=True
 DOTNET_ENABLED=True
 JAVA_ENABLED=True
+DOTNET_API_SEARCH_PATHS=['../src/api/dotnet']
+JAVA_API_SEARCH_PATHS=['../src/api/java']
 
 def parse_options():
     global ML_ENABLED, BUILD_DIR, DOXYGEN_EXE, TEMP_DIR, OUTPUT_DIRECTORY
     global Z3PY_PACKAGE_PATH, Z3PY_ENABLED, DOTNET_ENABLED, JAVA_ENABLED
+    global DOTNET_API_SEARCH_PATHS, JAVA_API_SEARCH_PATHS
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-b',
         '--build',
@@ -80,6 +83,18 @@ def parse_options():
         default=False,
         help='Do not generate documentation for Java bindings',
     )
+    parser.add_argument('--dotnet-search-paths',
+        dest='dotnet_search_paths',
+        nargs='+',
+        default=DOTNET_API_SEARCH_PATHS,
+        help='Specify one or more path to look for .NET files (default: %(default)s).',
+    )
+    parser.add_argument('--java-search-paths',
+        dest='java_search_paths',
+        nargs='+',
+        default=JAVA_API_SEARCH_PATHS,
+        help='Specify one or more paths to look for Java files (default: %(default)s).',
+    )
     pargs = parser.parse_args()
     ML_ENABLED = pargs.ml
     BUILD_DIR = pargs.build
@@ -94,6 +109,8 @@ def parse_options():
     Z3PY_ENABLED = not pargs.no_z3py
     DOTNET_ENABLED = not pargs.no_dotnet
     JAVA_ENABLED = not pargs.no_java
+    DOTNET_API_SEARCH_PATHS = pargs.dotnet_search_paths
+    JAVA_API_SEARCH_PATHS = pargs.java_search_paths
     return
 
 def mk_dir(d):
@@ -171,7 +188,11 @@ try:
     if DOTNET_ENABLED:
         print(".NET documentation enabled")
         doxygen_config_substitutions['DOTNET_API_FILES'] = '*.cs'
-        doxygen_config_substitutions['DOTNET_API_SEARCH_PATHS'] = '../src/api/dotnet'
+        dotnet_api_search_path_str = ""
+        for p in DOTNET_API_SEARCH_PATHS:
+            # Quote path so that paths with spaces are handled correctly
+            dotnet_api_search_path_str += "\"{}\" ".format(p)
+        doxygen_config_substitutions['DOTNET_API_SEARCH_PATHS'] = dotnet_api_search_path_str
     else:
         print(".NET documentation disabled")
         doxygen_config_substitutions['DOTNET_API_FILES'] = ''
@@ -179,7 +200,11 @@ try:
     if JAVA_ENABLED:
         print("Java documentation enabled")
         doxygen_config_substitutions['JAVA_API_FILES'] = '*.java'
-        doxygen_config_substitutions['JAVA_API_SEARCH_PATHS'] = '../src/api/java'
+        java_api_search_path_str = ""
+        for p in JAVA_API_SEARCH_PATHS:
+            # Quote path so that paths with spaces are handled correctly
+            java_api_search_path_str += "\"{}\" ".format(p)
+        doxygen_config_substitutions['JAVA_API_SEARCH_PATHS'] = java_api_search_path_str
     else:
         print("Java documentation disabled")
         doxygen_config_substitutions['JAVA_API_FILES'] = ''

--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -13,11 +13,13 @@ ML_ENABLED=False
 BUILD_DIR='../build'
 
 def display_help(exit_code):
+    assert isinstance(exit_code, int)
     print("mk_api_doc.py: Z3 documentation generator\n")
     print("\nOptions:")
     print("  -h, --help                    display this message.")
     print("  -b <subdir>, --build=<subdir> subdirectory where Z3 is built (default: ../build).")
     print("  --ml                          include ML/OCaml API documentation.")
+    sys.exit(exit_code)
 
 def parse_options():
     global ML_ENABLED, BUILD_DIR
@@ -34,8 +36,7 @@ def parse_options():
         if opt in ('-b', '--build'):
             BUILD_DIR = mk_util.norm_path(arg)
         elif opt in ('h', '--help'):
-            display_help()
-            exit(1)
+            display_help(0)
         elif opt in ('--ml'):
             ML_ENABLED=True
         else:
@@ -128,7 +129,7 @@ try:
         print("Generated ML/OCaml documentation.")
 
     print("Documentation was successfully generated at subdirectory './api/html'.")
-except:
+except Exception:
     exctype, value = sys.exc_info()[:2]
     print("ERROR: failed to generate documentation: %s" % value)
     exit(1)

--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -18,9 +18,10 @@ BUILD_DIR='../build'
 DOXYGEN_EXE='doxygen'
 TEMP_DIR=os.path.join(os.getcwd(), 'tmp')
 OUTPUT_DIRECTORY=os.path.join(os.getcwd(), 'api')
+Z3PY_PACKAGE_PATH='../src/api/python/z3'
 
 def parse_options():
-    global ML_ENABLED, BUILD_DIR, DOXYGEN_EXE, TEMP_DIR, OUTPUT_DIRECTORY
+    global ML_ENABLED, BUILD_DIR, DOXYGEN_EXE, TEMP_DIR, OUTPUT_DIRECTORY, Z3PY_PACKAGE_PATH
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-b',
         '--build',
@@ -48,12 +49,22 @@ def parse_options():
         default=OUTPUT_DIRECTORY,
         help='Path to output directory (default: %(default)s)',
     )
+    parser.add_argument('--z3py-package-path',
+        dest='z3py_package_path',
+        default=Z3PY_PACKAGE_PATH,
+        help='Path to directory containing Z3py package (default: %(default)s)',
+    )
     pargs = parser.parse_args()
     ML_ENABLED = pargs.ml
     BUILD_DIR = pargs.build
     DOXYGEN_EXE = pargs.doxygen_executable
     TEMP_DIR = pargs.temp_dir
     OUTPUT_DIRECTORY = pargs.output_dir
+    Z3PY_PACKAGE_PATH = pargs.z3py_package_path
+    if not os.path.exists(Z3PY_PACKAGE_PATH):
+        raise Exception('"{}" does not exist'.format(Z3PY_PACKAGE_PATH))
+    if not os.path.basename(Z3PY_PACKAGE_PATH) == 'z3':
+        raise Exception('"{}" does not end with "z3"'.format(Z3PY_PACKAGE_PATH))
     return
 
 def mk_dir(d):
@@ -154,7 +165,7 @@ try:
     print("Generated C and .NET API documentation.")
     shutil.rmtree(os.path.realpath(TEMP_DIR))
     print("Removed temporary directory \"{}\"".format(TEMP_DIR))
-    sys.path.append('../src/api/python/z3')
+    sys.path.append(os.path.dirname(Z3PY_PACKAGE_PATH))
     pydoc.writedoc('z3')
     shutil.move('z3.html', os.path.join(OUTPUT_DIRECTORY, 'html', 'z3.html'))
     print("Generated Python documentation.")

--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -165,7 +165,9 @@ try:
     print("Generated C and .NET API documentation.")
     shutil.rmtree(os.path.realpath(TEMP_DIR))
     print("Removed temporary directory \"{}\"".format(TEMP_DIR))
-    sys.path.append(os.path.dirname(Z3PY_PACKAGE_PATH))
+    # Put z3py at the beginning of the search path to try to avoid picking up
+    # an installed copy of Z3py.
+    sys.path.insert(0, os.path.dirname(Z3PY_PACKAGE_PATH))
     pydoc.writedoc('z3')
     shutil.move('z3.html', os.path.join(OUTPUT_DIRECTORY, 'html', 'z3.html'))
     print("Generated Python documentation.")

--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -234,7 +234,7 @@ try:
     if DOTNET_ENABLED:
         website_dox_substitutions['DOTNET_API'] = (
             '{prefix}'
-            '<a class="el" href="class_microsoft_1_1_z3_1_1_context.html">'
+            '<a class="el" href="namespace_microsoft_1_1_z3.html">'
             '.NET API</a>').format(
                 prefix=bullet_point_prefix)
     else:

--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -50,15 +50,16 @@ def mk_dir(d):
     if not os.path.exists(d):
         os.makedirs(d)
 
-# Eliminate def_API and extra_API directives from file 'inf'.
+# Eliminate def_API, extra_API, and def_Type directives from file 'inf'.
 # The result is stored in 'outf'.
 def cleanup_API(inf, outf):
     pat1  = re.compile(".*def_API.*")
     pat2  = re.compile(".*extra_API.*")
+    pat3  = re.compile(r".*def_Type\(.*")
     _inf  = open(inf, 'r')
     _outf = open(outf, 'w')
     for line in _inf:
-        if not pat1.match(line) and not pat2.match(line):
+        if not pat1.match(line) and not pat2.match(line) and not pat3.match(line):
             _outf.write(line)
 
 try:

--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -119,6 +119,7 @@ try:
     # Create configuration file from template
     doxygen_config_substitutions = {
         'OUTPUT_DIRECTORY': OUTPUT_DIRECTORY,
+        'TEMP_DIR': TEMP_DIR
     }
     doxygen_config_file = temp_path('z3api.cfg')
     configure_file('z3api.cfg.in', doxygen_config_file, doxygen_config_substitutions)

--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -24,6 +24,7 @@ DOTNET_ENABLED=True
 JAVA_ENABLED=True
 DOTNET_API_SEARCH_PATHS=['../src/api/dotnet']
 JAVA_API_SEARCH_PATHS=['../src/api/java']
+SCRIPT_DIR=os.path.abspath(os.path.dirname(__file__))
 
 def parse_options():
     global ML_ENABLED, BUILD_DIR, DOXYGEN_EXE, TEMP_DIR, OUTPUT_DIRECTORY
@@ -172,11 +173,15 @@ try:
     # Short-hand for path to temporary file
     def temp_path(path):
         return os.path.join(TEMP_DIR, path)
+    # Short-hand for path to file in `doc` directory
+    def doc_path(path):
+        return os.path.join(SCRIPT_DIR, path)
 
     # Create configuration file from template
     doxygen_config_substitutions = {
         'OUTPUT_DIRECTORY': OUTPUT_DIRECTORY,
-        'TEMP_DIR': TEMP_DIR
+        'TEMP_DIR': TEMP_DIR,
+        'CXX_API_SEARCH_PATHS': doc_path('../src/api/c++'),
     }
 
     if Z3PY_ENABLED:
@@ -211,7 +216,10 @@ try:
         doxygen_config_substitutions['JAVA_API_SEARCH_PATHS'] = ''
 
     doxygen_config_file = temp_path('z3api.cfg')
-    configure_file('z3api.cfg.in', doxygen_config_file, doxygen_config_substitutions)
+    configure_file(
+        doc_path('z3api.cfg.in'),
+        doxygen_config_file,
+        doxygen_config_substitutions)
 
     website_dox_substitutions = {}
     bullet_point_prefix='\n   - '
@@ -245,20 +253,23 @@ try:
                 prefix=bullet_point_prefix)
     else:
         website_dox_substitutions['OCAML_API'] = ''
-    configure_file('website.dox.in', temp_path('website.dox'), website_dox_substitutions)
+    configure_file(
+        doc_path('website.dox.in'),
+        temp_path('website.dox'),
+        website_dox_substitutions)
 
     mk_dir(os.path.join(OUTPUT_DIRECTORY, 'html'))
     if Z3PY_ENABLED:
-        shutil.copyfile('../src/api/python/z3/z3.py', temp_path('z3py.py'))
-    cleanup_API('../src/api/z3_api.h', temp_path('z3_api.h'))
-    cleanup_API('../src/api/z3_ast_containers.h', temp_path('z3_ast_containers.h'))
-    cleanup_API('../src/api/z3_algebraic.h', temp_path('z3_algebraic.h'))
-    cleanup_API('../src/api/z3_polynomial.h', temp_path('z3_polynomial.h'))
-    cleanup_API('../src/api/z3_rcf.h', temp_path('z3_rcf.h'))
-    cleanup_API('../src/api/z3_fixedpoint.h', temp_path('z3_fixedpoint.h'))
-    cleanup_API('../src/api/z3_optimization.h', temp_path('z3_optimization.h'))
-    cleanup_API('../src/api/z3_interp.h', temp_path('z3_interp.h'))
-    cleanup_API('../src/api/z3_fpa.h', temp_path('z3_fpa.h'))
+        shutil.copyfile(doc_path('../src/api/python/z3/z3.py'), temp_path('z3py.py'))
+    cleanup_API(doc_path('../src/api/z3_api.h'), temp_path('z3_api.h'))
+    cleanup_API(doc_path('../src/api/z3_ast_containers.h'), temp_path('z3_ast_containers.h'))
+    cleanup_API(doc_path('../src/api/z3_algebraic.h'), temp_path('z3_algebraic.h'))
+    cleanup_API(doc_path('../src/api/z3_polynomial.h'), temp_path('z3_polynomial.h'))
+    cleanup_API(doc_path('../src/api/z3_rcf.h'), temp_path('z3_rcf.h'))
+    cleanup_API(doc_path('../src/api/z3_fixedpoint.h'), temp_path('z3_fixedpoint.h'))
+    cleanup_API(doc_path('../src/api/z3_optimization.h'), temp_path('z3_optimization.h'))
+    cleanup_API(doc_path('../src/api/z3_interp.h'), temp_path('z3_interp.h'))
+    cleanup_API(doc_path('../src/api/z3_fpa.h'), temp_path('z3_fpa.h'))
 
     print("Removed annotations from z3_api.h.")
     try:
@@ -282,7 +293,7 @@ try:
     if ML_ENABLED:
         ml_output_dir = os.path.join(OUTPUT_DIRECTORY, 'html', 'ml')
         mk_dir(ml_output_dir)
-        if subprocess.call(['ocamldoc', '-html', '-d', ml_output_dir, '-sort', '-hide', 'Z3', '-I', '%s/api/ml' % BUILD_DIR, '../src/api/ml/z3enums.mli', '../src/api/ml/z3.mli']) != 0:
+        if subprocess.call(['ocamldoc', '-html', '-d', ml_output_dir, '-sort', '-hide', 'Z3', '-I', '%s/api/ml' % BUILD_DIR, doc_path('../src/api/ml/z3enums.mli'), doc_path('../src/api/ml/z3.mli')]) != 0:
             print("ERROR: ocamldoc failed.")
             exit(1)
         print("Generated ML/OCaml documentation.")

--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -15,9 +15,10 @@ import shutil
 
 ML_ENABLED=False
 BUILD_DIR='../build'
+DOXYGEN_EXE='doxygen'
 
 def parse_options():
-    global ML_ENABLED, BUILD_DIR
+    global ML_ENABLED, BUILD_DIR, DOXYGEN_EXE
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-b',
         '--build',
@@ -29,9 +30,15 @@ def parse_options():
         default=False,
         help='Include ML/OCaml API documentation'
     )
+    parser.add_argument('--doxygen-executable',
+        dest='doxygen_executable',
+        default=DOXYGEN_EXE,
+        help='Doxygen executable to use (default: %(default)s)',
+    )
     pargs = parser.parse_args()
     ML_ENABLED = pargs.ml
     BUILD_DIR = pargs.build
+    DOXYGEN_EXE = pargs.doxygen_executable
     return
 
 def mk_dir(d):
@@ -81,7 +88,7 @@ try:
 
     print("Removed annotations from z3_api.h.")
     try:
-        if subprocess.call(['doxygen', 'z3api.dox']) != 0:
+        if subprocess.call([DOXYGEN_EXE, 'z3api.dox']) != 0:
             print("ERROR: doxygen returned nonzero return code")
             exit(1)
     except:

--- a/doc/website.dox.in
+++ b/doc/website.dox.in
@@ -14,7 +14,6 @@
    - \ref cppapi
    - <a class="el" href="class_microsoft_1_1_z3_1_1_context.html">.NET API</a>
    - <a class="el" href="namespacecom_1_1microsoft_1_1z3.html">Java API</a>
-   - <a class="el" href="namespacez3py.html">Python API</a> (also available in <a class="el" href="z3.html">pydoc format</a>)
-[ML]
+   - <a class="el" href="namespacez3py.html">Python API</a> (also available in <a class="el" href="z3.html">pydoc format</a>)@OCAML_API@
    - Try Z3 online at <a href="http://rise4fun.com/z3">RiSE4Fun</a>.
 */

--- a/doc/website.dox.in
+++ b/doc/website.dox.in
@@ -10,10 +10,7 @@
 
    This website hosts the automatically generated documentation for the Z3 APIs.
 
-   - \ref capi 
-   - \ref cppapi
-   - <a class="el" href="class_microsoft_1_1_z3_1_1_context.html">.NET API</a>
-   - <a class="el" href="namespacecom_1_1microsoft_1_1z3.html">Java API</a>
-   - <a class="el" href="namespacez3py.html">Python API</a> (also available in <a class="el" href="z3.html">pydoc format</a>)@OCAML_API@
+   - \ref capi
+   - \ref cppapi @DOTNET_API@ @JAVA_API@ @PYTHON_API@ @OCAML_API@
    - Try Z3 online at <a href="http://rise4fun.com/z3">RiSE4Fun</a>.
 */

--- a/doc/z3api.cfg.in
+++ b/doc/z3api.cfg.in
@@ -703,15 +703,15 @@ INPUT_ENCODING         = UTF-8
 # *.f90 *.f *.for *.vhd *.vhdl
 
 FILE_PATTERNS          = website.dox \
-			 z3_api.h \
-			 z3_algebraic.h \
-			 z3_polynomial.h \
-			 z3_rcf.h \
-			 z3_interp.h \
-			 z3_fpa.h \
+                         z3_api.h \
+                         z3_algebraic.h \
+                         z3_polynomial.h \
+                         z3_rcf.h \
+                         z3_interp.h \
+                         z3_fpa.h \
                          z3++.h \
                          z3py.py \
-						 *.cs \
+                         *.cs \
                          *.java
 
 # The RECURSIVE tag can be used to turn specify whether or not subdirectories

--- a/doc/z3api.cfg.in
+++ b/doc/z3api.cfg.in
@@ -52,7 +52,7 @@ PROJECT_LOGO           =
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = api
+OUTPUT_DIRECTORY       = @OUTPUT_DIRECTORY@
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output

--- a/doc/z3api.cfg.in
+++ b/doc/z3api.cfg.in
@@ -52,7 +52,7 @@ PROJECT_LOGO           =
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @OUTPUT_DIRECTORY@
+OUTPUT_DIRECTORY       = "@OUTPUT_DIRECTORY@"
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output
@@ -681,7 +681,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = @TEMP_DIR@ \
+INPUT                  = "@TEMP_DIR@" \
                          ../src/api/c++ \
                          @DOTNET_API_SEARCH_PATHS@ @JAVA_API_SEARCH_PATHS@
 

--- a/doc/z3api.cfg.in
+++ b/doc/z3api.cfg.in
@@ -681,10 +681,9 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = ../src/api/dotnet \
-                         ../src/api/java \
+INPUT                  = @TEMP_DIR@ \
                          ../src/api/c++ \
-                         @TEMP_DIR@
+                         @DOTNET_API_SEARCH_PATHS@ @JAVA_API_SEARCH_PATHS@
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is
@@ -710,9 +709,7 @@ FILE_PATTERNS          = website.dox \
                          z3_interp.h \
                          z3_fpa.h \
                          z3++.h \
-                         z3py.py \
-                         *.cs \
-                         *.java
+                         @PYTHON_API_FILES@ @DOTNET_API_FILES@ @JAVA_API_FILES@
 
 # The RECURSIVE tag can be used to turn specify whether or not subdirectories
 # should be searched for input files as well. Possible values are YES and NO.

--- a/doc/z3api.cfg.in
+++ b/doc/z3api.cfg.in
@@ -682,7 +682,7 @@ WARN_LOGFILE           =
 # with spaces.
 
 INPUT                  = "@TEMP_DIR@" \
-                         ../src/api/c++ \
+                         "@CXX_API_SEARCH_PATHS@" \
                          @DOTNET_API_SEARCH_PATHS@ @JAVA_API_SEARCH_PATHS@
 
 # This tag can be used to specify the character encoding of the source files

--- a/doc/z3api.cfg.in
+++ b/doc/z3api.cfg.in
@@ -684,7 +684,7 @@ WARN_LOGFILE           =
 INPUT                  = ../src/api/dotnet \
                          ../src/api/java \
                          ../src/api/c++ \
-                         ./tmp
+                         @TEMP_DIR@
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is

--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -1500,7 +1500,7 @@ extern "C" {
        All main interaction with Z3 happens in the context of a \c Z3_context.
 
        In contrast to #Z3_mk_context_rc, the life time of Z3_ast objects
-       are determined by the scope level of #Z3_push and #Z3_pop.
+       are determined by the scope level of #Z3_solver_push and #Z3_solver_pop.
        In other words, a Z3_ast object remains valid until there is a
        call to Z3_pop that takes the current scope below the level where
        the object was created.

--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -3091,8 +3091,8 @@ extern "C" {
        \brief Create a numeral of a given sort.
 
        \param c logical context.
-       \param numeral A string representing the numeral value in decimal notation. The string may be of the form \code{[num]*[.[num]*][E[+|-][num]+]}.
-                      If the given sort is a real, then the numeral can be a rational, that is, a string of the form \ccode{[num]* / [num]*}.
+       \param numeral A string representing the numeral value in decimal notation. The string may be of the form `[num]*[.[num]*][E[+|-][num]+]`.
+                      If the given sort is a real, then the numeral can be a rational, that is, a string of the form `[num]* / [num]*` .
        \param ty The sort of the numeral. In the current implementation, the given sort can be an int, real, finite-domain, or bit-vectors of arbitrary size.
 
        \sa Z3_mk_int

--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -3306,7 +3306,7 @@ extern "C" {
     Z3_ast Z3_API Z3_mk_seq_replace(Z3_context c, Z3_ast s, Z3_ast src, Z3_ast dst);
 
     /**
-       \brief Retrieve from \s the unit sequence positioned at position \c index.
+       \brief Retrieve from \c s the unit sequence positioned at position \c index.
 
        def_API('Z3_mk_seq_at' ,AST ,(_in(CONTEXT), _in(AST), _in(AST)))
      */


### PR DESCRIPTION
This PR starts with fixing the `mk_api_doc.py` to be in a good enough and flexible enough that it can be used from CMake and then adds CMake support (81a7a55). The CMake support also installs documentation by default.

I have only added new behaviour to `mk_api_doc.py` so it should function as before when none of the new command line arguments are used.

I ended up finding quite a few bugs a long the way so I fixed those as I went (e.g. 5508bfee2ba1f6129a55974a06418d58e5dcfcc2, 896c82924d51c1dabc3ac2bee969509558dfd7ff , fd6602727f1691d7ec56899003b6b92b5b512786, c9a462d9bf32dd26ca0b523ab64f2ff0bae75003)