### PR TITLE
[WIP][CMake] Fix broken regeneration of some .cpp files

### DIFF
--- a/scripts/mk_genfile_common.py
+++ b/scripts/mk_genfile_common.py
@@ -587,7 +587,7 @@ def mk_def_file_internal(defname, dll_name, export_header_files):
 ###############################################################################
 # Functions for generating ``gparams_register_modules.cpp``
 ###############################################################################
-def mk_gparams_register_modules_internal(component_src_dirs, path):
+def mk_gparams_register_modules_internal(h_files_full_path, path):
     """
         Generate a ``gparams_register_modules.cpp`` file in the directory ``path``.
         Returns the path to the generated file.
@@ -600,7 +600,7 @@ def mk_gparams_register_modules_internal(component_src_dirs, path):
 
         This procedure is invoked by gparams::init()
     """
-    assert isinstance(component_src_dirs, list)
+    assert isinstance(h_files_full_path, list)
     assert check_dir_exists(path)
     cmds = []    
     mod_cmds = []
@@ -612,11 +612,6 @@ def mk_gparams_register_modules_internal(component_src_dirs, path):
     reg_pat = re.compile('[ \t]*REG_PARAMS\(\'([^\']*)\'\)')
     reg_mod_pat = re.compile('[ \t]*REG_MODULE_PARAMS\(\'([^\']*)\', *\'([^\']*)\'\)')
     reg_mod_descr_pat = re.compile('[ \t]*REG_MODULE_DESCRIPTION\(\'([^\']*)\', *\'([^\']*)\'\)')
-    h_files_full_path = []
-    for component_src_dir in component_src_dirs:
-        h_files = filter(lambda f: f.endswith('.h') or f.endswith('.hpp'), os.listdir(component_src_dir))
-        h_files = list(map(lambda p: os.path.join(component_src_dir, p), h_files))
-        h_files_full_path.extend(h_files)
     for h_file in sorted_headers_by_component(h_files_full_path):
         added_include = False
         with open(h_file, 'r') as fin:

--- a/scripts/mk_genfile_common.py
+++ b/scripts/mk_genfile_common.py
@@ -731,7 +731,7 @@ def mk_install_tactic_cpp_internal(h_files_full_path, path):
 # Functions for generating ``mem_initializer.cpp``
 ###############################################################################
 
-def mk_mem_initializer_cpp_internal(component_src_dirs, path):
+def mk_mem_initializer_cpp_internal(h_files_full_path, path):
     """
         Generate a ``mem_initializer.cpp`` file in the directory ``path``.
         Returns the path to the generated file.
@@ -745,7 +745,7 @@ def mk_mem_initializer_cpp_internal(component_src_dirs, path):
 
        These procedures are invoked by the Z3 memory_manager
     """
-    assert isinstance(component_src_dirs, list)
+    assert isinstance(h_files_full_path, list)
     assert check_dir_exists(path)
     initializer_cmds = []
     finalizer_cmds   = []
@@ -756,11 +756,6 @@ def mk_mem_initializer_cpp_internal(component_src_dirs, path):
     # ADD_INITIALIZER with priority
     initializer_prio_pat = re.compile('[ \t]*ADD_INITIALIZER\(\'([^\']*)\',[ \t]*(-?[0-9]*)\)')
     finalizer_pat        = re.compile('[ \t]*ADD_FINALIZER\(\'([^\']*)\'\)')
-    h_files_full_path = []
-    for component_src_dir in sorted(component_src_dirs):
-        h_files = filter(lambda f: f.endswith('.h') or f.endswith('.hpp'), os.listdir(component_src_dir))
-        h_files = list(map(lambda p: os.path.join(component_src_dir, p), h_files))
-        h_files_full_path.extend(h_files)
     for h_file in sorted_headers_by_component(h_files_full_path):
         added_include = False
         with open(h_file, 'r') as fin:

--- a/scripts/mk_genfile_common.py
+++ b/scripts/mk_genfile_common.py
@@ -651,7 +651,7 @@ def mk_gparams_register_modules_internal(component_src_dirs, path):
 # Functions/data structures for generating ``install_tactics.cpp``
 ###############################################################################
 
