### PR TITLE
Changed makefile generation for ml bindings to use OCAMLFIND variable

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -1955,8 +1955,8 @@ class MLComponent(Component):
                 OCAML_FLAGS += '-g'
 
             if OCAMLFIND:
-                OCAMLCF = OCAMLC + ' ' + 'ocamlc -package zarith' + ' ' + OCAML_FLAGS
-                OCAMLOPTF = OCAMLOPT + ' ' + 'ocamlopt -package zarith' + ' ' + OCAML_FLAGS
+                OCAMLCF = OCAMLFIND + ' ' + 'ocamlc -package zarith' + ' ' + OCAML_FLAGS
+                OCAMLOPTF = OCAMLFIND + ' ' + 'ocamlopt -package zarith' + ' ' + OCAML_FLAGS
             else:
                 OCAMLCF = OCAMLC + ' ' + OCAML_FLAGS
                 OCAMLOPTF = OCAMLOPT + ' ' + OCAML_FLAGS


### PR DESCRIPTION
I believe the python mk_util.py file was changed recently to add a new dependency for the ocaml bindings and some variables got mixed up. It did not build on my system until I made these changes.