### PR TITLE
Define NO_Z3_DEBUGGER for iOS builds.

### DIFF
--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -44,6 +44,13 @@ bool assertions_enabled();
 #define DEBUG_CODE(CODE) ((void) 0)
 #endif
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#if !TARGET_OS_OSX
+#define NO_Z3_DEBUGGER
+#endif
+#endif
+
 #ifdef NO_Z3_DEBUGGER
 #define INVOKE_DEBUGGER() exit(ERR_INTERNAL_FATAL)
 #else


### PR DESCRIPTION
This is defined because we can't call `system` (via `invoke_gdb`)
on iOS and related platforms.