### PR TITLE
[CMake] Remove FOCI2 stub code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,18 +275,6 @@ else()
 endif()
 
 ################################################################################
-# FOCI2 support
-################################################################################
-# FIXME: What is this?
-option(USE_FOCI2 "Use FOCI2" OFF)
-if (USE_FOCI2)
-  message(FATAL_ERROR "TODO")
-  message(STATUS "Using FOCI2")
-else()
-  message(STATUS "Not using FOCI2")
-endif()
-
-################################################################################
 # OpenMP support
 ################################################################################
 option(USE_OPENMP "Use OpenMP" ON)


### PR DESCRIPTION
The CMake build system doesn't need to support FOCI2 because it
has been removed from Z3's codebase in 4b61a864e20ff82ef8dac89eae31f81976667734 .