### PR TITLE
Convert BVULT(X,Y) into !BVULE(Y,X)

### DIFF
--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -25,7 +25,7 @@ Notes:
 #include "ast/fpa/fpa2bv_converter.h"
 #include "ast/rewriter/fpa_rewriter.h"
 
-#define BVULT(X,Y,R) { expr_ref bvult_eq(m), bvult_not(m); m_simp.mk_eq(X, Y, bvult_eq); m_simp.mk_not(bvult_eq, bvult_not); expr_ref t(m); t = m_bv_util.mk_ule(X,Y); m_simp.mk_and(t, bvult_not, R); }
+#define BVULT(X,Y,R) { expr_ref t(m); t = m_bv_util.mk_ule(Y,X); m_simp.mk_not(t, R); }
 
 fpa2bv_converter::fpa2bv_converter(ast_manager & m) :
     m(m),


### PR DESCRIPTION
Just a small change in the fpa2bv converter, the macro BVULT(X,Y,R) was:

BVULT(X,Y,R) := !(X == Y) && (X <= Y)

so I changed it into:

BVULT(X,Y,R) := !(Y <= X)

which generates a smaller number of variables/clauses.

Signed-off-by: Mikhail Ramalho <mikhail.ramalho@gmail.com>