### PR TITLE
Change error message from "internal failure" to "Object allocation failed"

### DIFF
--- a/src/api/ml/z3native_stubs.c.pre
+++ b/src/api/ml/z3native_stubs.c.pre
@@ -458,7 +458,7 @@ CAMLprim DLL_PUBLIC value n_mk_config() {
   z3rv = Z3_mk_config();
 
   if (z3rv == NULL) {
-    caml_raise_with_string(*caml_named_value("Z3EXCEPTION"), "internal error");
+    caml_raise_with_string(*caml_named_value("Z3EXCEPTION"), "Object allocation failed");
   }
 
   /* construct simple return value */


### PR DESCRIPTION
For consistency with https://github.com/Z3Prover/z3/commit/ad49c3269a7a0e238d27e06532eb15482e285de2 and Java/dotNet APIs