### PR TITLE
Handle dynamic sort of Nth()'s return value in the Python API

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -9976,7 +9976,7 @@ class SeqRef(ExprRef):
     def __getitem__(self, i):
         if _is_int(i):
             i = IntVal(i, self.ctx)
-        return SeqRef(Z3_mk_seq_nth(self.ctx_ref(), self.as_ast(), i.as_ast()), self.ctx)
+        return _to_expr_ref(Z3_mk_seq_nth(self.ctx_ref(), self.as_ast(), i.as_ast()), self.ctx)
 
     def at(self, i):
         if _is_int(i):


### PR DESCRIPTION
When using the Python API at HEAD, I noticed sort mismatches doing things like:
```
a = Const('a', SeqSort(IntSort()))
a[3] + 1
```
No idea whether this the following fix is the right one, but it helped me. Use or ignore at will :)
