### PR TITLE
z3str3: make counterexamples less naive, and check regex membership more efficiently

### DIFF
--- a/src/smt/theory_str_regex.cpp
+++ b/src/smt/theory_str_regex.cpp
@@ -206,69 +206,8 @@ namespace smt {
                         regex_inc_counter(regex_length_attempt_count, re);
                         continue;
                     } else {
-                        expr_ref pathConstraint(m);
-                        expr_ref characterConstraints(m);
-                        pathConstraint = generate_regex_path_constraints(str, assumption.get_automaton(), exact_length_value, characterConstraints);
-                        TRACE("str", tout << "generated regex path constraint " << mk_pp(pathConstraint, m) << std::endl;);
-                        TRACE("str", tout << "character constraints are " << mk_pp(characterConstraints, m) << std::endl;);
-
-                        expr_ref_vector lhs_terms(m);
-                        if (current_assignment == l_true) {
-                            lhs_terms.push_back(str_in_re);
-                        } else {
-                            lhs_terms.push_back(m.mk_not(str_in_re));
-                        }
-                        lhs_terms.push_back(ctx.mk_eq_atom(mk_strlen(str), m_autil.mk_numeral(exact_length_value, true)));
-                        expr_ref lhs(mk_and(lhs_terms), m);
-
-                        // If the path constraint comes out as "false", this means there are no paths of that length
-                        // in the automaton. If the polarity is the same, we can assert a conflict clause.
-                        // If the polarity is opposite, we ignore the path constraint.
-
-                        if (m.is_false(pathConstraint)) {
-                            if ( (current_assignment == l_true && assumption.get_polarity())
-                                    || (current_assignment == l_false && !assumption.get_polarity())) {
-                                // automaton and constraint have same polarity -- assert conflict clause
-                                TRACE("str", tout << "path constraint is false with matching polarity; asserting conflict clause" << std::endl;);
-                                expr_ref conflict(m.mk_not(mk_and(lhs_terms)), m);
-                                assert_axiom(conflict);
-                                // don't set up "regex_terms_with_path_constraints" as a conflict clause is not a path constraint
-                            } else {
-                                // automaton and constraint have opposite polarity -- ignore path constraint
-                                TRACE("str", tout << "path constraint is false with opposite polarity; ignoring path constraint" << std::endl;);
-                                assert_implication(lhs, characterConstraints);
-                                regex_terms_with_path_constraints.insert(str_in_re);
-                                m_trail_stack.push(insert_obj_trail<theory_str, expr>(regex_terms_with_path_constraints, str_in_re));
-                            }
-                            regex_axiom_add = true;
-                        } else {
-                            // If the automaton was built with the same polarity as the constraint,
-                            // assert directly. Otherwise, negate the path constraint
-                            if ( (current_assignment == l_true && assumption.get_polarity())
-                                    || (current_assignment == l_false && !assumption.get_polarity())) {
-                                TRACE("str", tout << "automaton and regex term have same polarity" << std::endl;);
-                                expr_ref rhs(m.mk_and(pathConstraint, characterConstraints), m);
-                                assert_implication(lhs, rhs);
-                            } else {
-                                TRACE("str", tout << "automaton and regex term have opposite polarity" << std::endl;);
-                                expr_ref rhs(m.mk_and(m.mk_not(pathConstraint), characterConstraints), m);
-                                assert_implication(lhs, rhs);
-                            }
-                            regex_terms_with_path_constraints.insert(str_in_re);
-                            m_trail_stack.push(insert_obj_trail<theory_str, expr>(regex_terms_with_path_constraints, str_in_re));
-                            regex_axiom_add = true;
-                        }
-
-                        // increment LengthAttemptCount
-                        regex_inc_counter(regex_length_attempt_count, re);
-
-                        TRACE("str",
-                              {
-                                  unsigned v = regex_get_counter(regex_length_attempt_count, re);
-                                  tout << "length attempt count for " << mk_pp(re, m) << " is " << v << std::endl;
-                              });
-
-                        continue;
+                        // fixed-length model construction handles path constraints on our behalf, and with a better reduction
+                        return;
                     }
                 } else {
                     // no automata available, or else all bounds assumptions are invalid


### PR DESCRIPTION
Fixes #4271. Fixes #4423.

Due to the scope of these changes, I need to test this one more thoroughly on my end, so this will be a draft until it's ready to merge.