### PR TITLE
Refine default_tactic for better support of pure SAT instances

### DIFF
--- a/src/tactic/portfolio/default_tactic.cpp
+++ b/src/tactic/portfolio/default_tactic.cpp
@@ -31,9 +31,11 @@ Notes:
 #include "tactic/fpa/qffplra_tactic.h"
 #include "tactic/smtlogics/qfaufbv_tactic.h"
 #include "tactic/smtlogics/qfauflia_tactic.h"
+#include "tactic/portfolio/fd_solver.h"
 
 tactic * mk_default_tactic(ast_manager & m, params_ref const & p) {
     tactic * st = using_params(and_then(mk_simplify_tactic(m),
+                                        cond(mk_is_propositional_probe(), if_no_proofs(mk_fd_tactic(m, p)),
                                         cond(mk_is_qfbv_probe(), mk_qfbv_tactic(m),
                                         cond(mk_is_qfaufbv_probe(), mk_qfaufbv_tactic(m),
                                         cond(mk_is_qflia_probe(), mk_qflia_tactic(m),
@@ -46,7 +48,7 @@ tactic * mk_default_tactic(ast_manager & m, params_ref const & p) {
                                         cond(mk_is_qffp_probe(), mk_qffp_tactic(m, p),
                                         cond(mk_is_qffplra_probe(), mk_qffplra_tactic(m, p),
                                         //cond(mk_is_qfufnra_probe(), mk_qfufnra_tactic(m, p),
-                                             mk_smt_tactic())))))))))))),
+                                             mk_smt_tactic()))))))))))))),
                                p);
     return st;
 }


### PR DESCRIPTION
If the constraint is an SAT instance and proof is not enabled, then use the qffd tactic.