### PR TITLE
Improve UX for unreachable/unimplemented errors

### DIFF
--- a/src/util/debug.cpp
+++ b/src/util/debug.cpp
@@ -23,6 +23,7 @@ Revision History:
 #include<iostream>
 #include "util/str_hashtable.h"
 #include "util/z3_exception.h"
+#include "util/z3_version.h"
 
 static volatile bool g_enable_assertions = true;
 
@@ -39,6 +40,10 @@ void notify_assertion_violation(const char * fileName, int line, const char * co
     std::cerr << "File: " << fileName << "\n";
     std::cerr << "Line: " << line << "\n";
     std::cerr << condition << "\n";
+#ifndef Z3DEBUG
+    std::cerr << Z3_FULL_VERSION << "\n";
+    std::cerr << "Please file an issue with this message and more detail about how you encountered it at https://github.com/Z3Prover/z3/issues/new\n";
+#endif
 }
 
 static str_hashtable* g_enabled_debug_tags = nullptr;

--- a/src/util/error_codes.h
+++ b/src/util/error_codes.h
@@ -33,6 +33,7 @@ Revision History:
 #define ERR_TYPE_CHECK          111
 #define ERR_UNKNOWN_RESULT      112
 #define ERR_ALLOC_EXCEEDED      113
+#define ERR_UNREACHABLE         114
 
 #endif /* ERROR_CODES_H_ */
 

--- a/src/util/z3_exception.cpp
+++ b/src/util/z3_exception.cpp
@@ -49,6 +49,7 @@ char const * z3_error::msg() const {
     case ERR_INTERNAL_FATAL: return "internal error";
     case ERR_TYPE_CHECK: return "type error";
     case ERR_ALLOC_EXCEEDED: return "number of configured allocations exceeded";
+    case ERR_UNREACHABLE: return "unreachable code was reached";
     default: return "unknown error";
     }
 }


### PR DESCRIPTION
This should replace several "segfaults" and "illegal instruction" errors with messages that contain a bit more context. I also put in a link to the bug tracker to make users' lives a bit easier.

For context, `__builtin_unreachable`'s behavior is undefined and is intended only as a mechanism to help the compiler see that code will not return. I do still include it in the new code because if I don't, compilation produces a lot more warnings as it can't see that `NOT_IMPLEMENTED_YET` and `UNREACHABLE` cannot return.