### PR TITLE
z3str3: negative lengths in get_len_value don't count

### DIFF
--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -5062,7 +5062,7 @@ namespace smt {
         }
 
         TRACE("str", tout << "length of " << mk_ismt2_pp(e, m) << " is " << val << std::endl;);
-        return val.is_int();
+        return val.is_int() && val.is_nonneg();
     }
 
     /*


### PR DESCRIPTION
Fixes #2713 