### PR TITLE
Fix #1540 Remove extraneous function

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -368,9 +368,6 @@ class AstRef(Z3PPObject):
     def __copy__(self):
         return self.translate(self.ctx)
 
-    def __deepcopy__(self):
-        return self.translate(self.ctx)
-
     def hash(self):
         """Return a hashcode for the `self`.
 


### PR DESCRIPTION
Remove extra __deepcopy__ function definition that shadows working implementation.