### PR TITLE
Fix Z3_PRINT_SMTLIB_FULL not working as expected

### DIFF
--- a/src/api/api_ast.cpp
+++ b/src/api/api_ast.cpp
@@ -821,9 +821,13 @@ extern "C" {
         RESET_ERROR_CODE();
         std::ostringstream buffer;
         switch (mk_c(c)->get_print_mode()) {
-        case Z3_PRINT_SMTLIB_FULL:
-            buffer << mk_pp(to_ast(a), mk_c(c)->m());
+        case Z3_PRINT_SMTLIB_FULL: {
+            params_ref p;
+            p.set_uint("max_depth", 4294967295u);
+            p.set_uint("min_alias_size", 4294967295u);
+            buffer << mk_pp(to_ast(a), mk_c(c)->m(), p);
             break;
+        }
         case Z3_PRINT_LOW_LEVEL:
             buffer << mk_ll_pp(to_ast(a), mk_c(c)->m());
             break;
@@ -1066,7 +1070,7 @@ extern "C" {
             case OP_BIT2BOOL: return Z3_OP_BIT2BOOL;
             case OP_BSMUL_NO_OVFL: return Z3_OP_BSMUL_NO_OVFL;
             case OP_BUMUL_NO_OVFL: return Z3_OP_BUMUL_NO_OVFL;
-            case OP_BSMUL_NO_UDFL: return Z3_OP_BSMUL_NO_UDFL;                
+            case OP_BSMUL_NO_UDFL: return Z3_OP_BSMUL_NO_UDFL;
             case OP_BSDIV_I: return Z3_OP_BSDIV_I;
             case OP_BUDIV_I: return Z3_OP_BUDIV_I;
             case OP_BSREM_I: return Z3_OP_BSREM_I;


### PR DESCRIPTION
This patch fixes the bug that pretty print mode `Z3_PRINT_SMTLIB_FULL` is not working as expected.

It is said in API documentation that:

(Docstring for `void Z3_API Z3_set_ast_print_mode(Z3_context c, Z3_ast_print_mode mode)`)

>Selects the format used for pretty-printing expressions. Remarks: The default mode for pretty printing expressions is to produce SMT-LIB style output where common subexpressions are printed at each occurrence. The mode is called Z3_PRINT_SMTLIB_FULL. To print shared common subexpressions only once, use the Z3_PRINT_LOW_LEVEL mode. To print in way that conforms to SMT-LIB standards and uses let expressions to share common sub-expressions use Z3_PRINT_SMTLIB_COMPLIANT.

However, in practice, use `Z3_PRINT_SMTLIB_FULL` and `Z3_PRINT_SMTLIB2_COMPLIANT` makes no difference, both would generate `(let ...)` expressions in output for multiple occurrences of common sub-expressions and deep expressions.

This is because now we're using `mk_pp` as an alias to `mk_ismt2_pp`, whose default behavior is to use let expressions, thus not behaving as expected.

In my patch I set up maximum value for `max_depth` and `min_alias_size` for `mk_pp` when it is called in `Z3_PRINT_SMTLIB_FULL`, suppressing the use of let expressions in pretty printer.