### PR TITLE
Merge navigations for stable and nightly builds on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ under the [MIT license](LICENSE.txt).
 
 If you are not familiar with Z3, you can start [here](https://github.com/Z3Prover/z3/wiki#background).
 
-Pre-built binaries for releases are available from [here](https://github.com/Z3Prover/z3/releases), 
-and nightly builds from [here](https://github.com/Z3Prover/bin/tree/master/nightly).
+Pre-built binaries for stable and nightly releases are available from [here](https://github.com/Z3Prover/z3/releases).
 
 Z3 can be built using [Visual Studio][1], a [Makefile][2] or using [CMake][3]. It provides
 [bindings for several programming languages][4]. 
@@ -194,4 +193,4 @@ See [``examples/python``](examples/python) for examples.
 
 ### ``Web Assembly``
 
-[WebAssembly](https://github.com/cpitclaudel/z3.wasm) bindings are provided by Clément Pit-Claudel.
+[WebAssembly](https://github.com/cpitclaudel/z3.wasm) bindings are provided by ClÃ©ment Pit-Claudel.


### PR DESCRIPTION
Merged navigations for stable and nightly builds on README.md, reflecting the very recent update.
I set the encoding to UTF-8.