### PR TITLE
Z3 now will also try to find libz3 in PYTHONPATH

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1657,7 +1657,7 @@ else:
   if hasattr(builtins, "Z3_LIB_DIRS"):
     _all_dirs = builtins.Z3_LIB_DIRS
 
-for v in ('Z3_LIBRARY_PATH', 'PATH'):
+for v in ('Z3_LIBRARY_PATH', 'PATH', 'PYTHONPATH'):
   if v in os.environ:
     lp = os.environ[v];
     lds = lp.split(';') if sys.platform in ('win32') else lp.split(':')


### PR DESCRIPTION
I think when searching the z3 lib (i.e. `libz3.so` under Linux), it should also look for `PYTHONPATH`. I think this makes sense because sometimes we don't want to install z3 in standard directories. When we do so, we set `PYTHONPATH` to the z3 python api directory in order to allow Python to find the z3 library directory. This implements and fixes #1586 .

Thanks