### PR TITLE
Fix #2736

### DIFF
--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -1879,6 +1879,10 @@ namespace smt {
             expr_ref axiom1(ctx.mk_eq_atom(axiom1_lhs, axiom1_rhs), m);
             SASSERT(axiom1);
             assert_axiom(axiom1);
+
+            expr_ref zero(mk_string("0"), m);
+            expr_ref pref(u.str.mk_prefix(zero, ex), m);
+            assert_implication(pref, ctx.mk_eq_atom(ex, zero));
         }
     }
 

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -1884,8 +1884,9 @@ namespace smt {
         // axiom 2: (str.from-int N) should not result in a string with leading zeros.
         expr_ref zero(mk_string("0"), m);
         expr_ref pref(u.str.mk_prefix(zero, ex), m);
-        // The result does not start with a "0" xor the result is "0"
-        assert_axiom(m.mk_or(m.mk_and(mk_not(m, pref), ctx.mk_eq_atom(ex, zero)), m.mk_and(pref, mk_not(m, ctx.mk_eq_atom(ex, zero)))));
+        // The result does not start with a "0" (~p) xor the result is "0" (q)
+        // ~p xor q == (p or q) and (~p or ~q)
+        assert_axiom(m.mk_and(m.mk_or(pref, ctx.mk_eq_atom(ex, zero)), m.mk_or(mk_not(m, pref), mk_not(m, ctx.mk_eq_atom(ex, zero)))));
     }
 
     expr * theory_str::mk_RegexIn(expr * str, expr * regexp) {

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -1879,11 +1879,13 @@ namespace smt {
             expr_ref axiom1(ctx.mk_eq_atom(axiom1_lhs, axiom1_rhs), m);
             SASSERT(axiom1);
             assert_axiom(axiom1);
-
-            expr_ref zero(mk_string("0"), m);
-            expr_ref pref(u.str.mk_prefix(zero, ex), m);
-            assert_implication(pref, ctx.mk_eq_atom(ex, zero));
         }
+
+        // axiom 2: (str.from-int N) should not result in a string with leading zeros.
+        expr_ref zero(mk_string("0"), m);
+        expr_ref pref(u.str.mk_prefix(zero, ex), m);
+        // The result does not start with a "0" xor the result is "0"
+        assert_axiom(m.mk_or(m.mk_and(mk_not(m, pref), ctx.mk_eq_atom(ex, zero)), m.mk_and(pref, mk_not(m, ctx.mk_eq_atom(ex, zero)))));
     }
 
     expr * theory_str::mk_RegexIn(expr * str, expr * regexp) {

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -1882,14 +1882,16 @@ namespace smt {
         }
 
         // axiom 2: The only (str.from-int N) that starts with a "0" is "0".
-        expr_ref zero(mk_string("0"), m);
-        // let (the result starts with a "0") be p
-        expr_ref p(u.str.mk_prefix(zero, ex), m);
-        // let (the result is "0") be q  
-        expr_ref q(ctx.mk_eq_atom(ex, zero), m);
-        // encoding: the result does NOT start with a "0" (~p) xor the result is "0" (q)
-        // ~p xor q == (~p or q) and (p or ~q)
-        assert_axiom(m.mk_and(m.mk_or(mk_not(m, p), q), m.mk_or(p, mk_not(m, q))));
+        {
+            expr_ref zero(mk_string("0"), m);
+            // let (the result starts with a "0") be p
+            expr_ref starts_with_zero(u.str.mk_prefix(zero, ex), m);
+            // let (the result is "0") be q  
+            expr_ref is_zero(ctx.mk_eq_atom(ex, zero), m);
+            // encoding: the result does NOT start with a "0" (~p) xor the result is "0" (q)
+            // ~p xor q == (~p or q) and (p or ~q)
+            assert_axiom(m.mk_and(m.mk_or(m.mk_not(starts_with_zero), is_zero), m.mk_or(starts_with_zero, m.mk_not(is_zero))));
+        }
     }
 
     expr * theory_str::mk_RegexIn(expr * str, expr * regexp) {

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -1881,12 +1881,15 @@ namespace smt {
             assert_axiom(axiom1);
         }
 
-        // axiom 2: (str.from-int N) should not result in a string with leading zeros.
+        // axiom 2: The only (str.from-int N) that starts with a "0" is "0".
         expr_ref zero(mk_string("0"), m);
-        expr_ref pref(u.str.mk_prefix(zero, ex), m);
-        // The result does not start with a "0" (~p) xor the result is "0" (q)
-        // ~p xor q == (p or q) and (~p or ~q)
-        assert_axiom(m.mk_and(m.mk_or(pref, ctx.mk_eq_atom(ex, zero)), m.mk_or(mk_not(m, pref), mk_not(m, ctx.mk_eq_atom(ex, zero)))));
+        // let (the result starts with a "0") be p
+        expr_ref p(u.str.mk_prefix(zero, ex), m);
+        // let (the result is "0") be q  
+        expr_ref q(ctx.mk_eq_atom(ex, zero), m);
+        // encoding: the result does NOT start with a "0" (~p) xor the result is "0" (q)
+        // ~p xor q == (~p or q) and (p or ~q)
+        assert_axiom(m.mk_and(m.mk_or(mk_not(m, p), q), m.mk_or(p, mk_not(m, q))));
     }
 
     expr * theory_str::mk_RegexIn(expr * str, expr * regexp) {


### PR DESCRIPTION
Issue #2736 exploits that the translation from a string to an int in finalcheck_int2str ignores leading zeros. The fix is to enforce that int.to.str does not produce a string with a prefix of "0", unless the string is "0".