### PR TITLE
Fixed documentation of Z3_param_descrs_get_name method

### DIFF
--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -1715,7 +1715,7 @@ extern "C" {
     unsigned Z3_API Z3_param_descrs_size(Z3_context c, Z3_param_descrs p);
 
     /**
-       \brief Return the number of parameters in the given parameter description set.
+       \brief Return the name of the parameter at index \c i.
 
        \pre i < Z3_param_descrs_size(c, p)
 

--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -1715,7 +1715,7 @@ extern "C" {
     unsigned Z3_API Z3_param_descrs_size(Z3_context c, Z3_param_descrs p);
 
     /**
-       \brief Return the name of the parameter at index \c i.
+       \brief Return the name of the parameter at given index \c i.
 
        \pre i < Z3_param_descrs_size(c, p)
 


### PR DESCRIPTION
It seems like the documentation for this method was copied and pasted from Z3_param_descrs_size and wasn't properly changed.