### PR TITLE
Allow for `__truediv__` and `__rtruediv__` even when not using Python3

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -8955,14 +8955,13 @@ class FPRef(ExprRef):
         [a, b] = _coerce_fp_expr_list([other, self], self.ctx)
         return fpDiv(_dflt_rm(), a, b, self.ctx)
 
-    if not sys.version < '3':
-        def __truediv__(self, other):
-            """Create the Z3 expression division `self / other`."""
-            return self.__div__(other)
+    def __truediv__(self, other):
+        """Create the Z3 expression division `self / other`."""
+        return self.__div__(other)
 
-        def __rtruediv__(self, other):
-            """Create the Z3 expression division `other / self`."""
-            return self.__rdiv__(other)
+    def __rtruediv__(self, other):
+        """Create the Z3 expression division `other / self`."""
+        return self.__rdiv__(other)
 
     def __mod__(self, other):
         """Create the Z3 expression mod `self % other`."""


### PR DESCRIPTION
Currently, the `__truediv__` and `__rtruediv__` methods inside of `FPRef` are guarded such that they are only exposed if you're running Python 3+.

This causes an issue if you try to use the floating point theory _and_ you've imported `division` from Python's `future` module (see: [PEP 238 -- Changing the Division Operator](https://www.python.org/dev/peps/pep-0238/)).

Script:

```
from __future__ import division

from z3 import FP, FPSort

x = FP('x', FPSort(8, 24))
y = FP('y', FPSort(8, 24))

print (x / y).sort()
```

Output:

```
Traceback (most recent call last):
  File "test.py", line 8, in <module>
    print (x / y).sort()
TypeError: unsupported operand type(s) for /: 'instance' and 'instance'
```

Looking at the other datatypes that have `__truediv__` and `__rtruediv__` implemented (`ArithRef` and `BitVecRef`) these _are not_ guarded in the same way (i.e., they exist in Python 2, even if Python 2 does not use them).

This PR modifies the `FPRef` class such that `__truediv__` and `__rtruediv__` are exposed, irrespective of the Python version (and therefore works with Python 2 and the `future` module).