### PR TITLE
CMake: Add options to control building of executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ endif()
 # Useful CMake functions/Macros
 ################################################################################
 include(CheckCXXSourceCompiles)
+include(CMakeDependentOption)
 
 ################################################################################
 # Compiler flags for Z3 components.

--- a/README-CMake.md
+++ b/README-CMake.md
@@ -271,6 +271,8 @@ The following useful options can be passed to CMake whilst configuring.
 * ``WARNINGS_AS_ERRORS`` - STRING. If set to ``TRUE`` compiler warnings will be treated as errors. If set to ``False`` compiler warnings will not be treated as errors.
     If set to ``SERIOUS_ONLY`` a subset of compiler warnings will be treated as errors.
 * ``Z3_C_EXAMPLES_FORCE_CXX_LINKER`` - BOOL. If set to ``TRUE`` the C API examples will request that the C++ linker is used rather than the C linker.
+* ``Z3_BUILD_EXECUTABLE`` - BOOL. If set to ``TRUE`` build the z3 executable. Defaults to ``TRUE`` unless z3 is being built as a submodule in which case it defaults to ``FALSE``.
+* ``Z3_BUILD_TEST_EXECUTABLES`` - BOOL. If set to ``TRUE`` build the z3 test executables. Defaults to ``TRUE`` unless z3 is being built as a submodule in which case it defaults to ``FALSE``.
 
 On the command line these can be passed to ``cmake`` using the ``-D`` option. In ``ccmake`` and ``cmake-gui`` these can be set in the user interface.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -209,13 +209,24 @@ endif()
 ################################################################################
 # Z3 executable
 ################################################################################
-add_subdirectory(shell)
+cmake_dependent_option(Z3_BUILD_EXECUTABLE
+    "Build the z3 executable" ON
+    "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+
+if(Z3_BUILD_EXECUTABLE)
+    add_subdirectory(shell)
+endif()
 
 ################################################################################
 # z3-test
 ################################################################################
-add_subdirectory(test)
+cmake_dependent_option(Z3_BUILD_TEST_EXECUTABLES
+    "Build test executables" ON
+    "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
+if(Z3_BUILD_TEST_EXECUTABLES)
+    add_subdirectory(test)
+endif()
 
 ################################################################################
 # Z3 API bindings


### PR DESCRIPTION
- `Z3_BUILD_EXECUTABLE` - build the z3 executable
- `Z3_BUILD_TEST_EXECUTABLES` - build the test executables

If building z3 as a submodule, the default is to not build these executables.

Fixes #2708