### PR TITLE
MSYS2 and CMake based Compilation Support for Clang and GCC

### DIFF
--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -39,6 +39,10 @@ Revision History:
 #include "util/file_path.h"
 #include "shell/lp_frontend.h"
 
+#if defined( _WINDOWS ) && defined( __MINGW32__ ) && ( defined( __GNUG__ ) || defined( __clang__ ) )
+#include <crtdbg.h>
+#endif
+
 typedef enum { IN_UNSPECIFIED, IN_SMTLIB_2, IN_DATALOG, IN_DIMACS, IN_WCNF, IN_OPB, IN_LP, IN_Z3_LOG, IN_MPS } input_kind;
 
 static std::string  g_aux_input_file;

--- a/src/util/warning.cpp
+++ b/src/util/warning.cpp
@@ -25,6 +25,10 @@ Revision History:
 #include "util/vector.h"
 
 #ifdef _WINDOWS
+#if defined( __MINGW32__ ) && ( defined( __GNUG__ ) || defined( __clang__ ) )
+#include <crtdbg.h>
+#endif
+
 #define VPRF vsprintf_s
 
 void STD_CALL myInvalidParameterHandler(


### PR DESCRIPTION
`cmake`-based builds in a Windows `msys2` environment are not compiling correct with `gcc` and `clang`, because the `ifdef` guards for `_Windows` platforms expect in some situations only a present `_MSC_VER`, but this leads to compiler errors and warnings.

This PR fixes the following compilation issues:

~~~
Building CXX object src/util/CMakeFiles/util.dir/hwf.cpp.obj
C:/z3/src/util/hwf.cpp:24:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma float_control( except, on )   // exception semantics; this does _not_ mean that exceptions are enabled (we want them off!)
        ^
C:/z3/src/util/hwf.cpp:25:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma float_control( precise, on )  // precise semantics (no guessing!)
        ^
C:/z3/src/util/hwf.cpp:26:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma fp_contract(off)              // contractions off (`contraction' means x*y+z is turned into a fused-mul-add).
        ^
C:/z3/src/util/hwf.cpp:27:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma fenv_access(on)               // fpu environment sensitivity (needed to be allowed to make FPU mode changes).
        ^
C:/z3/src/util/hwf.cpp:278:37: error: invalid operands to binary expression ('double' and 'const hwf')
      o.value = (x.value * y.value) + z;
                ~~~~~~~~~~~~~~~~~~~ ^ ~
C:/z3/src/util/hwf.cpp:327:11: error: expected '(' after 'asm'
    __asm {
          ^
4 warnings and 2 errors generated.
~~~


~~~
Building CXX object src/util/CMakeFiles/util.dir/warning.cpp.obj
C:/z3/src/util/warning.cpp:84:5: error: use of undeclared identifier '_CRT_ASSERT'
    BEGIN_ERR_HANDLER();
    ^
C:/z3/src/util/warning.cpp:44:23: note: expanded from macro 'BEGIN_ERR_HANDLER'
    _CrtSetReportMode(_CRT_ASSERT, 0); \
                      ^
1 error generated.
~~~

~~~
Building CXX object src/shell/CMakeFiles/shell.dir/main.cpp.obj
C:/z3/src/shell/main.cpp:384:9: error: use of undeclared identifier '_CrtDumpMemoryLeaks'
        _CrtDumpMemoryLeaks();
1 error generated.
~~~
 