### PR TITLE
lp_tokenizer: Add missing verbose print

### DIFF
--- a/src/opt/opt_parse.cpp
+++ b/src/opt/opt_parse.cpp
@@ -411,6 +411,7 @@ private:
                     }
                     m_buffer.push_back(0);
                     m_tokens.push_back(asymbol(symbol(m_buffer.c_ptr()), in.line()));
+                    IF_VERBOSE(10, verbose_stream() << "tok: " << m_tokens.back() << "\n");
                     continue;
                 }
             }


### PR DESCRIPTION
Three out of two places that call m_tokens.push_back() in
lp_tokenizer::parse_all() were followed by a verbose print. This commit
adds a verbose print to the third such place.

Signed-off-by: Uli Schlachter <psychon@znc.in>