### PR TITLE
z3str3: fix handling of non-theory terms that return String

### DIFF
--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -8417,7 +8417,7 @@ namespace smt {
                     TRACE("str", tout << "found string-integer conversion term: " << mk_pp(ex, get_manager()) << std::endl;);
                     string_int_conversion_terms.push_back(ap);
                     m_library_aware_axiom_todo.push_back(n);
-                } else if (ap->get_num_args() == 0 && !u.str.is_string(ap)) {
+                } else if (/*ap->get_num_args() == 0 &&*/ !u.str.is_string(ap)) {
                     // if ex is a variable, add it to our list of variables
                     TRACE("str", tout << "tracking variable " << mk_ismt2_pp(ap, get_manager()) << std::endl;);
                     variable_set.insert(ex);

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -8374,6 +8374,21 @@ namespace smt {
         }
     }
 
+    bool theory_str::is_var(expr * e) const {
+        ast_manager & m = get_manager();
+        sort * ex_sort = m.get_sort(e);
+        sort * str_sort = u.str.mk_string_sort();
+        // non-string-sort terms cannot be string variables
+        if (ex_sort != str_sort) return false;
+        // string constants cannot be variables
+        if (u.str.is_string(e)) return false;
+        if (u.str.is_concat(e) || u.str.is_at(e) || u.str.is_extract(e) || u.str.is_replace(e) || u.str.is_itos(e))
+            return false;
+        if (m.is_ite(e))
+            return false;
+        return true;
+    }
+
     void theory_str::set_up_axioms(expr * ex) {
         ast_manager & m = get_manager();
         context & ctx = get_context();
@@ -8417,7 +8432,7 @@ namespace smt {
                     TRACE("str", tout << "found string-integer conversion term: " << mk_pp(ex, get_manager()) << std::endl;);
                     string_int_conversion_terms.push_back(ap);
                     m_library_aware_axiom_todo.push_back(n);
-                } else if (/*ap->get_num_args() == 0 &&*/ !u.str.is_string(ap)) {
+                } else if (is_var(ex)) {
                     // if ex is a variable, add it to our list of variables
                     TRACE("str", tout << "tracking variable " << mk_ismt2_pp(ap, get_manager()) << std::endl;);
                     variable_set.insert(ex);

--- a/src/smt/theory_str.h
+++ b/src/smt/theory_str.h
@@ -572,6 +572,7 @@ protected:
     expr * z3str2_get_eqc_value(expr * n , bool & hasEqcValue);
     bool in_same_eqc(expr * n1, expr * n2);
     expr * collect_eq_nodes(expr * n, expr_ref_vector & eqcSet);
+    bool is_var(expr * e) const;
 
     bool get_arith_value(expr* e, rational& val) const;
     bool get_len_value(expr* e, rational& val);


### PR DESCRIPTION
Fixes #2571 

Changes the variable enumeration phase of the solver to consider non-theory terms (i.e. terms without an interpretation in `theory_str`) to be string variables, allowing the solver to solve for them. We adopt a similar semantics of what counts as a variable as the sequence solver does.