### PR TITLE
Fix "Unbound module Z" error when invoking ocamldoc.

### DIFF
--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -317,7 +317,7 @@ try:
     if ML_ENABLED:
         ml_output_dir = os.path.join(OUTPUT_DIRECTORY, 'html', 'ml')
         mk_dir(ml_output_dir)
-        if subprocess.call(['ocamldoc', '-html', '-d', ml_output_dir, '-sort', '-hide', 'Z3', '-I', '%s/api/ml' % BUILD_DIR, '%s/api/ml/z3enums.mli' % BUILD_DIR, '%s/api/ml/z3.mli' % BUILD_DIR]) != 0:
+        if subprocess.call(['ocamldoc', '-html', '-d', ml_output_dir, '-sort', '-hide', 'Z3', '-I', '+zarith', '-I', '%s/api/ml' % BUILD_DIR, '%s/api/ml/z3enums.mli' % BUILD_DIR, '%s/api/ml/z3.mli' % BUILD_DIR]) != 0:
             print("ERROR: ocamldoc failed.")
             exit(1)
         print("Generated ML/OCaml documentation.")


### PR DESCRIPTION
With the 4.8.7 release, if ocaml is enabled, then the ocamldoc invocation fails:
```
File "../build/api/ml/z3.mli", line 1162, characters 35-38:
1162 |     val get_big_int : Expr.expr -> Z.t
                                          ^^^
Error: Unbound module Z
1 error(s) encountered
ERROR: ocamldoc failed.
```
Adding "-I +zarith" to the ocamldoc invocation fixes the problem.