### PR TITLE
Ensuring correct 'set' call is used when setting 'smtlib2_log'

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -6470,7 +6470,7 @@ class Solver(Z3PPObject):
             self.solver = solver
         Z3_solver_inc_ref(self.ctx.ref(), self.solver)
         if logFile is not None:
-            self.set("solver.smtlib2_log", logFile)
+            self.set("smtlib2_log", logFile)
 
     def __del__(self):
         if self.solver is not None and self.ctx.ref() is not None:


### PR DESCRIPTION
## Issue

When running the following file:

```
#!/usr/bin/env python3

from z3 import *
import os
import pathlib


def get_expr():
    a = Int("a")
    b = Int("b")
    f = And(Or(a > If(b > 0, -b, b) + 1, a <= 0), b > 0)
    return f


def encode(solver):
    expr = get_expr()
    solver.push()
    solver.add(expr)
    solver.push()
    solver.add(expr)
    solver.pop()
    solver.check()
    solver.pop()
    solver.check()


def check(solver_getter):
    log_name = "{:s}.smt2".format(solver_getter.__name__)
    if os.path.exists(log_name):
        pathlib.Path(log_name).unlink()
    solver = solver_getter(log_name)
    encode(solver)
    return os.path.exists(log_name)


def create_with_kwarg(log_name):
    solver = Solver(logFile=log_name)
    return solver


def create_with_attr(log_name):
    solver = Solver()
    solver.smtlib2_log = log_name
    return solver


def create_and_set_with_solver(log_name):
    solver = Solver()
    solver.set("solver.smtlib2_log", log_name)
    return solver


def create_and_set_no_solver(log_name):
    solver = Solver()
    solver.set("smtlib2_log", log_name)
    return solver


def main():
    assert not check(create_with_kwarg)
    assert not check(create_with_attr)
    assert not check(create_and_set_with_solver)
    assert check(create_and_set_no_solver)


if __name__ == "__main__":
    main()

# EOF
```

it is only `create_and_set_no_solver` that correct sets the option `smtlib2_log`, which, critically, means the kwarg `logFile` for `Solver` does not do the correct thing.

## Solution

This PR corrects the API call inside of `__init__` for `Solver` such that the correct parameter name is set.

## Notes

Weirdly, `solver.set("solver.smtlib2_log", log_name)` does not raise `z3.z3types.Z3Exception`, although it does not seem to work.

Calling `solver.help()` lists the the option as `smtlib2_log` (so not `solver.smtlib2_log`), which means I am uncertain why `solver.set("solver.smtlib2_log", log_name)` doesn't raise `z3.z3types.Z3Exception`, like doing `solver.set("IDONTEXIST", log_name)` would.
