### PR TITLE
Remove usages of Z3_TRUE / Z3_FALSE.

### DIFF
--- a/examples/c/test_capi.c
+++ b/examples/c/test_capi.c
@@ -899,7 +899,7 @@ void prove_example1()
     /* prove g(x) = g(y) */
     f           = Z3_mk_eq(ctx, gx, gy);
     printf("prove: x = y implies g(x) = g(y)\n");
-    prove(ctx, s, f, Z3_TRUE);
+    prove(ctx, s, f, true);
 
     /* create g(g(x)) */
     ggx         = mk_unary_app(ctx, g, gx);
@@ -907,7 +907,7 @@ void prove_example1()
     /* disprove g(g(x)) = g(y) */
     f           = Z3_mk_eq(ctx, ggx, gy);
     printf("disprove: x = y implies g(g(x)) = g(y)\n");
-    prove(ctx, s, f, Z3_FALSE);
+    prove(ctx, s, f, false);
 
     del_solver(ctx, s);
     Z3_del_context(ctx);
@@ -979,13 +979,13 @@ void prove_example2()
     /* prove z < 0 */
     f           = Z3_mk_lt(ctx, z, zero);
     printf("prove: not(g(g(x) - g(y)) = g(z)), x + z <= y <= x implies z < 0\n");
-    prove(ctx, s, f, Z3_TRUE);
+    prove(ctx, s, f, true);
 
     /* disprove z < -1 */
     minus_one   = mk_int(ctx, -1);
     f           = Z3_mk_lt(ctx, z, minus_one);
     printf("disprove: not(g(g(x) - g(y)) = g(z)), x + z <= y <= x implies z < -1\n");
-    prove(ctx, s, f, Z3_FALSE);
+    prove(ctx, s, f, false);
 
     del_solver(ctx, s);
     Z3_del_context(ctx);
@@ -1131,7 +1131,7 @@ void quantifier_example1()
     /* prove f(x, y) = f(w, v) implies y = v */
     p2          = Z3_mk_eq(ctx, y, v);
     printf("prove: f(x, y) = f(w, v) implies y = v\n");
-    prove(ctx, s, p2, Z3_TRUE);
+    prove(ctx, s, p2, true);
 
     /* disprove f(x, y) = f(w, v) implies x = w */
     /* using check2 instead of prove */
@@ -1198,7 +1198,7 @@ void array_example1()
     thm         = Z3_mk_implies(ctx, antecedent, consequent);
     printf("prove: store(a1, i1, v1) = store(a2, i2, v2) implies (i1 = i3 or i2 = i3 or select(a1, i3) = select(a2, i3))\n");
     printf("%s\n", Z3_ast_to_string(ctx, thm));
-    prove(ctx, s, thm, Z3_TRUE);
+    prove(ctx, s, thm, true);
 
     del_solver(ctx, s);
     Z3_del_context(ctx);
@@ -1339,13 +1339,13 @@ void tuple_example1()
         eq2  = Z3_mk_eq(ctx, x, one);
         thm  = Z3_mk_implies(ctx, eq1, eq2);
         printf("prove: get_x(mk_pair(x, y)) = 1 implies x = 1\n");
-        prove(ctx, s, thm, Z3_TRUE);
+        prove(ctx, s, thm, true);
 
         /* disprove that get_x(mk_pair(x,y)) == 1 implies y = 1*/
         eq3  = Z3_mk_eq(ctx, y, one);
         thm  = Z3_mk_implies(ctx, eq1, eq3);
         printf("disprove: get_x(mk_pair(x, y)) = 1 implies y = 1\n");
-        prove(ctx, s, thm, Z3_FALSE);
+        prove(ctx, s, thm, false);
     }
 
     {
@@ -1366,12 +1366,12 @@ void tuple_example1()
         consequent     = Z3_mk_eq(ctx, p1, p2);
         thm            = Z3_mk_implies(ctx, antecedent, consequent);
         printf("prove: get_x(p1) = get_x(p2) and get_y(p1) = get_y(p2) implies p1 = p2\n");
-        prove(ctx, s, thm, Z3_TRUE);
+        prove(ctx, s, thm, true);
 
         /* disprove that get_x(p1) = get_x(p2) implies p1 = p2 */
         thm            = Z3_mk_implies(ctx, antecedents[0], consequent);
         printf("disprove: get_x(p1) = get_x(p2) implies p1 = p2\n");
-        prove(ctx, s, thm, Z3_FALSE);
+        prove(ctx, s, thm, false);
     }
 
     {
@@ -1390,14 +1390,14 @@ void tuple_example1()
         consequent     = Z3_mk_eq(ctx, x, ten);
         thm            = Z3_mk_implies(ctx, antecedent, consequent);
         printf("prove: p2 = update(p1, 0, 10) implies get_x(p2) = 10\n");
-        prove(ctx, s, thm, Z3_TRUE);
+        prove(ctx, s, thm, true);
 
         /* disprove that p2 = update(p1, 0, 10) implies get_y(p2) = 10 */
         y              = mk_unary_app(ctx, get_y_decl, p2);
         consequent     = Z3_mk_eq(ctx, y, ten);
         thm            = Z3_mk_implies(ctx, antecedent, consequent);
         printf("disprove: p2 = update(p1, 0, 10) implies get_y(p2) = 10\n");
-        prove(ctx, s, thm, Z3_FALSE);
+        prove(ctx, s, thm, false);
     }
 
     del_solver(ctx, s);
@@ -1429,7 +1429,7 @@ void bitvector_example1()
     c2          = Z3_mk_bvsle(ctx, x_minus_ten, zero);
     thm         = Z3_mk_iff(ctx, c1, c2);
     printf("disprove: x - 10 <= 0 IFF x <= 10 for (32-bit) machine integers\n");
-    prove(ctx, s, thm, Z3_FALSE);
+    prove(ctx, s, thm, false);
 
     del_solver(ctx, s);
     Z3_del_context(ctx);
@@ -1717,7 +1717,7 @@ void parser_example3()
                            0, 0, 0,
                            1, &g_name, &g);
     printf("formula: %s\n", Z3_ast_vector_to_string(ctx, thm));
-    prove(ctx, s, Z3_ast_vector_get(ctx, thm, 0), Z3_TRUE);
+    prove(ctx, s, Z3_ast_vector_get(ctx, thm, 0), true);
 
     del_solver(ctx, s);
     Z3_del_context(ctx);
@@ -1781,13 +1781,13 @@ void numeral_example() {
     n2 = Z3_mk_numeral(ctx, "0.5", real_ty);
     printf("Numerals n1:%s", Z3_ast_to_string(ctx, n1));
     printf(" n2:%s\n", Z3_ast_to_string(ctx, n2));
-    prove(ctx, s, Z3_mk_eq(ctx, n1, n2), Z3_TRUE);
+    prove(ctx, s, Z3_mk_eq(ctx, n1, n2), true);
 
     n1 = Z3_mk_numeral(ctx, "-1/3", real_ty);
     n2 = Z3_mk_numeral(ctx, "-0.33333333333333333333333333333333333333333333333333", real_ty);
     printf("Numerals n1:%s", Z3_ast_to_string(ctx, n1));
     printf(" n2:%s\n", Z3_ast_to_string(ctx, n2));
-    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, n1, n2)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, n1, n2)), true);
     del_solver(ctx, s);
     Z3_del_context(ctx);
 }