-def mk_install_tactic_cpp_internal(component_src_dirs, path):
+def mk_install_tactic_cpp_internal(h_files_full_path, path):
     """
         Generate a ``install_tactics.cpp`` file in the directory ``path``.
         Returns the path the generated file.
@@ -662,9 +662,10 @@ def mk_install_tactic_cpp_internal(component_src_dirs, path):
         void install_tactics(tactic_manager & ctx)
         ```
 
-        It installs all tactics found in the given component directories
-        ``component_src_dirs`` The procedure looks for ``ADD_TACTIC`` commands
-        in the ``.h``  and ``.hpp`` files of these components.
+        It installs all tactics declared in the given header files
+        ``h_files_full_path`` The procedure looks for ``ADD_TACTIC`` and
+        ``ADD_PROBE``commands in the ``.h``  and ``.hpp`` files of these
+        components.
     """
     ADD_TACTIC_DATA = []
     ADD_PROBE_DATA = []
@@ -679,7 +680,7 @@ def mk_install_tactic_cpp_internal(component_src_dirs, path):
         'ADD_PROBE': ADD_PROBE,
     }
 
-    assert isinstance(component_src_dirs, list)
+    assert isinstance(h_files_full_path, list)
     assert check_dir_exists(path)
     fullname = os.path.join(path, 'install_tactic.cpp')
     fout  = open(fullname, 'w')
@@ -689,11 +690,6 @@ def mk_install_tactic_cpp_internal(component_src_dirs, path):
     fout.write('#include"cmd_context.h"\n')
     tactic_pat   = re.compile('[ \t]*ADD_TACTIC\(.*\)')
     probe_pat    = re.compile('[ \t]*ADD_PROBE\(.*\)')
-    h_files_full_path = []
-    for component_src_dir in sorted(component_src_dirs):
-        h_files = filter(lambda f: f.endswith('.h') or f.endswith('.hpp'), os.listdir(component_src_dir))
-        h_files = list(map(lambda p: os.path.join(component_src_dir, p), h_files))
-        h_files_full_path.extend(h_files)
     for h_file in sorted_headers_by_component(h_files_full_path):
         added_include = False
         with open(h_file, 'r') as fin:

--- a/scripts/mk_gparams_register_modules_cpp.py
+++ b/scripts/mk_gparams_register_modules_cpp.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 """
-Determines the available global parameters
-in header files in the list of source directions
-and generates a ``gparams_register_modules.cpp`` file in
-the destination directory that defines a function
-``void gparams_register_modules()``.
+Determines the available global parameters from a list of header files and
+generates a ``gparams_register_modules.cpp`` file in the destination directory
+that defines a function ``void gparams_register_modules()``.
 """
 import mk_genfile_common
 import argparse
@@ -16,19 +14,22 @@ def main(args):
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("destination_dir", help="destination directory")
-    parser.add_argument("source_dirs", nargs="+",
-                        help="One or more source directories to search")
+    parser.add_argument("header_files", nargs="+",
+                        help="One or more header files to parse")
     pargs = parser.parse_args(args)
 
     if not mk_genfile_common.check_dir_exists(pargs.destination_dir):
         return 1
 
-    for source_dir in pargs.source_dirs:
-        if not mk_genfile_common.check_dir_exists(source_dir):
-            return 1
+    if not mk_genfile_common.check_files_exist(pargs.header_files):
+        return 1
+
+    h_files_full_path = []
+    for header_file in pargs.header_files:
+        h_files_full_path.append(os.path.abspath(header_file))
 
     output = mk_genfile_common.mk_gparams_register_modules_internal(
-        pargs.source_dirs,
+        h_files_full_path,
         pargs.destination_dir
     )
     logging.info('Generated "{}"'.format(output))

--- a/scripts/mk_install_tactic_cpp.py
+++ b/scripts/mk_install_tactic_cpp.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 """
-Determines the available tactics
-in header files in the list of source directions
-and generates a ``install_tactic.cpp`` file in
-the destination directory that defines a function
-``void install_tactics(tactic_manager& ctx)``.
+Determines the available tactics from a list of header files and generates a
+``install_tactic.cpp`` file in the destination directory that defines a
+function ``void install_tactics(tactic_manager& ctx)``.
 """
 import mk_genfile_common
 import argparse
