### PR TITLE
Don't delete the reference to the native library in the python bindings

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1704,7 +1704,6 @@ def write_exe_c_preamble(exe_c):
 def write_core_py_post(core_py):
   core_py.write("""
 # Clean up
-del _lib
 del _default_dirs
 del _all_dirs
 del _ext


### PR DESCRIPTION
In angr, we need direct access to the reference to the native library object.

I don't think this should cause any issues, but I also don't understand the issue which prompted this change, so someone else should test this or explain to me how to test it.