### PR TITLE
Change from CMAKE_*_DIR to PROJECT_*_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set(z3_polluted_tree_msg
 ################################################################################
 # Sanity check - Disallow building in source
 ################################################################################
-if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
+if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
   message(FATAL_ERROR "In source builds are not allowed. You should invoke "
           "CMake from a different directory.")
 endif()
@@ -61,12 +61,12 @@ endif()
 ################################################################################
 # Add our CMake module directory to the list of module search directories
 ################################################################################
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
 
 ################################################################################
 # Handle git hash and description
 ################################################################################
-include(${CMAKE_SOURCE_DIR}/cmake/git_utils.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/git_utils.cmake)
 macro(disable_git_describe)
   message(WARNING "Disabling INCLUDE_GIT_DESCRIBE")
   set(INCLUDE_GIT_DESCRIBE OFF CACHE BOOL "Include git describe output in version output" FORCE)
@@ -79,11 +79,11 @@ endmacro()
 option(INCLUDE_GIT_HASH "Include git hash in version output" ON)
 option(INCLUDE_GIT_DESCRIBE "Include git describe output in version output" ON)
 
-set(GIT_DIR "${CMAKE_SOURCE_DIR}/.git")
+set(GIT_DIR "${PROJECT_SOURCE_DIR}/.git")
 if (EXISTS "${GIT_DIR}")
   # Try to make CMake configure depend on the current git HEAD so that
   # a re-configure is triggered when the HEAD changes.
-  add_git_dir_dependency("${CMAKE_SOURCE_DIR}" ADD_GIT_DEP_SUCCESS)
+  add_git_dir_dependency("${PROJECT_SOURCE_DIR}" ADD_GIT_DEP_SUCCESS)
   if (ADD_GIT_DEP_SUCCESS)
     if (INCLUDE_GIT_HASH)
       get_git_head_hash("${GIT_DIR}" Z3GITHASH)
@@ -185,7 +185,7 @@ message(STATUS "PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")
 ################################################################################
 # Target architecture detection
 ################################################################################
-include(${CMAKE_SOURCE_DIR}/cmake/target_arch_detect.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/target_arch_detect.cmake)
 detect_target_architecture(TARGET_ARCHITECTURE)
 message(STATUS "Detected target architecture: ${TARGET_ARCHITECTURE}")
 
@@ -193,7 +193,7 @@ message(STATUS "Detected target architecture: ${TARGET_ARCHITECTURE}")
 ################################################################################
 # Function for detecting C++ compiler flag support
 ################################################################################
-include(${CMAKE_SOURCE_DIR}/cmake/z3_add_cxx_flag.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/z3_add_cxx_flag.cmake)
 
 ################################################################################
 # C++ language version
@@ -251,8 +251,8 @@ else()
 endif()
 
 list(APPEND Z3_COMPONENT_EXTRA_INCLUDE_DIRS 
-  "${CMAKE_BINARY_DIR}/src"
-  "${CMAKE_SOURCE_DIR}/src"
+  "${PROJECT_BINARY_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 ################################################################################
@@ -361,7 +361,7 @@ list(APPEND Z3_DEPENDENT_LIBS ${CMAKE_THREAD_LIBS_INIT})
 ################################################################################
 # Compiler warnings
 ################################################################################
-include(${CMAKE_SOURCE_DIR}/cmake/compiler_warnings.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/compiler_warnings.cmake)
 
 ################################################################################
 # Save Clang optimization records
@@ -428,7 +428,7 @@ endif()
 ################################################################################
 # Link time optimization
 ################################################################################
-include(${CMAKE_SOURCE_DIR}/cmake/compiler_lto.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/compiler_lto.cmake)
 
 ################################################################################
 # Control flow integrity
@@ -466,7 +466,7 @@ endif()
 # MSVC specific flags inherited from old build system
 ################################################################################
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-  include(${CMAKE_SOURCE_DIR}/cmake/msvc_legacy_quirks.cmake)
+  include(${PROJECT_SOURCE_DIR}/cmake/msvc_legacy_quirks.cmake)
 endif()
 
 ################################################################################
@@ -527,7 +527,7 @@ message(STATUS "CMAKE_INSTALL_Z3_CMAKE_PACKAGE_DIR: \"${CMAKE_INSTALL_Z3_CMAKE_P
 # Uninstall rule
 ################################################################################
 configure_file(
-  "${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+  "${PROJECT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
   @ONLY
 )
@@ -547,9 +547,9 @@ add_custom_target(uninstall
 ################################################################################
 # To mimic the python build system output these into the root of the build
 # directory
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}")
 
 ################################################################################
 # Extra dependencies for build rules that use the Python infrastructure to
@@ -559,14 +559,14 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 # Note: ``update_api.py`` is deliberately not here because it not used
 # to generate every generated file. The targets that need it list it explicitly.
 set(Z3_GENERATED_FILE_EXTRA_DEPENDENCIES
-  "${CMAKE_SOURCE_DIR}/scripts/mk_genfile_common.py"
+  "${PROJECT_SOURCE_DIR}/scripts/mk_genfile_common.py"
 )
 
 ################################################################################
 # Z3 components, library and executables
 ################################################################################
-include(${CMAKE_SOURCE_DIR}/cmake/z3_add_component.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/z3_append_linker_flag_list_to_target.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/z3_add_component.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/z3_append_linker_flag_list_to_target.cmake)
 add_subdirectory(src)
 
 ################################################################################
@@ -578,22 +578,22 @@ if ("${CMAKE_VERSION}" VERSION_LESS "3.0")
   # FIXME: Remove this once we drop support for CMake 2.8.12
   export(TARGETS libz3
     NAMESPACE z3::
-    FILE "${CMAKE_BINARY_DIR}/Z3Targets.cmake"
+    FILE "${PROJECT_BINARY_DIR}/Z3Targets.cmake"
   )
 else()
   export(EXPORT Z3_EXPORTED_TARGETS
     NAMESPACE z3::
-    FILE "${CMAKE_BINARY_DIR}/Z3Targets.cmake"
+    FILE "${PROJECT_BINARY_DIR}/Z3Targets.cmake"
   )
 endif()
-set(Z3_FIRST_PACKAGE_INCLUDE_DIR "${CMAKE_BINARY_DIR}/src/api")
-set(Z3_SECOND_PACKAGE_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/api")
-set(Z3_CXX_PACKAGE_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/api/c++")
+set(Z3_FIRST_PACKAGE_INCLUDE_DIR "${PROJECT_BINARY_DIR}/src/api")
+set(Z3_SECOND_PACKAGE_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/src/api")
+set(Z3_CXX_PACKAGE_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/src/api/c++")
 set(AUTO_GEN_MSG "Automatically generated. DO NOT EDIT")
 set(CONFIG_FILE_TYPE "build tree")
-configure_package_config_file("${CMAKE_SOURCE_DIR}/cmake/Z3Config.cmake.in"
+configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/Z3Config.cmake.in"
   "Z3Config.cmake"
-  INSTALL_DESTINATION "${CMAKE_BINARY_DIR}"
+  INSTALL_DESTINATION "${PROJECT_BINARY_DIR}"
   PATH_VARS
     Z3_FIRST_PACKAGE_INCLUDE_DIR
     Z3_SECOND_PACKAGE_INCLUDE_DIR
@@ -617,7 +617,7 @@ install(EXPORT
   NAMESPACE z3::
   DESTINATION "${CMAKE_INSTALL_Z3_CMAKE_PACKAGE_DIR}"
 )
-set(Z3_INSTALL_TREE_CMAKE_CONFIG_FILE "${CMAKE_BINARY_DIR}/cmake/Z3Config.cmake")
+set(Z3_INSTALL_TREE_CMAKE_CONFIG_FILE "${PROJECT_BINARY_DIR}/cmake/Z3Config.cmake")
 set(Z3_FIRST_PACKAGE_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
 set(Z3_SECOND_INCLUDE_DIR "")
 set(Z3_CXX_PACKAGE_INCLUDE_DIR "")
@@ -626,7 +626,7 @@ set(CONFIG_FILE_TYPE "install tree")
 # We use `configure_package_config_file()` to try and create CMake files
 # that are re-locatable so that it doesn't matter if the files aren't placed
 # in the original install prefix.
-configure_package_config_file("${CMAKE_SOURCE_DIR}/cmake/Z3Config.cmake.in"
+configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/Z3Config.cmake.in"
   "${Z3_INSTALL_TREE_CMAKE_CONFIG_FILE}"
   INSTALL_DESTINATION "${CMAKE_INSTALL_Z3_CMAKE_PACKAGE_DIR}"
   PATH_VARS Z3_FIRST_PACKAGE_INCLUDE_DIR

--- a/cmake/modules/FindDotnet.cmake
+++ b/cmake/modules/FindDotnet.cmake
@@ -136,11 +136,11 @@ EXECUTE_PROCESS(
 )
 
 IF(WIN32)
-   FIND_PROGRAM(NUGET_EXE nuget PATHS ${CMAKE_BINARY_DIR}/tools)
+   FIND_PROGRAM(NUGET_EXE nuget PATHS ${PROJECT_BINARY_DIR}/tools)
    IF(NUGET_EXE)
        MESSAGE("-- Found nuget: ${NUGET_EXE}")
    ELSE()
-        SET(NUGET_EXE ${CMAKE_BINARY_DIR}/tools/nuget.exe)
+        SET(NUGET_EXE ${PROJECT_BINARY_DIR}/tools/nuget.exe)
         MESSAGE("-- Downloading nuget...")
         FILE(DOWNLOAD https://dist.nuget.org/win-x86-commandline/latest/nuget.exe ${NUGET_EXE})
         MESSAGE("nuget.exe downloaded and saved to ${NUGET_EXE}")
@@ -238,11 +238,11 @@ FUNCTION(DOTNET_GET_DEPS _DN_PROJECT arguments)
         SET(_DN_OUTPUT_PATH ${_DN_projname_noext})
     ENDIF()
 
-    GET_FILENAME_COMPONENT(_DN_OUTPUT_PATH ${CMAKE_BINARY_DIR}/${_DN_OUTPUT_PATH} ABSOLUTE)
+    GET_FILENAME_COMPONENT(_DN_OUTPUT_PATH ${PROJECT_BINARY_DIR}/${_DN_OUTPUT_PATH} ABSOLUTE)
 
     # In a cmake build, the XPLAT libraries are always copied over.
     # Set the proper directory for .NET projects.
-    SET(_DN_XPLAT_LIB_DIR ${CMAKE_BINARY_DIR})
+    SET(_DN_XPLAT_LIB_DIR ${PROJECT_BINARY_DIR})
 
     SET(DOTNET_PACKAGES ${_DN_PACKAGE}  PARENT_SCOPE)
     SET(DOTNET_CONFIG   ${_DN_CONFIG}   PARENT_SCOPE)
@@ -403,7 +403,7 @@ FUNCTION(TEST_DOTNET DOTNET_PROJECT)
     ENDIF()
 
     ADD_TEST(NAME              ${DOTNET_PROJNAME}
-             COMMAND           ${DOTNET_EXE} test ${test_framework_args} --results-directory "${CMAKE_BINARY_DIR}" --logger trx ${DOTNET_ARGUMENTS}
+             COMMAND           ${DOTNET_EXE} test ${test_framework_args} --results-directory "${PROJECT_BINARY_DIR}" --logger trx ${DOTNET_ARGUMENTS}
              WORKING_DIRECTORY ${DOTNET_OUTPUT_PATH})
 
 ENDFUNCTION()
@@ -457,8 +457,8 @@ FUNCTION(GEN_DOTNET_PROPS target_props_file)
         SET(_DN_CUSTOM_BUILDPROPS ${_DNP_XML_INJECT})
     ENDIF()
 
-    SET(_DN_OUTPUT_PATH ${CMAKE_BINARY_DIR})
-    SET(_DN_XPLAT_LIB_DIR ${CMAKE_BINARY_DIR})
+    SET(_DN_OUTPUT_PATH ${PROJECT_BINARY_DIR})
+    SET(_DN_XPLAT_LIB_DIR ${PROJECT_BINARY_DIR})
     SET(_DN_VERSION ${_DNP_PACKAGE_VERSION})
     CONFIGURE_FILE(${DOTNET_IMPORTS_TEMPLATE} ${target_props_file})
     UNSET(_DN_OUTPUT_PATH)

--- a/cmake/target_arch_detect.cmake
+++ b/cmake/target_arch_detect.cmake
@@ -8,8 +8,8 @@
 function(detect_target_architecture OUTPUT_VAR)
   try_run(run_result
     compile_result
-    "${CMAKE_BINARY_DIR}"
-    "${CMAKE_SOURCE_DIR}/cmake/target_arch_detect.cpp"
+    "${PROJECT_BINARY_DIR}"
+    "${PROJECT_SOURCE_DIR}/cmake/target_arch_detect.cpp"
     COMPILE_OUTPUT_VARIABLE compiler_output
   )
   if (compile_result)

--- a/cmake/z3_add_component.cmake
+++ b/cmake/z3_add_component.cmake
@@ -116,9 +116,9 @@ macro(z3_add_component component_name)
     set(_full_output_file_path "${CMAKE_CURRENT_BINARY_DIR}/${_output_file}")
     message(STATUS "Adding rule to generate \"${_output_file}\"")
     add_custom_command(OUTPUT "${_output_file}"
-      COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/scripts/pyg2hpp.py" "${_full_pyg_file_path}" "${CMAKE_CURRENT_BINARY_DIR}"
+      COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/scripts/pyg2hpp.py" "${_full_pyg_file_path}" "${CMAKE_CURRENT_BINARY_DIR}"
       MAIN_DEPENDENCY "${_full_pyg_file_path}"
-      DEPENDS "${CMAKE_SOURCE_DIR}/scripts/pyg2hpp.py"
+      DEPENDS "${PROJECT_SOURCE_DIR}/scripts/pyg2hpp.py"
               ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
       COMMENT "Generating \"${_full_output_file_path}\" from \"${pyg_file}\""
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
@@ -270,10 +270,10 @@ macro(z3_add_install_tactic_rule)
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/install_tactic.deps" ${_tactic_header_files})
   add_custom_command(OUTPUT "install_tactic.cpp"
     COMMAND "${PYTHON_EXECUTABLE}"
-    "${CMAKE_SOURCE_DIR}/scripts/mk_install_tactic_cpp.py"
+    "${PROJECT_SOURCE_DIR}/scripts/mk_install_tactic_cpp.py"
     "${CMAKE_CURRENT_BINARY_DIR}"
     "${CMAKE_CURRENT_BINARY_DIR}/install_tactic.deps"
-    DEPENDS "${CMAKE_SOURCE_DIR}/scripts/mk_install_tactic_cpp.py"
+    DEPENDS "${PROJECT_SOURCE_DIR}/scripts/mk_install_tactic_cpp.py"
             ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
             "${CMAKE_CURRENT_BINARY_DIR}/install_tactic.deps"
     COMMENT "Generating \"${CMAKE_CURRENT_BINARY_DIR}/install_tactic.cpp\""
@@ -308,10 +308,10 @@ macro(z3_add_memory_initializer_rule)
 
   add_custom_command(OUTPUT "mem_initializer.cpp"
     COMMAND "${PYTHON_EXECUTABLE}"
-    "${CMAKE_SOURCE_DIR}/scripts/mk_mem_initializer_cpp.py"
+    "${PROJECT_SOURCE_DIR}/scripts/mk_mem_initializer_cpp.py"
     "${CMAKE_CURRENT_BINARY_DIR}"
     ${_mem_init_finalize_headers}
-    DEPENDS "${CMAKE_SOURCE_DIR}/scripts/mk_mem_initializer_cpp.py"
+    DEPENDS "${PROJECT_SOURCE_DIR}/scripts/mk_mem_initializer_cpp.py"
             ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
             ${_mem_init_finalize_headers}
     COMMENT "Generating \"${CMAKE_CURRENT_BINARY_DIR}/mem_initializer.cpp\""
@@ -344,10 +344,10 @@ macro(z3_add_gparams_register_modules_rule)
 
   add_custom_command(OUTPUT "gparams_register_modules.cpp"
     COMMAND "${PYTHON_EXECUTABLE}"
-    "${CMAKE_SOURCE_DIR}/scripts/mk_gparams_register_modules_cpp.py"
+    "${PROJECT_SOURCE_DIR}/scripts/mk_gparams_register_modules_cpp.py"
     "${CMAKE_CURRENT_BINARY_DIR}"
     ${_register_module_header_files}
-    DEPENDS "${CMAKE_SOURCE_DIR}/scripts/mk_gparams_register_modules_cpp.py"
+    DEPENDS "${PROJECT_SOURCE_DIR}/scripts/mk_gparams_register_modules_cpp.py"
             ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
             ${_register_module_header_files}
     COMMENT "Generating \"${CMAKE_CURRENT_BINARY_DIR}/gparams_register_modules.cpp\""

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -13,7 +13,7 @@ SET(DOC_EXTRA_DEPENDS "")
 
 if (BUILD_PYTHON_BINDINGS)
   # FIXME: Don't hard code this path
-  list(APPEND PYTHON_API_OPTIONS "--z3py-package-path" "${CMAKE_BINARY_DIR}/python/z3")
+  list(APPEND PYTHON_API_OPTIONS "--z3py-package-path" "${PROJECT_BINARY_DIR}/python/z3")
   list(APPEND DOC_EXTRA_DEPENDS "build_z3_python_bindings")
 else()
   list(APPEND PYTHON_API_OPTIONS "--no-z3py")
@@ -22,8 +22,8 @@ endif()
 if (BUILD_DOTNET_BINDINGS)
   # FIXME: Don't hard code these paths
   list(APPEND DOTNET_API_OPTIONS "--dotnet-search-paths"
-    "${CMAKE_SOURCE_DIR}/src/api/dotnet"
-    "${CMAKE_BINARY_DIR}/src/api/dotnet"
+    "${PROJECT_SOURCE_DIR}/src/api/dotnet"
+    "${PROJECT_BINARY_DIR}/src/api/dotnet"
   )
   list(APPEND DOC_EXTRA_DEPENDS "build_z3_dotnet_bindings")
 else()
@@ -33,8 +33,8 @@ endif()
 if (BUILD_JAVA_BINDINGS)
   # FIXME: Don't hard code these paths
   list(APPEND JAVA_API_OPTIONS "--java-search-paths"
-    "${CMAKE_SOURCE_DIR}/src/api/java"
-    "${CMAKE_BINARY_DIR}/src/api/java"
+    "${PROJECT_SOURCE_DIR}/src/api/java"
+    "${PROJECT_BINARY_DIR}/src/api/java"
   )
   list(APPEND DOC_EXTRA_DEPENDS "build_z3_java_bindings")
 else()
@@ -59,7 +59,7 @@ endif()
 add_custom_target(api_docs ${ALWAYS_BUILD_DOCS_ARG}
   COMMAND
   "${PYTHON_EXECUTABLE}" "${MK_API_DOC_SCRIPT}"
-  --build "${CMAKE_BINARY_DIR}"
+  --build "${PROJECT_BINARY_DIR}"
   --doxygen-executable "${DOXYGEN_EXECUTABLE}"
   --output-dir "${DOC_DEST_DIR}"
   --temp-dir "${DOC_TEMP_DIR}"

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,7 +39,7 @@ ExternalProject_Add(c_example
   # Configure step
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/c"
   CMAKE_ARGS
-    "-DZ3_DIR=${CMAKE_BINARY_DIR}"
+    "-DZ3_DIR=${PROJECT_BINARY_DIR}"
     "${EXTERNAL_C_PROJ_USE_CXX_LINKER_ARG}"
     "${EXTERNAL_PROJECT_CMAKE_BUILD_TYPE_ARG}"
   # Build step
@@ -58,7 +58,7 @@ ExternalProject_Add(c_maxsat_example
   # Configure step
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/maxsat"
   CMAKE_ARGS
-    "-DZ3_DIR=${CMAKE_BINARY_DIR}"
+    "-DZ3_DIR=${PROJECT_BINARY_DIR}"
     "${EXTERNAL_C_PROJ_USE_CXX_LINKER_ARG}"
     "${EXTERNAL_PROJECT_CMAKE_BUILD_TYPE_ARG}"
   # Build step
@@ -78,7 +78,7 @@ ExternalProject_Add(cpp_example
   # Configure step
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/c++"
   CMAKE_ARGS
-    "-DZ3_DIR=${CMAKE_BINARY_DIR}"
+    "-DZ3_DIR=${PROJECT_BINARY_DIR}"
     "${EXTERNAL_PROJECT_CMAKE_BUILD_TYPE_ARG}"
   # Build step
   ${EXTERNAL_PROJECT_BUILD_ALWAYS_ARG}
@@ -96,7 +96,7 @@ ExternalProject_Add(z3_tptp5
   # Configure step
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tptp"
   CMAKE_ARGS
-    "-DZ3_DIR=${CMAKE_BINARY_DIR}"
+    "-DZ3_DIR=${PROJECT_BINARY_DIR}"
     "${EXTERNAL_PROJECT_CMAKE_BUILD_TYPE_ARG}"
   # Build step
   ${EXTERNAL_PROJECT_BUILD_ALWAYS_ARG}

--- a/examples/dotnet/CMakeLists.txt
+++ b/examples/dotnet/CMakeLists.txt
@@ -16,17 +16,17 @@ ADD_DOTNET(${CMAKE_CURRENT_BINARY_DIR}/dotnet.csproj
     DEPENDS Microsoft.Z3)
 
 if(UNIX AND NOT APPLE)
-    set(z3_dotnet_native_lib ${CMAKE_BINARY_DIR}/libz3.so)
+    set(z3_dotnet_native_lib ${PROJECT_BINARY_DIR}/libz3.so)
     set(z3_dotnet_test_manual_copy_deps
-        ${CMAKE_BINARY_DIR}/Microsoft.Z3/netstandard2.0/Microsoft.Z3.dll 
+        ${PROJECT_BINARY_DIR}/Microsoft.Z3/netstandard2.0/Microsoft.Z3.dll 
         ${z3_dotnet_native_lib}
         )
 
     add_custom_target(
         z3_dotnet_test_manual_copy_assembly_hack ALL
-        COMMAND ${CMAKE_COMMAND} -E copy ${z3_dotnet_test_manual_copy_deps} ${CMAKE_BINARY_DIR}/dotnet/netcoreapp2.0/
+        COMMAND ${CMAKE_COMMAND} -E copy ${z3_dotnet_test_manual_copy_deps} ${PROJECT_BINARY_DIR}/dotnet/netcoreapp2.0/
         # hack the libz3 entry in deps so it's easy enough for dotnet to reach it...
-        COMMAND sed \"s/runtimes\\/.*libz3\\.so/libz3.so/\" -i ${CMAKE_BINARY_DIR}/dotnet/netcoreapp2.0/dotnet.deps.json
+        COMMAND sed \"s/runtimes\\/.*libz3\\.so/libz3.so/\" -i ${PROJECT_BINARY_DIR}/dotnet/netcoreapp2.0/dotnet.deps.json
         )
 
     add_dependencies(z3_dotnet_test_manual_copy_assembly_hack BUILD_dotnet)

--- a/examples/python/CMakeLists.txt
+++ b/examples/python/CMakeLists.txt
@@ -9,7 +9,7 @@ set(python_example_files
   visitor.py
 )
 
-set(z3py_bindings_build_dest "${CMAKE_BINARY_DIR}/python")
+set(z3py_bindings_build_dest "${PROJECT_BINARY_DIR}/python")
 
 set(build_z3_python_examples_target_depends "")
 foreach (example_file ${python_example_files})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,7 +164,7 @@ set (libz3_public_headers
 )
 foreach (header ${libz3_public_headers})
   set_property(TARGET libz3 APPEND PROPERTY
-    PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/src/api/${header}")
+    PUBLIC_HEADER "${PROJECT_SOURCE_DIR}/src/api/${header}")
 endforeach()
 set_property(TARGET libz3 APPEND PROPERTY
     PUBLIC_HEADER "${CMAKE_CURRENT_BINARY_DIR}/util/z3_version.h")
@@ -187,12 +187,12 @@ if (MSVC)
   add_custom_command(OUTPUT "${dll_module_exports_file}"
     COMMAND
       "${PYTHON_EXECUTABLE}"
-      "${CMAKE_SOURCE_DIR}/scripts/mk_def_file.py"
+      "${PROJECT_SOURCE_DIR}/scripts/mk_def_file.py"
       "${dll_module_exports_file}"
       "libz3"
       ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
     DEPENDS
-      "${CMAKE_SOURCE_DIR}/scripts/mk_def_file.py"
+      "${PROJECT_SOURCE_DIR}/scripts/mk_def_file.py"
       ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
       ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
     COMMENT "Generating \"${dll_module_exports_file}\""

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -19,15 +19,15 @@ endforeach()
 
 add_custom_command(OUTPUT ${generated_files}
   COMMAND "${PYTHON_EXECUTABLE}"
-  "${CMAKE_SOURCE_DIR}/scripts/update_api.py"
+  "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
   ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
   "--api_output_dir"
   "${CMAKE_CURRENT_BINARY_DIR}"
-  DEPENDS "${CMAKE_SOURCE_DIR}/scripts/update_api.py"
+  DEPENDS "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
           ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
           ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
           # FIXME: When update_api.py no longer uses ``mk_util`` drop this dependency
-          "${CMAKE_SOURCE_DIR}/scripts/mk_util.py"
+          "${PROJECT_SOURCE_DIR}/scripts/mk_util.py"
   COMMENT "Generating ${generated_files}"
   ${ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG}
   VERBATIM

--- a/src/api/dotnet/CMakeLists.txt
+++ b/src/api/dotnet/CMakeLists.txt
@@ -10,16 +10,16 @@ set(VER_TWEAK "${Z3_VERSION_TWEAK}")
 set(Z3_DOTNET_NATIVE_FILE "${CMAKE_CURRENT_BINARY_DIR}/Native.cs")
 add_custom_command(OUTPUT "${Z3_DOTNET_NATIVE_FILE}"
   COMMAND "${PYTHON_EXECUTABLE}"
-    "${CMAKE_SOURCE_DIR}/scripts/update_api.py"
+    "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
     "--dotnet-output-dir"
     "${CMAKE_CURRENT_BINARY_DIR}"
   DEPENDS
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
-    "${CMAKE_SOURCE_DIR}/scripts/update_api.py"
+    "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
     # FIXME: When update_api.py no longer uses ``mk_util`` drop this dependency
-    "${CMAKE_SOURCE_DIR}/scripts/mk_util.py"
+    "${PROJECT_SOURCE_DIR}/scripts/mk_util.py"
   COMMENT "Generating ${Z3_DOTNET_NATIVE_FILE}"
   ${ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG}
 )
@@ -28,13 +28,13 @@ add_custom_command(OUTPUT "${Z3_DOTNET_NATIVE_FILE}"
 set(Z3_DOTNET_CONST_FILE "${CMAKE_CURRENT_BINARY_DIR}/Enumerations.cs")
 add_custom_command(OUTPUT "${Z3_DOTNET_CONST_FILE}"
   COMMAND "${PYTHON_EXECUTABLE}"
-    "${CMAKE_SOURCE_DIR}/scripts/mk_consts_files.py"
+    "${PROJECT_SOURCE_DIR}/scripts/mk_consts_files.py"
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
     "--dotnet-output-dir"
     "${CMAKE_CURRENT_BINARY_DIR}"
   DEPENDS
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
-    "${CMAKE_SOURCE_DIR}/scripts/mk_consts_files.py"
+    "${PROJECT_SOURCE_DIR}/scripts/mk_consts_files.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
   COMMENT "Generating ${Z3_DOTNET_CONST_FILE}"
   ${ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG}
@@ -166,7 +166,7 @@ add_custom_target(build_z3_dotnet_bindings ALL DEPENDS BUILD_Microsoft.Z3)
 
 # Register the local nupkg repo
 set(Z3_DOTNET_LOCALREPO_NAME "Microsoft Z3 Local Repository")
-DOTNET_REGISTER_LOCAL_REPOSITORY(${Z3_DOTNET_LOCALREPO_NAME} ${CMAKE_BINARY_DIR})
+DOTNET_REGISTER_LOCAL_REPOSITORY(${Z3_DOTNET_LOCALREPO_NAME} ${PROJECT_BINARY_DIR})
 
 ###############################################################################
 # Install: register a local nuget repo and install our package.
@@ -176,10 +176,10 @@ DOTNET_REGISTER_LOCAL_REPOSITORY(${Z3_DOTNET_LOCALREPO_NAME} ${CMAKE_BINARY_DIR}
 option(INSTALL_DOTNET_BINDINGS "Install .NET bindings when invoking install target" ON)
 
 if(INSTALL_DOTNET_BINDINGS)
-    install(FILES "${CMAKE_BINARY_DIR}/Microsoft.Z3/Microsoft.Z3.${Z3_DOTNET_NUPKG_VERSION}.nupkg" DESTINATION "${CMAKE_INSTALL_LIBDIR}/z3.nuget")
+    install(FILES "${PROJECT_BINARY_DIR}/Microsoft.Z3/Microsoft.Z3.${Z3_DOTNET_NUPKG_VERSION}.nupkg" DESTINATION "${CMAKE_INSTALL_LIBDIR}/z3.nuget")
     # move the local repo to the installation directory (cancel the build-time repo)
     install(CODE "include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/modules/FindDotnet.cmake)\n DOTNET_REGISTER_LOCAL_REPOSITORY(\"${Z3_DOTNET_LOCALREPO_NAME}\" \"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/z3.nuget\")")
-    install(FILES "${CMAKE_BINARY_DIR}/Microsoft.Z3/Microsoft.Z3.xml" DESTINATION "${CMAKE_INSTALL_LIBDIR}/z3.nuget")
+    install(FILES "${PROJECT_BINARY_DIR}/Microsoft.Z3/Microsoft.Z3.xml" DESTINATION "${CMAKE_INSTALL_LIBDIR}/z3.nuget")
 # TODO GAC?
 #  set(GAC_PKG_NAME "Microsoft.Z3.Sharp")
 #  set(PREFIX "${CMAKE_INSTALL_PREFIX}")

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -17,7 +17,7 @@ set(Z3_JAVA_NATIVE_JAVA "${CMAKE_CURRENT_BINARY_DIR}/Native.java")
 set(Z3_JAVA_NATIVE_CPP "${CMAKE_CURRENT_BINARY_DIR}/Native.cpp")
 add_custom_command(OUTPUT "${Z3_JAVA_NATIVE_JAVA}" "${Z3_JAVA_NATIVE_CPP}"
   COMMAND "${PYTHON_EXECUTABLE}"
-    "${CMAKE_SOURCE_DIR}/scripts/update_api.py"
+    "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
     "--java-output-dir"
     "${CMAKE_CURRENT_BINARY_DIR}"
@@ -25,10 +25,10 @@ add_custom_command(OUTPUT "${Z3_JAVA_NATIVE_JAVA}" "${Z3_JAVA_NATIVE_CPP}"
     ${Z3_JAVA_PACKAGE_NAME}
   DEPENDS
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
-    "${CMAKE_SOURCE_DIR}/scripts/update_api.py"
+    "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
     # FIXME: When update_api.py no longer uses ``mk_util`` drop this dependency
-    "${CMAKE_SOURCE_DIR}/scripts/mk_util.py"
+    "${PROJECT_SOURCE_DIR}/scripts/mk_util.py"
   COMMENT "Generating \"${Z3_JAVA_NATIVE_JAVA}\" and \"${Z3_JAVA_NATIVE_CPP}\""
   ${ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG}
 )
@@ -44,8 +44,8 @@ target_link_libraries(z3java PRIVATE libz3)
 target_compile_options(z3java PRIVATE ${Z3_COMPONENT_CXX_FLAGS})
 target_compile_definitions(z3java PRIVATE ${Z3_COMPONENT_CXX_DEFINES})
 target_include_directories(z3java PRIVATE
-  "${CMAKE_SOURCE_DIR}/src/api"
-  "${CMAKE_BINARY_DIR}/src/api"
+  "${PROJECT_SOURCE_DIR}/src/api"
+  "${PROJECT_BINARY_DIR}/src/api"
   ${JNI_INCLUDE_DIRS}
 )
 # FIXME: Should this library have SONAME and VERSION set?
@@ -75,7 +75,7 @@ foreach (enum_file ${Z3_JAVA_ENUMERATION_PACKAGE_FILES})
 endforeach()
 add_custom_command(OUTPUT ${Z3_JAVA_ENUMERATION_PACKAGE_FILES_FULL_PATH}
   COMMAND "${PYTHON_EXECUTABLE}"
-    "${CMAKE_SOURCE_DIR}/scripts/mk_consts_files.py"
+    "${PROJECT_SOURCE_DIR}/scripts/mk_consts_files.py"
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
     "--java-output-dir"
     "${CMAKE_CURRENT_BINARY_DIR}"
@@ -83,7 +83,7 @@ add_custom_command(OUTPUT ${Z3_JAVA_ENUMERATION_PACKAGE_FILES_FULL_PATH}
     ${Z3_JAVA_PACKAGE_NAME}
   DEPENDS
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
-    "${CMAKE_SOURCE_DIR}/scripts/mk_consts_files.py"
+    "${PROJECT_SOURCE_DIR}/scripts/mk_consts_files.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
   COMMENT "Generating ${Z3_JAVA_PACKAGE_NAME}.enumerations package"
   ${ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG}
@@ -203,7 +203,7 @@ add_custom_target(build_z3_java_bindings
 add_jar(z3JavaJar
   SOURCES ${Z3_JAVA_JAR_SOURCE_FILES_FULL_PATH}
   OUTPUT_NAME ${Z3_JAVA_PACKAGE_NAME}
-  OUTPUT_DIR "${CMAKE_BINARY_DIR}"
+  OUTPUT_DIR "${PROJECT_BINARY_DIR}"
   VERSION "${Z3_VERSION}"
 )
 

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -15,7 +15,7 @@ set(z3py_files
   z3/z3util.py
 )
 
-set(z3py_bindings_build_dest "${CMAKE_BINARY_DIR}/python")
+set(z3py_bindings_build_dest "${PROJECT_BINARY_DIR}/python")
 file(MAKE_DIRECTORY "${z3py_bindings_build_dest}")
 file(MAKE_DIRECTORY "${z3py_bindings_build_dest}/z3")
 
@@ -34,16 +34,16 @@ endforeach()
 # Generate z3core.py
 add_custom_command(OUTPUT "${z3py_bindings_build_dest}/z3/z3core.py"
   COMMAND "${PYTHON_EXECUTABLE}"
-    "${CMAKE_SOURCE_DIR}/scripts/update_api.py"
+    "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
     "--z3py-output-dir"
     "${z3py_bindings_build_dest}"
   DEPENDS
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
-    "${CMAKE_SOURCE_DIR}/scripts/update_api.py"
+    "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
     # FIXME: When update_api.py no longer uses ``mk_util`` drop this dependency
-    "${CMAKE_SOURCE_DIR}/scripts/mk_util.py"
+    "${PROJECT_SOURCE_DIR}/scripts/mk_util.py"
   COMMENT "Generating z3core.py"
   ${ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG}
 )
@@ -52,13 +52,13 @@ list(APPEND build_z3_python_bindings_target_depends "${z3py_bindings_build_dest}
 # Generate z3consts.py
 add_custom_command(OUTPUT "${z3py_bindings_build_dest}/z3/z3consts.py"
   COMMAND "${PYTHON_EXECUTABLE}"
-    "${CMAKE_SOURCE_DIR}/scripts/mk_consts_files.py"
+    "${PROJECT_SOURCE_DIR}/scripts/mk_consts_files.py"
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
     "--z3py-output-dir"
     "${z3py_bindings_build_dest}"
   DEPENDS
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
-    "${CMAKE_SOURCE_DIR}/scripts/mk_consts_files.py"
+    "${PROJECT_SOURCE_DIR}/scripts/mk_consts_files.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
   COMMENT "Generating z3consts.py"
   ${ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG}
@@ -74,7 +74,7 @@ endif()
 # Link libz3 into the python directory so bindings work out of the box
 add_custom_command(OUTPUT "${z3py_bindings_build_dest}/libz3${CMAKE_SHARED_MODULE_SUFFIX}"
   COMMAND "${CMAKE_COMMAND}" "-E" "${LINK_COMMAND}"
-    "${CMAKE_BINARY_DIR}/libz3${CMAKE_SHARED_MODULE_SUFFIX}"
+    "${PROJECT_BINARY_DIR}/libz3${CMAKE_SHARED_MODULE_SUFFIX}"
     "${z3py_bindings_build_dest}/libz3${CMAKE_SHARED_MODULE_SUFFIX}"
   DEPENDS libz3
   COMMENT "Linking libz3 into python directory"

--- a/src/ast/pattern/CMakeLists.txt
+++ b/src/ast/pattern/CMakeLists.txt
@@ -8,11 +8,11 @@ endif()
 
 add_custom_command(OUTPUT "database.h"
   COMMAND "${PYTHON_EXECUTABLE}"
-          "${CMAKE_SOURCE_DIR}/scripts/mk_pat_db.py"
+          "${PROJECT_SOURCE_DIR}/scripts/mk_pat_db.py"
           "${CMAKE_CURRENT_SOURCE_DIR}/database.smt2"
           "${CMAKE_CURRENT_BINARY_DIR}/database.h"
   MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/database.smt2"
-  DEPENDS "${CMAKE_SOURCE_DIR}/scripts/mk_pat_db.py"
+  DEPENDS "${PROJECT_SOURCE_DIR}/scripts/mk_pat_db.py"
           ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
   COMMENT "Generating \"database.h\""
   ${ADD_CUSTOM_COMMAND_USES_TERMINAL_ARG}


### PR DESCRIPTION
Z3 uses CMAKE_BINARY_DIR amd CMAKE_SOURCE_DIR all over the place to refer to the root of z3's source code tree. This is great except that it prevents users from embedding z3 as a subfolder in their project. Also PROJECT_BINARY_DIR and PROJECT_SOURCE_DIR are more clear imo.

PROJECT_SOURCE_DIR and PROJECT_BINARY_DIR have existed at least since cmake 3.0. I tested the build after this change but did not run the tests because I couldn't figure out how to build them :D