### PR TITLE
Fixed Segfault when failing to load datalog file

### DIFF
--- a/src/muz/fp/datalog_parser.cpp
+++ b/src/muz/fp/datalog_parser.cpp
@@ -108,7 +108,9 @@ public:
 #endif
     }
     ~line_reader() {
-        fclose(m_file);
+        if (m_file != nullptr){
+            fclose(m_file);
+        }
     }
 
     bool operator()() { return m_ok; }


### PR DESCRIPTION
Hi,
my faculty is currently working on symbolic execution of C++ code using KLEE. 
Z3 turned out to be a good test subject for our implementation, because z3 does not have many external dependencies.

Through testing we found this bug, which segfaults while loading a non-existent datalog file.

Reproduce using 'z3 A.dl', given A.dl is not in the current directory of course.