### PR TITLE
Fix generation of symbolic automata with no moves but accepting initial state

### DIFF
--- a/src/math/automata/symbolic_automata_def.h
+++ b/src/math/automata/symbolic_automata_def.h
@@ -451,7 +451,15 @@ typename symbolic_automata<T, M>::automaton_t* symbolic_automata<T, M>::mk_produ
         }
     }
     if (mvs1.empty()) {
-        return alloc(automaton_t, m);
+        if (a.is_final_state(a.init()) && b.is_final_state(b.init())) {
+            // special case: automaton has no moves, but the initial state is final on both sides
+            // this results in the automaton which accepts the empty sequence and nothing else
+            final.clear();
+            final.push_back(0);
+            return alloc(automaton_t, m, 0, final, mvs1);
+        } else {
+            return alloc(automaton_t, m);
+        }
     }
     else {
         return alloc(automaton_t, m, 0, final, mvs1);


### PR DESCRIPTION
This fixes a special case of the product automaton construction where both of the input automata `a` and `b` have an accepting initial state but the resulting product automaton has no moves. The expected behaviour is for the product automaton to accept the empty sequence (more specifically, the initial state should also be accepting), since it is in the languages of both of the input automata. However, the existing code bypasses the check done earlier for this case and returns an automaton with no accepting states. This patch re-inserts this logic at the time the product automaton is generated.