### PR TITLE
[TravisCI] Try to make the LTO build more reliable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,7 @@ env:
 #    - os: osx
 #      osx_image: xcode 8.2
 script:
-  - contrib/ci/scripts/travis_ci_entry_point.sh
+  # Use `travis_wait` to handle commands that don't show output for a long period of time.
+  # Currently this is the LTO build which can be very slow.
+  # Allow at most 45 minutes for the build.
+  - travis_wait 45 contrib/ci/scripts/travis_ci_entry_point.sh


### PR DESCRIPTION
TravisCI kills builds that don't show output for over 10 minutes [1].
This sometimes causes LTO builds to fail because gcc shows no output
during linking which can take many minutes to complete.

To workaround this we use the `travis_wait` command to allow at
most 45 minutes for the build to run. This command will force output
to appear at regular intervals.

The change is made in the top-level `.travis.yml` file rather than
the other scripts because I don't want to pollute them with TravisCI
specific details.

[1] https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received