### PR TITLE
Fix encoding error

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -889,7 +889,7 @@ def is_CXX_gpp():
     return is_compiler(CXX, 'g++')
 
 def is_clang_in_gpp_form(cc):
-    version_string = check_output([cc, '--version']).encode('utf-8').decode('utf-8')
+    version_string = check_output([cc, '--version'])
     return version_string.find('clang') != -1
 
 def is_CXX_clangpp():


### PR DESCRIPTION
The encode/decode is not needed and fails if any non-ASCII character is returned by g++ or clang++
#1461 