### PR TITLE
[TravisCI] Fix running unit tests.

### DIFF
--- a/contrib/ci/scripts/test_z3_unit_tests_cmake.sh
+++ b/contrib/ci/scripts/test_z3_unit_tests_cmake.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 SCRIPT_DIR="$( cd ${BASH_SOURCE[0]%/*} ; echo $PWD )"
+. ${SCRIPT_DIR}/run_quiet.sh
 
 set -x
 set -e
@@ -21,4 +22,5 @@ cd "${Z3_BUILD_DIR}"
 
 # Build and run internal tests
 cmake --build $(pwd) --target test-z3 "${GENERATOR_ARGS[@]}"
-./test-z3
+# Run all tests that don't require arguments
+run_quiet ./test-z3 /a


### PR DESCRIPTION
Previously the `test-z3` executable was run without arguments which
appears to run no tests. To fix this the `/a` argument is passed
which will run all tests that don't require arguments.

This was noticed in #1159 when @KarenHuang2016 reported a failing
test.