### PR TITLE
[ASan] Fix some leaks reported in the small object allocator test

### DIFF
--- a/src/test/small_object_allocator.cpp
+++ b/src/test/small_object_allocator.cpp
@@ -18,8 +18,11 @@ void tst_small_object_allocator() {
     TRACE("small_object_allocator", 
           tout << "p1: " << (void*)p1 << " q1: " << (void*)q1 << " p2: " << (void*)p2 << "\n";);
     soa.deallocate(13,p1);
+    soa.deallocate(14,q1);
+    soa.deallocate(13,p2);
     char * p3 = new (soa) char[13];
     TRACE("small_object_allocator", tout << "p3: " << (void*)p3 << "\n";);
+    soa.deallocate(13,p3);
 
     char * r1 = new (soa) char[1];
     char * r2 = new (soa) char[1];
@@ -36,6 +39,10 @@ void tst_small_object_allocator() {
     r3 = new (soa) char[1];
     TRACE("small_object_allocator", 
           tout << "r1: " << (void*)r1 << " r2: " << (void*)r2 << " r3: " << (void*)r3 << " r4: " << (void*)r4 << "\n";);
+    soa.deallocate(1,r1);
+    soa.deallocate(1,r2);
+    soa.deallocate(1,r3);
+    soa.deallocate(1,r4);
     (void)r1;
     (void)r2;
     (void)r3;


### PR DESCRIPTION
This is related to my work in PR #1289 to enable ASan support in continuous integration.