### PR TITLE
feat(api/ml): release runtime lock on some long-running functions

### DIFF
--- a/src/api/ml/META.in
+++ b/src/api/ml/META.in
@@ -1,7 +1,7 @@
 # META file for the "z3" package:
 version = "@VERSION@"
 description = "Z3 Theorem Prover (OCaml API)"
-requires = "num"
+requires = "num threads"
 archive(byte) = "z3ml.cma"
 archive(native) = "z3ml.cmxa"
 archive(byte,plugin) = "z3ml.cma"

--- a/src/api/ml/z3native_stubs.c.pre
+++ b/src/api/ml/z3native_stubs.c.pre
@@ -11,6 +11,7 @@ extern "C" {
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/callback.h>
+#include <caml/threads.h>
 
 #ifdef Custom_tag
 #include <caml/custom.h>


### PR DESCRIPTION
When calling `Z3.Solver.check` from OCaml, the whole program can be blocked for an arbitrary amount of time, waiting for Z3 to return. Currently other OCaml threads won't even be scheduled as the whole runtime is blocked in the call. This PR changes that (for a handful of functions) by using `caml_{release,acquire}_runtime_system` for the duration of the C call (see <https://caml.inria.fr/pub/docs/manual-ocaml/intfc.html#sec476> sec 20.12.2 for more details), allowing other threads to run and giving them a chance to call `Z3.Tactic.interrupt` in case the computation takes too long.

Note that the list of functions with this wrapper is currently limited to `{check,simplify}` because I don't think this is useful for most (quickly-returning) functions.

This also adds a dependency on `threads`, but as far as I can tell, if you can run Z3 it means you're on a native machine and pthreads should be available.