### PR TITLE
[DO NOT MERGE][CMake] .NET signing and resource linking

### DIFF
--- a/README-CMake.md
+++ b/README-CMake.md
@@ -253,6 +253,7 @@ The following useful options can be passed to CMake whilst configuring.
 * ``INSTALL_DOTNET_BINDINGS`` - BOOL. If set to ``TRUE`` and ``BUILD_DOTNET_BINDINGS`` is ``TRUE`` then running the ``install`` target will install Z3's .NET bindings.
 * ``DOTNET_CSC_EXECUTABLE`` - STRING. The path to the C# compiler to use. Only relevant if ``BUILD_DOTNET_BINDINGS`` is set to ``TRUE``.
 * ``DOTNET_GACUTIL_EXECUTABLE`` - STRING. The path to the gacutil program to use. Only relevant if ``BUILD_DOTNET_BINDINGS`` is set to ``TRUE``.
+* ``DOTNET_BINDINGS_SNK`` - STRING. The path to the SN (strong name) key file used to sign the .NET bindings. Only relevant if ``BUILD_DOTNET_BINDINGS`` is set to ``TRUE``.
 * ``BUILD_JAVA_BINDINGS`` - BOOL. If set to ``TRUE`` then Z3's Java bindings will be built.
 * ``INSTALL_JAVA_BINDINGS`` - BOOL. If set to ``TRUE`` and ``BUILD_JAVA_BINDINGS`` is ``TRUE`` then running the ``install`` target will install Z3's Java bindings.
 * ``Z3_JAVA_JAR_INSTALLDIR`` - STRING. The path to directory to install the Z3 Java ``.jar`` file. This path should be relative to ``CMAKE_INSTALL_PREFIX``.

--- a/src/api/dotnet/CMakeLists.txt
+++ b/src/api/dotnet/CMakeLists.txt
@@ -138,8 +138,29 @@ foreach (csfile_path ${Z3_DOTNET_ASSEMBLY_SOURCES})
   list(APPEND Z3_DOTNET_ASSEMBLY_SOURCES_NATIVE_PATH "${csfile_path_native}")
 endforeach()
 
+set(DOTNET_BINDINGS_SNK
+  "${CMAKE_CURRENT_SOURCE_DIR}/Microsoft.Z3.snk"
+  CACHE
+  FILEPATH
+  "Path to SN key file. Empty value causes signing to be skipped"
+)
+
 set(CSC_FLAGS "")
+
+if (NOT EXISTS "${DOTNET_BINDINGS_SNK}")
+  message(FATAL_ERROR "DOTNET_BINDINGS_SNK (\"${DOTNET_BINDINGS_SNK}\") does not exist")
+endif()
+file(TO_NATIVE_PATH "${DOTNET_BINDINGS_SNK}" DOTNET_BINDINGS_SNK_NATIVE)
+# On Mono platforms we need to give the assembly a strong name so that it
+# can installed into the GAC.
+list(APPEND CSC_FLAGS
+  "/keyfile:${DOTNET_BINDINGS_SNK_NATIVE}"
+)
+message(STATUS "Using SN key \"${DOTNET_BINDINGS_SNK_NATIVE}\" for .NET bindings")
+
+
 if (DOTNET_TOOLCHAIN_IS_WINDOWS)
+  message(STATUS "Adding csc flags for .NET toolchain on Windows")
   # FIXME: Why use these flags?
   # Note these flags have been copied from the Python build system.
   list(APPEND CSC_FLAGS
@@ -153,11 +174,7 @@ if (DOTNET_TOOLCHAIN_IS_WINDOWS)
   # just don't set the flag for now.
   #list(APPEND CSC_FLAGS "/linkresource:$<TARGET_FILE_NAME:libz3>")
 elseif (DOTNET_TOOLCHAIN_IS_MONO)
-  # We need to give the assembly a strong name so that it can be installed
-  # into the GAC.
-  list(APPEND CSC_FLAGS
-    "/keyfile:${CMAKE_CURRENT_SOURCE_DIR}/Microsoft.Z3.snk"
-  )
+  message(STATUS "Adding csc flags for mono .NET toolchain")
 else()
   message(FATAL_ERROR "Unknown .NET toolchain")
 endif()

--- a/src/api/dotnet/CMakeLists.txt
+++ b/src/api/dotnet/CMakeLists.txt
@@ -172,7 +172,14 @@ if (DOTNET_TOOLCHAIN_IS_WINDOWS)
   # the directory containing the ``libz3`` target. I can't get this to work
   # correctly with multi-configuration generators (i.e. Visual Studio) so
   # just don't set the flag for now.
-  #list(APPEND CSC_FLAGS "/linkresource:$<TARGET_FILE_NAME:libz3>")
+  if (DEFINED CMAKE_CONFIGURATION_TYPES)
+    # Multi-configuration build
+    message(WARNING "Passing \"/linkresource:\" flag is not supported"
+      " when doing multi-configuration builds. The .NET bindings will
+      not have z3.dll as a linked resource")
+  else()
+    list(APPEND CSC_FLAGS "/linkresource:$<TARGET_FILE_NAME:libz3>")
+  endif()
 elseif (DOTNET_TOOLCHAIN_IS_MONO)
   message(STATUS "Adding csc flags for mono .NET toolchain")
 else()


### PR DESCRIPTION
@wintersteiger This implements

* An option  (`DOTNET_BINDINGS_SNK`) to specify the SN key file used to sign the .NET assembly
* Passing the `/linkresource` flag on Windows when using a single configuration generation (e.g. `make`, `ninja`)

Although these changes won't cause any problems for Mono (Linux/macOS) I don't know about Windows. I unfortunately no longer have access to a Windows test machine so I can't this change. Windows CI also isn't set up (AppVeyor set up looks broken and also isn't using CMake).

Given that you asked for these changes could you check that the .NET bindings and built as you would expect?