### PR TITLE
remove unsound contains/indexof heuristic in theory_str

### DIFF
--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -1382,22 +1382,6 @@ namespace smt {
         expr_ref finalAxiom(m.mk_and(breakdownAssert, reduceToIndex), m);
         SASSERT(finalAxiom);
         assert_axiom(finalAxiom);
-
-        {
-            // heuristic: integrate with str.contains information
-            // (but don't introduce it if it isn't already in the instance)
-            expr_ref haystack(ex->get_arg(0), m), needle(ex->get_arg(1), m), startIdx(ex->get_arg(2), m);
-            expr_ref zeroAst(mk_int(0), m);
-            // (H contains N) <==> (H indexof N, i) >= 0
-            expr_ref premise(u.str.mk_contains(haystack, needle), m);
-            ctx.internalize(premise, false);
-            expr_ref conclusion(m_autil.mk_ge(ex, zeroAst), m);
-            expr_ref containsAxiom(ctx.mk_eq_atom(premise, conclusion), m);
-            SASSERT(containsAxiom);
-
-            // we can't assert this during init_search as it breaks an invariant if the instance becomes inconsistent
-            //m_delayed_axiom_setup_terms.push_back(containsAxiom);
-        }
     }
 
     void theory_str::instantiate_axiom_Indexof_extended(enode * _e) {
@@ -1477,19 +1461,6 @@ namespace smt {
 
             expr_ref conclusion(mk_and(conclusion_terms), m);
             assert_implication(premise, conclusion);
-        }
-
-        {
-            // heuristic: integrate with str.contains information
-            // (but don't introduce it if it isn't already in the instance)
-            // (H contains N) <==> (H indexof N, i) >= 0
-            expr_ref premise(u.str.mk_contains(H, N), m);
-            ctx.internalize(premise, false);
-            expr_ref conclusion(m_autil.mk_ge(e, zero), m);
-            expr_ref containsAxiom(ctx.mk_eq_atom(premise, conclusion), m);
-            SASSERT(containsAxiom);
-            // we can't assert this during init_search as it breaks an invariant if the instance becomes inconsistent
-            m_delayed_assertions_todo.push_back(containsAxiom);
         }
     }
 


### PR DESCRIPTION
Fixes #1726. I'll revisit the contains/indexof integration when I have time, for now this makes things behave correctly.