### PR TITLE
Link librt when compiling with --staticbin on Linux

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2632,7 +2632,7 @@ def mk_config():
         config.write('LINK_FLAGS=\n')
         config.write('LINK_OUT_FLAG=-o \n')
         if is_linux() and (build_static_lib() or build_static_bin()):
-            config.write('LINK_EXTRA_FLAGS=-Wl,--whole-archive -lpthread -Wl,--no-whole-archive %s\n' % LDFLAGS)
+            config.write('LINK_EXTRA_FLAGS=-Wl,--whole-archive -lrt -lpthread -Wl,--no-whole-archive %s\n' % LDFLAGS)
         else:
             config.write('LINK_EXTRA_FLAGS=-lpthread %s\n' % LDFLAGS)
         config.write('SO_EXT=%s\n' % SO_EXT)


### PR DESCRIPTION
Fix for issue #2457. The workaround is described here: https://stackoverflow.com/questions/58848694/gcc-whole-archive-recipe-for-static-linking-to-pthread-stopped-working-in-rec.

On Ubuntu 19.04 this is enough to avoid a SIGSEGV when running `z3 -v`.
