### PR TITLE
Fix the Julia bindings paragraph in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,12 +200,13 @@ python -c 'import z3; print(z3.get_version_string())'
 
 See [``examples/python``](examples/python) for examples.
 
+### ``Julia``
+
+[Julia bindings](src/api/julia) can be enabled using the build option `Z3_BUILD_JULIA_BINDINGS` from the CMake system.
+
 ### ``Web Assembly``
 
 [WebAssembly](https://github.com/cpitclaudel/z3.wasm) bindings are provided by Clément Pit-Claudel.
-
-### ``Julia```
-Julia bindings can be enabled using the build option Z3_BUILD_JULIA_BINDINGS from the CMake system.
 
 ## System Overview
 


### PR DESCRIPTION
Fixing the formatting, also moved below Python, since it's semantically closer to it.