### PR TITLE
Bug in AIG finder

### DIFF
--- a/src/sat/sat_aig_finder.cpp
+++ b/src/sat/sat_aig_finder.cpp
@@ -110,7 +110,7 @@ namespace sat {
         struct binary {
             literal x, y;
             use_list_t* use_list;
-            binary(literal x, literal y, use_list_t* u): x(x), y(y), use_list(u) {
+            binary(literal _x, literal _y, use_list_t* u): x(_x), y(_y), use_list(u) {
                 if (x.index() > y.index()) std::swap(x, y);
             }
             binary():x(null_literal), y(null_literal), use_list(nullptr) {}
@@ -140,8 +140,8 @@ namespace sat {
         struct ternary {
             literal x, y, z;
             clause* orig;
-            ternary(literal x, literal y, literal z, clause* c):
-                x(x), y(y), z(z), orig(c) {
+            ternary(literal _x, literal _y, literal _z, clause* c):
+                x(_x), y(_y), z(_z), orig(c) {
                 if (x.index() > y.index()) std::swap(x, y);
                 if (y.index() > z.index()) std::swap(y, z);
                 if (x.index() > y.index()) std::swap(x, y);

--- a/src/sat/sat_aig_finder.h
+++ b/src/sat/sat_aig_finder.h
@@ -53,8 +53,8 @@ namespace sat {
     public:
         aig_finder(solver& s);
         ~aig_finder() {}                
-        void set(std::function<void (literal head, literal_vector const& ands)>& f) { m_on_aig = f; }
-        void set(std::function<void (literal head, literal cond, literal th, literal el)>& f) { m_on_if = f; }
+        void set(std::function<void (literal head, literal_vector const& ands)> const& f) { m_on_aig = f; }
+        void set(std::function<void (literal head, literal cond, literal th, literal el)> const& f) { m_on_if = f; }
         void operator()(clause_vector& clauses);
     };
 }


### PR DESCRIPTION
Constructor compares (and orders) constructor arguments, and not the member variables, since they have the same name.

Also changed signature of functors to `const&` in order to pass lambdas.
