### PR TITLE
Remove dependency on TargetPlatform macro

### DIFF
--- a/src/api/dotnet/Microsoft.Z3.targets.in
+++ b/src/api/dotnet/Microsoft.Z3.targets.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemGroup>
-        <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-$(PlatformTarget)\native\libz3.dll">
+        <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\libz3.dll">
             <Visible>false</Visible>
             <Link>libz3.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Unnecessary, since dropping support for x86