### PR TITLE
Fix buffering issue in print_success for declare-datatype

### DIFF
--- a/src/parsers/smt2/smt2parser.cpp
+++ b/src/parsers/smt2/smt2parser.cpp
@@ -949,8 +949,9 @@ namespace smt2 {
             check_duplicate(d, line, pos);
 
             d->commit(pm());
-            check_rparen_next("invalid end of datatype declaration, ')' expected");
+            check_rparen("invalid end of datatype declaration, ')' expected");
             m_ctx.print_success();
+            next();
         }
 
 


### PR DESCRIPTION
Without this patch, the success message seems to get buffered after `declare-datatype` and is only printed after the next command. This does not happen for `declare-datatypes` only for `declare-datatype`. I am not entirely sure what is going on here but adjusting the check for the final rparen to match the one in `parse_declare_datatypes` (which also doesn’t use `check_rparen_next`) seems to fix the buffering problem and causes `success` to be printed immediately.