### PR TITLE
Spacer cex

### DIFF
--- a/src/qe/qe_lite.cpp
+++ b/src/qe/qe_lite.cpp
@@ -145,6 +145,7 @@ namespace eq {
                     continue;
                 if (is_sub_extract(vars[i]->get_idx(), definitions[i])) {
                     order.push_back(i);
+                    done.mark(definitions[i]);
                     continue;
                 }
                 var * v = vars[i];


### PR DESCRIPTION
Use strategic_smt_solver to validate counterexamples. Guarantees that counterexamples can be validated (and computed) as long as there is some strategy to decide all necessary queries.