### PR TITLE
Make z3::exception a subclass of std::exception

### DIFF
--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -80,11 +80,12 @@ namespace z3 {
     /**
        \brief Exception used to sign API usage errors.
     */
-    class exception {
+    class exception : public std::exception {
         std::string m_msg;
     public:
         exception(char const * msg):m_msg(msg) {}
         char const * msg() const { return m_msg.c_str(); }
+        char const * what() const noexcept { return m_msg.c_str(); }
         friend std::ostream & operator<<(std::ostream & out, exception const & e);
     };
     inline std::ostream & operator<<(std::ostream & out, exception const & e) { out << e.msg(); return out; }


### PR DESCRIPTION
I'm writing a [Julia wrapper](https://github.com/ahumenberger/Z3.jl) for Z3 by using [CxxWrap.jl](https://github.com/JuliaInterop/CxxWrap.jl). CxxWrap makes wrapping C++ code pretty easy and straightforward, and it also catches `std::exception`s and turns them into Julia exceptions. So, instead of Julia crashing because of the unhandled exception, this change would improve the experience in Julia (especially in REPL mode). Is there any reason for not subclassing `std::exception`?