### PR TITLE
[CMake] When invoking `mk_api_doc.py` pass the build directory.

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -59,6 +59,7 @@ endif()
 add_custom_target(api_docs ${ALWAYS_BUILD_DOCS_ARG}
   COMMAND
   "${PYTHON_EXECUTABLE}" "${MK_API_DOC_SCRIPT}"
+  --build "${CMAKE_BINARY_DIR}"
   --doxygen-executable "${DOXYGEN_EXECUTABLE}"
   --output-dir "${DOC_DEST_DIR}"
   --temp-dir "${DOC_TEMP_DIR}"


### PR DESCRIPTION
[CMake] When invoking `mk_api_doc.py` pass the build directory.

This change was requested by @wintersteiger as an alternative way
to unbreak the TravisCI builds.