### PR TITLE
Revert "Fix encoding error"

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -889,7 +889,7 @@ def is_CXX_gpp():
     return is_compiler(CXX, 'g++')
 
 def is_clang_in_gpp_form(cc):
-    version_string = check_output([cc, '--version'])
+    version_string = check_output([cc, '--version']).encode('utf-8').decode('utf-8')
     return version_string.find('clang') != -1
 
 def is_CXX_clangpp():


### PR DESCRIPTION
Reverts Z3Prover/z3#1462

Revert Python encode/decode unicode fix to restore the mostly-working previous solution.