### PR TITLE
Add Memory.reset to OCaml API

### DIFF
--- a/src/api/ml/z3.ml
+++ b/src/api/ml/z3.ml
@@ -2023,3 +2023,7 @@ let toggle_warning_messages = Z3native.toggle_warning_messages
 let enable_trace = Z3native.enable_trace
 
 let disable_trace = Z3native.enable_trace
+
+module Memory = struct
+  let reset = Z3native.reset_memory
+end

--- a/src/api/ml/z3.mli
+++ b/src/api/ml/z3.mli
@@ -3472,3 +3472,11 @@ val enable_trace : string -> unit
    Remarks: It is a NOOP otherwise.
 *)
 val disable_trace : string -> unit
+
+
+(** Memory management **)
+module Memory :
+sig
+  (** Reset all allocated resourced **)
+  val reset : unit -> unit
+end


### PR DESCRIPTION
As per title, added a `Memory.reset ()` binding mapping to `Z3native.reset_memory`