### PR TITLE
Specify encoding of source files in mk_util.py

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -780,7 +780,7 @@ def extract_c_includes(fname):
     # We should generate and error for any occurrence of #include that does not match the previous pattern.
     non_std_inc_pat = re.compile(".*#include.*")
 
-    f = open(fname, 'r')
+    f = open(fname, encoding='utf-8', mode='r')
     linenum = 1
     for line in f:
         m1 = std_inc_pat.match(line)


### PR DESCRIPTION
I got a Python exception because the source files contains UTF-8 characters that the ascii decoder couldn't handle. Specifying the encoding as UTF-8 solved by issue.