### PR TITLE
add iterator accessors to obj_pair_set

### DIFF
--- a/src/util/obj_pair_set.h
+++ b/src/util/obj_pair_set.h
@@ -46,6 +46,11 @@ public:
     bool contains(obj_pair const & p) const { return m_set.contains(p); }
     void reset() { m_set.reset(); }
     bool empty() const { return m_set.empty(); }
+
+    typedef typename chashtable<obj_pair, hash_proc, eq_proc>::iterator iterator;
+
+    iterator begin() { return m_set.begin(); }
+    iterator end() { return m_set.end(); }
 };
 
 #endif


### PR DESCRIPTION
This adds accessors for `begin()` and `end()` to `obj_pair_set`. 