### PR TITLE
Fix Markdown heading

### DIFF
--- a/README-CMake.md
+++ b/README-CMake.md
@@ -1,4 +1,4 @@
-    # Z3's CMake build system
+# Z3's CMake build system
 
 [CMake](https://cmake.org/) is a "meta build system" that reads a description
 of the project written in the ``CMakeLists.txt`` files and emits a build


### PR DESCRIPTION
With the tab preceding the heading, GitHub was rendering it as a code block.

### Before:
![before](https://cloud.githubusercontent.com/assets/251545/26597613/2b4ca702-4538-11e7-8713-f1cd91bc3fe4.png)


### After:
![after](https://cloud.githubusercontent.com/assets/251545/26597607/25a66f0e-4538-11e7-9138-2960710625f7.png)