@@ -1852,14 +1852,14 @@ void enum_example() {
     orange = Z3_mk_app(ctx, enum_consts[2], 0, 0);
 
     /* Apples are different from oranges */
-    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, apple, orange)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, apple, orange)), true);
 
     /* Apples pass the apple test */
-    prove(ctx, s, Z3_mk_app(ctx, enum_testers[0], 1, &apple), Z3_TRUE);
+    prove(ctx, s, Z3_mk_app(ctx, enum_testers[0], 1, &apple), true);
 
     /* Oranges fail the apple test */
-    prove(ctx, s, Z3_mk_app(ctx, enum_testers[0], 1, &orange), Z3_FALSE);
-    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_app(ctx, enum_testers[0], 1, &orange)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_app(ctx, enum_testers[0], 1, &orange), false);
+    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_app(ctx, enum_testers[0], 1, &orange)), true);
 
     fruity = mk_var(ctx, "fruity", fruit);
 
@@ -1868,7 +1868,7 @@ void enum_example() {
     ors[1] = Z3_mk_eq(ctx, fruity, banana);
     ors[2] = Z3_mk_eq(ctx, fruity, orange);
 
-    prove(ctx, s, Z3_mk_or(ctx, 3, ors), Z3_TRUE);
+    prove(ctx, s, Z3_mk_or(ctx, 3, ors), true);
 
     /* delete logical context */
     del_solver(ctx, s);
@@ -1900,41 +1900,41 @@ void list_example() {
     l2 = mk_binary_app(ctx, cons_decl, mk_int(ctx, 2), nil);
 
     /* nil != cons(1, nil) */
-    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, nil, l1)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, nil, l1)), true);
 
     /* cons(2,nil) != cons(1, nil) */
-    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, l1, l2)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, l1, l2)), true);
 
     /* cons(x,nil) = cons(y, nil) => x = y */
     x = mk_var(ctx, "x", int_ty);
     y = mk_var(ctx, "y", int_ty);
     l1 = mk_binary_app(ctx, cons_decl, x, nil);
 	l2 = mk_binary_app(ctx, cons_decl, y, nil);
-    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, x, y)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, x, y)), true);
 
     /* cons(x,u) = cons(x, v) => u = v */
     u = mk_var(ctx, "u", int_list);
     v = mk_var(ctx, "v", int_list);
     l1 = mk_binary_app(ctx, cons_decl, x, u);
 	l2 = mk_binary_app(ctx, cons_decl, y, v);
-    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, u, v)), Z3_TRUE);
-    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, x, y)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, u, v)), true);
+    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, x, y)), true);
 
     /* is_nil(u) or is_cons(u) */
     ors[0] = Z3_mk_app(ctx, is_nil_decl, 1, &u);
     ors[1] = Z3_mk_app(ctx, is_cons_decl, 1, &u);
-    prove(ctx, s, Z3_mk_or(ctx, 2, ors), Z3_TRUE);
+    prove(ctx, s, Z3_mk_or(ctx, 2, ors), true);
 
     /* occurs check u != cons(x,u) */
-    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, u, l1)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, u, l1)), true);
 
     /* destructors: is_cons(u) => u = cons(head(u),tail(u)) */
     fml1 = Z3_mk_eq(ctx, u, mk_binary_app(ctx, cons_decl, mk_unary_app(ctx, head_decl, u), mk_unary_app(ctx, tail_decl, u)));
     fml = Z3_mk_implies(ctx, Z3_mk_app(ctx, is_cons_decl, 1, &u), fml1);
     printf("Formula %s\n", Z3_ast_to_string(ctx, fml));
-    prove(ctx, s, fml, Z3_TRUE);
+    prove(ctx, s, fml, true);
 
-    prove(ctx, s, fml1, Z3_FALSE);
+    prove(ctx, s, fml1, false);
 
     /* delete logical context */
     del_solver(ctx, s);
@@ -1982,7 +1982,7 @@ void tree_example() {
     l2 = mk_binary_app(ctx, cons_decl, l1, nil);
 
     /* nil != cons(nil, nil) */
-    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, nil, l1)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, nil, l1)), true);
 
     /* cons(x,u) = cons(x, v) => u = v */
     u = mk_var(ctx, "u", cell);
@@ -1991,24 +1991,24 @@ void tree_example() {
     y = mk_var(ctx, "y", cell);
     l1 = mk_binary_app(ctx, cons_decl, x, u);
     l2 = mk_binary_app(ctx, cons_decl, y, v);
-    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, u, v)), Z3_TRUE);
-    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, x, y)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, u, v)), true);
+    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, x, y)), true);
 
     /* is_nil(u) or is_cons(u) */
     ors[0] = Z3_mk_app(ctx, is_nil_decl, 1, &u);
     ors[1] = Z3_mk_app(ctx, is_cons_decl, 1, &u);
-    prove(ctx, s, Z3_mk_or(ctx, 2, ors), Z3_TRUE);
+    prove(ctx, s, Z3_mk_or(ctx, 2, ors), true);
 
     /* occurs check u != cons(x,u) */
-    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, u, l1)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, u, l1)), true);
 
     /* destructors: is_cons(u) => u = cons(car(u),cdr(u)) */
     fml1 = Z3_mk_eq(ctx, u, mk_binary_app(ctx, cons_decl, mk_unary_app(ctx, car_decl, u), mk_unary_app(ctx, cdr_decl, u)));
     fml = Z3_mk_implies(ctx, Z3_mk_app(ctx, is_cons_decl, 1, &u), fml1);
     printf("Formula %s\n", Z3_ast_to_string(ctx, fml));
-    prove(ctx, s, fml, Z3_TRUE);
+    prove(ctx, s, fml, true);
 
-    prove(ctx, s, fml1, Z3_FALSE);
+    prove(ctx, s, fml1, false);
 
     /* delete logical context */
     del_solver(ctx, s);
@@ -2100,8 +2100,8 @@ void forest_example() {
 
 
     /* nil != cons(nil,nil) */
-    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, nil1, f1)), Z3_TRUE);
-    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, nil2, t1)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, nil1, f1)), true);
+    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, nil2, t1)), true);
 
 
     /* cons(x,u) = cons(x, v) => u = v */
@@ -2111,16 +2111,16 @@ void forest_example() {
     y = mk_var(ctx, "y", tree);
     l1 = mk_binary_app(ctx, cons1_decl, x, u);
     l2 = mk_binary_app(ctx, cons1_decl, y, v);
-    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, u, v)), Z3_TRUE);
-    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, x, y)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, u, v)), true);
+    prove(ctx, s, Z3_mk_implies(ctx, Z3_mk_eq(ctx,l1,l2), Z3_mk_eq(ctx, x, y)), true);
 
     /* is_nil(u) or is_cons(u) */
     ors[0] = Z3_mk_app(ctx, is_nil1_decl, 1, &u);
     ors[1] = Z3_mk_app(ctx, is_cons1_decl, 1, &u);
-    prove(ctx, s, Z3_mk_or(ctx, 2, ors), Z3_TRUE);
+    prove(ctx, s, Z3_mk_or(ctx, 2, ors), true);
 
     /* occurs check u != cons(x,u) */
