### PR TITLE
Unicode escape sequences in string literals

### DIFF
--- a/src/parsers/smt2/smt2parser.cpp
+++ b/src/parsers/smt2/smt2parser.cpp
@@ -1189,7 +1189,7 @@ namespace smt2 {
 
         void parse_string_const() {
             SASSERT(curr() == scanner::STRING_TOKEN);
-            expr_stack().push_back(sutil().str.mk_string(symbol(m_scanner.get_string())));
+            expr_stack().push_back(sutil().str.mk_string(symbol(m_scanner.get_string()))); // TODO mk_string directly from a Unicode zstring
             TRACE("smt2parser", tout << "new string: " << mk_pp(expr_stack().back(), m()) << "\n";);
             next();
         }

--- a/src/parsers/smt2/smt2parser.cpp
+++ b/src/parsers/smt2/smt2parser.cpp
@@ -1189,7 +1189,7 @@ namespace smt2 {
 
         void parse_string_const() {
             SASSERT(curr() == scanner::STRING_TOKEN);
-            expr_stack().push_back(sutil().str.mk_string(symbol(m_scanner.get_string()))); // TODO mk_string directly from a Unicode zstring
+            expr_stack().push_back(sutil().str.mk_string(symbol(m_scanner.get_string()))); // UNICODE: mk_string directly from a Unicode zstring
             TRACE("smt2parser", tout << "new string: " << mk_pp(expr_stack().back(), m()) << "\n";);
             next();
         }

--- a/src/parsers/smt2/smt2scanner.h
+++ b/src/parsers/smt2/smt2scanner.h
@@ -85,7 +85,7 @@ namespace smt2 {
         symbol const & get_id() const { return m_id; }
         rational get_number() const { return m_number; }
         unsigned get_bv_size() const { return m_bv_size; }
-        char const * get_string() const { return m_string.begin(); }
+        char const * get_string() const { return m_string.begin(); } // TODO fix this to return a zstring
         token scan();
         
         token read_symbol_core();

--- a/src/parsers/smt2/smt2scanner.h
+++ b/src/parsers/smt2/smt2scanner.h
@@ -85,7 +85,7 @@ namespace smt2 {
         symbol const & get_id() const { return m_id; }
         rational get_number() const { return m_number; }
         unsigned get_bv_size() const { return m_bv_size; }
-        char const * get_string() const { return m_string.begin(); } // TODO fix this to return a zstring
+        char const * get_string() const { return m_string.begin(); } // UNICODE: return a zstring
         token scan();
         
         token read_symbol_core();


### PR DESCRIPTION
This introduces Unicode codepoint escape sequences of the form `\u####` and `\u{#....}` according to the SMT-LIB 2.6 standard for Unicode strings. Currently the scanner rejects codepoints greater than 255, since we expect to be working with ASCII for now, but the code paths for full support are mostly in place.

I also added some notes in comments where I observed some further changes will need to be made in the scanner and parser for future Unicode support. These are marked as `// UNICODE`.