### PR TITLE
fixes compilation flags for OCaml plugins

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -1990,7 +1990,7 @@ class MLComponent(Component):
             out.write('%s.cmxa: %s %s %s %s.cma\n' % (z3mls, cmxs, stubso, z3dllso, z3mls))
             out.write('\t%s -o %s -I %s %s %s %s\n' % (OCAMLMKLIB, z3mls, self.sub_dir, stubso, cmxs, LIBZ3))
             out.write('%s.cmxs: %s.cmxa\n' % (z3mls, z3mls))
-            out.write('\t%s -shared -o %s.cmxs -I %s %s.cmxa\n' % (OCAMLOPTF, z3mls, self.sub_dir, z3mls))
+            out.write('\t%s -linkall -shared -o %s.cmxs -I %s %s.cmxa\n' % (OCAMLOPTF, z3mls, self.sub_dir, z3mls))
 
             out.write('\n')
             out.write('ml: %s.cma %s.cmxa %s.cmxs\n' % (z3mls, z3mls, z3mls))


### PR DESCRIPTION
The `-linkall` option is needed for a plugin to be standalone, otherwise it will miss those dependencies that are not used. Thus, without this option, the generated `cmxs` file is unusable (i.e., it can't be used to load the z3ml in runtime, since it misses `z3.cmx` module). 