### PR TITLE
Use std::hexfloat more.

### DIFF
--- a/src/util/mpf.cpp
+++ b/src/util/mpf.cpp
@@ -1624,10 +1624,10 @@ std::string mpf_manager::to_string_hexfloat(mpf const & x) {
                                     std::ios_base::showpoint | std::ios_base::showpos);
     ss.setf(ff);
     ss.precision(13);
-#if defined(_WIN32) && _MSC_VER >= 1800
-    ss << std::hexfloat << to_double(x);
-#else
+#if defined(_WIN32) && _MSC_VER < 1800
     ss << std::hex << (*reinterpret_cast<const unsigned long long *>(&(x)));
+#else
+    ss << std::hexfloat << to_double(x);
 #endif
     return ss.str();
 }


### PR DESCRIPTION
Previously, we were only using `std::hexfloat` on Windows on VS2013
and later. This flips that to only using non-hexfloat on Windows
where we're using older than VS2013.

Since `std::hexfloat` is part of C++11 and we require C++11 to build
the Z3 library, this should be supported everywhere.

A follow up commit can probably remove the std::hex code path entirely
since we don't support older than VS2013.