### PR TITLE
Small regex fixes in theory_str

### DIFF
--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -6189,27 +6189,33 @@ namespace smt {
             expr * arg_str = a->get_arg(0);
             zstring str;
             if (u.str.is_string(arg_str, str)) {
-                TRACE("str", tout << "build NFA for '" << str << "'" << "\n";);
-                /*
-                 * For an n-character string, we make (n-1) intermediate states,
-                 * labelled i_(0) through i_(n-2).
-                 * Then we construct the following transitions:
-                 * start --str[0]--> i_(0) --str[1]--> i_(1) --...--> i_(n-2) --str[n-1]--> final
-                 */
-                unsigned last = start;
-                for (int i = 0; i <= ((int)str.length()) - 2; ++i) {
-                    unsigned i_state = next_id();
-                    make_transition(last, str[i], i_state);
-                    TRACE("str", tout << "string transition " << last << "--" << str[i] << "--> " << i_state << "\n";);
-                    last = i_state;
-                }
-                make_transition(last, str[(str.length() - 1)], end);
-                TRACE("str", tout << "string transition " << last << "--" << str[(str.length() - 1)] << "--> " << end << "\n";);
-            } else {
-                TRACE("str", tout << "invalid string constant in Str2Reg" << std::endl;);
-                m_valid = false;
-                return;
-            }
+                if (str.length() == 0) {
+		  // transitioning on the empty string is handled specially
+		  TRACE("str", tout << "empty string epsilon-move " << start << " --> " << end << std::endl;);
+		  make_epsilon_move(start, end);
+	        } else {
+                  TRACE("str", tout << "build NFA for '" << str << "'" << "\n";);
+                  /*
+                   * For an n-character string, we make (n-1) intermediate states,
+                   * labelled i_(0) through i_(n-2).
+                   * Then we construct the following transitions:
+                   * start --str[0]--> i_(0) --str[1]--> i_(1) --...--> i_(n-2) --str[n-1]--> final
+                   */
+                  unsigned last = start;
+                  for (int i = 0; i <= ((int)str.length()) - 2; ++i) {
+		    unsigned i_state = next_id();
+		    make_transition(last, str[i], i_state);
+		    TRACE("str", tout << "string transition " << last << "--" << str[i] << "--> " << i_state << "\n";);
+		    last = i_state;
+                  }
+                  make_transition(last, str[(str.length() - 1)], end);
+                  TRACE("str", tout << "string transition " << last << "--" << str[(str.length() - 1)] << "--> " << end << "\n";);
+		}
+	    } else { // ! u.str.is_string(arg_str, str)
+              TRACE("str", tout << "invalid string constant in Str2Reg" << std::endl;);
+              m_valid = false;
+              return;
+	    }
         } else if (u.re.is_concat(e)){
             app * a = to_app(e);
             expr * re1 = a->get_arg(0);

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -1685,6 +1685,8 @@ namespace smt {
             u.str.is_string(range1, range1val);
             u.str.is_string(range2, range2val);
             return zstring("[") + range1val + zstring("-") + range2val + zstring("]");
+        } else if (u.re.is_full(a_regex)) {
+            return zstring("(.*)");
         } else {
             TRACE("str", tout << "BUG: unrecognized regex term " << mk_pp(regex, get_manager()) << std::endl;);
             UNREACHABLE(); return zstring("");
@@ -1714,6 +1716,12 @@ namespace smt {
 
         expr_ref str(ex->get_arg(0), m);
         app * regex = to_app(ex->get_arg(1));
+
+        // quick reference for the following code:
+        //  - ex: top-level regex membership term
+        //  - str: string term appearing in ex
+        //  - regex: regex term appearing in ex
+        //  ex ::= (str.in.re str regex)
 
         if (u.re.is_to_re(regex)) {
             expr_ref rxStr(regex->get_arg(0), m);
@@ -1794,6 +1802,9 @@ namespace smt {
             expr_ref finalAxiom(m.mk_iff(ex, rhs), m);
             SASSERT(finalAxiom);
             assert_axiom(finalAxiom);
+        } else if (u.re.is_full(regex)) {
+            // trivially true for any string!
+            assert_axiom(ex);
         } else {
             TRACE("str", tout << "ERROR: unknown regex expression " << mk_pp(regex, m) << "!" << std::endl;);
             NOT_IMPLEMENTED_YET();
@@ -6284,6 +6295,10 @@ namespace smt {
             }
 
             TRACE("str", tout << "range NFA: start = " << start << ", end = " << end << std::endl;);
+        } else if (u.re.is_full(e)) {
+            NOT_IMPLEMENTED_YET();
+            m_valid = false;
+            return;
         } else {
             TRACE("str", tout << "invalid regular expression" << std::endl;);
             m_valid = false;

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -1685,6 +1685,8 @@ namespace smt {
             u.str.is_string(range1, range1val);
             u.str.is_string(range2, range2val);
             return zstring("[") + range1val + zstring("-") + range2val + zstring("]");
+        } else if (u.re.is_full(a_regex)) {
+            return zstring(".");
         } else {
             TRACE("str", tout << "BUG: unrecognized regex term " << mk_pp(regex, get_manager()) << std::endl;);
             UNREACHABLE(); return zstring("");
@@ -1791,6 +1793,13 @@ namespace smt {
                 range_cases.push_back(rhs);
             }
             expr_ref rhs(mk_or(range_cases), m);
+            expr_ref finalAxiom(m.mk_iff(ex, rhs), m);
+            SASSERT(finalAxiom);
+            assert_axiom(finalAxiom);
+        } else if (u.re.is_full(regex)) {
+            // equivalent to regex "." operator, match any one character.
+            // we rewrite to expr IFF len(str) == 1
+            expr_ref rhs(ctx.mk_eq_atom(mk_strlen(str), m_autil.mk_numeral(rational::one(), true)), m);
             expr_ref finalAxiom(m.mk_iff(ex, rhs), m);
             SASSERT(finalAxiom);
             assert_axiom(finalAxiom);
@@ -6190,32 +6199,32 @@ namespace smt {
             zstring str;
             if (u.str.is_string(arg_str, str)) {
                 if (str.length() == 0) {
-		  // transitioning on the empty string is handled specially
-		  TRACE("str", tout << "empty string epsilon-move " << start << " --> " << end << std::endl;);
-		  make_epsilon_move(start, end);
-	        } else {
-                  TRACE("str", tout << "build NFA for '" << str << "'" << "\n";);
-                  /*
-                   * For an n-character string, we make (n-1) intermediate states,
-                   * labelled i_(0) through i_(n-2).
-                   * Then we construct the following transitions:
-                   * start --str[0]--> i_(0) --str[1]--> i_(1) --...--> i_(n-2) --str[n-1]--> final
-                   */
-                  unsigned last = start;
-                  for (int i = 0; i <= ((int)str.length()) - 2; ++i) {
-		    unsigned i_state = next_id();
-		    make_transition(last, str[i], i_state);
-		    TRACE("str", tout << "string transition " << last << "--" << str[i] << "--> " << i_state << "\n";);
-		    last = i_state;
-                  }
-                  make_transition(last, str[(str.length() - 1)], end);
-                  TRACE("str", tout << "string transition " << last << "--" << str[(str.length() - 1)] << "--> " << end << "\n";);
-		}
-	    } else { // ! u.str.is_string(arg_str, str)
-              TRACE("str", tout << "invalid string constant in Str2Reg" << std::endl;);
-              m_valid = false;
-              return;
-	    }
+                    // transitioning on the empty string is handled specially
+                    TRACE("str", tout << "empty string epsilon-move " << start << " --> " << end << std::endl;);
+                    make_epsilon_move(start, end);
+                } else {
+                    TRACE("str", tout << "build NFA for '" << str << "'" << "\n";);
+                    /*
+                     * For an n-character string, we make (n-1) intermediate states,
+                     * labelled i_(0) through i_(n-2).
+                     * Then we construct the following transitions:
+                     * start --str[0]--> i_(0) --str[1]--> i_(1) --...--> i_(n-2) --str[n-1]--> final
+                     */
+                    unsigned last = start;
+                    for (int i = 0; i <= ((int)str.length()) - 2; ++i) {
+                        unsigned i_state = next_id();
+                        make_transition(last, str[i], i_state);
+                        TRACE("str", tout << "string transition " << last << "--" << str[i] << "--> " << i_state << "\n";);
+                        last = i_state;
+                    }
+                    make_transition(last, str[(str.length() - 1)], end);
+                    TRACE("str", tout << "string transition " << last << "--" << str[(str.length() - 1)] << "--> " << end << "\n";);
+                }
+            } else { // ! u.str.is_string(arg_str, str)
+                TRACE("str", tout << "invalid string constant in Str2Reg" << std::endl;);
+                m_valid = false;
+                return;
+            }
         } else if (u.re.is_concat(e)){
             app * a = to_app(e);
             expr * re1 = a->get_arg(0);
@@ -6284,6 +6293,15 @@ namespace smt {
             }
 
             TRACE("str", tout << "range NFA: start = " << start << ", end = " << end << std::endl;);
+        } else if (u.re.is_full(e)) {
+            // equivalent to "transition on each character in the alphabet"
+
+            // TODO this hard-codes something about theory_str's char set here
+
+            for (unsigned i = 1; i <= 255; ++i) {
+                char ch = (char)i;
+                make_transition(start, ch, end);
+            }
         } else {
             TRACE("str", tout << "invalid regular expression" << std::endl;);
             m_valid = false;

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -6297,9 +6297,18 @@ namespace smt {
 
             TRACE("str", tout << "range NFA: start = " << start << ", end = " << end << std::endl;);
         } else if (u.re.is_full(e)) {
-            NOT_IMPLEMENTED_YET();
-            m_valid = false;
-            return;
+            // effectively the same as .* where . can be any single character
+            // start --e--> tmp
+            // tmp --e--> end
+            // tmp --C--> tmp for every character C
+            unsigned tmp = next_id();
+            make_epsilon_move(start, tmp);
+            make_epsilon_move(tmp, end);
+            for (unsigned int i = 0; i < 256; ++i) {
+                char ch = (char)i;
+                make_transition(tmp, ch, tmp);
+            }
+            TRACE("str", tout << "re.all NFA: start = " << start << ", end = " << end << std::endl;);
         } else {
             TRACE("str", tout << "invalid regular expression" << std::endl;);
             m_valid = false;

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -6190,32 +6190,32 @@ namespace smt {
             zstring str;
             if (u.str.is_string(arg_str, str)) {
                 if (str.length() == 0) {
-		  // transitioning on the empty string is handled specially
-		  TRACE("str", tout << "empty string epsilon-move " << start << " --> " << end << std::endl;);
-		  make_epsilon_move(start, end);
-	        } else {
-                  TRACE("str", tout << "build NFA for '" << str << "'" << "\n";);
-                  /*
-                   * For an n-character string, we make (n-1) intermediate states,
-                   * labelled i_(0) through i_(n-2).
-                   * Then we construct the following transitions:
-                   * start --str[0]--> i_(0) --str[1]--> i_(1) --...--> i_(n-2) --str[n-1]--> final
-                   */
-                  unsigned last = start;
-                  for (int i = 0; i <= ((int)str.length()) - 2; ++i) {
-		    unsigned i_state = next_id();
-		    make_transition(last, str[i], i_state);
-		    TRACE("str", tout << "string transition " << last << "--" << str[i] << "--> " << i_state << "\n";);
-		    last = i_state;
-                  }
-                  make_transition(last, str[(str.length() - 1)], end);
-                  TRACE("str", tout << "string transition " << last << "--" << str[(str.length() - 1)] << "--> " << end << "\n";);
-		}
-	    } else { // ! u.str.is_string(arg_str, str)
-              TRACE("str", tout << "invalid string constant in Str2Reg" << std::endl;);
-              m_valid = false;
-              return;
-	    }
+                    // transitioning on the empty string is handled specially
+                    TRACE("str", tout << "empty string epsilon-move " << start << " --> " << end << std::endl;);
+                    make_epsilon_move(start, end);
+                } else {
+                    TRACE("str", tout << "build NFA for '" << str << "'" << "\n";);
+                    /*
+                     * For an n-character string, we make (n-1) intermediate states,
+                     * labelled i_(0) through i_(n-2).
+                     * Then we construct the following transitions:
+                     * start --str[0]--> i_(0) --str[1]--> i_(1) --...--> i_(n-2) --str[n-1]--> final
+                     */
+                    unsigned last = start;
+                    for (int i = 0; i <= ((int)str.length()) - 2; ++i) {
+                        unsigned i_state = next_id();
+                        make_transition(last, str[i], i_state);
+                        TRACE("str", tout << "string transition " << last << "--" << str[i] << "--> " << i_state << "\n";);
+                        last = i_state;
+                    }
+                    make_transition(last, str[(str.length() - 1)], end);
+                    TRACE("str", tout << "string transition " << last << "--" << str[(str.length() - 1)] << "--> " << end << "\n";);
+                }
+            } else { // ! u.str.is_string(arg_str, str)
+                TRACE("str", tout << "invalid string constant in Str2Reg" << std::endl;);
+                m_valid = false;
+                return;
+            }
         } else if (u.re.is_concat(e)){
             app * a = to_app(e);
             expr * re1 = a->get_arg(0);

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -6223,7 +6223,8 @@ namespace smt {
                     TRACE("str", tout << "string transition " << last << "--" << str[(str.length() - 1)] << "--> " << end << "\n";);
                 }
             } else { // ! u.str.is_string(arg_str, str)
-                TRACE("str", tout << "invalid string constant in Str2Reg" << std::endl;);
+                TRACE("str", tout << "WARNING: invalid string constant in str.to.re! Cancelling." << std::endl;);
+                u.get_manager().raise_exception("invalid term in str.to.re, argument must be a string constant");
                 m_valid = false;
                 return;
             }


### PR DESCRIPTION
This fixes three issues with regex support in theory_str:

* Matching against the empty string in `str.to.re` would cause a segfault.
* theory_str now supports `re.all`.
* The error message emitted when encountering an invalid term in `str.to.re` (such as a string variable) has been improved. This addresses some feedback discussed in #871.