### PR TITLE
Use Position Independent Code flag on Static library builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,16 +374,15 @@ endif()
 # Position independent code
 ################################################################################
 # This is required because code built in the components will end up in a shared
-# library. If not building a shared library ``-fPIC`` isn't needed and would add
-# unnecessary overhead.
-if (Z3_BUILD_LIBZ3_SHARED)
-  # Avoid adding -fPIC compiler switch if we compile with MSVC (which does not
-  # support the flag) or if we target Windows, which generally does not use
-  # position independent code for native code shared libraries (DLLs).
-  if (NOT (MSVC OR MINGW OR WIN32))
-    z3_add_cxx_flag("-fPIC" REQUIRED)
-  endif()
+# library.
+
+# Avoid adding -fPIC compiler switch if we compile with MSVC (which does not
+# support the flag) or if we target Windows, which generally does not use
+# position independent code for native code shared libraries (DLLs).
+if (NOT (MSVC OR MINGW OR WIN32))
+  z3_add_cxx_flag("-fPIC" REQUIRED)
 endif()
+
 
 ################################################################################
 # Link time optimization


### PR DESCRIPTION
Not compiling libz3 with `-fPIC` may lead to errors when using it in his static flavor from a shared library.

Related https://github.com/Z3Prover/z3/issues/4038