### PR TITLE
Add example of using Z3's new model construction C API. 

### DIFF
--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -7,6 +7,19 @@
 # the C++ standard library in resulting in a link failure.
 project(Z3_C_EXAMPLE C CXX)
 cmake_minimum_required(VERSION 2.8.12)
+
+# Set C version required to C99
+if ("${CMAKE_VERSION}" VERSION_LESS "3.1")
+  if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR
+      ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 ")
+  endif()
+else()
+  set(CMAKE_C_STANDARD_REQUIRED ON)
+  set(CMAKE_C_STANDARD 99)
+  set(CMAKE_C_EXTENSIONS OFF)
+endif()
+
 find_package(Z3
   REQUIRED
   CONFIG


### PR DESCRIPTION
This API was requested in #1223.

This example uses the new `Z3_mk_model()`, `Z3_add_const_interp()`
, `Z3_add_func_interp()`, and `Z3_mk_as_array()` API calls.