### PR TITLE
Fix python build flags/clean

### DIFF
--- a/src/api/python/setup.py
+++ b/src/api/python/setup.py
@@ -16,7 +16,7 @@ from setuptools.command.bdist_egg import bdist_egg as _bdist_egg
 
 build_env = dict(os.environ)
 build_env['PYTHON'] = sys.executable
-build_env['CXXFLAGS'] = "-std=c++11"
+build_env['CXXFLAGS'] = build_env.get('CXXFLAGS', '') + " -std=c++11"
 
 ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 SRC_DIR_LOCAL = os.path.join(ROOT_DIR, 'core')

--- a/src/api/python/setup.py
+++ b/src/api/python/setup.py
@@ -10,6 +10,7 @@ from distutils.util import get_platform
 from distutils.errors import LibError
 from distutils.command.build import build as _build
 from distutils.command.sdist import sdist as _sdist
+from distutils.command.clean import clean as _clean
 from setuptools.command.develop import develop as _develop
 from setuptools.command.bdist_egg import bdist_egg as _bdist_egg
 
@@ -37,13 +38,23 @@ else:
     LIBRARY_FILE = "libz3.so"
     EXECUTABLE_FILE = "z3"
 
+def rmtree(tree):
+    if os.path.exists(tree):
+        shutil.rmtree(tree, ignore_errors=False)
+
 def _clean_bins():
     """
     Clean up the binary files and headers that are installed along with the bindings
     """
-    shutil.rmtree(LIBS_DIR, ignore_errors=True)
-    shutil.rmtree(BINS_DIR, ignore_errors=True)
-    shutil.rmtree(HEADERS_DIR, ignore_errors=True)
+    rmtree(LIBS_DIR)
+    rmtree(BINS_DIR)
+    rmtree(HEADERS_DIR)
+
+def _clean_native_build():
+    """
+    Clean the "build" directory in the z3 native root
+    """
+    rmtree(BUILD_DIR)
 
 def _z3_version():
     post = os.getenv('Z3_VERSION_SUFFIX', '')
@@ -146,9 +157,15 @@ class bdist_egg(_bdist_egg):
 
 class sdist(_sdist):
     def run(self):
-        self.execute(_clean_bins, (), msg="Cleaning binary files")
+        self.execute(_clean_bins, (), msg="Cleaning binary files and headers")
         self.execute(_copy_sources, (), msg="Copying source files")
         _sdist.run(self)
+
+class clean(_clean):
+    def run(self):
+        self.execute(_clean_bins, (), msg="Cleaning binary files and headers")
+        self.execute(_clean_native_build, (), msg="Cleaning native build")
+        _clean.run(self)
 
 # the build directory needs to exist
 #try: os.makedirs(os.path.join(ROOT_DIR, 'build'))
@@ -191,5 +208,5 @@ setup(
         'z3': [os.path.join('lib', '*'), os.path.join('include', '*.h'), os.path.join('include', 'c++', '*.h')]
     },
     data_files=[('bin',[os.path.join('bin',EXECUTABLE_FILE)])],
-    cmdclass={'build': build, 'develop': develop, 'sdist': sdist, 'bdist_egg': bdist_egg},
+    cmdclass={'build': build, 'develop': develop, 'sdist': sdist, 'bdist_egg': bdist_egg, 'clean': clean},
 )


### PR DESCRIPTION
- appends to CXXFLAGS instead of overwriting them
- makes `python setup.py clean` actually reset all state it touches