### PR TITLE
Pipelines now use SNK file in repo instead of secure file

### DIFF
--- a/scripts/mk_win_dist.cmd
+++ b/scripts/mk_win_dist.cmd
@@ -1,9 +1,9 @@
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 
-python scripts\mk_win_dist.py --x64-only --dotnet-key=$(Agent.TempDirectory)\z3.snk
+python scripts\mk_win_dist.py --x64-only --dotnet-key=$(Build.SourcesDirectory/resources/z3.snk
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
 
-python scripts\mk_win_dist.py --x86-only --dotnet-key=$(Agent.TempDirectory)\z3.snk
+python scripts\mk_win_dist.py --x86-only --dotnet-key=$(Build.SourcesDirectory)/resources/z3.snk
 

--- a/scripts/nightly.yaml
+++ b/scripts/nightly.yaml
@@ -8,10 +8,7 @@ jobs:
   pool:
     vmImage: "macOS-10.14"
   steps:
-  - task: DownloadSecureFile@1
-    inputs:
-      secureFile: 'z3.snk'
-  - script: python scripts/mk_unix_dist.py --dotnet-key=$(Agent.TempDirectory)/z3.snk
+  - script: python scripts/mk_unix_dist.py --dotnet-key=$(Build.SourcesDirectory)/resources/z3.snk
   - script: git clone https://github.com/z3prover/z3test z3test
   - script: python z3test/scripts/test_benchmarks.py build-dist/z3 z3test/regressions/smt2    
   - script: cp dist/*.zip $(Build.ArtifactStagingDirectory)/.
@@ -25,10 +22,7 @@ jobs:
   pool:
     vmImage: "ubuntu-16.04"
   steps:
-  - task: DownloadSecureFile@1
-    inputs:
-      secureFile: 'z3.snk'
-  - script: python scripts/mk_unix_dist.py --dotnet-key=$(Agent.TempDirectory)/z3.snk
+  - script: python scripts/mk_unix_dist.py --dotnet-key=$(Build.SourcesDirectory)/resources/z3.snk
   - script: git clone https://github.com/z3prover/z3test z3test
   - script: python z3test/scripts/test_benchmarks.py build-dist/z3 z3test/regressions/smt2    
   - script: cp dist/*.zip $(Build.ArtifactStagingDirectory)/.
@@ -59,9 +53,6 @@ jobs:
   pool:
     vmImage: "vs2017-win2016"
   steps:
-  - task: DownloadSecureFile@1
-    inputs:
-      secureFile: 'z3.snk'
   - script: scripts\mk_win_dist.cmd
 #  - script: git clone https://github.com/z3prover/z3test z3test
 #  - script: python z3test/scripts/test_benchmarks.py build-dist\z3.exe z3test/regressions/smt2    

--- a/scripts/release.yml
+++ b/scripts/release.yml
@@ -5,10 +5,7 @@ jobs:
   pool:
     vmImage: "macOS-10.14"
   steps:
-  - task: DownloadSecureFile@1
-    inputs:
-      secureFile: 'z3.snk'
-  - script: python scripts/mk_unix_dist.py --dotnet-key=$(Agent.TempDirectory)/z3.snk
+  - script: python scripts/mk_unix_dist.py --dotnet-key=$(Build.SourcesDirectory)/resources/z3.snk
   - script: git clone https://github.com/z3prover/z3test z3test
   - script: python z3test/scripts/test_benchmarks.py build-dist/z3 z3test/regressions/smt2
   - script: cp dist/*.zip $(Build.ArtifactStagingDirectory)/.
@@ -22,10 +19,7 @@ jobs:
   pool:
     vmImage: "ubuntu-16.04"
   steps:
-  - task: DownloadSecureFile@1
-    inputs:
-      secureFile: 'z3.snk'
-  - script: python scripts/mk_unix_dist.py --dotnet-key=$(Agent.TempDirectory)/z3.snk
+  - script: python scripts/mk_unix_dist.py --dotnet-key=$(Build.SourcesDirectory)/resources/z3.snk
   - script: git clone https://github.com/z3prover/z3test z3test
   - script: python z3test/scripts/test_benchmarks.py build-dist/z3 z3test/regressions/smt2
   - script: cp dist/*.zip $(Build.ArtifactStagingDirectory)/.
@@ -56,9 +50,6 @@ jobs:
   pool:
     vmImage: "vs2017-win2016"
   steps:
-  - task: DownloadSecureFile@1
-    inputs:
-      secureFile: 'z3.snk'
   - script: scripts\mk_win_dist.cmd
   - script: xcopy dist\*.zip $(Build.ArtifactStagingDirectory)\* /y
   - task: PublishPipelineArtifact@0


### PR DESCRIPTION
The SNK file for strongname-signing .NET assemblies was open-sourced in repo; these changes switch the pipelines to use that SNK file instead of the file stored in the Azure Dev Ops pipeline secure file store.