### PR TITLE
Use release commit hash in nuspec

### DIFF
--- a/scripts/mk_nuget_release.py
+++ b/scripts/mk_nuget_release.py
@@ -36,7 +36,7 @@ def mk_dir(d):
         os.makedirs(d)
 
 def download_installs():
-    for asset in latest_release_data['assets']:
+    for asset in release_data['assets']:
         url = asset['browser_download_url']
         name = asset['name']
         print("Downloading ", url)

--- a/scripts/mk_nuget_release.py
+++ b/scripts/mk_nuget_release.py
@@ -20,19 +20,23 @@ import subprocess
 import mk_util
 import mk_project
 
-data = json.loads(urllib.request.urlopen("https://api.github.com/repos/Z3Prover/z3/releases/latest").read().decode())
+release_data = json.loads(urllib.request.urlopen("https://api.github.com/repos/Z3Prover/z3/releases/latest").read().decode())
+release_tag_name = release_data['tag_name']
+release_tag_ref_data = json.loads(urllib.request.urlopen("https://api.github.com/repos/Z3Prover/z3/git/refs/tags/%s" % release_tag_name).read().decode())
+release_tag_sha = release_tag_ref_data['object']['sha']
+release_tag_data = json.loads(urllib.request.urlopen("https://api.github.com/repos/Z3Prover/z3/git/tags/%s" % release_tag_sha).read().decode())
 
-version_str = data['tag_name']
-version_num = version_str[3:]
+release_version = release_tag_name[3:]
+release_commit = release_tag_data['object']['sha']
 
-print(version_str)
+print(release_version)
 
 def mk_dir(d):
     if not os.path.exists(d):
         os.makedirs(d)
 
 def download_installs():
-    for asset in data['assets']:
+    for asset in latest_release_data['assets']:
         url = asset['browser_download_url']
         name = asset['name']
         print("Downloading ", url)
@@ -85,18 +89,13 @@ def unpack():
 def mk_targets():
     mk_dir("out/build")
     shutil.copy("../src/api/dotnet/Microsoft.Z3.targets.in", "out/build/Microsoft.Z3.targets")
-
-def mk_license():
-    mk_dir("out/license")
-    shutil.copy("../LICENSE.txt", "out/license/LICENSE.txt")
     
 def create_nuget_spec():
-    mk_license()
     contents = """<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Microsoft.Z3.x64</id>
-        <version>%s</version>
+        <version>{0}</version>
         <authors>Microsoft</authors>
         <description>
 Z3 is a satisfiability modulo theories solver from Microsoft Research.
@@ -106,17 +105,22 @@ Linux Dependencies:
         </description>
         <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
         <tags>smt constraint solver theorem prover</tags>
-        <iconUrl>https://raw.githubusercontent.com/Z3Prover/z3/master/package/icon.jpg</iconUrl>
+        <iconUrl>https://raw.githubusercontent.com/Z3Prover/z3/{1}/package/icon.jpg</iconUrl>
         <projectUrl>https://github.com/Z3Prover/z3</projectUrl>
-        <licenseUrl>https://raw.githubusercontent.com/Z3Prover/z3/master/LICENSE.txt</licenseUrl>
-        <repository type="git" url="https://github.com/Z3Prover/z3.git" />
+        <licenseUrl>https://raw.githubusercontent.com/Z3Prover/z3/{1}/LICENSE.txt</licenseUrl>
+        <repository
+            type="git"
+            url="https://github.com/Z3Prover/z3.git"
+            branch="master"
+            commit="{1}"
+        />
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <language>en</language>
     </metadata>
-</package>"""
+</package>""".format(release_version, release_commit)
 
     with open("out/Microsoft.Z3.x64.nuspec", 'w') as f:
-        f.write(contents % version_num)
+        f.write(contents)
         
 def create_nuget_package():
     subprocess.call(["nuget", "pack"], cwd="out")
@@ -162,11 +166,11 @@ nuget_sign_input = """
 }"""
 
 def sign_nuget_package():
-    package_name = "Microsoft.Z3.x64.%s.nupkg" % version_num
+    package_name = "Microsoft.Z3.x64.%s.nupkg" % release_version
     input_file = "out/nuget_sign_input.json"
     output_path = os.path.abspath("out").replace("\\","\\\\") 
     with open(input_file, 'w') as f:
-        f.write(nuget_sign_input % (output_path, output_path, version_num, version_num))
+        f.write(nuget_sign_input % (output_path, output_path, release_version, release_version))
     subprocess.call(["EsrpClient.exe", "sign", "-a", "authorization.json", "-p", "policy.json", "-i", input_file, "-o", "out\\diagnostics.json"])
     
     


### PR DESCRIPTION
Ensures links will not break if files are moved
Adding commit to repo metadata assists customer debugging
Ensures license and icon remain unchanged over lifetime of package