### PR TITLE
Remove Z3_get_manager.

### DIFF
--- a/src/api/api_context.cpp
+++ b/src/api/api_context.cpp
@@ -489,9 +489,3 @@ extern "C" {
     }
     
 };
-
-Z3_API ast_manager& Z3_get_manager(Z3_context c) {
-    return mk_c(c)->m();
-}
-
-


### PR DESCRIPTION
This was publicly exported from the shared library, but it isn't
in any header files and isn't used anywhere in the repository.