### PR TITLE
`Expr.update()` in java API should not return super class

### DIFF
--- a/src/api/java/Expr.java
+++ b/src/api/java/Expr.java
@@ -126,7 +126,7 @@ public class Expr extends AST
         if (isApp() && args.length != getNumArgs()) {
             throw new Z3Exception("Number of arguments does not match");
         }
-        return new Expr(getContext(), Native.updateTerm(getContext().nCtx(), getNativeObject(),
+        return Expr.create(getContext(), Native.updateTerm(getContext().nCtx(), getNativeObject(),
                 args.length, Expr.arrayToNative(args)));
     }
 


### PR DESCRIPTION
The `Expr.update()` method in java API source `src/api/java/Expr.java` is using `new Expr()` to construct the java object that is to be returned to the method call. This will result in getting super class `Expr` instances and not being able to convert them to the corresponding sub classes they used to be before the update.

Thus `Expr.create()` should be used instead so that the corresponding sub class instance is created to be returned to the call.