### PR TITLE
Add Clang-Format configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+﻿---
+BasedOnStyle: LLVM
+IndentCaseLabels: 'false'
+IndentWidth: '4'
+PointerAlignment: Left
+BreakBeforeBraces: Custom
+BraceWrapping:
+  BeforeElse: true
+AccessModifierOffset: 0
+
+...

--- a/.clang-format
+++ b/.clang-format
@@ -6,6 +6,6 @@ PointerAlignment: Left
 BreakBeforeBraces: Custom
 BraceWrapping:
   BeforeElse: true
-AccessModifierOffset: 0
+AccessModifierOffset: -4
 
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -7,5 +7,6 @@ BreakBeforeBraces: Custom
 BraceWrapping:
   BeforeElse: true
 AccessModifierOffset: -4
+AllowShortFunctionsOnASingleLine: false
 
 ...

--- a/src/solver/mus.cpp
+++ b/src/solver/mus.cpp
@@ -39,7 +39,8 @@ struct mus::imp {
 
     imp(solver& s)
         : m_solver(s), m(s.get_manager()), m_lit2expr(m), m_assumptions(m),
-          m_soft(m) {}
+          m_soft(m) {
+    }
 
     void reset() {
         m_lit2expr.reset();
@@ -63,7 +64,9 @@ struct mus::imp {
         return idx;
     }
 
-    void add_assumption(expr* lit) { m_assumptions.push_back(lit); }
+    void add_assumption(expr* lit) {
+        m_assumptions.push_back(lit);
+    }
 
     lbool get_mus(expr_ref_vector& mus) {
         m_model.reset();
@@ -297,7 +300,9 @@ struct mus::imp {
             : m_fmls(fmls1), m_size(fmls1.size()) {
             fmls1.push_back(fml);
         }
-        ~scoped_append() { m_fmls.shrink(m_size); }
+        ~scoped_append() {
+            m_fmls.shrink(m_size);
+        }
     };
 
     template <class T> void display_vec(std::ostream& out, T const& v) const {
@@ -353,17 +358,29 @@ struct mus::imp {
     }
 };
 
-mus::mus(solver& s) { m_imp = alloc(imp, s); }
+mus::mus(solver& s) {
+    m_imp = alloc(imp, s);
+}
 
-mus::~mus() { dealloc(m_imp); }
+mus::~mus() {
+    dealloc(m_imp);
+}
 
-unsigned mus::add_soft(expr* lit) { return m_imp->add_soft(lit); }
+unsigned mus::add_soft(expr* lit) {
+    return m_imp->add_soft(lit);
+}
 
-void mus::add_assumption(expr* lit) { return m_imp->add_assumption(lit); }
+void mus::add_assumption(expr* lit) {
+    return m_imp->add_assumption(lit);
+}
 
-lbool mus::get_mus(expr_ref_vector& mus) { return m_imp->get_mus(mus); }
+lbool mus::get_mus(expr_ref_vector& mus) {
+    return m_imp->get_mus(mus);
+}
 
-void mus::reset() { m_imp->reset(); }
+void mus::reset() {
+    m_imp->reset();
+}
 
 void mus::set_soft(unsigned sz, expr* const* soft, rational const* weights) {
     m_imp->set_soft(sz, soft, weights);

--- a/src/solver/mus.cpp
+++ b/src/solver/mus.cpp
@@ -275,7 +275,7 @@ struct mus::imp {
         expr_ref_vector& m_fmls;
         unsigned m_size;
 
-        public:
+    public:
         scoped_append(imp& imp, expr_ref_vector& fmls1, expr_set const& fmls2)
             : m_fmls(fmls1), m_size(fmls1.size()) {
             expr_set::iterator it = fmls2.begin(), end = fmls2.end();

--- a/src/solver/mus.h
+++ b/src/solver/mus.h
@@ -6,7 +6,7 @@ Module Name:
     mus.h
 
 Abstract:
-   
+
     Basic MUS extraction
 
 Author:
@@ -19,49 +19,52 @@ Notes:
 #ifndef MUS_H_
 #define MUS_H_
 
+#include "solver/solver.h"
+
 class mus {
     struct imp;
-    imp * m_imp;
- public:
+    imp* m_imp;
+
+public:
     mus(solver& s);
     ~mus();
     /**
        Add soft constraint.
-       
-       Assume that the solver context enforces that 
+
+       Assume that the solver context enforces that
        cls is equivalent to a disjunction of args.
-       Assume also that cls is a literal.           
+       Assume also that cls is a literal.
     */
     unsigned add_soft(expr* cls);
 
     void add_soft(unsigned sz, expr* const* clss) {
-        for (unsigned i = 0; i < sz; ++i) add_soft(clss[i]);
+        for (unsigned i = 0; i < sz; ++i)
+            add_soft(clss[i]);
     }
-    
+
     /**
-       Additional assumption for solver to be used along with solver context, 
+       Additional assumption for solver to be used along with solver context,
        but not used in core computation. This facility is useful when querying
-       for a core over only a subset of soft constraints. It has the same 
-       logical functionality as asserting 'lit' to the solver and pushing a scope
-       (and popping the scope before the solver is used for other constraints).
+       for a core over only a subset of soft constraints. It has the same
+       logical functionality as asserting 'lit' to the solver and pushing a
+       scope (and popping the scope before the solver is used for other
+       constraints).
      */
     void add_assumption(expr* lit);
 
     lbool get_mus(expr_ref_vector& mus);
-    
+
     void reset();
-    
+
     /**
        Instrument MUS extraction to also provide the minimal
        penalty model, if any is found.
-       The minimal penalty model has the least weight for the 
+       The minimal penalty model has the least weight for the
        supplied soft constraints.
     */
     void set_soft(unsigned sz, expr* const* soft, rational const* weights);
 
     rational get_best_model(model_ref& mdl);
-    
 };
-
 
 #endif


### PR DESCRIPTION
This patch introduces Clang-Format configuration and reformats a single source file to see the outcome of reformatting the sources.

Fixes #1441.