### PR TITLE
Improved theory_arith integration in theory_str::get_arith_value()

### DIFF
--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -4653,30 +4653,23 @@ namespace smt {
     }
 
     bool theory_str::get_arith_value(expr* e, rational& val) const {
-        if (opt_DisableIntegerTheoryIntegration) {
-            TRACE("str", tout << "WARNING: integer theory integration disabled" << std::endl;);
-            return false;
-        }
-
         context& ctx = get_context();
         ast_manager & m = get_manager();
-        theory_mi_arith* tha = get_th_arith(ctx, m_autil.get_family_id(), e);
-        if (!tha) {
+
+        // if an integer constant exists in the eqc, it should be the root
+        enode * en_e = ctx.get_enode(e);
+        enode * root_e = en_e->get_root();
+        if (m_autil.is_numeral(root_e->get_owner(), val) && val.is_int()) {
+            TRACE("str", tout << mk_pp(e, m) << " ~= " << mk_pp(root_e->get_owner(), m) << std::endl;);
+            return true;
+        } else {
+            TRACE("str", tout << "root of eqc of " << mk_pp(e, m) << " is not a numeral" << std::endl;);
             return false;
         }
 
-        // first query theory_arith directly
-
-        expr_ref ival(m);
-        if (ctx.e_internalized(e) && tha->get_value(ctx.get_enode(e), ival)
-                && m_autil.is_numeral(ival, val) && val.is_int()) {
-            TRACE("str", tout << "theory_arith: " << mk_pp(e, m) << " = " << val << std::endl;);
-            return true;
-        }
-
-        // if this fails, fall back to checking eqc
-
-        TRACE("str", tout << "no result in theory_arith! checking eqc of " << mk_pp(e, m) << " for arithmetic value" << std::endl;);
+        // fallback code: iterate over eqc (slow for large cases, e.g. many terms with length 0)
+        /*
+        TRACE("str", tout << "checking eqc of " << mk_pp(e, m) << " for arithmetic value" << std::endl;);
         expr_ref _val(m);
         enode * en_e = ctx.get_enode(e);
         enode * it = en_e;
@@ -4693,6 +4686,7 @@ namespace smt {
         } while (it != en_e);
         TRACE("str", tout << "no arithmetic values found in eqc" << std::endl;);
         return false;
+        */
     }
 
     bool theory_str::lower_bound(expr* _e, rational& lo) {

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -4664,7 +4664,19 @@ namespace smt {
         if (!tha) {
             return false;
         }
-        TRACE("str", tout << "checking eqc of " << mk_pp(e, m) << " for arithmetic value" << std::endl;);
+
+        // first query theory_arith directly
+
+        expr_ref ival(m);
+        if (ctx.e_internalized(e) && tha->get_value(ctx.get_enode(e), ival)
+                && m_autil.is_numeral(ival, val) && val.is_int()) {
+            TRACE("str", tout << "theory_arith: " << mk_pp(e, m) << " = " << val << std::endl;);
+            return true;
+        }
+
+        // if this fails, fall back to checking eqc
+
+        TRACE("str", tout << "no result in theory_arith! checking eqc of " << mk_pp(e, m) << " for arithmetic value" << std::endl;);
         expr_ref _val(m);
         enode * en_e = ctx.get_enode(e);
         enode * it = en_e;

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -4656,6 +4656,11 @@ namespace smt {
         context& ctx = get_context();
         ast_manager & m = get_manager();
 
+	// safety
+	if (!ctx.e_internalized(e)) {
+	  return false;
+	}
+	
         // if an integer constant exists in the eqc, it should be the root
         enode * en_e = ctx.get_enode(e);
         enode * root_e = en_e->get_root();

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -4666,27 +4666,6 @@ namespace smt {
             TRACE("str", tout << "root of eqc of " << mk_pp(e, m) << " is not a numeral" << std::endl;);
             return false;
         }
-
-        // fallback code: iterate over eqc (slow for large cases, e.g. many terms with length 0)
-        /*
-        TRACE("str", tout << "checking eqc of " << mk_pp(e, m) << " for arithmetic value" << std::endl;);
-        expr_ref _val(m);
-        enode * en_e = ctx.get_enode(e);
-        enode * it = en_e;
-        do {
-            if (m_autil.is_numeral(it->get_owner(), val) && val.is_int()) {
-                // found an arithmetic term
-                TRACE("str", tout << mk_pp(it->get_owner(), m) << " is an integer ( ~= " << val << " )"
-                      << std::endl;);
-                return true;
-            } else {
-                TRACE("str", tout << mk_pp(it->get_owner(), m) << " not a numeral" << std::endl;);
-            }
-            it = it->get_next();
-        } while (it != en_e);
-        TRACE("str", tout << "no arithmetic values found in eqc" << std::endl;);
-        return false;
-        */
     }
 
     bool theory_str::lower_bound(expr* _e, rational& lo) {


### PR DESCRIPTION
This is a simple fix for a common case in Z3str3 that performs badly when the equivalence class of arithmetic terms is very large (e.g. a lot of terms having length 0). Instead of iterating over the equivalence class to find an arithmetic constant, we first ask the arithmetic solver directly whether it knows a value for the term; if that fails, we fall back to the eqc approach.