### PR TITLE
Guard against null wrapped functions in OCaml API

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1528,6 +1528,11 @@ def mk_z3native_stubs_c(ml_src_dir, ml_output_dir): # C interface
             i = i + 1
         ml_wrapper.write(');\n')
 
+        if name in NULLWrapped:
+            ml_wrapper.write('  if (z3rv_m == NULL) {\n')
+            ml_wrapper.write('    caml_raise_with_string(*caml_named_value("Z3EXCEPTION"), "Object allocation failed");\n')
+            ml_wrapper.write('  }\n')
+
         if release_caml_gc:
             ml_wrapper.write('\n  caml_acquire_runtime_system();\n')
 


### PR DESCRIPTION
This fixes another segfault, caused by attempting to assign a potentially NULL pointer.
This is the same approach used in the dotnet and java APIs https://github.com/Bronsa/z3/blob/ad49c3269a7a0e238d27e06532eb15482e285de2/scripts/update_api.py#L461-L463