### PR TITLE
Add python "core" functions which return bytes instead of strings

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1704,6 +1704,7 @@ def write_exe_c_preamble(exe_c):
 def write_core_py_post(core_py):
   core_py.write("""
 # Clean up
+del _lib
 del _default_dirs
 del _all_dirs
 del _ext


### PR DESCRIPTION
as per https://github.com/Z3Prover/z3/pull/2132. Also reverts #2132, for which implementing this ad-hoc was the only use-case.

sample from my generated z3core.py:

```python
def Z3_get_string(a0, a1, _elems=Elementaries(_lib.Z3_get_string)):
  r = _elems.f(a0, a1)
  _elems.Check(a0)
  return _to_pystr(r)

def Z3_get_string_bytes(a0, a1, _elems=Elementaries(_lib.Z3_get_string)):
  r = _elems.f(a0, a1)
  _elems.Check(a0)
  return r
```

suggestions welcome!