### PR TITLE
Fixing z3 binary setup to data_files

### DIFF
--- a/src/api/python/setup.py
+++ b/src/api/python/setup.py
@@ -164,6 +164,6 @@ setup(
     package_data={
         'z3': [os.path.join('lib', '*'), os.path.join('include', '*.h'), os.path.join('include', 'c++', '*.h')]
     },
-    scripts=[os.path.join('bin', EXECUTABLE_FILE)],
+    data_files=[('bin',[os.path.join('bin',EXECUTABLE_FILE)])],
     cmdclass={'build': build, 'develop': develop, 'sdist': sdist, 'bdist_egg': bdist_egg},
 )


### PR DESCRIPTION
There are errors when using scripts keyword for the z3 binary on python3. That keyword is meant for python source files and when the files are not source, setup can fail. Instead, I've switched the install to use data_files. I can confirm that pip install works on this version and the z3 binary ends up in the bin directory.