### PR TITLE
Fix assignment of family ids

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -1532,6 +1532,17 @@ void ast_manager::copy_families_plugins(ast_manager const & from) {
               tout << "fid: " << fid << " fidname: " << get_family_name(fid) << "\n";
           });
     ast_translation trans(const_cast<ast_manager&>(from), *this, false);
+    // Inheriting plugins can create new family ids. Since new family ids are
+    // assigned in the order that they are created, this can result in differing
+    // family ids. To avoid this, we first assign all family ids and only then inherit plugins.
+    for (family_id fid = 0; from.m_family_manager.has_family(fid); fid++) {
+      symbol fid_name   = from.get_family_name(fid);
+      if (!m_family_manager.has_family(fid)) {
+          family_id new_fid = mk_family_id(fid_name);
+          (void)new_fid;
+          TRACE("copy_families_plugins", tout << "new target fid created: " << new_fid << " fid_name: " << fid_name << "\n";);
+      }
+    }
     for (family_id fid = 0; from.m_family_manager.has_family(fid); fid++) {
       SASSERT(from.is_builtin_family_id(fid) == is_builtin_family_id(fid));
       SASSERT(!from.is_builtin_family_id(fid) || m_family_manager.has_family(fid));
@@ -1539,11 +1550,6 @@ void ast_manager::copy_families_plugins(ast_manager const & from) {
       TRACE("copy_families_plugins", tout << "copying: " << fid_name << ", src fid: " << fid
             << ", target has_family: " << m_family_manager.has_family(fid) << "\n";
             if (m_family_manager.has_family(fid)) tout << get_family_id(fid_name) << "\n";);
-      if (!m_family_manager.has_family(fid)) {
-          family_id new_fid = mk_family_id(fid_name);
-          (void)new_fid;
-          TRACE("copy_families_plugins", tout << "new target fid created: " << new_fid << " fid_name: " << fid_name << "\n";);
-      }
       TRACE("copy_families_plugins", tout << "target fid: " << get_family_id(fid_name) << "\n";);
       SASSERT(fid == get_family_id(fid_name));
       if (from.has_plugin(fid) && !has_plugin(fid)) {


### PR DESCRIPTION
https://gist.github.com/cocreature/1bd8f696918e395269e8862cc155a29f produces an assertion failure in https://github.com/Z3Prover/z3/blob/41e0a1267854ef698908a1d025989108ad648c05/src/ast/ast.cpp#L1548.

After stepping through the code I figured out what’s going wrong:
Inheriting the `datatype` plugin with `fid` 6 ends up creating a family id for `array`. The next free id at this point is `7` so this is the one that gets assigned to `array`. However `from` already has an assignment for `7` to `bv`. So in the next iteration the assertion fails. Here’s a backtrace for the creation of the family id for `array`:
```
#0  family_manager::mk_family_id (this=0x7fffffffc060, s=...) at ../src/ast/ast.cpp:150
#1  0x0000555555a2a91a in ast_manager::mk_family_id (this=0x7fffffffbe28, s=...) at ../src/ast/ast.h:1534
#2  0x0000555555a2a961 in ast_manager::mk_family_id (this=0x7fffffffbe28, s=0x555556aaf206 "array") at ../src/ast/ast.h:1535
#3  0x0000555555a30124 in array_util::array_util (this=0x7fffffffb710, m=...) at ../src/ast/array_decl_plugin.cpp:568
#4  0x0000555555a8d5cd in datatype::util::get_sort_size (this=0x5555574210a8, params=..., s=0x555557421738) at ../src/ast/datatype_decl_plugin.cpp:599
#5  0x0000555555a8dd84 in datatype::util::compute_datatype_size_functions (this=0x5555574210a8, names=...) at ../src/ast/datatype_decl_plugin.cpp:673
#6  0x0000555555a8a276 in datatype::decl::plugin::inherit (this=0x555557420f48, other_p=0x55555727a748, tr=...) at ../src/ast/datatype_decl_plugin.cpp:187
#7  0x0000555555a3b3d8 in ast_manager::copy_families_plugins (this=0x7fffffffbe28, from=...) at ../src/ast/ast.cpp:1556
```

The workaround I came up with consists of simply creating all family ids first so when we inherit the family id for `array` has already been assigned. This fixes the assertion failure in the example.