### PR TITLE
Remove undef max/min on macOS.

### DIFF
--- a/src/util/trace.h
+++ b/src/util/trace.h
@@ -24,10 +24,6 @@ Revision History:
 #undef max
 #undef min
 #endif
-#ifdef __APPLE__
-#undef max
-#undef min
-#endif
 #include<fstream>
 
 #ifdef _TRACE


### PR DESCRIPTION
This is no longer needed.