### PR TITLE
[Doxygen] Fix function name in docstring

### DIFF
--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -1530,7 +1530,7 @@ extern "C" {
        In contrast to #Z3_mk_context_rc, the life time of Z3_ast objects
        are determined by the scope level of #Z3_solver_push and #Z3_solver_pop.
        In other words, a Z3_ast object remains valid until there is a
-       call to Z3_pop that takes the current scope below the level where
+       call to Z3_solver_pop that takes the current scope below the level where
        the object was created.
 
        Note that all other reference counted objects, including Z3_model,


### PR DESCRIPTION
Minor fix. Amending the changes made in https://github.com/Z3Prover/z3/commit/fe702d7782db990cb90ff2bea390b100fdd65872. See comments on that commit as well