### PR TITLE
Unbreak Z3 C++ API exception support for GCC < 5.0.

### DIFF
--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -87,7 +87,7 @@ namespace z3 {
     inline std::ostream & operator<<(std::ostream & out, exception const & e) { out << e.msg(); return out; }
 
 #if !defined(Z3_THROW)
-#if __cpp_exceptions || _CPPUNWIND
+#if __cpp_exceptions || _CPPUNWIND || __EXCEPTIONS
 #define Z3_THROW(x) throw x
 #else
 #define Z3_THROW(x) {}
@@ -2796,6 +2796,6 @@ namespace z3 {
 
 /*@}*/
 /*@}*/
-
+#undef Z3_THROW
 #endif
 


### PR DESCRIPTION
Unbreak Z3 C++ API exception support for GCC < 5.0. This was broken
by 0b1d5645097d41eec4c43946407e08d57b41ad64 .

Older versions of GCC do not define `__cpp_exceptions` which caused
exceptions to not be raised leading to unexpected failures. To fix
this also check the `__EXCEPTIONS` macro which is used by older GCC
versions.

Also `#undef` the `Z3_THROW` macro at the end of the header file
because this is an implementation detail that we don't want to leak
to clients.