### PR TITLE
`lp::permutation_matrix::values` attempts an incorrect conversion

### DIFF
--- a/src/util/lp/permutation_matrix.h
+++ b/src/util/lp/permutation_matrix.h
@@ -132,7 +132,7 @@ class permutation_matrix : public tail_matrix<T, X> {
 
         unsigned size() const { return static_cast<unsigned>(m_rev.size()); }
 
-        unsigned * values() const { return m_permutation; }
+        unsigned * values() const { return m_permutation.c_ptr(); }
 
         void resize(unsigned size) {
             unsigned old_size = m_permutation.size();


### PR DESCRIPTION
This causes compilation with GCC 8 to fail. I suspect it worked previously due to SFINAE (`permutation_matrix` is a class template).

As far as I can tell, `lp::permutation_matrix::values` is actually unused, so an alternative might be to completely remove this function.