### PR TITLE
Pass /RELEASE to MSVC linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,14 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 endif()
 
 ################################################################################
+# Pass /RELEASE to the linker so that checksums in PE files are calculated.
+################################################################################
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  string(APPEND CMAKE_EXE_LINKER_FLAGS " /RELEASE")
+  string(APPEND CMAKE_SHARED_LINKER_FLAGS " /RELEASE")
+endif()
+
+################################################################################
 # Report default CMake flags
 ################################################################################
 # This is mainly for debugging.


### PR DESCRIPTION
Without /RELEASE passed to MSVC linker, the checksum field in exe/dll is not calculated. When you load the exe/dll in windbg (e.g., windbg -z libz3.dll), a warning "Unable to verify checksum", see below, will show. With /RELEASE passed to linker, the warning will be gone.

![Capture](https://user-images.githubusercontent.com/6384579/60676133-f35ca800-9e32-11e9-898b-898166ffacbc.JPG)
