### PR TITLE
Link pthread using the --whole-archive option

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2631,7 +2631,10 @@ def mk_config():
         config.write('LINK=%s\n' % CXX)
         config.write('LINK_FLAGS=\n')
         config.write('LINK_OUT_FLAG=-o \n')
-        config.write('LINK_EXTRA_FLAGS= -lpthread %s\n' % LDFLAGS)
+        if is_linux() and (build_static_lib() or build_static_bin()):
+            config.write('LINK_EXTRA_FLAGS=-Wl,--whole-archive -lpthread -Wl,--no-whole-archive %s\n' % LDFLAGS)
+        else:
+            config.write('LINK_EXTRA_FLAGS=-lpthread %s\n' % LDFLAGS)
         config.write('SO_EXT=%s\n' % SO_EXT)
         config.write('SLINK=%s\n' % CXX)
         config.write('SLINK_FLAGS=%s\n' % SLIBFLAGS)


### PR DESCRIPTION
This fixes a SIGSEGV on Ubuntu 16.04 when running z3 compiled with `--staticbin` (issue #2457). It seems that without the `--whole-archive` option the linker does not statically link all pthread symbols.

The fix is described here: https://stackoverflow.com/a/45271521/2491528

Note: also `SLINK_EXTRA_FLAGS` provides a `-lpthread`, but I haven't modified it because I'm not sure how it's used.
