### PR TITLE
Ignore current dir when searching for jni

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -396,7 +396,7 @@ def check_java():
                 libdirs = m.group(1).split(',')
                 for libdir in libdirs:
                     q = os.path.dirname(libdir)
-                    if cdirs.count(q) == 0:
+                    if cdirs.count(q) == 0 and len(q) > 0:
                         cdirs.append(q)
         t.close()
 


### PR DESCRIPTION
When looking for jni.h in the parent directory of the `z3` directory, it can be very slow, and even if it can be found, it is generally not what we want.