@@ -16,19 +14,22 @@ def main(args):
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("destination_dir", help="destination directory")
-    parser.add_argument("source_dirs", nargs="+",
-                        help="One or more source directories to search")
+    parser.add_argument("header_files", nargs="+",
+                        help="One or more header files to parse")
     pargs = parser.parse_args(args)
 
     if not mk_genfile_common.check_dir_exists(pargs.destination_dir):
         return 1
 
-    for source_dir in pargs.source_dirs:
-        if not mk_genfile_common.check_dir_exists(source_dir):
-            return 1
+    if not mk_genfile_common.check_files_exist(pargs.header_files):
+        return 1
+
+    h_files_full_path = []
+    for header_file in pargs.header_files:
+        h_files_full_path.append(os.path.abspath(header_file))
 
     output = mk_genfile_common.mk_install_tactic_cpp_internal(
-        pargs.source_dirs,
+        h_files_full_path,
         pargs.destination_dir
     )
     logging.info('Generated "{}"'.format(output))

--- a/scripts/mk_mem_initializer_cpp.py
+++ b/scripts/mk_mem_initializer_cpp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Scans the source directories for
+Scans the listed header files for
 memory initializers and finalizers and
 emits and implementation of
 ``void mem_initialize()`` and
@@ -17,19 +17,19 @@ def main(args):
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("destination_dir", help="destination directory")
-    parser.add_argument("source_dirs", nargs="+",
-                        help="One or more source directories to search")
+    parser.add_argument("header_files", nargs="+",
+                        help="One or more header files to parse")
     pargs = parser.parse_args(args)
 
     if not mk_genfile_common.check_dir_exists(pargs.destination_dir):
         return 1
 
-    for source_dir in pargs.source_dirs:
-        if not mk_genfile_common.check_dir_exists(source_dir):
-            return 1
+    h_files_full_path = []
+    for header_file in pargs.header_files:
+        h_files_full_path.append(os.path.abspath(header_file))
 
     output = mk_genfile_common.mk_mem_initializer_cpp_internal(
-        pargs.source_dirs,
+        h_files_full_path,
         pargs.destination_dir
     )
     logging.info('Generated "{}"'.format(output))

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2763,7 +2763,8 @@ def mk_gparams_register_modules(cnames, path):
     for cname in cnames:
         c = get_component(cname)
         component_src_dirs.append(c.src_dir)
-    generated_file = mk_genfile_common.mk_gparams_register_modules_internal(component_src_dirs, path)
+    h_files_full_path = get_header_files_for_components(component_src_dirs)
+    generated_file = mk_genfile_common.mk_gparams_register_modules_internal(h_files_full_path, path)
     if VERBOSE:
         print("Generated '{}'".format(generated_file))
 

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2745,7 +2745,8 @@ def mk_mem_initializer_cpp(cnames, path):
     for cname in cnames:
         c = get_component(cname)
         component_src_dirs.append(c.src_dir)
-    generated_file = mk_genfile_common.mk_mem_initializer_cpp_internal(component_src_dirs, path)
+    h_files_full_path = get_header_files_for_components(component_src_dirs)
+    generated_file = mk_genfile_common.mk_mem_initializer_cpp_internal(h_files_full_path, path)
     if VERBOSE:
         print("Generated '{}'".format(generated_file))
 

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2712,12 +2712,22 @@ def mk_all_assembly_infos(major, minor, build, revision):
             else:
                 raise MKException("Failed to find assembly template info file '%s'" % assembly_info_template)
 
+def get_header_files_for_components(component_src_dirs):
+    assert isinstance(component_src_dirs, list)
+    h_files_full_path = []
+    for component_src_dir in sorted(component_src_dirs):
+        h_files = filter(lambda f: f.endswith('.h') or f.endswith('.hpp'), os.listdir(component_src_dir))
+        h_files = list(map(lambda p: os.path.join(component_src_dir, p), h_files))
+        h_files_full_path.extend(h_files)
+    return h_files_full_path
+
 def mk_install_tactic_cpp(cnames, path):
     component_src_dirs = []
     for cname in cnames:
         c = get_component(cname)
         component_src_dirs.append(c.src_dir)
