### PR TITLE
Z3str3/Seq: canonicalize encoding of string constants/symbols

### DIFF
--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -842,7 +842,9 @@ void seq_decl_plugin::get_sort_names(svector<builtin_name> & sort_names, symbol 
 }
 
 app* seq_decl_plugin::mk_string(symbol const& s) {
-    parameter param(s);
+    zstring canonStr(s.bare_str());
+    symbol canonSym(canonStr.encode().c_str());
+    parameter param(canonSym);
     func_decl* f = m_manager->mk_const_decl(m_stringc_sym, m_string,
                                             func_decl_info(m_family_id, OP_STRING_CONST, 1, &param));
     return m_manager->mk_const(f);


### PR DESCRIPTION
This fixes a bug where string constants with different encodings, e.g. "\xF1" and "\xf1", were treated as distinct constants even though they encode to the same string. Now we treat the `zstring` encoding of a string constant as "canonical" and use that when escape characters are present.

I have a regression test that will be submitted to Z3Test as well.