### PR TITLE
z3str3: don't call propagate() in init_search_eh()

### DIFF
--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -7748,10 +7748,6 @@ namespace smt {
             set_up_axioms(ex);
         }
 
-        // this might be cheating but we need to make sure that certain maps are populated
-        // before the first call to new_eq_eh()
-        propagate();
-
         TRACE("str", tout << "search started" << std::endl;);
         search_started = true;
     }


### PR DESCRIPTION
Fixes #2692. 

@NikolajBjorner would the following statements be considered best practice wrt. the context of this change?
- theory solvers shouldn't assert axioms in init_search() (since the core solver asserts that the context does not become inconsistent after init_search() is called)
- theory solvers shouldn't manually call propagate() (this shouldn't ever really be necessary)