### PR TITLE
Reconcile ocaml get_const_interp api with Java and C#

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -1955,8 +1955,8 @@ class MLComponent(Component):
                 OCAML_FLAGS += '-g'
 
             if OCAMLFIND:
-                OCAMLCF = OCAMLC + ' ' + 'ocamlc -package zarith' + ' ' + OCAML_FLAGS
-                OCAMLOPTF = OCAMLOPT + ' ' + 'ocamlopt -package zarith' + ' ' + OCAML_FLAGS
+                OCAMLCF = OCAMLFIND + ' ' + 'ocamlc -package zarith' + ' ' + OCAML_FLAGS
+                OCAMLOPTF = OCAMLFIND + ' ' + 'ocamlopt -package zarith' + ' ' + OCAML_FLAGS
             else:
                 OCAMLCF = OCAMLC + ' ' + OCAML_FLAGS
                 OCAMLOPTF = OCAMLOPT + ' ' + OCAML_FLAGS

--- a/src/api/ml/z3.ml
+++ b/src/api/ml/z3.ml
@@ -1546,8 +1546,7 @@ struct
   end
 
   let get_const_interp (x:model) (f:func_decl) =
-    if FuncDecl.get_arity f <> 0 ||
-       (sort_kind_of_int (Z3native.get_sort_kind (FuncDecl.gc f) (Z3native.get_range (FuncDecl.gc f) f))) = ARRAY_SORT then
+    if FuncDecl.get_arity f <> 0 then
       raise (Error "Non-zero arity functions and arrays have FunctionInterpretations as a model. Use FuncInterp.")
     else
       let np = Z3native.model_get_const_interp (gc x) x f  in

--- a/src/api/ml/z3.ml
+++ b/src/api/ml/z3.ml
@@ -1547,7 +1547,7 @@ struct
 
   let get_const_interp (x:model) (f:func_decl) =
     if FuncDecl.get_arity f <> 0 then
-      raise (Error "Non-zero arity functions and arrays have FunctionInterpretations as a model. Use FuncInterp.")
+      raise (Error "Non-zero arity functions have FunctionInterpretations as a model. Use FuncInterp.")
     else
       let np = Z3native.model_get_const_interp (gc x) x f  in
       if Z3native.is_null_ast np then


### PR DESCRIPTION
This commit for issue #2400 was not propagated over to the ocaml bindings.
https://github.com/Z3Prover/z3/commit/2d4e9a0f67983e8dca9a84666d0ff5f31fb5cb09