### PR TITLE
Insert sort declaration for nullary sorts declared using declare-datatype

### DIFF
--- a/src/parsers/smt2/smt2parser.cpp
+++ b/src/parsers/smt2/smt2parser.cpp
@@ -970,6 +970,9 @@ namespace smt2 {
                 check_rparen_next("invalid datatype declaration, ')' expected");
             }
             else {
+                if (dt_name) {
+                    m_ctx.insert(pm().mk_psort_dt_decl(0, *dt_name));
+                }
                 parse_constructor_decls(ct_decls);
             }
             check_rparen_next("invalid datatype declaration, ')' expected");


### PR DESCRIPTION
Given the following SMT
```smt2
(declare-datatype IList ((Nil) (Cons (head Int) (tail IList))))
(declare-fun Concat (IList IList IList) Bool)
```
Z3 throws the error
```
(error "line 4 column 21: Parsing function declaration. Expecting sort list '(': unknown sort 'IList'")
```

However, according to the SMT-Lib 2.6 standard, this should be equivalent to
```smt2
(declare-datatypes ((IList 0)) (((Nil) (Cons (head Int) (tail IList)))))
(declare-fun Concat (IList IList IList) Bool)
```
which works just fine.

Afaict the problem is that for nullary sorts, Z3 does not currently generate and insert the sort declaration (if you take a look at the code snippet above this patch you can see how it’s being inserted for sorts declared with `par`).

I am not at all familiar with the codebase so my fix might be wrong but it does at least seem to fix the examples shown above.