### PR TITLE
AIG finder does not find all structural ite occurrences 

### DIFF
--- a/src/sat/sat_aig_finder.cpp
+++ b/src/sat/sat_aig_finder.cpp
@@ -217,8 +217,11 @@ namespace sat {
             if (c.size() != 3 || c.was_used()) continue;
             literal x = c[0], y = c[1], z = c[2];
             if (try_ite(x, z, y, c)) continue;
+            if (try_ite(x, y, z, c)) continue;
             if (try_ite(y, x, z, c)) continue;
-            if (try_ite(z, y, x, c)) continue;            
+            if (try_ite(z, x, y, c)) continue;
+            if (try_ite(z, y, x, c)) continue;
+            if (try_ite(y, z, x, c)) continue;
         }
         
         std::function<bool(clause*)> not_used = [](clause* cp) { return !cp->was_used(); };


### PR DESCRIPTION
I needed to add these cases to find more ite. The current code (without the fix) won't e.g. find the following if-then-else:

```
reslimit r;

sat::solver s({}, r);
s.mk_var();
s.mk_var();
s.mk_var();
s.mk_var();

s.mk_clause({ 0, true }, { 1, true }, { 3, false });
s.mk_clause({ 0, true }, { 1, false }, { 3, true });
s.mk_clause({ 0, false }, { 2, true }, { 3, false });
s.mk_clause({ 0, false }, { 2, false }, { 3, true });

sat::aig_finder f_aig(s);
f_aig.set([](sat::literal head, sat::literal c, sat::literal t, sat::literal e) {
    std::cout << head << " = " << c << " ? " << t << " : " << e << '\n';
});
sat::clause_vector clauses(s.clauses());
f_aig(clauses);
```