-    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, u, l1)), Z3_TRUE);
+    prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, u, l1)), true);
 
     /* delete logical context */
     del_solver(ctx, s);
@@ -2193,19 +2193,19 @@ void binary_tree_example() {
         Z3_ast node3    = Z3_mk_app(ctx, node_decl, 3, args3);
 
         /* prove that nil != node1 */
-        prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, nil, node1)), Z3_TRUE);
+        prove(ctx, s, Z3_mk_not(ctx, Z3_mk_eq(ctx, nil, node1)), true);
 
         /* prove that nil = left(node1) */
-        prove(ctx, s, Z3_mk_eq(ctx, nil, mk_unary_app(ctx, left_decl, node1)), Z3_TRUE);
+        prove(ctx, s, Z3_mk_eq(ctx, nil, mk_unary_app(ctx, left_decl, node1)), true);
 
         /* prove that node1 = right(node3) */
-        prove(ctx, s, Z3_mk_eq(ctx, node1, mk_unary_app(ctx, right_decl, node3)), Z3_TRUE);
+        prove(ctx, s, Z3_mk_eq(ctx, node1, mk_unary_app(ctx, right_decl, node3)), true);
 
         /* prove that !is-nil(node2) */
-        prove(ctx, s, Z3_mk_not(ctx, mk_unary_app(ctx, is_nil_decl, node2)), Z3_TRUE);
+        prove(ctx, s, Z3_mk_not(ctx, mk_unary_app(ctx, is_nil_decl, node2)), true);
 
         /* prove that value(node2) >= 0 */
-        prove(ctx, s, Z3_mk_ge(ctx, mk_unary_app(ctx, value_decl, node2), mk_int(ctx, 0)), Z3_TRUE);
+        prove(ctx, s, Z3_mk_ge(ctx, mk_unary_app(ctx, value_decl, node2), mk_int(ctx, 0)), true);
     }
 
     /* delete logical context */
@@ -2347,7 +2347,7 @@ unsigned assert_retractable_cnstr(Z3_ext_context ctx, Z3_ast c) {
     ans_lit = Z3_mk_fresh_const(ctx->m_context, "k", ty);
     result  = ctx->m_num_answer_literals;
     ctx->m_answer_literals[result] = ans_lit;
-    ctx->m_retracted[result]       = Z3_FALSE;
+    ctx->m_retracted[result]       = false;
     ctx->m_num_answer_literals++;
     // assert: c OR (not ans_lit)
     args[0] = c;
@@ -2363,7 +2363,7 @@ void retract_cnstr(Z3_ext_context ctx, unsigned id) {
     if (id >= ctx->m_num_answer_literals) {
         exitf("invalid constraint id.");
     }
-    ctx->m_retracted[id] = Z3_TRUE;
+    ctx->m_retracted[id] = true;
 }
 
 /**
@@ -2373,7 +2373,7 @@ void reassert_cnstr(Z3_ext_context ctx, unsigned id) {
     if (id >= ctx->m_num_answer_literals) {
         exitf("invalid constraint id.");
     }
-    ctx->m_retracted[id] = Z3_FALSE;
+    ctx->m_retracted[id] = false;
 }
 
 /**
@@ -2387,7 +2387,7 @@ Z3_lbool ext_check(Z3_ext_context ctx) {
     unsigned core_size;
     unsigned i;
     for (i = 0; i < ctx->m_num_answer_literals; i++) {
-        if (ctx->m_retracted[i] == Z3_FALSE) {
+        if (ctx->m_retracted[i] == false) {
             // Since the answer literal was not retracted, we added it as an assumption.
             // Recall that we assert (C \/ (not ans_lit)). Therefore, adding ans_lit as an assumption has the effect of "asserting" C.
             // If the constraint was "retracted" (ctx->m_retracted[i] == Z3_true), then we don't really need to add (not ans_lit) as an assumption.
@@ -2874,8 +2874,8 @@ void mk_model_example() {
         Z3_ast aPlusBEval = NULL;
         Z3_bool aPlusBEvalSuccess =
             Z3_model_eval(ctx, m, aPlusB,
-                          /*model_completion=*/Z3_FALSE, &aPlusBEval);
-        if (aPlusBEvalSuccess != Z3_TRUE) {
+                          /*model_completion=*/false, &aPlusBEval);
+        if (aPlusBEvalSuccess != true) {
             printf("Failed to evaluate model\n");
             exit(1);
         }