-    generated_file = mk_genfile_common.mk_install_tactic_cpp_internal(component_src_dirs, path)
+    h_files_full_path = get_header_files_for_components(component_src_dirs)
+    generated_file = mk_genfile_common.mk_install_tactic_cpp_internal(h_files_full_path, path)
     if VERBOSE:
         print("Generated '{}'".format(generated_file))
 

--- a/src/ackermannization/CMakeLists.txt
+++ b/src/ackermannization/CMakeLists.txt
@@ -17,4 +17,7 @@ z3_add_component(ackermannization
   PYG_FILES
     ackermannization_params.pyg
     ackermannize_bv_tactic_params.pyg
+  TACTIC_HEADERS
+    ackermannize_bv_tactic.h
+    ackr_bound_probe.h
 )

--- a/src/ast/normal_forms/CMakeLists.txt
+++ b/src/ast/normal_forms/CMakeLists.txt
@@ -8,4 +8,6 @@ z3_add_component(normal_forms
     rewriter
   PYG_FILES
     nnf_params.pyg
+  EXTRA_REGISTER_MODULE_HEADERS
+    nnf.h
 )

--- a/src/cmd_context/CMakeLists.txt
+++ b/src/cmd_context/CMakeLists.txt
@@ -18,4 +18,6 @@ z3_add_component(cmd_context
     interp
     rewriter
     solver
+  EXTRA_REGISTER_MODULE_HEADERS
+    context_params.h
 )

--- a/src/math/polynomial/CMakeLists.txt
+++ b/src/math/polynomial/CMakeLists.txt
@@ -11,5 +11,7 @@ z3_add_component(polynomial
     util
   PYG_FILES
     algebraic_params.pyg
+  EXTRA_REGISTER_MODULE_HEADERS
+    polynomial.h
 )
 

--- a/src/math/subpaving/tactic/CMakeLists.txt
+++ b/src/math/subpaving/tactic/CMakeLists.txt
@@ -5,4 +5,6 @@ z3_add_component(subpaving_tactic
   COMPONENT_DEPENDENCIES
     core_tactics
     subpaving
+  TACTIC_HEADERS
+    subpaving_tactic.h
 )

--- a/src/muz/fp/CMakeLists.txt
+++ b/src/muz/fp/CMakeLists.txt
@@ -13,4 +13,6 @@ z3_add_component(fp
     pdr
     rel
     tab
+  TACTIC_HEADERS
+    horn_tactic.h
 )

--- a/src/nlsat/tactic/CMakeLists.txt
+++ b/src/nlsat/tactic/CMakeLists.txt
@@ -7,4 +7,7 @@ z3_add_component(nlsat_tactic
     arith_tactics
     nlsat
     sat_tactic
+  TACTIC_HEADERS
+    nlsat_tactic.h
+    qfnra_nlsat_tactic.h
 )

--- a/src/qe/CMakeLists.txt
+++ b/src/qe/CMakeLists.txt
@@ -23,6 +23,13 @@ z3_add_component(qe
     nlsat_tactic
     nlsat
     sat
-    smt   
-    tactic 
+    smt
+    tactic
+  TACTIC_HEADERS
+    nlqsat.h
+    qe_lite.h
+    qe_sat_tactic.h
+    qe_tactic.h
+    qsat.h
+    vsubst_tactic.h
 )

--- a/src/sat/tactic/CMakeLists.txt
+++ b/src/sat/tactic/CMakeLists.txt
@@ -6,4 +6,6 @@ z3_add_component(sat_tactic
   COMPONENT_DEPENDENCIES
     sat
     tactic
+  TACTIC_HEADERS
+    sat_tactic.h
 )

--- a/src/smt/tactic/CMakeLists.txt
+++ b/src/smt/tactic/CMakeLists.txt
@@ -5,4 +5,8 @@ z3_add_component(smt_tactic
     unit_subsumption_tactic.cpp
   COMPONENT_DEPENDENCIES
     smt
+  TACTIC_HEADERS
+    ctx_solver_simplify_tactic.h
+    smt_tactic.h
+    unit_subsumption_tactic.h
 )

