### PR TITLE
Require verbosity=1 to log parallel tactic progress

### DIFF
--- a/src/solver/parallel_tactic.cpp
+++ b/src/solver/parallel_tactic.cpp
@@ -351,7 +351,7 @@ private:
     }
 
     void log_branches(lbool status) {
-        IF_VERBOSE(0, verbose_stream() << "(tactic.parallel :progress " << m_progress << "% ";
+        IF_VERBOSE(1, verbose_stream() << "(tactic.parallel :progress " << m_progress << "% ";
                    if (status == l_true)  verbose_stream() << ":status sat";
                    if (status == l_undef) verbose_stream() << ":status unknown";
                    if (m_num_unsat > 0) verbose_stream() << " :closed " << m_num_unsat << "@" << m_last_depth;


### PR DESCRIPTION
The parallel tactic has a lot of output, this makes it silent by default and ups verbosity requirement by 1.