@@ -2884,7 +2884,7 @@ void mk_model_example() {
             int aPlusBValue = 0;
             Z3_bool getAPlusBValueSuccess =
                 Z3_get_numeral_int(ctx, aPlusBEval, &aPlusBValue);
-            if (getAPlusBValueSuccess != Z3_TRUE) {
+            if (getAPlusBValueSuccess != true) {
                 printf("Failed to get integer value for a+b\n");
                 exit(1);
             }
@@ -2908,8 +2908,8 @@ void mk_model_example() {
         Z3_ast arrayAddEval = NULL;
         Z3_bool arrayAddEvalSuccess =
             Z3_model_eval(ctx, m, arrayAdd,
-                          /*model_completion=*/Z3_FALSE, &arrayAddEval);
-        if (arrayAddEvalSuccess != Z3_TRUE) {
+                          /*model_completion=*/false, &arrayAddEval);
+        if (arrayAddEvalSuccess != true) {
             printf("Failed to evaluate model\n");
             exit(1);
         }
@@ -2917,7 +2917,7 @@ void mk_model_example() {
             int arrayAddValue = 0;
             Z3_bool getArrayAddValueSuccess =
                 Z3_get_numeral_int(ctx, arrayAddEval, &arrayAddValue);
-            if (getArrayAddValueSuccess != Z3_TRUE) {
+            if (getArrayAddValueSuccess != true) {
                 printf("Failed to get integer value for c[0] + c[1] + c[2]\n");
                 exit(1);
             }

--- a/examples/maxsat/maxsat.c
+++ b/examples/maxsat/maxsat.c
@@ -382,7 +382,7 @@ unsigned get_num_disabled_soft_constraints(Z3_context ctx, Z3_model m, unsigned 
     Z3_ast t = Z3_mk_true(ctx);
     for (i = 0; i < num_soft_cnstrs; i++) {
         Z3_ast val;
-        if (Z3_model_eval(ctx, m, aux_vars[i], 1, &val) == Z3_TRUE) {
+        if (Z3_model_eval(ctx, m, aux_vars[i], 1, &val) == true) {
             // printf("%s", Z3_ast_to_string(ctx, aux_vars[i]));
             // printf(" -> %s\n", Z3_ast_to_string(ctx, val));
             if (Z3_is_eq_ast(ctx, val, t)) {

--- a/src/api/api_algebraic.cpp
+++ b/src/api/api_algebraic.cpp
@@ -83,8 +83,8 @@ extern "C" {
         Z3_TRY;
         LOG_Z3_algebraic_is_value(c, a);
         RESET_ERROR_CODE();
-        return Z3_algebraic_is_value_core(c, a) ? Z3_TRUE : Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return Z3_algebraic_is_value_core(c, a) ? true : false;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_algebraic_is_pos(Z3_context c, Z3_ast a) {
@@ -283,7 +283,7 @@ extern "C" {
                 r = _am.IRAT_PRED(av, bv);                              \
             }                                                           \
         }                                                               \
-        return r ? Z3_TRUE : Z3_FALSE;
+        return r ? true : false;
 
 
     Z3_bool Z3_API Z3_algebraic_lt(Z3_context c, Z3_ast a, Z3_ast b) {
@@ -293,7 +293,7 @@ extern "C" {
         CHECK_IS_ALGEBRAIC(a, 0);
         CHECK_IS_ALGEBRAIC(b, 0);
         BIN_PRED(<,lt);
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_algebraic_gt(Z3_context c, Z3_ast a, Z3_ast b) {

--- a/src/api/api_arith.cpp
+++ b/src/api/api_arith.cpp
@@ -121,7 +121,7 @@ extern "C" {
 
     Z3_bool Z3_API Z3_is_algebraic_number(Z3_context c, Z3_ast a) {
         LOG_Z3_is_algebraic_number(c, a);
-        return mk_c(c)->autil().is_irrational_algebraic_numeral(to_expr(a)) ? Z3_TRUE : Z3_FALSE;
+        return mk_c(c)->autil().is_irrational_algebraic_numeral(to_expr(a)) ? true : false;
     }
 
     Z3_ast Z3_API Z3_get_algebraic_number_lower(Z3_context c, Z3_ast a, unsigned precision) {

--- a/src/api/api_ast.cpp
+++ b/src/api/api_ast.cpp
@@ -313,7 +313,7 @@ extern "C" {
         LOG_Z3_is_well_sorted(c, t);
         RESET_ERROR_CODE();
         return is_well_sorted(mk_c(c)->m(), to_expr(t));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_symbol_kind Z3_API Z3_get_symbol_kind(Z3_context c, Z3_symbol s) {

--- a/src/api/api_ast_map.cpp
+++ b/src/api/api_ast_map.cpp
@@ -62,7 +62,7 @@ extern "C" {
         LOG_Z3_ast_map_contains(c, m, k);
         RESET_ERROR_CODE();
         return to_ast_map_ref(m).contains(to_ast(k));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_ast Z3_API Z3_ast_map_find(Z3_context c, Z3_ast_map m, Z3_ast k) {

--- a/src/api/api_config_params.cpp
+++ b/src/api/api_config_params.cpp
@@ -57,13 +57,13 @@ extern "C" {
         try {
             g_Z3_global_param_get_buffer = gparams::get_value(param_id);
             *param_value = g_Z3_global_param_get_buffer.c_str();
-            return Z3_TRUE;
+            return true;
         }
         catch (z3_exception & ex) {
             // The error handler is only available for contexts
             // Just throw a warning.
             warning_msg("%s", ex.msg());
-            return Z3_FALSE;
+            return false;
         }
     }
 

--- a/src/api/api_datalog.cpp
+++ b/src/api/api_datalog.cpp
@@ -205,17 +205,17 @@ extern "C" {
             *out = 0;
         }
         if (Z3_get_sort_kind(c, s) != Z3_FINITE_DOMAIN_SORT) {
-            return Z3_FALSE;
+            return false;
         }
         if (!out) {
-            return Z3_FALSE;
+            return false;
         }
         // must start logging here, since function uses Z3_get_sort_kind above
         LOG_Z3_get_finite_domain_sort_size(c, s, out);
         RESET_ERROR_CODE();  
         VERIFY(mk_c(c)->datalog_util().try_get_size(to_sort(s), *out));
-        return Z3_TRUE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return true;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_fixedpoint Z3_API Z3_mk_fixedpoint(Z3_context c) {

--- a/src/api/api_fpa.cpp
+++ b/src/api/api_fpa.cpp
@@ -1243,7 +1243,7 @@ extern "C" {
             return false;
         }
         return fu.is_nan(to_expr(t));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_fpa_is_numeral_inf(Z3_context c, Z3_ast t) {
@@ -1257,7 +1257,7 @@ extern "C" {
             return false;
         }
         return fu.is_inf(to_expr(t));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_fpa_is_numeral_zero(Z3_context c, Z3_ast t) {
@@ -1271,7 +1271,7 @@ extern "C" {
             return false;
         }
         return fu.is_zero(to_expr(t));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_fpa_is_numeral_normal(Z3_context c, Z3_ast t) {
@@ -1285,7 +1285,7 @@ extern "C" {
             return false;
         }
         return fu.is_normal(to_expr(t));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_fpa_is_numeral_subnormal(Z3_context c, Z3_ast t) {
@@ -1299,7 +1299,7 @@ extern "C" {
             return false;
         }
         return fu.is_subnormal(to_expr(t));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_fpa_is_numeral_positive(Z3_context c, Z3_ast t) {
@@ -1313,7 +1313,7 @@ extern "C" {
             return false;
         }
         return fu.is_positive(to_expr(t));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_fpa_is_numeral_negative(Z3_context c, Z3_ast t) {
@@ -1327,7 +1327,7 @@ extern "C" {
             return false;
         }
         return fu.is_negative(to_expr(t));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
 };

--- a/src/api/api_goal.cpp
+++ b/src/api/api_goal.cpp
@@ -87,7 +87,7 @@ extern "C" {
         LOG_Z3_goal_inconsistent(c, g);
         RESET_ERROR_CODE();
         return to_goal_ref(g)->inconsistent();
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     unsigned Z3_API Z3_goal_depth(Z3_context c, Z3_goal g) {
@@ -141,7 +141,7 @@ extern "C" {
         LOG_Z3_goal_is_decided_sat(c, g);
         RESET_ERROR_CODE();
         return to_goal_ref(g)->is_decided_sat();
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
     
     Z3_bool Z3_API Z3_goal_is_decided_unsat(Z3_context c, Z3_goal g) {
@@ -149,7 +149,7 @@ extern "C" {
         LOG_Z3_goal_is_decided_unsat(c, g);
         RESET_ERROR_CODE();
         return to_goal_ref(g)->is_decided_unsat();
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_model Z3_API Z3_goal_convert_model(Z3_context c, Z3_goal g, Z3_model m) {

--- a/src/api/api_log.cpp
+++ b/src/api/api_log.cpp
@@ -34,7 +34,7 @@ extern "C" {
     }
 
     Z3_bool Z3_API Z3_open_log(Z3_string filename) {
-        Z3_bool res = Z3_TRUE;
+        Z3_bool res = true;
 
 #ifdef Z3_LOG_SYNC
         #pragma omp critical (z3_log)
@@ -46,7 +46,7 @@ extern "C" {
             if (g_z3_log->bad() || g_z3_log->fail()) {
                 dealloc(g_z3_log);
                 g_z3_log = nullptr;
-                res = Z3_FALSE;
+                res = false;
             }
             else {
                 *g_z3_log << "V \"" << Z3_MAJOR_VERSION << "." << Z3_MINOR_VERSION << "." << Z3_BUILD_NUMBER << "." << Z3_REVISION_NUMBER << " " << __DATE__ << "\"\n";

--- a/src/api/api_model.cpp
+++ b/src/api/api_model.cpp
@@ -80,11 +80,11 @@ extern "C" {
         LOG_Z3_model_has_interp(c, m, a);
         CHECK_NON_NULL(m, 0);
         if (to_model_ref(m)->has_interpretation(to_func_decl(a))) {
-            return Z3_TRUE;
+            return true;
         } else {
-            return Z3_FALSE;
+            return false;
         }
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_func_interp Z3_API Z3_model_get_func_interp(Z3_context c, Z3_model m, Z3_func_decl f) {
@@ -162,15 +162,15 @@ extern "C" {
         LOG_Z3_model_eval(c, m, t, model_completion, v);
         if (v) *v = nullptr;
         RESET_ERROR_CODE();
-        CHECK_NON_NULL(m, Z3_FALSE);
-        CHECK_IS_EXPR(t, Z3_FALSE);
+        CHECK_NON_NULL(m, false);
+        CHECK_IS_EXPR(t, false);
         model * _m = to_model_ref(m);
         expr_ref result(mk_c(c)->m());
-        model::scoped_model_completion _scm(*_m, model_completion == Z3_TRUE);
+        model::scoped_model_completion _scm(*_m, model_completion == true);
         result = (*_m)(to_expr(t));
         mk_c(c)->save_ast_trail(result.get());
         *v = of_ast(result.get());
-        RETURN_Z3_model_eval Z3_TRUE;
+        RETURN_Z3_model_eval true;
         Z3_CATCH_RETURN(0);
     }
 
@@ -230,7 +230,7 @@ extern "C" {
         LOG_Z3_is_as_array(c, a);
         RESET_ERROR_CODE();
         return a && is_expr(to_ast(a)) && is_app_of(to_expr(a), mk_c(c)->get_array_fid(), OP_AS_ARRAY);
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
     
     Z3_func_decl Z3_API Z3_get_as_array_func_decl(Z3_context c, Z3_ast a) {

--- a/src/api/api_numeral.cpp
+++ b/src/api/api_numeral.cpp
@@ -146,7 +146,7 @@ extern "C" {
         Z3_TRY;
         LOG_Z3_is_numeral_ast(c, a);
         RESET_ERROR_CODE();        
-        CHECK_IS_EXPR(a, Z3_FALSE);
+        CHECK_IS_EXPR(a, false);
         expr* e = to_expr(a);
         return
             mk_c(c)->autil().is_numeral(e) ||
@@ -154,29 +154,29 @@ extern "C" {
             mk_c(c)->fpautil().is_numeral(e) ||
             mk_c(c)->fpautil().is_rm_numeral(e) ||
             mk_c(c)->datalog_util().is_numeral_ext(e);
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_get_numeral_rational(Z3_context c, Z3_ast a, rational& r) {
         Z3_TRY;
         // This function is not part of the public API
         RESET_ERROR_CODE();
-        CHECK_IS_EXPR(a, Z3_FALSE);
+        CHECK_IS_EXPR(a, false);
         expr* e = to_expr(a);
         if (mk_c(c)->autil().is_numeral(e, r)) {
-            return Z3_TRUE;
+            return true;
         }
         unsigned bv_size;
         if (mk_c(c)->bvutil().is_numeral(e, r, bv_size)) {
-            return Z3_TRUE;
+            return true;
         }
         uint64_t v;
         if (mk_c(c)->datalog_util().is_numeral(e, v)) {
             r = rational(v, rational::ui64());
-            return Z3_TRUE;
+            return true;
         }
-        return Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return false;
+        Z3_CATCH_RETURN(false);
     }
 
 
@@ -188,7 +188,7 @@ extern "C" {
         CHECK_IS_EXPR(a, "");
         rational r;
         Z3_bool ok = Z3_get_numeral_rational(c, a, r);
-        if (ok == Z3_TRUE) {
+        if (ok == true) {
             return mk_c(c)->mk_external_string(r.to_string());
         }
         else {
@@ -253,7 +253,7 @@ extern "C" {
             return mk_c(c)->mk_external_string(buffer.str());
         }
         Z3_bool ok = Z3_get_numeral_rational(c, a, r);
-        if (ok == Z3_TRUE) {
+        if (ok == true) {
             return mk_c(c)->mk_external_string(r.to_string());
         }
         else {
@@ -268,24 +268,24 @@ extern "C" {
         // This function invokes Z3_get_numeral_rational, but it is still ok to add LOG command here because it does not return a Z3 object.
         LOG_Z3_get_numeral_small(c, a, num, den);
         RESET_ERROR_CODE();
-        CHECK_IS_EXPR(a, Z3_FALSE);
+        CHECK_IS_EXPR(a, false);
         rational r;
         Z3_bool ok = Z3_get_numeral_rational(c, a, r);
-        if (ok == Z3_TRUE) {
+        if (ok == true) {
             rational n = numerator(r);
             rational d = denominator(r);
             if (n.is_int64() && d.is_int64()) {
                 *num = n.get_int64();
                 *den = d.get_int64();
-                return Z3_TRUE;
+                return true;
             }
             else {
-                return Z3_FALSE;
+                return false;
             }
         }
         SET_ERROR_CODE(Z3_INVALID_ARG, nullptr);
-        return Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return false;
+        Z3_CATCH_RETURN(false);
     }
 
 
@@ -294,18 +294,18 @@ extern "C" {
         // This function invokes Z3_get_numeral_int64, but it is still ok to add LOG command here because it does not return a Z3 object.
         LOG_Z3_get_numeral_int(c, v, i);
         RESET_ERROR_CODE();
-        CHECK_IS_EXPR(v, Z3_FALSE);
+        CHECK_IS_EXPR(v, false);
         if (!i) {
             SET_ERROR_CODE(Z3_INVALID_ARG, nullptr);
-            return Z3_FALSE;
+            return false;
         }
         int64_t l;
         if (Z3_get_numeral_int64(c, v, &l) && l >= INT_MIN && l <= INT_MAX) {
             *i = static_cast<int>(l);
-            return Z3_TRUE;
+            return true;
         }
-        return Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return false;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_get_numeral_uint(Z3_context c, Z3_ast v, unsigned* u) {
@@ -313,18 +313,18 @@ extern "C" {
         // This function invokes Z3_get_numeral_uint64, but it is still ok to add LOG command here because it does not return a Z3 object.
         LOG_Z3_get_numeral_uint(c, v, u);
         RESET_ERROR_CODE();
-        CHECK_IS_EXPR(v, Z3_FALSE);
+        CHECK_IS_EXPR(v, false);
         if (!u) {
             SET_ERROR_CODE(Z3_INVALID_ARG, nullptr);
-            return Z3_FALSE;
+            return false;
         }
         uint64_t l;
         if (Z3_get_numeral_uint64(c, v, &l) && (l <= 0xFFFFFFFF)) {
             *u = static_cast<unsigned>(l);
-            return Z3_TRUE;
+            return true;
         }
-        return Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return false;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_get_numeral_uint64(Z3_context c, Z3_ast v, uint64_t* u) {
@@ -332,20 +332,20 @@ extern "C" {
         // This function invokes Z3_get_numeral_rational, but it is still ok to add LOG command here because it does not return a Z3 object.
         LOG_Z3_get_numeral_uint64(c, v, u);
         RESET_ERROR_CODE();
-        CHECK_IS_EXPR(v, Z3_FALSE);
+        CHECK_IS_EXPR(v, false);
         if (!u) {
             SET_ERROR_CODE(Z3_INVALID_ARG, nullptr);
-            return Z3_FALSE;
+            return false;
         }
         rational r;
         Z3_bool ok = Z3_get_numeral_rational(c, v, r);
         SASSERT(u);
-        if (ok == Z3_TRUE && r.is_uint64()) {
+        if (ok == true && r.is_uint64()) {
             *u = r.get_uint64();
             return ok;
         }
-        return Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return false;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_get_numeral_int64(Z3_context c, Z3_ast v, int64_t* i) {
@@ -353,19 +353,19 @@ extern "C" {
         // This function invokes Z3_get_numeral_rational, but it is still ok to add LOG command here because it does not return a Z3 object.
         LOG_Z3_get_numeral_int64(c, v, i);
         RESET_ERROR_CODE();
-        CHECK_IS_EXPR(v, Z3_FALSE);
+        CHECK_IS_EXPR(v, false);
         if (!i) {
             SET_ERROR_CODE(Z3_INVALID_ARG, nullptr);
-            return Z3_FALSE;
+            return false;
         }
         rational r;
         Z3_bool ok = Z3_get_numeral_rational(c, v, r);
-        if (ok == Z3_TRUE && r.is_int64()) {
+        if (ok == true && r.is_int64()) {
             *i = r.get_int64();
             return ok;
         }
-        return Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return false;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_get_numeral_rational_int64(Z3_context c, Z3_ast v, int64_t* num, int64_t* den) {
@@ -373,14 +373,14 @@ extern "C" {
         // This function invokes Z3_get_numeral_rational, but it is still ok to add LOG command here because it does not return a Z3 object.
         LOG_Z3_get_numeral_rational_int64(c, v, num, den);
         RESET_ERROR_CODE();
-        CHECK_IS_EXPR(v, Z3_FALSE);
+        CHECK_IS_EXPR(v, false);
         if (!num || !den) {
             SET_ERROR_CODE(Z3_INVALID_ARG, nullptr);
-            return Z3_FALSE;
+            return false;
         }
         rational r;
         Z3_bool ok = Z3_get_numeral_rational(c, v, r);
-        if (ok != Z3_TRUE) {
+        if (ok != true) {
             return ok;
         }
         rational n = numerator(r);
@@ -390,8 +390,8 @@ extern "C" {
             *den = d.get_int64();
             return ok;
         }
-        return Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return false;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_ast Z3_API Z3_mk_bv_numeral(Z3_context c, unsigned sz, Z3_bool const* bits) {

--- a/src/api/api_quant.cpp
+++ b/src/api/api_quant.cpp
@@ -347,24 +347,24 @@ extern "C" {
         Z3_TRY;
         LOG_Z3_is_quantifier_forall(c, a);
         RESET_ERROR_CODE();
-        return ::is_forall(to_ast(a)) ? Z3_TRUE : Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return ::is_forall(to_ast(a)) ? true : false;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_is_quantifier_exists(Z3_context c, Z3_ast a) {
         Z3_TRY;
         LOG_Z3_is_quantifier_exists(c, a);
         RESET_ERROR_CODE();
-        return ::is_exists(to_ast(a))  ? Z3_TRUE : Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return ::is_exists(to_ast(a))  ? true : false;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_is_lambda(Z3_context c, Z3_ast a) {
         Z3_TRY;
         LOG_Z3_is_lambda(c, a);
         RESET_ERROR_CODE();
-        return ::is_lambda(to_ast(a))  ? Z3_TRUE : Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return ::is_lambda(to_ast(a))  ? true : false;
+        Z3_CATCH_RETURN(false);
     }
 
 

--- a/src/api/api_rcf.cpp
+++ b/src/api/api_rcf.cpp
@@ -220,7 +220,7 @@ extern "C" {
         RESET_ERROR_CODE();
         reset_rcf_cancel(c);
         return rcfm(c).lt(to_rcnumeral(a), to_rcnumeral(b));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_rcf_gt(Z3_context c, Z3_rcf_num a, Z3_rcf_num b) {
@@ -229,7 +229,7 @@ extern "C" {
         RESET_ERROR_CODE();
         reset_rcf_cancel(c);
         return rcfm(c).gt(to_rcnumeral(a), to_rcnumeral(b));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_rcf_le(Z3_context c, Z3_rcf_num a, Z3_rcf_num b) {
@@ -238,7 +238,7 @@ extern "C" {
         RESET_ERROR_CODE();
         reset_rcf_cancel(c);
         return rcfm(c).le(to_rcnumeral(a), to_rcnumeral(b));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_rcf_ge(Z3_context c, Z3_rcf_num a, Z3_rcf_num b) {
@@ -247,7 +247,7 @@ extern "C" {
         RESET_ERROR_CODE();
         reset_rcf_cancel(c);
         return rcfm(c).ge(to_rcnumeral(a), to_rcnumeral(b));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_rcf_eq(Z3_context c, Z3_rcf_num a, Z3_rcf_num b) {
@@ -256,7 +256,7 @@ extern "C" {
         RESET_ERROR_CODE();
         reset_rcf_cancel(c);
         return rcfm(c).eq(to_rcnumeral(a), to_rcnumeral(b));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_rcf_neq(Z3_context c, Z3_rcf_num a, Z3_rcf_num b) {
@@ -265,7 +265,7 @@ extern "C" {
         RESET_ERROR_CODE();
         reset_rcf_cancel(c);
         return rcfm(c).neq(to_rcnumeral(a), to_rcnumeral(b));
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_string Z3_API Z3_rcf_num_to_string(Z3_context c, Z3_rcf_num a, Z3_bool compact, Z3_bool html) {

--- a/src/api/api_seq.cpp
+++ b/src/api/api_seq.cpp
@@ -70,8 +70,8 @@ extern "C" {
         LOG_Z3_is_seq_sort(c, s);
         RESET_ERROR_CODE();
         bool result = mk_c(c)->sutil().is_seq(to_sort(s));
-        return result?Z3_TRUE:Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return result?true:false;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_is_re_sort(Z3_context c, Z3_sort s) {
@@ -79,8 +79,8 @@ extern "C" {
         LOG_Z3_is_re_sort(c, s);
         RESET_ERROR_CODE();
         bool result = mk_c(c)->sutil().is_re(to_sort(s));
-        return result?Z3_TRUE:Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return result?true:false;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_is_string_sort(Z3_context c, Z3_sort s) {
@@ -88,8 +88,8 @@ extern "C" {
         LOG_Z3_is_string_sort(c, s);
         RESET_ERROR_CODE();
         bool result = mk_c(c)->sutil().is_string(to_sort(s));
-        return result?Z3_TRUE:Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return result?true:false;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_bool Z3_API Z3_is_string(Z3_context c, Z3_ast s) {
@@ -97,8 +97,8 @@ extern "C" {
         LOG_Z3_is_string(c, s);
         RESET_ERROR_CODE();
         bool result = mk_c(c)->sutil().str.is_string(to_expr(s));
-        return result?Z3_TRUE:Z3_FALSE;
-        Z3_CATCH_RETURN(Z3_FALSE);
+        return result?true:false;
+        Z3_CATCH_RETURN(false);
     }
 
     Z3_string Z3_API Z3_get_string(Z3_context c, Z3_ast s) {

--- a/src/api/api_stats.cpp
+++ b/src/api/api_stats.cpp
@@ -80,7 +80,7 @@ extern "C" {
         RESET_ERROR_CODE();
         if (idx >= to_stats_ref(s).size()) {
             SET_ERROR_CODE(Z3_IOB, nullptr);
-            return Z3_FALSE;
+            return false;
         }
         return to_stats_ref(s).is_uint(idx);
         Z3_CATCH_RETURN(0);
@@ -92,10 +92,10 @@ extern "C" {
         RESET_ERROR_CODE();
         if (idx >= to_stats_ref(s).size()) {
             SET_ERROR_CODE(Z3_IOB, nullptr);
-            return Z3_FALSE;
+            return false;
         }
         return !to_stats_ref(s).is_uint(idx);
-        Z3_CATCH_RETURN(Z3_FALSE);
+        Z3_CATCH_RETURN(false);
     }
     
     unsigned Z3_API Z3_stats_get_uint_value(Z3_context c, Z3_stats s, unsigned idx) {

--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -2038,7 +2038,7 @@ namespace z3 {
             Z3_ast r = 0;
             Z3_bool status = Z3_model_eval(ctx(), m_model, n, model_completion, &r);
             check_error();
-            if (status == Z3_FALSE && ctx().enable_exceptions())
+            if (status == false && ctx().enable_exceptions())
                 Z3_THROW(exception("failed to evaluate expression"));
             return expr(ctx(), r);
         }

--- a/src/api/z3_algebraic.h
+++ b/src/api/z3_algebraic.h
@@ -31,7 +31,7 @@ extern "C" {
     /** @name Algebraic Numbers */
     /*@{*/
     /**
-       \brief Return Z3_TRUE if \c a can be used as value in the Z3 real algebraic
+       \brief Return \c true if \c a can be used as value in the Z3 real algebraic
        number package.
 
        def_API('Z3_algebraic_is_value', BOOL, (_in(CONTEXT), _in(AST)))
@@ -39,7 +39,7 @@ extern "C" {
     Z3_bool Z3_API Z3_algebraic_is_value(Z3_context c, Z3_ast a);
 
     /**
-       \brief Return the Z3_TRUE if \c a is positive, and Z3_FALSE otherwise.
+       \brief Return \c true if \c a is positive, and \c false otherwise.
 
        \pre Z3_algebraic_is_value(c, a)
 
@@ -48,7 +48,7 @@ extern "C" {
     Z3_bool Z3_API Z3_algebraic_is_pos(Z3_context c, Z3_ast a);
 
     /**
-       \brief Return the Z3_TRUE if \c a is negative, and Z3_FALSE otherwise.
+       \brief Return \c true if \c a is negative, and \c false otherwise.
 
        \pre Z3_algebraic_is_value(c, a)
 
@@ -57,7 +57,7 @@ extern "C" {
     Z3_bool Z3_API Z3_algebraic_is_neg(Z3_context c, Z3_ast a);
 
     /**
-       \brief Return the Z3_TRUE if \c a is zero, and Z3_FALSE otherwise.
+       \brief Return \c true if \c a is zero, and \c false otherwise.
 
        \pre Z3_algebraic_is_value(c, a)
 
@@ -141,7 +141,7 @@ extern "C" {
     Z3_ast Z3_API Z3_algebraic_power(Z3_context c, Z3_ast a, unsigned k);
 
     /**
-       \brief Return Z3_TRUE if a < b, and Z3_FALSE otherwise.
+       \brief Return \c true if a < b, and \c false otherwise.
 
        \pre Z3_algebraic_is_value(c, a)
        \pre Z3_algebraic_is_value(c, b)
@@ -151,7 +151,7 @@ extern "C" {
     Z3_bool Z3_API Z3_algebraic_lt(Z3_context c, Z3_ast a, Z3_ast b);
 
     /**
-       \brief Return Z3_TRUE if a > b, and Z3_FALSE otherwise.
+       \brief Return \c true if a > b, and \c false otherwise.
 
        \pre Z3_algebraic_is_value(c, a)
        \pre Z3_algebraic_is_value(c, b)
@@ -161,7 +161,7 @@ extern "C" {
     Z3_bool Z3_API Z3_algebraic_gt(Z3_context c, Z3_ast a, Z3_ast b);
 
     /**
-       \brief Return Z3_TRUE if a <= b, and Z3_FALSE otherwise.
+       \brief Return \c true if a <= b, and \c false otherwise.
 
        \pre Z3_algebraic_is_value(c, a)
        \pre Z3_algebraic_is_value(c, b)
@@ -171,7 +171,7 @@ extern "C" {
     Z3_bool Z3_API Z3_algebraic_le(Z3_context c, Z3_ast a, Z3_ast b);
 
     /**
-       \brief Return Z3_TRUE if a >= b, and Z3_FALSE otherwise.
+       \brief Return \c true if a >= b, and \c false otherwise.
 
        \pre Z3_algebraic_is_value(c, a)
        \pre Z3_algebraic_is_value(c, b)
@@ -181,7 +181,7 @@ extern "C" {
     Z3_bool Z3_API Z3_algebraic_ge(Z3_context c, Z3_ast a, Z3_ast b);
 
     /**
-       \brief Return Z3_TRUE if a == b, and Z3_FALSE otherwise.
+       \brief Return \c true if a == b, and \c false otherwise.
 
        \pre Z3_algebraic_is_value(c, a)
        \pre Z3_algebraic_is_value(c, b)
@@ -191,7 +191,7 @@ extern "C" {
     Z3_bool Z3_API Z3_algebraic_eq(Z3_context c, Z3_ast a, Z3_ast b);
 
     /**
-       \brief Return Z3_TRUE if a != b, and Z3_FALSE otherwise.
+       \brief Return \c true if a != b, and \c false otherwise.
 
        \pre Z3_algebraic_is_value(c, a)
        \pre Z3_algebraic_is_value(c, b)

--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -1435,7 +1435,7 @@ extern "C" {
     /**
        \brief Get a global (or module) parameter.
 
-       Returns \c Z3_FALSE if the parameter value does not exist.
+       Returns \c false if the parameter value does not exist.
 
        \sa Z3_global_param_set
 
@@ -3953,7 +3953,7 @@ extern "C" {
     unsigned Z3_API Z3_get_bv_sort_size(Z3_context c, Z3_sort t);
 
     /**
-        \brief Store the size of the sort in \c r. Return Z3_FALSE if the call failed.
+        \brief Store the size of the sort in \c r. Return \c false if the call failed.
         That is, Z3_get_sort_kind(s) == Z3_FINITE_DOMAIN_SORT
 
         def_API('Z3_get_finite_domain_sort_size', BOOL, (_in(CONTEXT), _in(SORT), _out(UINT64)))
@@ -4518,7 +4518,7 @@ extern "C" {
        \param num numerator.
        \param den denominator.
 
-       Return \c Z3_TRUE if the numeral value fits in 64 bit numerals, \c Z3_FALSE otherwise.
+       Return \c true if the numeral value fits in 64 bit numerals, \c false otherwise.
 
        \pre Z3_get_ast_kind(a) == Z3_NUMERAL_AST
 
@@ -4528,7 +4528,7 @@ extern "C" {
 
     /**
        \brief Similar to #Z3_get_numeral_string, but only succeeds if
-       the value can fit in a machine int. Return Z3_TRUE if the call succeeded.
+       the value can fit in a machine int. Return \c true if the call succeeded.
 
        \pre Z3_get_ast_kind(c, v) == Z3_NUMERAL_AST
 
@@ -4540,7 +4540,7 @@ extern "C" {
 
     /**
        \brief Similar to #Z3_get_numeral_string, but only succeeds if
-       the value can fit in a machine unsigned int. Return Z3_TRUE if the call succeeded.
+       the value can fit in a machine unsigned int. Return \c true if the call succeeded.
 
        \pre Z3_get_ast_kind(c, v) == Z3_NUMERAL_AST
 
@@ -4552,7 +4552,7 @@ extern "C" {
 
     /**
        \brief Similar to #Z3_get_numeral_string, but only succeeds if
-       the value can fit in a machine \c uint64_t int. Return Z3_TRUE if the call succeeded.
+       the value can fit in a machine \c uint64_t int. Return \c true if the call succeeded.
 
        \pre Z3_get_ast_kind(c, v) == Z3_NUMERAL_AST
 
@@ -4564,7 +4564,7 @@ extern "C" {
 
     /**
        \brief Similar to #Z3_get_numeral_string, but only succeeds if
-       the value can fit in a machine \c int64_t int. Return Z3_TRUE if the call succeeded.
+       the value can fit in a machine \c int64_t int. Return \c true if the call succeeded.
 
        \pre Z3_get_ast_kind(c, v) == Z3_NUMERAL_AST
 
@@ -4576,7 +4576,7 @@ extern "C" {
 
     /**
        \brief Similar to #Z3_get_numeral_string, but only succeeds if
-       the value can fit as a rational number as machine \c int64_t int. Return Z3_TRUE if the call succeeded.
+       the value can fit as a rational number as machine \c int64_t int. Return \c true if the call succeeded.
 
        \pre Z3_get_ast_kind(c, v) == Z3_NUMERAL_AST
 
@@ -4853,12 +4853,12 @@ extern "C" {
 
     /**
        \brief Evaluate the AST node \c t in the given model.
-       Return \c Z3_TRUE if succeeded, and store the result in \c v.
+       Return \c true if succeeded, and store the result in \c v.
 
-       If \c model_completion is Z3_TRUE, then Z3 will assign an interpretation for any constant or function that does
+       If \c model_completion is \c true, then Z3 will assign an interpretation for any constant or function that does
        not have an interpretation in \c m. These constants and functions were essentially don't cares.
 
-       If \c model_completion is Z3_FALSE, then Z3 will not assign interpretations to constants for functions that do
+       If \c model_completion is \c false, then Z3 will not assign interpretations to constants for functions that do
        not have interpretations in \c m. Evaluation behaves as the identify function in this case.
 
        The evaluation may fail for the following reasons:
@@ -4995,7 +4995,7 @@ extern "C" {
     /**
        \brief The \ccode{(_ as-array f)} AST node is a construct for assigning interpretations for arrays in Z3.
        It is the array such that forall indices \c i we have that \ccode{(select (_ as-array f) i)} is equal to \ccode{(f i)}.
-       This procedure returns Z3_TRUE if the \c a is an \c as-array AST node.
+       This procedure returns \c true if the \c a is an \c as-array AST node.
 
        Z3 current solvers have minimal support for \c as_array nodes.
 
@@ -6370,7 +6370,7 @@ extern "C" {
     Z3_string Z3_API Z3_stats_get_key(Z3_context c, Z3_stats s, unsigned idx);
 
     /**
-       \brief Return Z3_TRUE if the given statistical data is a unsigned integer.
+       \brief Return \c true if the given statistical data is a unsigned integer.
 
        \pre idx < Z3_stats_size(c, s)
 
@@ -6379,7 +6379,7 @@ extern "C" {
     Z3_bool Z3_API Z3_stats_is_uint(Z3_context c, Z3_stats s, unsigned idx);
 
     /**
-       \brief Return Z3_TRUE if the given statistical data is a double.
+       \brief Return \c true if the given statistical data is a double.
 
        \pre idx < Z3_stats_size(c, s)
 

--- a/src/api/z3_rcf.h
+++ b/src/api/z3_rcf.h
@@ -134,42 +134,42 @@ extern "C" {
     Z3_rcf_num Z3_API Z3_rcf_power(Z3_context c, Z3_rcf_num a, unsigned k);
 
     /**
-       \brief Return Z3_TRUE if a < b
+       \brief Return \c true if a < b
 
        def_API('Z3_rcf_lt', BOOL, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
     Z3_bool Z3_API Z3_rcf_lt(Z3_context c, Z3_rcf_num a, Z3_rcf_num b);
 
     /**
-       \brief Return Z3_TRUE if a > b
+       \brief Return \c true if a > b
 
        def_API('Z3_rcf_gt', BOOL, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
     Z3_bool Z3_API Z3_rcf_gt(Z3_context c, Z3_rcf_num a, Z3_rcf_num b);
 
     /**
-       \brief Return Z3_TRUE if a <= b
+       \brief Return \c true if a <= b
 
        def_API('Z3_rcf_le', BOOL, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
     Z3_bool Z3_API Z3_rcf_le(Z3_context c, Z3_rcf_num a, Z3_rcf_num b);
 
     /**
-       \brief Return Z3_TRUE if a >= b
+       \brief Return \c true if a >= b
 
        def_API('Z3_rcf_ge', BOOL, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
     Z3_bool Z3_API Z3_rcf_ge(Z3_context c, Z3_rcf_num a, Z3_rcf_num b);
 
     /**
-       \brief Return Z3_TRUE if a == b
+       \brief Return \c true if a == b
 
        def_API('Z3_rcf_eq', BOOL, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */
     Z3_bool Z3_API Z3_rcf_eq(Z3_context c, Z3_rcf_num a, Z3_rcf_num b);
 
     /**
-       \brief Return Z3_TRUE if a != b
+       \brief Return \c true if a != b
 
        def_API('Z3_rcf_neq', BOOL, (_in(CONTEXT), _in(RCF_NUM), _in(RCF_NUM)))
     */

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -10608,7 +10608,6 @@ namespace smt {
         std::map<expr*, std::map<expr*, int> > var_eq_concat_map;
         int conflictInDep = ctx_dep_analysis(varAppearInAssign, freeVar_map, unrollGroup_map, var_eq_concat_map);
         if (conflictInDep == -1) {
-            // return Z3_TRUE;
             return FC_DONE;
         }
 

--- a/src/test/no_overflow.cpp
+++ b/src/test/no_overflow.cpp
@@ -662,7 +662,7 @@ void test_equiv(Equivalence_params params, unsigned bvsize, bool is_signed) {
 //    Z3_solver_assert(ctx, s, Z3_mk_eq(ctx, t2, Z3_mk_numeral(ctx, "1", bv)));
 //    //TEST_NO_UNDERFLOW;
 //    Z3_solver_assert(ctx, s, test_udfl);
-//    ENSURE(Z3_check(ctx) == Z3_TRUE);
+//    ENSURE(Z3_check(ctx) == true);
 //    Z3_solver_pop(ctx, s, 1);
 //
 //    Z3_del_config(cfg);


### PR DESCRIPTION
Now that this is all using stdbool.h, we can just use true/false.

For now, we leave the aliases in place in z3_api.h.