### PR TITLE
Z3str3: disable compute_contains() and get_grounded_concats() checks

### DIFF
--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -7626,9 +7626,11 @@ namespace smt {
                                    var_eq_concat_map, var_eq_unroll_map,
                                    concat_eq_constStr_map, concat_eq_concat_map, unrollGroupMap););
 
+        /*
         if (!contain_pair_bool_map.empty()) {
             compute_contains(aliasIndexMap, concats_eq_index_map, var_eq_constStr_map, concat_eq_constStr_map, var_eq_concat_map);
         }
+        */
 
         // step 4: dependence analysis
 


### PR DESCRIPTION
Disables a handful of legacy code in Z3str3 that is extremely prone to stack overflows and crashes. It will be redesigned or rewritten in a future release.

Fixes #4291. Fixes #3088.