--- a/src/tactic/CMakeLists.txt
+++ b/src/tactic/CMakeLists.txt
@@ -18,4 +18,8 @@ z3_add_component(tactic
   COMPONENT_DEPENDENCIES
     ast
     model
+  TACTIC_HEADERS
+    probe.h
+    sine_filter.h
+    tactic.h
 )

--- a/src/tactic/aig/CMakeLists.txt
+++ b/src/tactic/aig/CMakeLists.txt
@@ -4,4 +4,6 @@ z3_add_component(aig_tactic
     aig_tactic.cpp
   COMPONENT_DEPENDENCIES
     tactic
+  TACTIC_HEADERS
+    aig_tactic.h
 )

--- a/src/tactic/arith/CMakeLists.txt
+++ b/src/tactic/arith/CMakeLists.txt
@@ -28,4 +28,23 @@ z3_add_component(arith_tactics
   COMPONENT_DEPENDENCIES
     core_tactics
     sat
+  TACTIC_HEADERS
+    add_bounds_tactic.h
+    card2bv_tactic.h
+    degree_shift_tactic.h
+    diff_neq_tactic.h
+    elim01_tactic.h
+    eq2bv_tactic.h
+    factor_tactic.h
+    fix_dl_var_tactic.h
+    fm_tactic.h
+    lia2pb_tactic.h
+    lia2card_tactic.h
+    nla2bv_tactic.h
+    normalize_bounds_tactic.h
+    pb2bv_tactic.h
+    probe_arith.h
+    propagate_ineqs_tactic.h
+    purify_arith_tactic.h
+    recover_01_tactic.h
 )

--- a/src/tactic/bv/CMakeLists.txt
+++ b/src/tactic/bv/CMakeLists.txt
@@ -15,4 +15,14 @@ z3_add_component(bv_tactics
     bit_blaster
     core_tactics
     tactic
+  TACTIC_HEADERS
+    bit_blaster_tactic.h
+    bv1_blaster_tactic.h
+    bv_bound_chk_tactic.h
+    bv_bounds_tactic.h
+    bv_size_reduction_tactic.h
+    bvarray2uf_tactic.h
+    dt2bv_tactic.h
+    elim_small_bv_tactic.h
+    max_bv_sharing_tactic.h
 )

