### PR TITLE
Fix Python API docs done with `make api_docs`

### DIFF
--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -288,8 +288,21 @@ try:
         # Put z3py at the beginning of the search path to try to avoid picking up
         # an installed copy of Z3py.
         sys.path.insert(0, os.path.dirname(Z3PY_PACKAGE_PATH))
-        pydoc.writedoc('z3')
-        shutil.move('z3.html', os.path.join(OUTPUT_DIRECTORY, 'html', 'z3.html'))
+        for modulename in (
+                'z3',
+                'z3.z3consts',
+                'z3.z3core',
+                'z3.z3num',
+                'z3.z3poly',
+                'z3.z3printer',
+                'z3.z3rcf',
+                'z3.z3types',
+                'z3.z3util',
+                ):
+            pydoc.writedoc(modulename)
+            doc = modulename + '.html'
+            shutil.move(doc, os.path.join(OUTPUT_DIRECTORY, 'html', doc))
+
         print("Generated pydoc Z3Py documentation.")
 
     if ML_ENABLED:

--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -188,7 +188,7 @@ try:
 
     if Z3PY_ENABLED:
         print("Z3Py documentation enabled")
-        doxygen_config_substitutions['PYTHON_API_FILES'] = 'z3.py'
+        doxygen_config_substitutions['PYTHON_API_FILES'] = 'z3*.py'
     else:
         print("Z3Py documentation disabled")
         doxygen_config_substitutions['PYTHON_API_FILES'] = ''


### PR DESCRIPTION
Hi,

I've noticed that `make api_docs` (I'm building with CMake) on current master produces broken html tree with 404 links right on the `index.html` page. The C and C++ parts are okay; not so much for Python. Both pydoc and doxygen/python outputs seemed to be missing from the build directory.

So I fixed this. Please consider pulling; thanks!