### PR TITLE
Remove include of immintrin.h.

### DIFF
--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -30,7 +30,6 @@ Revision History:
 #else
 #error No multi-precision library selected.
 #endif
-#include <immintrin.h> 
 
 // Available GCD algorithms
 // #define EUCLID_GCD


### PR DESCRIPTION
This file doesn't appear to be used and isn't available on all
platforms.