### PR TITLE
If NO_Z3_DEBUGGER, also drop defining invoke_gdb.

### DIFF
--- a/src/util/debug.cpp
+++ b/src/util/debug.cpp
@@ -69,7 +69,7 @@ bool is_debug_enabled(const char * tag) {
     return g_enabled_debug_tags->contains(const_cast<char *>(tag));
 }
 
-#ifndef _WINDOWS
+#if !defined(_WINDOWS) && !defined(NO_Z3_DEBUGGER)
 void invoke_gdb() {
     char buffer[1024];
     int * x = nullptr;


### PR DESCRIPTION
When `NO_Z3_DEBUGGER` is defined, then `exit` is called instead of `invoke_gdb`, so don't bother defining and building `invoke_gdb`.