### PR TITLE
[spacer] Keep temporary reference to keep the pob tree alive long enough while resetting.

### DIFF
--- a/src/muz/spacer/spacer_context.cpp
+++ b/src/muz/spacer/spacer_context.cpp
@@ -162,6 +162,7 @@ void pob_queue::pop() {
 
 void pob_queue::set_root(pob& root)
 {
+    pob_ref tmp = m_root;
     m_root = &root;
     m_max_level = root.level ();
     m_min_depth = root.depth ();


### PR DESCRIPTION
I'm entirely unfamiliar with the z3 or spacer code base - but we're using it in the solidity compiler https://github.com/ethereum/solidity and noticed some memory issues in Z3 using valgrind in our test runs.

The issue was reported in src/muz/spacer/spacer_context.cpp line 177 ``p->set_in_queue(false)`` and stated that ``p`` was already freed.
If I understand the code correctly, then ``m_root`` is kept alive using reference counting and the assignment ``m_root = &root;`` decreases the reference count (potentially) causing the pob tree to be freed. Yet *afterwards* the ``reset()`` call still accesses the elements in the queue, even though they may already be freed.

If I'm right, then one solution would be to keep ``m_root`` alive for the scope of ``set_root`` until after the ``reset()`` call by adding a temporary reference to it - that's what I do in this PR and at least for our test runs it solves the issue reported by valgrind.
