### PR TITLE
fix hex digit radix in unicode escape

### DIFF
--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -88,7 +88,7 @@ static bool is_escape_char(char const *& s, unsigned& result) {
         result = 0;
         for (unsigned i = 0; i < 5; ++i) {
             if (is_hex_digit(*(s+3+i), d1)) {
-                result = 64*result + d1;
+                result = 16*result + d1;
             }
             else if (*(s+3+i) == '}') {
                 s += 4 + i;
@@ -105,7 +105,7 @@ static bool is_escape_char(char const *& s, unsigned& result) {
         unsigned i = 0;
         for (; i < 4; ++i) {
             if (is_hex_digit(*(s+3+i), d1)) {
-                result = 64*result + d1;
+                result = 16*result + d1;
             }
             else {
                 break;


### PR DESCRIPTION
Fixes a minor bug where we should multiply by 16, not 64, for hex digits in a Unicode codepoint escape sequence