### PR TITLE
Revert "[TravisCI] Temporarily disable the macOS build configuration."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,17 +60,15 @@ env:
     - LINUX_BASE=ubuntu_14.04 C_COMPILER=/usr/bin/gcc-4.8 CXX_COMPILER=/usr/bin/g++-4.8 TARGET_ARCH=x86_64 Z3_BUILD_TYPE=Debug
 
 # macOS (a.k.a OSX) support
-# FIXME: macOS support is temporarily disabled due to @wintersteiger 's concerns.
-# See https://github.com/Z3Prover/z3/pull/1207#issuecomment-322200998
-# matrix:
-#   include:
-#     # For now just test a single configuration. macOS builds on TravisCI are
-#     # very slow so we should keep the number of configurations we test on this
-#     # OS to a minimum.
-#     - os: osx
-#       osx_image: xcode8.3
-#       # Note: Apple Clang does not support OpenMP
-#       env: Z3_BUILD_TYPE=RelWithDebInfo USE_OPENMP=0
+matrix:
+  include:
+    # For now just test a single configuration. macOS builds on TravisCI are
+    # very slow so we should keep the number of configurations we test on this
+    # OS to a minimum.
+    - os: osx
+      osx_image: xcode8.3
+      # Note: Apple Clang does not support OpenMP
+      env: Z3_BUILD_TYPE=RelWithDebInfo USE_OPENMP=0
 script:
   # Use `travis_wait` when doing LTO builds because this configuration will
   # have long link times during which it will not show any output which


### PR DESCRIPTION
This reverts commit 9dc332ae9d4e1650af47daafe9821bbd8a2edf59.

@wintersteiger is now satisfied that using TravisCI's macOS support
is legal [1].

This fixes #1211

[1] https://github.com/Z3Prover/z3/issues/1211#issuecomment-328535885