### PR TITLE
Simpler include paths (fixes #534)

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1573,7 +1573,7 @@ def def_APIs(api_files):
 
 def write_log_h_preamble(log_h):
   log_h.write('// Automatically generated file\n')
-  log_h.write('#include\"z3.h\"\n')
+  log_h.write('#include\"api/z3.h\"\n')
   log_h.write('#ifdef __GNUC__\n')
   log_h.write('#define _Z3_UNUSED __attribute__((unused))\n')
   log_h.write('#else\n')
@@ -1592,14 +1592,14 @@ def write_log_h_preamble(log_h):
 def write_log_c_preamble(log_c):
   log_c.write('// Automatically generated file\n')
   log_c.write('#include<iostream>\n')
-  log_c.write('#include\"z3.h\"\n')
-  log_c.write('#include\"api_log_macros.h\"\n')
-  log_c.write('#include\"z3_logger.h\"\n')
+  log_c.write('#include\"api/z3.h\"\n')
+  log_c.write('#include\"api/api_log_macros.h\"\n')
+  log_c.write('#include\"api/z3_logger.h\"\n')
 
 def write_exe_c_preamble(exe_c):
   exe_c.write('// Automatically generated file\n')
-  exe_c.write('#include\"z3.h\"\n')
-  exe_c.write('#include\"z3_replayer.h\"\n')
+  exe_c.write('#include\"api/z3.h\"\n')
+  exe_c.write('#include\"api/z3_replayer.h\"\n')
   #
   exe_c.write('void Z3_replayer_error_handler(Z3_context ctx, Z3_error_code c) { printf("[REPLAYER ERROR HANDLER]: %s\\n", Z3_get_error_msg(ctx, c)); }\n')
 

--- a/src/api/api_algebraic.cpp
+++ b/src/api/api_algebraic.cpp
@@ -18,7 +18,7 @@ Notes:
 
 --*/
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_ast_vector.h"
 #include "math/polynomial/algebraic_numbers.h"

--- a/src/api/api_arith.cpp
+++ b/src/api/api_arith.cpp
@@ -16,7 +16,7 @@ Revision History:
 
 --*/
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_util.h"
 #include "ast/arith_decl_plugin.h"

--- a/src/api/api_array.cpp
+++ b/src/api/api_array.cpp
@@ -16,7 +16,7 @@ Revision History:
 
 --*/
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_util.h"
 #include "ast/array_decl_plugin.h"

--- a/src/api/api_ast.cpp
+++ b/src/api/api_ast.cpp
@@ -16,7 +16,7 @@ Revision History:
 
 --*/
 #include<iostream>
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_util.h"
 #include "ast/well_sorted.h"

--- a/src/api/api_ast_map.cpp
+++ b/src/api/api_ast_map.cpp
@@ -17,7 +17,7 @@ Revision History:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_ast_map.h"
 #include "api/api_ast_vector.h"

--- a/src/api/api_ast_vector.cpp
+++ b/src/api/api_ast_vector.cpp
@@ -17,7 +17,7 @@ Revision History:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_ast_vector.h"
 #include "ast/ast_translation.h"

--- a/src/api/api_bv.cpp
+++ b/src/api/api_bv.cpp
@@ -16,7 +16,7 @@ Revision History:
 
 --*/
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_util.h"
 #include "ast/bv_decl_plugin.h"

--- a/src/api/api_config_params.cpp
+++ b/src/api/api_config_params.cpp
@@ -18,7 +18,7 @@ Revision History:
 #include "api/z3.h"
 #include "api/api_context.h"
 #include "ast/pp.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_util.h"
 #include "cmd_context/cmd_context.h"
 #include "util/symbol.h"

--- a/src/api/api_context.cpp
+++ b/src/api/api_context.cpp
@@ -20,10 +20,10 @@ Revision History:
 #include<typeinfo>
 #include "api/api_context.h"
 #include "parsers/smt/smtparser.h"
-#include"version.h"
+#include "util/version.h"
 #include "ast/ast_pp.h"
 #include "ast/ast_ll_pp.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_util.h"
 #include "ast/reg_decl_plugins.h"
 #include "math/realclosure/realclosure.h"

--- a/src/api/api_datalog.cpp
+++ b/src/api/api_datalog.cpp
@@ -20,7 +20,7 @@ Revision History:
 #include "api/api_util.h"
 #include "ast/ast_pp.h"
 #include "api/api_ast_vector.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_stats.h"
 #include "muz/fp/datalog_parser.h"
 #include "util/cancel_eh.h"

--- a/src/api/api_datatype.cpp
+++ b/src/api/api_datatype.cpp
@@ -16,7 +16,7 @@ Revision History:
 
 --*/
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_util.h"
 #include "ast/datatype_decl_plugin.h"

--- a/src/api/api_fpa.cpp
+++ b/src/api/api_fpa.cpp
@@ -18,7 +18,7 @@ Notes:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "ast/fpa_decl_plugin.h"
 

--- a/src/api/api_goal.cpp
+++ b/src/api/api_goal.cpp
@@ -17,7 +17,7 @@ Revision History:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_goal.h"
 #include "ast/ast_translation.h"

--- a/src/api/api_interp.cpp
+++ b/src/api/api_interp.cpp
@@ -18,7 +18,7 @@
 #include<sstream>
 #include<vector>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_tactic.h"
 #include "api/api_solver.h"

--- a/src/api/api_log.cpp
+++ b/src/api/api_log.cpp
@@ -17,9 +17,9 @@ Revision History:
 --*/
 #include<fstream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "util/util.h"
-#include"version.h"
+#include "util/version.h"
 
 std::ostream * g_z3_log = 0;
 bool g_z3_log_enabled   = false;

--- a/src/api/api_model.cpp
+++ b/src/api/api_model.cpp
@@ -17,7 +17,7 @@ Revision History:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_model.h"
 #include "api/api_ast_vector.h"

--- a/src/api/api_numeral.cpp
+++ b/src/api/api_numeral.cpp
@@ -17,7 +17,7 @@ Revision History:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_util.h"
 #include "ast/arith_decl_plugin.h"

--- a/src/api/api_opt.cpp
+++ b/src/api/api_opt.cpp
@@ -17,7 +17,7 @@ Revision History:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_stats.h"
 #include "api/api_context.h"
 #include "api/api_util.h"

--- a/src/api/api_params.cpp
+++ b/src/api/api_params.cpp
@@ -19,7 +19,7 @@ Revision History:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_util.h"
 #include "util/params.h"

--- a/src/api/api_parsers.cpp
+++ b/src/api/api_parsers.cpp
@@ -17,7 +17,7 @@ Revision History:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_util.h"
 #include "cmd_context/cmd_context.h"

--- a/src/api/api_pb.cpp
+++ b/src/api/api_pb.cpp
@@ -16,7 +16,7 @@ Revision History:
 
 --*/
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_util.h"
 #include "ast/pb_decl_plugin.h"

--- a/src/api/api_polynomial.cpp
+++ b/src/api/api_polynomial.cpp
@@ -17,7 +17,7 @@ Notes:
 
 --*/
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_polynomial.h"
 #include "api/api_ast_vector.h"

--- a/src/api/api_qe.cpp
+++ b/src/api/api_qe.cpp
@@ -19,7 +19,7 @@ Notes:
 
 #include <iostream>
 #include "api/z3.h"
-#include "api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_util.h"
 #include "api/api_model.h"

--- a/src/api/api_quant.cpp
+++ b/src/api/api_quant.cpp
@@ -16,7 +16,7 @@ Revision History:
 
 --*/
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_util.h"
 #include "parsers/util/pattern_validation.h"

--- a/src/api/api_rcf.cpp
+++ b/src/api/api_rcf.cpp
@@ -21,7 +21,7 @@ Notes:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "math/realclosure/realclosure.h"
 

--- a/src/api/api_seq.cpp
+++ b/src/api/api_seq.cpp
@@ -17,7 +17,7 @@ Revision History:
 
 --*/
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_util.h"
 #include "ast/ast_pp.h"

--- a/src/api/api_solver.cpp
+++ b/src/api/api_solver.cpp
@@ -18,7 +18,7 @@ Revision History:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_tactic.h"
 #include "api/api_solver.h"

--- a/src/api/api_stats.cpp
+++ b/src/api/api_stats.cpp
@@ -17,7 +17,7 @@ Revision History:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_stats.h"
 

--- a/src/api/api_tactic.cpp
+++ b/src/api/api_tactic.cpp
@@ -17,7 +17,7 @@ Revision History:
 --*/
 #include<iostream>
 #include "api/z3.h"
-#include"api_log_macros.h"
+#include "api/api_log_macros.h"
 #include "api/api_context.h"
 #include "api/api_tactic.h"
 #include "api/api_model.h"

--- a/src/cmd_context/basic_cmds.cpp
+++ b/src/cmd_context/basic_cmds.cpp
@@ -16,7 +16,7 @@ Notes:
 
 --*/
 #include "cmd_context/cmd_context.h"
-#include"version.h"
+#include "util/version.h"
 #include "ast/ast_smt_pp.h"
 #include "ast/ast_smt2_pp.h"
 #include "ast/ast_pp.h"

--- a/src/duality/duality_wrapper.h
+++ b/src/duality/duality_wrapper.h
@@ -27,7 +27,7 @@
 #include<vector>
 #include<list>
 #include <set>
-#include"version.h"
+#include "util/version.h"
 #include<limits.h>
 
 #include "interp/iz3hash.h"

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -26,7 +26,7 @@ Revision History:
 #include "shell/smtlib_frontend.h"
 #include "shell/z3_log_frontend.h"
 #include "util/warning.h"
-#include"version.h"
+#include "util/version.h"
 #include "shell/dimacs_frontend.h"
 #include "shell/datalog_frontend.h"
 #include "shell/opt_frontend.h"


### PR DESCRIPTION
# DO NOT MERGE UNTIL TESTS PASS

This PR simplifies the remaining includes and then performs a clean up to the CMake build system that we can gain from doing this.

A nice bonus from doing this is compiler invocations are a lot easier to read because now we only pass two include paths to the compiler rather than the directories of the transitive dependencies.
