### PR TITLE
Use const& to reduce copies.

### DIFF
--- a/src/ast/dl_decl_plugin.cpp
+++ b/src/ast/dl_decl_plugin.cpp
@@ -75,7 +75,7 @@ namespace datalog {
                 return nullptr;
             }
             sort* s = to_sort(parameters[i].get_ast());
-            sort_size sz1 = s->get_num_elements();
+            sort_size const& sz1 = s->get_num_elements();
             if (sz1.is_finite()) {
                 r *= rational(sz1.size(),rational::ui64());
             }

--- a/src/ast/pb_decl_plugin.cpp
+++ b/src/ast/pb_decl_plugin.cpp
@@ -70,7 +70,7 @@ func_decl * pb_decl_plugin::mk_func_decl(decl_kind k, unsigned num_parameters, p
             }
             else if (p.is_rational()) {
                 // HACK: ast pretty printer does not work with rationals.
-                rational r = p.get_rational();
+                rational const& r = p.get_rational();
                 if (r.is_int32()) {
                     params.push_back(parameter(r.get_int32()));
                 }

--- a/src/ast/rewriter/bv_bounds.cpp
+++ b/src/ast/rewriter/bv_bounds.cpp
@@ -590,7 +590,7 @@ bool bv_bounds::is_sat() {
 }
 
 struct interval_comp_t {
-    bool operator() (bv_bounds::interval i, bv_bounds::interval j) {
+    bool operator() (bv_bounds::interval const& i, bv_bounds::interval const& j) {
         return (i.first < j.first);
     }
 } interval_comp;

--- a/src/ast/rewriter/pb2bv_rewriter.cpp
+++ b/src/ast/rewriter/pb2bv_rewriter.cpp
@@ -370,7 +370,7 @@ struct pb2bv_rewriter::imp {
         rational         m_min_cost;
         vector<rational> m_base;
 
-        void create_basis(vector<rational> const& seq, rational carry_in, rational cost) {
+        void create_basis(vector<rational> const& seq, rational const& carry_in, rational const& cost) {
             if (cost >= m_min_cost) {
                 return;
             }

--- a/src/math/automata/automaton.h
+++ b/src/math/automata/automaton.h
@@ -495,7 +495,7 @@ public:
     moves const& get_moves_to(unsigned state) const { return m_delta_inv[state]; }
     bool initial_state_is_source() const { return m_delta_inv[m_init].empty(); }
     bool is_final_state(unsigned s) const { return m_final_set.contains(s); }
-    bool is_final_configuration(uint_set s) const {
+    bool is_final_configuration(uint_set const& s) const {
         for (unsigned i : s) {
             if (is_final_state(i))
                 return true;
@@ -547,7 +547,7 @@ public:
     void get_moves_from(unsigned state, moves& mvs, bool epsilon_closure = true) const {
         get_moves(state, m_delta, mvs, epsilon_closure);
     }
-    void get_moves_from_states(uint_set states, moves& mvs, bool epsilon_closure = true) const {
+    void get_moves_from_states(uint_set const& states, moves& mvs, bool epsilon_closure = true) const {
         for (unsigned i : states) {
             moves curr;
             get_moves(i, m_delta, curr, epsilon_closure);


### PR DESCRIPTION
These were found via `clang-tidy`.