### PR TITLE
Fix EOF detection when char is unsigned.

### DIFF
--- a/src/parsers/util/scanner.cpp
+++ b/src/parsers/util/scanner.cpp
@@ -480,7 +480,7 @@ scanner::token scanner::scan() {
             return read_number(ch, true);
         case '#':
             return read_bv_literal();
-        case -1:
+        case static_cast<char>(-1):
             m_state = EOF_TOKEN;
             break;
         default:


### PR DESCRIPTION
On systems where the `char` type is unsigned, such as s390x, gcc complains:
```
../src/parsers/util/scanner.cpp: In member function ‘scanner::token scanner::scan()’:
../src/parsers/util/scanner.cpp:483:9: warning: case label value is less than minimum value for type [-Wswitch-outside-range]
  483 |         case -1:
      |         ^~~~
```
This patch creates a case label with the correct `char` value, whether `char` is signed or unsigned.