### PR TITLE
Make z3py datatype recognizers export correctly in sexpr()

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -4451,7 +4451,7 @@ class Datatype:
         if __debug__:
             _z3_assert(isinstance(name, str), "String expected")
             _z3_assert(name != "", "Constructor name cannot be empty")
-        return self.declare_core(name, "is_" + name, *args)
+        return self.declare_core(name, "is-" + name, *args)
 
     def __repr__(self):
         return "Datatype(%s, %s)" % (self.name, self.constructors)
@@ -4575,7 +4575,7 @@ def CreateDatatypes(*ds):
                 cref = cref()
             setattr(dref, cref_name, cref)
             rref  = dref.recognizer(j)
-            setattr(dref, rref.name(), rref)
+            setattr(dref, rref.name().replace('-', '_', 1), rref)
             for k in range(cref_arity):
                 aref = dref.accessor(j, k)
                 setattr(dref, aref.name(), aref)


### PR DESCRIPTION
Love z3. Thanks!
I noticed an issue with solver.sexpr() not properly exporting algebraic datatype recognizers from the python API. (they get exported with the python-style "is_" prefix rather than "is-", which the command-line z3 binary rejects) I was able to fix it with the following change, but perhaps you have some more principled approach you'd prefer to take :)
