### PR TITLE
Update injectivity tactic

### DIFF
--- a/src/tactic/core/CMakeLists.txt
+++ b/src/tactic/core/CMakeLists.txt
@@ -25,6 +25,8 @@ z3_add_component(core_tactics
     normal_forms
     rewriter
     tactic
+  PYG_FILES
+    injectivity_params.pyg
   TACTIC_HEADERS
     blast_term_ite_tactic.h
     cofactor_term_ite_tactic.h

--- a/src/tactic/core/injectivity_params.pyg
+++ b/src/tactic/core/injectivity_params.pyg
@@ -1,0 +1,8 @@
+# -*- mode: python -*-
+def_module_params('injectivity',
+                  export=True,
+                  description='Preprocessor for reasoning on injective functions.',
+                  params=(
+						('eq', BOOL, 1, 'Push equalities down injective functions (rewrite (= (f x) (f y)) as (= x y)).'),
+						('inv', BOOL, 1, 'Rewrite (g (f x)) as (x) whenever g is a pseudoinverse of f')
+			  ))

--- a/src/tactic/core/injectivity_tactic.cpp
+++ b/src/tactic/core/injectivity_tactic.cpp
@@ -364,18 +364,18 @@ public:
             expr_ref  r_eq(m_manager), r_inv(m_manager);
             proof_ref pr(m_manager);
 
-            if (want_eq)
-                (*m_eq)(curr, r_eq, pr);
-            else
-                r_eq = curr;
-
             if (want_inv)
-                (*m_inv)(r_eq, r_inv, pr);
+                (*m_inv)(curr, r_inv, pr);
             else
-                r_inv = r_eq;
+                r_inv = curr;
+
+            if (want_eq)
+                (*m_eq)(r_inv, r_eq, pr);
+            else
+                r_eq = r_inv;
 
             expr_dependency* dep = m_manager.mk_join(g->dep(i), m_manager.mk_join(m_eq->dep(), m_inv->dep()));
-            g->update(i, r_inv, pr, dep);
+            g->update(i, r_eq, pr, dep);
         }
 
         result.push_back(g.get());

--- a/src/tactic/core/injectivity_tactic.cpp
+++ b/src/tactic/core/injectivity_tactic.cpp
@@ -177,7 +177,6 @@ class injectivity_tactic : public tactic {
                         expr_dependency_ref & core) {
             SASSERT(goal->is_well_sorted());
             mc = 0; pc = 0; core = 0;
-            tactic_report report("injectivity", *goal);
 
             for (unsigned i = 0; i < goal->size(); ++i) {
                 func_decl *f, *g;
@@ -354,6 +353,7 @@ public:
                             proof_converter_ref & pc,
                             expr_dependency_ref & core) {
         fail_if_proof_generation("injectivity", g);
+        tactic_report report("injectivity", *g);
 
         (*m_finder)(g, result, mc, pc, core);
 

--- a/src/tactic/core/injectivity_tactic.h
+++ b/src/tactic/core/injectivity_tactic.h
@@ -23,10 +23,10 @@ Notes:
 class ast_manager;
 class tactic;
 
-tactic * mk_injectivity_tactic(ast_manager & m, params_ref const & p = params_ref());
+tactic * mk_injectivity_tactic(ast_manager & m);
 
 /*
-  ADD_TACTIC("injectivity",  "Identifies and applies injectivity axioms.", "mk_injectivity_tactic(m, p)")
+  ADD_TACTIC("injectivity",  "Identifies and applies injectivity axioms.", "mk_injectivity_tactic(m)")
 */
 
 #endif

--- a/src/tactic/core/injectivity_tactic.h
+++ b/src/tactic/core/injectivity_tactic.h
@@ -23,10 +23,10 @@ Notes:
 class ast_manager;
 class tactic;
 
-tactic * mk_injectivity_tactic(ast_manager & m);
+tactic * mk_injectivity_tactic(ast_manager & m, params_ref const & p);
 
 /*
-  ADD_TACTIC("injectivity",  "Identifies and applies injectivity axioms.", "mk_injectivity_tactic(m)")
+  ADD_TACTIC("injectivity",  "Identifies and applies injectivity axioms.", "mk_injectivity_tactic(m, p)")
 */
 
 #endif


### PR DESCRIPTION
- [x] Add extra rewriter for `(g (f x)) -> (x)`.
- [x] Add parameters controlling which rewriters are called.
- [x] Support UNSAT core generation.

This is a follow-up on #1225.