### PR TITLE
Fix sudoku Java example

### DIFF
--- a/examples/java/JavaExample.java
+++ b/examples/java/JavaExample.java
@@ -521,8 +521,13 @@ class JavaExample
 
         // each column contains a digit at most once
         BoolExpr[] cols_c = new BoolExpr[9];
-        for (int j = 0; j < 9; j++)
-            cols_c[j] = ctx.mkDistinct(X[j]);
+        for (int j = 0; j < 9; j++) {
+            IntExpr[] col = new IntExpr[9];
+            for (int i = 0; i < 9; i++) {
+                col[i] = X[i][j];
+            }
+            cols_c[j] = ctx.mkDistinct(col);
+        }
 
         // each 3x3 square contains a digit at most once
         BoolExpr[][] sq_c = new BoolExpr[3][];
@@ -557,12 +562,10 @@ class JavaExample
         BoolExpr instance_c = ctx.mkTrue();
         for (int i = 0; i < 9; i++)
             for (int j = 0; j < 9; j++)
-                instance_c = ctx.mkAnd(
-                        instance_c,
-                        (BoolExpr) ctx.mkITE(
-                                ctx.mkEq(ctx.mkInt(instance[i][j]),
-                                        ctx.mkInt(0)), ctx.mkTrue(),
-                                ctx.mkEq(X[i][j], ctx.mkInt(instance[i][j]))));
+                if (0 != instance[i][j])
+                    instance_c = ctx.mkAnd(
+                            instance_c,
+                            ctx.mkEq(X[i][j], ctx.mkInt(instance[i][j])));
 
         Solver s = ctx.mkSolver();
         s.add(sudoku_c);


### PR DESCRIPTION
There is a bug in the sudoku Java example: the code that is commented "`// each column contains a digit at most once`" actually enforces that each row contains a digit.

This PR fixes that.

I have also simplified the initial conditions so that it uses an "if" in the Java layer, rather than in the Z3 constraints layer, which is a little more efficient.
