### PR TITLE
Fix Incorrect Logging of Newly Introduced Terms During Rewrite

### DIFF
--- a/src/ast/rewriter/th_rewriter.cpp
+++ b/src/ast/rewriter/th_rewriter.cpp
@@ -570,16 +570,46 @@ struct th_rewriter_cfg : public default_rewriter_cfg {
         }
     }
 
-    void log_enodes_for_new_terms(expr *term) {
-        map<expr *, unsigned, ptr_hash<expr>, ptr_eq<expr>> reference_map;
-        count_down_subterm_references(term, reference_map);
-
-        // Any term that was newly introduced by the rewrite step is only referenced within / reachable from the result term.
-        for (auto kv : reference_map) {
-            if (kv.m_value == 0) {
-                m().trace_stream() << "[attach-enode] #" << kv.m_key->get_id() << " 0\n";
+    void log_rewrite_axiom_instantiation(func_decl * f, unsigned num, expr * const * args, expr_ref & result, proof_ref & result_pr) {
+        family_id fid = f->get_family_id();
+        if (fid == m_b_rw.get_fid()) {
+            decl_kind k = f->get_decl_kind();
+            if (k == OP_EQ) {
+                SASSERT(num == 2);
+                fid = m().get_sort(args[0])->get_family_id();
+            }
+            else if (k == OP_ITE) {
+                SASSERT(num == 3);
+                fid = m().get_sort(args[1])->get_family_id();
             }
         }
+        app_ref tmp(m());
+        tmp = m().mk_app(f, num, args);
+        m().trace_stream() << "[inst-discovered] theory-solving " << static_cast<void *>(nullptr) << " " << m().get_family_name(fid) << "# ; #" << tmp->get_id() << "\n";
+        if (m().proofs_enabled())
+            result_pr = m().mk_rewrite(tmp, result);
+        tmp = m().mk_eq(tmp, result);
+        m().trace_stream() << "[instance] " << static_cast<void *>(nullptr) << " #" << tmp->get_id() << "\n";
+
+        // Make sure that both the result term and equality were newly introduced.
+        if (tmp->get_ref_count() == 1) {
+            if (result->get_ref_count() == 1) {
+                map<expr *, unsigned, ptr_hash<expr>, ptr_eq<expr>> reference_map;
+                count_down_subterm_references(result, reference_map);
+
+                // Any term that was newly introduced by the rewrite step is only referenced within / reachable from the result term.
+                for (auto kv : reference_map) {
+                    if (kv.m_value == 0) {
+                        m().trace_stream() << "[attach-enode] #" << kv.m_key->get_id() << " 0\n";
+                    }
+                }
+
+                m().trace_stream() << "[attach-enode] #" << result->get_id() << " 0\n";
+            }
+            m().trace_stream() << "[attach-enode] #" << tmp->get_id() << " 0\n";
+        }
+        m().trace_stream() << "[end-of-instance]\n";
+        m().trace_stream().flush();
     }
 
     br_status reduce_app(func_decl * f, unsigned num, expr * const * args, expr_ref & result, proof_ref & result_pr) {
@@ -587,36 +617,7 @@ struct th_rewriter_cfg : public default_rewriter_cfg {
         br_status st = reduce_app_core(f, num, args, result);
 
         if (st != BR_FAILED && m().has_trace_stream()) {
-            family_id fid = f->get_family_id();
-            if (fid == m_b_rw.get_fid()) {
-                decl_kind k = f->get_decl_kind();
-                if (k == OP_EQ) {
-                    SASSERT(num == 2);
-                    fid = m().get_sort(args[0])->get_family_id();
-                }
-                else if (k == OP_ITE) {
-                    SASSERT(num == 3);
-                    fid = m().get_sort(args[1])->get_family_id();
-                }
-            }
-            app_ref tmp(m());
-            tmp = m().mk_app(f, num, args);
-            m().trace_stream() << "[inst-discovered] theory-solving " << static_cast<void *>(nullptr) << " " << m().get_family_name(fid) << "# ; #" << tmp->get_id() << "\n";
-            if (m().proofs_enabled())
-                result_pr = m().mk_rewrite(tmp, result);
-            tmp = m().mk_eq(tmp, result);
-            m().trace_stream() << "[instance] " << static_cast<void *>(nullptr) << " #" << tmp->get_id() << "\n";
-
-            // Make sure that both the result term and equality were newly introduced.
-            if (tmp->get_ref_count() == 1) {
-                if (result->get_ref_count() == 1) {
-                    log_enodes_for_new_terms(result);
-                    m().trace_stream() << "[attach-enode] #" << result->get_id() << " 0\n";
-                }
-                m().trace_stream() << "[attach-enode] #" << tmp->get_id() << " 0\n";
-            }
-            m().trace_stream() << "[end-of-instance]\n";
-            m().trace_stream().flush();
+            log_rewrite_axiom_instantiation(f, num, args, result, result_pr);
         }
 
         if (st != BR_DONE && st != BR_FAILED) {

--- a/src/ast/rewriter/th_rewriter.cpp
+++ b/src/ast/rewriter/th_rewriter.cpp
@@ -34,8 +34,6 @@ Notes:
 #include "ast/ast_pp.h"
 #include "ast/ast_util.h"
 #include "ast/well_sorted.h"
-#include "ast/ast.h"
-#include <map>
 
 namespace {
 struct th_rewriter_cfg : public default_rewriter_cfg {

--- a/src/ast/rewriter/th_rewriter.cpp
+++ b/src/ast/rewriter/th_rewriter.cpp
@@ -574,7 +574,7 @@ struct th_rewriter_cfg : public default_rewriter_cfg {
         map<expr *, unsigned, ptr_hash<expr>, ptr_eq<expr>> reference_map;
         count_down_subterm_references(term, reference_map);
 
-        // Any term that was newly introduced by the rewrite step is only referenced within the result term.
+        // Any term that was newly introduced by the rewrite step is only referenced within / reachable from the result term.
         for (auto kv : reference_map) {
             if (kv.m_value == 0) {
                 m().trace_stream() << "[attach-enode] #" << kv.m_key->get_id() << " 0\n";


### PR DESCRIPTION
We need to log an ``attach-enode`` line for every term (and only those terms) that was newly introduced by a rewrite step. (Fixes https://bitbucket.org/viperproject/axiom-profiler/issues/13/version-486-of-z3-not-compatible-with)