### PR TITLE
Fix Makefile generation for the OCaml api

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2255,7 +2255,7 @@ class MLComponent(Component):
             for m in self.modules:
                 ff = os.path.join(src_dir, m + '.ml')
                 ft = os.path.join(self.sub_dir, m + '.cmx')
-                out.write('%s: %s %s\n' % (ft, ff, cmos))
+                out.write('%s: %s %s %s\n' % (ft, ff, cmos, cmxs))
                 out.write('\t%s -I %s -o %s -c %s\n' % (OCAMLOPTF, self.sub_dir, ft, ff))
                 cmxs = cmxs + ' ' + ft
 


### PR DESCRIPTION
When building the OCaml API each cmx files should depends on the previous ones as they are also used by recent versions of the compilers for optimization purpose:
```
Warning 58: no cmx file was found in path for module A, and its interface was not compiled with -opaque
```
Also, this fixes parallel build of the OCaml API. without this fix, the following problem can occur:
```
#=== ERROR while compiling z3.4.8.1 ===========================================#
# context              2.0.3 | linux/x86_64 | ocaml-base-compiler.4.04.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.04.2/.opam-switch/build/z3.4.8.1
# command              /usr/bin/make -C build -j 71
# exit-code            2
# env-file             ~/.opam/log/z3-1-4345db.env
# output-file          ~/.opam/log/z3-1-4345db.out
### output ###
# [...]
# src/sat/sat_clause.cpp
# src/sat/sat_bdd.cpp
# ocamlfind ocamlopt -package num  -I api/ml -o api/ml/z3enums.cmx -c ../src/api/ml/z3enums.ml
# src/util/mpz.cpp
# ocamlfind ocamlopt -package num  -I api/ml -o api/ml/z3native.cmx -c ../src/api/ml/z3native.ml
# ocamlfind ocamlopt -package num  -I api/ml -o api/ml/z3.cmx -c ../src/api/ml/z3.ml
# File "../src/api/ml/z3.ml", line 1:
# Error: Corrupted compiled interface
# api/ml/z3native.cmi
# make: *** [Makefile:4376: api/ml/z3.cmx] Error 2
# make: *** Waiting for unfinished jobs....
# make: Leaving directory '/home/opam/.opam/4.04.2/.opam-switch/build/z3.4.8.1/build'
```
I'm not too sure how what's the exact reason for it (other people with more knowledge on the subject will have a better idea than me) but I found that problem to reproducible in less than 30 minutes of repetitive build of the cmx files with `make -j 71`. With this patch, this doesn't happen.

cc @c-cube

*On a unrelated note: In the future, I would strongly recommend not staying with this custom build system but maybe use a specialized and tested OCaml build system for the OCaml part. But maybe you don't want to rely on another external dependency which I can understand.*