### PR TITLE
fix(union-find): keep values and representative in consistent order

### DIFF
--- a/src/util/union_find.h
+++ b/src/util/union_find.h
@@ -122,8 +122,10 @@ public:
         TRACE("union_find", tout << "merging " << r1 << " " << r2 << "\n";);
         if (r1 == r2)
             return;
-        if (m_size[r1] > m_size[r2])
+        if (m_size[r1] > m_size[r2]) {
             std::swap(r1, r2);
+            std::swap(v1, v2);
+        }
         m_ctx.merge_eh(r2, r1, v2, v1);
         m_find[r1] = r2;
         m_size[r2] += m_size[r1];


### PR DESCRIPTION
NOTE: I'm not totally sure if the semantics of `merge_eh` and `after_merge_eh` implies this, as it's not commented. But it seems natural to want the 4 values' order to matter?

This patch enforces that the merge handlers should be called with r1,r2,v1,v2 or r2,r1,v2,v1
but no other order.