### PR TITLE
improve performance of occurs check for datatypes

### DIFF
--- a/src/smt/smt_enode.h
+++ b/src/smt/smt_enode.h
@@ -171,6 +171,9 @@ namespace smt {
             m_interpreted = true;
         }
 
+        inline bool equal(const enode & other) const {
+            return m_owner == other.m_owner;
+        }
 
         void del_eh(ast_manager & m, bool update_children_parent = true);
         
@@ -422,6 +425,10 @@ namespace smt {
     };
 
 };
+
+inline bool operator==(const smt::enode & e1, const smt::enode & e2) {
+    return e1.equal(e2);
+}
 
 #endif /* SMT_ENODE_H_ */
 

--- a/src/smt/smt_enode.h
+++ b/src/smt/smt_enode.h
@@ -171,9 +171,6 @@ namespace smt {
             m_interpreted = true;
         }
 
-        inline bool equal(const enode & other) const {
-            return m_owner == other.m_owner;
-        }
 
         void del_eh(ast_manager & m, bool update_children_parent = true);
         
@@ -425,10 +422,6 @@ namespace smt {
     };
 
 };
-
-inline bool operator==(const smt::enode & e1, const smt::enode & e2) {
-    return e1.equal(e2);
-}
 
 #endif /* SMT_ENODE_H_ */
 

