### PR TITLE
Fix missing SONAME in libz3.so, which breaks loading from Java

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2460,7 +2460,7 @@ def mk_config():
         check_ar()
         CXX = find_cxx_compiler()
         CC  = find_c_compiler()
-        SLIBEXTRAFLAGS = ''
+        SLIBEXTRAFLAGS = '-Wl,-soname,libz3.so'
         EXE_EXT = ''
         LIB_EXT = '.a'
         if GPROF:


### PR DESCRIPTION
This patch sets the `SONAME` field of `libz3.so` to `libz3.so`.

The reason is that otherwise I cannot load the binaries for Z3 from Java.

The following code just attempts to load the native libraries, without even attempting to access the API:
```
System.loadLibrary("z3");
System.loadLibrary("z3java");
```
This fails in the second line with the following error, although `libz3` could be loaded successfully in the first line, and both libraries are in the same directory, which I put in `java.library.path`:
```
Exception in thread "main" java.lang.UnsatisfiedLinkError: .../libz3java.so: libz3.so: cannot open shared object file: No such file or directory
	at java.lang.ClassLoader$NativeLibrary.load(Native Method)
	at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1941)
	at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1857)
	at java.lang.Runtime.loadLibrary0(Runtime.java:870)
	at java.lang.System.loadLibrary(System.java:1122)
	at Test.main(Test.java:27)
```
(Tested with OpenJDK 1.8.0_171 on Ubuntu 16.04 64bit with Z3 4.7.1, both self-compiled and the official release.)

I managed to find out that this is due to a missing `SONAME` field of `libz3.so`:
After running the following command, the same code above works:
```
patchelf --set-soname libz3.so libz3.so
```
The binaries produced by the build system of Z3 do not have `SONAME` set (`readelf -d libz3.so | grep SONAME` returns nothing).

I assume the loading fails because `libz3java` has a dependency on `libz3.so`, and it is not detected that this dependency is satisfied by the previously loaded `libz3.so` if the latter does not have a matching `SONAME`.

So I suggest to adjust the build system to set the `SONAME` field of the `libz3.so` library to `libz3.so`. This can be done by passing `-Wl,-soname,libz3.so` to the linker. As far as I understood the Z3 build system, we can simply add this to `SLINK_EXTRA_FLAGS`. I am not aware of any side effects of this.