### PR TITLE
z3str3: fix a crash in the regex engine

### DIFF
--- a/src/smt/theory_str_regex.cpp
+++ b/src/smt/theory_str_regex.cpp
@@ -1154,8 +1154,9 @@ namespace smt {
                 expr_ref rhs2(m_autil.mk_ge(strlen, m_autil.mk_numeral(nonzero_lower_bound, true)), m);
                 rhs.push_back(rhs2);
             } else {
-                // shouldn't happen
-                UNREACHABLE();
+                // probably no solutions at all; just assume that 0 is a (safe) lower bound
+                regex_last_lower_bound.insert(str, rational::zero());
+                rhs.reset();
             }
         }
         // TODO upper bound check


### PR DESCRIPTION
Currently, if Z3str3 tries to deduce the initial lower bound of the length of a solution under a regex that has no solutions, it crashes due to "unreachable" code. Since this can actually happen, we take a default lower bound of 0 on the length of the solution instead.