### PR TITLE
Fix three Warnings

### DIFF
--- a/src/sat/sat_drat.cpp
+++ b/src/sat/sat_drat.cpp
@@ -83,7 +83,7 @@ namespace sat {
         char digits[20];     // enough for storing unsigned
         char* lastd = digits + sizeof(digits);
         
-        int len = 0;
+        unsigned len = 0;
         if (st == status::deleted) {
             buffer[0] = 'd';
             buffer[1] = ' ';

--- a/src/smt/theory_jobscheduler.cpp
+++ b/src/smt/theory_jobscheduler.cpp
@@ -499,7 +499,10 @@ namespace smt {
 
     std::ostream& theory_jobscheduler::display(std::ostream & out, job_resource const& jr) const {
         return out << "r:" << jr.m_resource_id << " cap:" << jr.m_capacity << " load:" << jr.m_loadpct << " end:" << jr.m_finite_capacity_end;
-        for (auto const& s : jr.m_properties) out << " " << s; out << "\n";
+        for (auto const& s : jr.m_properties) {
+			out << " " << s;
+		}
+		out << "\n";
     }
 
     std::ostream& theory_jobscheduler::display(std::ostream & out, job_info const& j) const {
@@ -511,7 +514,10 @@ namespace smt {
 
     std::ostream& theory_jobscheduler::display(std::ostream & out, res_available const& r) const {
         return out << "[" << r.m_start << ":" << r.m_end << "] @ " << r.m_loadpct << "%";
-        for (auto const& s : r.m_properties) out << " " << s; out << "\n";
+        for (auto const& s : r.m_properties) {
+			out << " " << s;
+		}
+		out << "\n";
     }
 
     std::ostream& theory_jobscheduler::display(std::ostream & out, res_info const& r) const {


### PR DESCRIPTION
Fixes a `-Wsign-compare` warning and two `-Wmisleading-indentation` warnings (compiling with gcc 8.2 on Arch Linux).