--- a/src/tactic/core/CMakeLists.txt
+++ b/src/tactic/core/CMakeLists.txt
@@ -3,7 +3,7 @@ z3_add_component(core_tactics
     blast_term_ite_tactic.cpp
     cofactor_elim_term_ite.cpp
     cofactor_term_ite_tactic.cpp
-    collect_statistics_tactic.cpp  
+    collect_statistics_tactic.cpp
     ctx_simplify_tactic.cpp
     der_tactic.cpp
     distribute_forall_tactic.cpp
@@ -23,5 +23,24 @@ z3_add_component(core_tactics
   COMPONENT_DEPENDENCIES
     normal_forms
     tactic
+  TACTIC_HEADERS
+    blast_term_ite_tactic.h
+    cofactor_term_ite_tactic.h
+    collect_statistics_tactic.h
+    ctx_simplify_tactic.h
+    der_tactic.h
+    distribute_forall_tactic.h
+    elim_term_ite_tactic.h
+    elim_uncnstr_tactic.h
+    nnf_tactic.h
+    occf_tactic.h
+    pb_preprocess_tactic.h
+    propagate_values_tactic.h
+    reduce_args_tactic.h
+    simplify_tactic.h
+    solve_eqs_tactic.h
+    split_clause_tactic.h
+    symmetry_reduce_tactic.h
+    tseitin_cnf_tactic.h
 )
 

--- a/src/tactic/fpa/CMakeLists.txt
+++ b/src/tactic/fpa/CMakeLists.txt
@@ -11,4 +11,7 @@ z3_add_component(fpa_tactics
     sat_tactic
     smtlogic_tactics
     smt_tactic
+  TACTIC_HEADERS
+    fpa2bv_tactic.h
+    qffp_tactic.h
 )

--- a/src/tactic/nlsat_smt/CMakeLists.txt
+++ b/src/tactic/nlsat_smt/CMakeLists.txt
@@ -4,4 +4,6 @@ z3_add_component(nlsat_smt_tactic
   COMPONENT_DEPENDENCIES
     nlsat_tactic
     smt_tactic
+  TACTIC_HEADERS
+    nl_purify_tactic.h
 )

--- a/src/tactic/portfolio/CMakeLists.txt
+++ b/src/tactic/portfolio/CMakeLists.txt
@@ -16,4 +16,6 @@ z3_add_component(portfolio
     smtlogic_tactics
     subpaving_tactic
     ufbv_tactic
+  TACTIC_HEADERS
+    default_tactic.h
 )

--- a/src/tactic/sls/CMakeLists.txt
+++ b/src/tactic/sls/CMakeLists.txt
@@ -10,4 +10,6 @@ z3_add_component(sls_tactic
     tactic
   PYG_FILES
     sls_params.pyg
+  TACTIC_HEADERS
+    sls_tactic.h
 )

--- a/src/tactic/smtlogics/CMakeLists.txt
+++ b/src/tactic/smtlogics/CMakeLists.txt
@@ -28,4 +28,18 @@ z3_add_component(smtlogic_tactics
     smt_tactic
   PYG_FILES
     qfufbv_tactic_params.pyg
+  TACTIC_HEADERS
+    nra_tactic.h
+    qfaufbv_tactic.h
+    qfauflia_tactic.h
+    qfbv_tactic.h
+    qfidl_tactic.h
+    qflia_tactic.h
+    qflra_tactic.h
+    qfnia_tactic.h
+    qfnra_tactic.h
+    qfuf_tactic.h
+    qfufbv_tactic.h
+    qfufnra_tactic.h
+    quant_tactics.h
 )

--- a/src/tactic/ufbv/CMakeLists.txt
+++ b/src/tactic/ufbv/CMakeLists.txt
@@ -11,4 +11,9 @@ z3_add_component(ufbv_tactic
     normal_forms
     rewriter
     smt_tactic
+  TACTIC_HEADERS
+    macro_finder_tactic.h
+    quasi_macros_tactic.h
+    ufbv_rewriter_tactic.h
+    ufbv_tactic.h
 )

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -59,4 +59,6 @@ z3_add_component(util
     util.cpp
     warning.cpp
     z3_exception.cpp
+  EXTRA_REGISTER_MODULE_HEADERS
+    env_params.h
 )

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -61,4 +61,11 @@ z3_add_component(util
     z3_exception.cpp
   EXTRA_REGISTER_MODULE_HEADERS
     env_params.h
+  MEMORY_INIT_FINALIZER_HEADERS
+    debug.h
+    gparams.h
+    prime_generator.h
+    rational.h
+    symbol.h
+    trace.h
 )


### PR DESCRIPTION
This PR fixes #1030.

This adds new optional arguments to `z3_add_component()` CMake macro

* `TACTIC_HEADERS` - Allows header files that declare tactics to be explicitly listed
* `EXTRA_REGISTER_MODULE_HEADERS` - Allows additional headers that declare module parameters/description to be explicitly listed. Note that all header files that are generated from
`.pyg` files are implicitly scanned too.
* `MEMORY_INIT_FINALIZER_HEADERS` - Allows header files that declare memory
initializers/finalizers to be explicitly listed.

The basic approach is to make the header files that need to be scanned explicit (in most cases)
so that CMake knows that when those headers change or the list of headers to scan changes that the 
`install_tactic.cpp`, `gparams_register_modules.cpp`, or `mem_initializer.cpp` files get automatically rebuilt.

Although this adds a little more maintenance work we get the benefit that incremental builds work correctly (i.e. when I do `$ git pull ; ninja` everything rebuilds correctly).

This PR is labelled WIP because I need to do more testing. So far I have verified on Arch Linux that the
generated `install_tactic.cpp`, `gparams_register_modules.cpp`, or `mem_initializer.cpp` files are identical between what is on Z3's `master` branch (both build systems) and what is in this PR (both build systems).

I want to check everything works fine on Windows and macOS before saying I think this is ready to review/merge.