### PR TITLE
Add explicit instantiation of update_inf_cost_for_column_tableau.

### DIFF
--- a/src/math/lp/lp_primal_core_solver.cpp
+++ b/src/math/lp/lp_primal_core_solver.cpp
@@ -38,5 +38,6 @@ template void lp::lp_primal_core_solver<double, double>::clear_breakpoints();
 template bool lp::lp_primal_core_solver<lp::mpq, lp::mpq>::update_basis_and_x_tableau(int, int, lp::mpq const&);
 template bool lp::lp_primal_core_solver<double, double>::update_basis_and_x_tableau(int, int, double const&);
 template bool lp::lp_primal_core_solver<lp::mpq, lp::numeric_pair<lp::mpq> >::update_basis_and_x_tableau(int, int, lp::numeric_pair<lp::mpq> const&);
+template void lp::lp_primal_core_solver<rational, lp::numeric_pair<rational> >::update_inf_cost_for_column_tableau(unsigned);
 
 }


### PR DESCRIPTION
We are currently building all Fedora packages with an early version of GCC 10.  The z3 package build failed on s390x due to a missing template instantiation.  Subsequent discussion is here:

https://bugzilla.redhat.com/show_bug.cgi?id=1794127

As noted in that bug, the explicit instantiation is needed to make the code correct.  See the link above for references to the standard.