### PR TITLE
Fix parameter expansion when configuring Z3

### DIFF
--- a/configure
+++ b/configure
@@ -14,4 +14,4 @@ if ! $PYTHON -c "print('testing')" > /dev/null ; then
    exit 1
 fi
 
-$PYTHON scripts/mk_make.py $*
+$PYTHON scripts/mk_make.py "$@"


### PR DESCRIPTION
This patch notably makes it safer to use parameters containing spaces when configuring Z3.

Originally from David Holland from the NetBSD Foundation for pkgsrc.