--- a/src/smt/smt_types.h
+++ b/src/smt/smt_types.h
@@ -47,7 +47,6 @@ namespace smt {
     typedef ptr_vector<enode> enode_vector;
     typedef std::pair<enode *, enode *> enode_pair;
     typedef svector<enode_pair> enode_pair_vector;
-    typedef ptr_hashtable<enode, obj_ptr_hash<enode>, deref_eq<enode> > enode_tbl;
 
     class context;
 

--- a/src/smt/smt_types.h
+++ b/src/smt/smt_types.h
@@ -21,6 +21,7 @@ Revision History:
 
 #include "util/list.h"
 #include "util/vector.h"
+#include "util/hashtable.h"
 #include "util/lbool.h"
 
 class model;
@@ -46,6 +47,7 @@ namespace smt {
     typedef ptr_vector<enode> enode_vector;
     typedef std::pair<enode *, enode *> enode_pair;
     typedef svector<enode_pair> enode_pair_vector;
+    typedef ptr_hashtable<enode, obj_ptr_hash<enode>, deref_eq<enode> > enode_tbl;
 
     class context;
 

--- a/src/smt/theory_datatype.cpp
+++ b/src/smt/theory_datatype.cpp
@@ -412,7 +412,7 @@ namespace smt {
     }
 
     // explain the cycle root -> … -> app -> root
-    void theory_datatype::occurs_check_explain(enode * app, enode * const root) {
+    void theory_datatype::occurs_check_explain(enode * app, enode * root) {
         TRACE("datatype", tout << "occurs_check_explain " << mk_bounded_pp(app->get_owner(), get_manager()) << " <-> " << mk_bounded_pp(root->get_owner(), get_manager()) << "\n";);
         enode* app_parent = nullptr;
 
@@ -424,8 +424,7 @@ namespace smt {
             SASSERT(d->m_constructor);
             if (app != d->m_constructor)
                 m_used_eqs.push_back(enode_pair(app, d->m_constructor));
-            bool found = m_parent.find(app->get_root(), app_parent);
-            SASSERT(found);
+            app_parent = m_parent[app->get_root()];
             app = app_parent;
         }
 

--- a/src/smt/theory_datatype.cpp
+++ b/src/smt/theory_datatype.cpp
@@ -452,7 +452,7 @@ namespace smt {
 
         SASSERT(app->get_root() == root->get_root());
         if (app != root)
-          m_used_eqs.push_back(enode_pair(app, root));
+            m_used_eqs.push_back(enode_pair(app, root));
     }
 
     // start exploring subgraph below `app`
@@ -511,7 +511,7 @@ namespace smt {
 
             switch (op) {
             case ENTER:
-              res = occurs_check_enter(app) || res;
+              res = occurs_check_enter(app);
               break;
 
             case EXIT:

--- a/src/smt/theory_datatype.cpp
+++ b/src/smt/theory_datatype.cpp
@@ -463,7 +463,7 @@ namespace smt {
             if (d->m_constructor) {
                 for (enode * arg : enode::args(d->m_constructor)) {
                     if (oc_cycle_free(arg)) {
-                        return false;
+                        continue;
                     }
                     if (oc_on_stack(arg)) {
                         // arg was explored before app, and is still on the stack: cycle

--- a/src/smt/theory_datatype.cpp
+++ b/src/smt/theory_datatype.cpp
@@ -429,9 +429,7 @@ namespace smt {
         // first: explain that root=v, given that app=cstor(…,v,…)
         {
             enode * app_cstor = oc_get_cstor(app);
-            unsigned n_args_app = app_cstor->get_num_args();
-            for (unsigned i=0; i < n_args_app; ++i) {
-                enode * arg = app_cstor->get_arg(i);
+            for (enode * arg : enode::args(app_cstor)) {
                 // found an argument which is equal to root
                 if (arg->get_root() == root->get_root()) {
                     if (arg != root)
@@ -463,9 +461,7 @@ namespace smt {
             v = m_find.find(v);
             var_data * d = m_var_data[v];
             if (d->m_constructor) {
-                unsigned num_args = d->m_constructor->get_num_args();
-                for (unsigned i = 0; i < num_args; i++) {
-                    enode * arg = d->m_constructor->get_arg(i);
+                for (enode * arg : enode::args(d->m_constructor)) {
                     if (oc_cycle_free(arg)) {
                         return false;
                     }

--- a/src/smt/theory_datatype.cpp
+++ b/src/smt/theory_datatype.cpp
@@ -393,7 +393,7 @@ namespace smt {
         for (int v = 0; v < num_vars; v++) {
             if (v == static_cast<int>(m_find.find(v))) {
                 enode * node = get_enode(v);
-                if (occurs_check(node)) {
+                if (!oc_cycle_free(node) && occurs_check(node)) {
                     // conflict was detected... 
                     // return...
                     return FC_CONTINUE;

--- a/src/smt/theory_datatype.cpp
+++ b/src/smt/theory_datatype.cpp
@@ -424,7 +424,7 @@ namespace smt {
             SASSERT(d->m_constructor);
             if (app != d->m_constructor)
                 m_used_eqs.push_back(enode_pair(app, d->m_constructor));
-            bool found = m_parent.find(app, app_parent);
+            bool found = m_parent.find(app->get_root(), app_parent);
             SASSERT(found);
             app = app_parent;
         }
@@ -455,7 +455,7 @@ namespace smt {
                     }
                     // explore `arg` (with parent `app`)
                     if (m_util.is_datatype(get_manager().get_sort(arg->get_owner()))) {
-                        m_parent.insert(arg, app);
+                        m_parent.insert(arg->get_root(), app);
                         oc_push_stack(arg);
                     }
                 }

--- a/src/smt/theory_datatype.h
+++ b/src/smt/theory_datatype.h
@@ -104,8 +104,8 @@ namespace smt {
             theory_datatype * th;
             public:
             final_check_st(theory_datatype * th) : th(th) {
-                th->m_to_unmark.reset();
-                th->m_to_unmark2.reset();
+                SASSERT(th->m_to_unmark.empty());
+                SASSERT(th->m_to_unmark2.empty());
                 th->m_used_eqs.reset();
                 th->m_stack.reset();
                 th->m_parent.reset();

--- a/src/smt/theory_datatype.h
+++ b/src/smt/theory_datatype.h
@@ -74,8 +74,24 @@ namespace smt {
         void sign_recognizer_conflict(enode * c, enode * r);
 
         ptr_vector<enode>    m_to_unmark;
+        ptr_vector<enode>    m_to_unmark2;
         enode_pair_vector    m_used_eqs;
         enode *              m_main;
+
+        void oc_mark_explore(enode * n) { n->set_mark(); m_to_unmark.push_back(n); }
+        bool oc_explored(enode * n) const { n->is_marked(); }
+
+        void oc_mark_cycle_free(enode * n) { n->set_mark2(); m_to_unmark2.push_back(n); }
+        bool oc_cycle_free(enode * n) const { n->is_marked2(); }
+
+        void init_final_check() {
+          m_to_unmark2.reset();
+        }
+        void cleanup_final_check() {
+          unmark_enodes2(m_to_unmark2.size(), m_to_unmark2.c_ptr());
+          m_to_unmark2.reset();
+        }
+
         bool occurs_check(enode * n);
         bool occurs_check_core(enode * n);
 

--- a/src/smt/theory_datatype.h
+++ b/src/smt/theory_datatype.h
@@ -121,6 +121,7 @@ namespace smt {
             }
         };
 
+        enode * oc_get_cstor(enode * n);
         bool occurs_check(enode * n);
         bool occurs_check_enter(enode * n);
         void occurs_check_explain(enode * top, enode * root);

--- a/src/smt/theory_datatype.h
+++ b/src/smt/theory_datatype.h
@@ -26,7 +26,6 @@ Revision History:
 #include "smt/proto_model/datatype_factory.h"
 
 namespace smt {
-    
     class theory_datatype : public theory {
         typedef trail_stack<theory_datatype> th_trail_stack;
         typedef union_find<theory_datatype>  th_union_find;
@@ -73,27 +72,57 @@ namespace smt {
         void propagate_recognizer(theory_var v, enode * r);
         void sign_recognizer_conflict(enode * c, enode * r);
 
-        ptr_vector<enode>    m_to_unmark;
-        ptr_vector<enode>    m_to_unmark2;
-        enode_pair_vector    m_used_eqs;
-        enode *              m_main;
+        typedef enum { ENTER, EXIT } stack_op;
+        typedef map<enode*, enode*, obj_ptr_hash<enode>, deref_eq<enode> > parent_tbl;
+        typedef std::pair<stack_op, enode*> stack_entry;
 
-        void oc_mark_explore(enode * n) { n->set_mark(); m_to_unmark.push_back(n); }
-        bool oc_explored(enode * n) const { n->is_marked(); }
+        ptr_vector<enode>     m_to_unmark;
+        ptr_vector<enode>     m_to_unmark2;
+        enode_pair_vector     m_used_eqs; // conflict, if any
+        parent_tbl            m_parent; // parent explanation for occurs_check
+        svector<stack_entry>  m_stack; // stack for DFS for occurs_check
 
-        void oc_mark_cycle_free(enode * n) { n->set_mark2(); m_to_unmark2.push_back(n); }
-        bool oc_cycle_free(enode * n) const { n->is_marked2(); }
+        void oc_mark_on_stack(enode * n) {
+          n = n->get_root();
+          n->set_mark();
+          m_to_unmark.push_back(n); }
+        bool oc_on_stack(enode * n) const { return n->get_root()->is_marked(); }
 
-        void init_final_check() {
-          m_to_unmark2.reset();
+        void oc_mark_cycle_free(enode * n) {
+          n = n->get_root();
+          n->set_mark2();
+          m_to_unmark2.push_back(n); }
+        bool oc_cycle_free(enode * n) const { return n->get_root()->is_marked2(); }
+
+        void oc_push_stack(enode * n) {
+            m_stack.push_back(std::make_pair(EXIT, n));
+            m_stack.push_back(std::make_pair(ENTER, n));
         }
-        void cleanup_final_check() {
-          unmark_enodes2(m_to_unmark2.size(), m_to_unmark2.c_ptr());
-          m_to_unmark2.reset();
-        }
+
+        // class for managing state of final_check
+        class final_check_st {
+            theory_datatype * th;
+            public:
+            final_check_st(theory_datatype * th) : th(th) {
+                th->m_to_unmark2.reset();
+                th->m_to_unmark.reset();
+                th->m_used_eqs.reset();
+                th->m_stack.reset();
+                th->m_parent.reset();
+            }
+            ~final_check_st() {
+                unmark_enodes(th->m_to_unmark.size(), th->m_to_unmark.c_ptr());
+                unmark_enodes2(th->m_to_unmark2.size(), th->m_to_unmark2.c_ptr());
+                th->m_to_unmark.reset();
+                th->m_to_unmark2.reset();
+                th->m_stack.reset();
+                th->m_parent.reset();
+            }
+        };
 
         bool occurs_check(enode * n);
-        bool occurs_check_core(enode * n);
+        bool occurs_check_enter(enode * n);
+        void occurs_check_explain(enode * top, enode * root);
 
         void mk_split(theory_var v);
 

--- a/src/smt/theory_datatype.h
+++ b/src/smt/theory_datatype.h
@@ -104,8 +104,8 @@ namespace smt {
             theory_datatype * th;
             public:
             final_check_st(theory_datatype * th) : th(th) {
-                th->m_to_unmark2.reset();
                 th->m_to_unmark.reset();
+                th->m_to_unmark2.reset();
                 th->m_used_eqs.reset();
                 th->m_stack.reset();
                 th->m_parent.reset();
@@ -115,6 +115,7 @@ namespace smt {
                 unmark_enodes2(th->m_to_unmark2.size(), th->m_to_unmark2.c_ptr());
                 th->m_to_unmark.reset();
                 th->m_to_unmark2.reset();
+                th->m_used_eqs.reset();
                 th->m_stack.reset();
                 th->m_parent.reset();
             }

--- a/src/smt/theory_datatype.h
+++ b/src/smt/theory_datatype.h
@@ -73,7 +73,7 @@ namespace smt {
         void sign_recognizer_conflict(enode * c, enode * r);
 
         typedef enum { ENTER, EXIT } stack_op;
-        typedef map<enode*, enode*, obj_ptr_hash<enode>, deref_eq<enode> > parent_tbl;
+        typedef map<enode*, enode*, obj_ptr_hash<enode>, ptr_eq<enode> > parent_tbl;
         typedef std::pair<stack_op, enode*> stack_entry;
 
         ptr_vector<enode>     m_to_unmark;


### PR DESCRIPTION
the goal of this change is to improve the performance of the acyclicity check for datatypes. It replaces the per-node occur check (which duplicates some work) by a global graph traversal with cycle detection.

Note: I don't know how to run tests on my local repo (it seems to work from a project that uses bindings, but more vetting is clearly needed)