### PR TITLE
Fix Python API examples

### DIFF
--- a/examples/python/CMakeLists.txt
+++ b/examples/python/CMakeLists.txt
@@ -1,5 +1,11 @@
 set(python_example_files
+  all_interval_series.py
+  complex/complex.py
   example.py
+  hamiltonian/hamiltonian.py
+  mus/marco.py
+  mus/mss.py
+  socrates.py
   visitor.py
 )
 
@@ -10,7 +16,10 @@ foreach (example_file ${python_example_files})
   add_custom_command(OUTPUT "${z3py_bindings_build_dest}/${example_file}"
     COMMAND "${CMAKE_COMMAND}" "-E" "copy"
       "${CMAKE_CURRENT_SOURCE_DIR}/${example_file}"
-      "${z3py_bindings_build_dest}/${example_file}"
+      # We flatten the hierarchy so that all python files have
+      # the `z3` directory in their directory so that their import
+      # statements "just work".
+      "${z3py_bindings_build_dest}/"
     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${example_file}"
     COMMENT "Copying \"${example_file}\" to ${z3py_bindings_build_dest}/${example_file}"
   )

--- a/examples/python/all_interval_series.py
+++ b/examples/python/all_interval_series.py
@@ -4,7 +4,7 @@
 # adjacent entries fall in the range 0,..,n-1
 # This is known as the "The All-Interval Series Problem"
 # See http://www.csplib.org/Problems/prob007/
-
+from __future__ import print_function
 from z3 import *
 import time
 
@@ -56,7 +56,7 @@ def process_model(s, xij, n):
                block += [xij[i][j]]
                k = j
         values += [k]
-    print values
+    print(values)
     sys.stdout.flush()
     return block
 
@@ -68,9 +68,9 @@ def all_models(n):
         block = process_model(s, xij, n)
         s.add(Not(And(block)))
         count += 1
-    print s.statistics()
-    print time.clock() - start
-    print count
+    print(s.statistics())
+    print(time.clock() - start)
+    print(count)
 
 set_option(verbose=1)  
 all_models(12)

--- a/examples/python/complex/complex.py
+++ b/examples/python/complex/complex.py
@@ -6,6 +6,10 @@
 #
 # Author: Leonardo de Moura (leonardo)
 ############################################
+from __future__ import print_function
+import sys
+if sys.version_info.major >= 3:
+    from functools import reduce
 from z3 import *
 
 def _to_complex(a):
@@ -53,7 +57,7 @@ class ComplexExpr:
             return self
         if k < 0:
             return (self ** (-k)).inv()
-        return reduce(lambda x, y: x * y, [self for _ in xrange(k)], ComplexExpr(1, 0))
+        return reduce(lambda x, y: x * y, [self for _ in range(k)], ComplexExpr(1, 0))
 
     def inv(self):
         den = self.r*self.r + self.i*self.i
@@ -62,6 +66,12 @@ class ComplexExpr:
     def __div__(self, other):
         inv_other = _to_complex(other).inv()
         return self.__mul__(inv_other)
+
+    if sys.version_info.major >= 3:
+      # In python 3 the meaning of the '/' operator
+      # was changed.
+      def __truediv__(self, other):
+        return self.__div__(other)
 
     def __rdiv__(self, other):
         other = _to_complex(other)
@@ -113,5 +123,5 @@ print(s.model())
 s.add(x.i != 1)
 print(s.check())
 # print(s.model())
-print ((3 + I) ** 2)/(5 - I)
-print ((3 + I) ** -3)/(5 - I)
+print(((3 + I) ** 2)/(5 - I))
+print(((3 + I) ** -3)/(5 - I))

--- a/examples/python/mus/mss.py
+++ b/examples/python/mus/mss.py
@@ -45,11 +45,6 @@ def enumerate_sets(solver):
         else:
            break
 
-class CompareSetSize():
-   def __call__(self, s1, s2):
-       return len(s1) < len(s2) 
-
-
 class MSSSolver:
    s = Solver()
    varcache = {}
@@ -157,7 +152,7 @@ class MSSSolver:
        mcs = [x for x in self.orig_soft_vars if not is_true(self.model[x])]
        self.s.add(Or(mcs))
        core_literals = set([])
-       cores.sort(CompareSetSize()) 
+       cores.sort(key=lambda element: len(element))
        for core in cores:
            if len(core & core_literals) == 0:
               self.relax_core(core)

--- a/examples/python/visitor.py
+++ b/examples/python/visitor.py
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft Corporation 2015
-
+from __future__ import print_function
 from z3 import *
 
 def visitor(e, seen):
@@ -22,8 +22,8 @@ fml = x + x + y > 2
 seen = {}
 for e in visitor(fml, seen):
     if is_const(e) and e.decl().kind() == Z3_OP_UNINTERPRETED:
-        print "Variable", e
+        print("Variable", e)
     else:
-        print e
+        print(e)
     
 


### PR DESCRIPTION
This PR does two things

* Teaches CMake to copy over some of the Python API examples it wasn't aware of previously
* Fixes the Python API examples so they are compatible with Python 3.