### PR TITLE
[TravisCI] Temporarily disable the macOS build configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,15 +60,17 @@ env:
     - LINUX_BASE=ubuntu_14.04 C_COMPILER=/usr/bin/gcc-4.8 CXX_COMPILER=/usr/bin/g++-4.8 TARGET_ARCH=x86_64 Z3_BUILD_TYPE=Debug
 
 # macOS (a.k.a OSX) support
-matrix:
-  include:
-    # For now just test a single configuration. macOS builds on TravisCI are
-    # very slow so we should keep the number of configurations we test on this
-    # OS to a minimum.
-    - os: osx
-      osx_image: xcode8.3
-      # Note: Apple Clang does not support OpenMP
-      env: Z3_BUILD_TYPE=RelWithDebInfo USE_OPENMP=0
+# FIXME: macOS support is temporarily disabled due to @wintersteiger 's concerns.
+# See https://github.com/Z3Prover/z3/pull/1207#issuecomment-322200998
+# matrix:
+#   include:
+#     # For now just test a single configuration. macOS builds on TravisCI are
+#     # very slow so we should keep the number of configurations we test on this
+#     # OS to a minimum.
+#     - os: osx
+#       osx_image: xcode8.3
+#       # Note: Apple Clang does not support OpenMP
+#       env: Z3_BUILD_TYPE=RelWithDebInfo USE_OPENMP=0
 script:
   # Use `travis_wait` when doing LTO builds because this configuration will
   # have long link times during which it will not show any output which


### PR DESCRIPTION
@wintersteiger is concerned there might be legal issues using
TravisCI's macOS infrastructure.

For context see:

https://github.com/Z3Prover/z3/pull/1207#issuecomment-322200998