### PR TITLE
[CMake] Fix #1437

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,46 @@ list(APPEND Z3_COMPONENT_EXTRA_INCLUDE_DIRS
   "${CMAKE_BINARY_DIR}/src"
   "${CMAKE_SOURCE_DIR}/src"
 )
+
+################################################################################
+# Linux specific configuration
+################################################################################
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+  # Try to detect if it is necessary to link against librt.
+  # Note that glibc < 2.17 required librt to be linked to use clock_gettime()
+  # and friends.
+  set(CLOCK_GETTIME_REQUIRES_LIBRT_TEST_CODE
+    "
+    #include <time.h>
+    int main() {
+      timespec res;
+      int result = clock_gettime(CLOCK_REALTIME, &res);
+      return result == 0;
+    }
+    "
+  )
+  check_cxx_source_compiles(
+    "${CLOCK_GETTIME_REQUIRES_LIBRT_TEST_CODE}"
+    CLOCK_GETTIME_NO_REQUIRE_LIBRT
+  )
+  if (NOT CLOCK_GETTIME_NO_REQUIRE_LIBRT)
+    # Try again with librt
+    message(STATUS "Failed to link against clock_gettime(), trying with librt")
+    set(CMAKE_REQUIRED_LIBRARIES_OLD "${CMAKE_REQUIRED_LIBRARIES}")
+    set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES} rt")
+    check_cxx_source_compiles(
+      "${CLOCK_GETTIME_REQUIRES_LIBRT_TEST_CODE}"
+      CLOCK_GETTIME_REQUIRES_LIBRT
+    )
+    set(CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES_OLD}")
+    if (CLOCK_GETTIME_REQUIRES_LIBRT)
+      list(APPEND Z3_DEPENDENT_LIBS "rt")
+    else()
+      message(FATAL_ERROR "Failed to link against clock_gettime()")
+    endif()
+  endif()
+endif()
+
 ################################################################################
 # GNU multiple precision library support
 ################################################################################


### PR DESCRIPTION
The `clock_gettime()` function in glibc < 2.17 required linking against
librt. Until #1437 nobody had tried using the CMake build system with
a really old version of glibc (in this case 2.12).

The python build system always linked against librt but the CMake build
system never tried to link against it leading to link failures.

This patch teaches the CMake build system to detect if librt is required
when linking against `clock_gettime()` and adds `rt` as a link
dependency if necessary.