### PR TITLE
Add context::internalize() API that takes multiple expressions at once

### DIFF
--- a/src/smt/smt_context.h
+++ b/src/smt/smt_context.h
@@ -741,7 +741,12 @@ namespace smt {
 
         bool should_internalize_rec(expr* e) const;
 
-        void top_sort_expr(expr * n, svector<expr_bool_pair> & sorted_exprs);
+        void top_sort_expr(expr* const* exprs, unsigned num_exprs, svector<expr_bool_pair> & sorted_exprs);
+
+        void internalize_rec(expr * n, bool gate_ctx);
+
+        void internalize_deep(expr * n);
+        void internalize_deep(expr* const* n, unsigned num_exprs);
 
         void assert_default(expr * n, proof * pr);
 
@@ -868,6 +873,7 @@ namespace smt {
         void ensure_internalized(expr* e);
 
         void internalize(expr * n, bool gate_ctx);
+        void internalize(expr* const* exprs, unsigned num_exprs, bool gate_ctx);
 
         void internalize(expr * n, bool gate_ctx, unsigned generation);
 
@@ -905,10 +911,6 @@ namespace smt {
         void add_theory_aware_branching_info(bool_var v, double priority, lbool phase);
 
     public:
-
-        void internalize_rec(expr * n, bool gate_ctx);
-
-        void internalize_deep(expr * n);
 
         // helper function for trail
         void undo_th_case_split(literal l);

--- a/src/smt/theory_array_full.cpp
+++ b/src/smt/theory_array_full.cpp
@@ -398,7 +398,7 @@ namespace smt {
         if (!is_default(n) && !is_select(n) && !is_map(n) && !is_const(n) && !is_as_array(n)){
             return;
         }
-        if (!ctx.e_internalized(n)) ctx.internalize(n, false);;
+        ctx.ensure_internalized(n);
         enode* node = ctx.get_enode(n);
         if (is_select(n)) {
             enode * arg = ctx.get_enode(n->get_arg(0));

--- a/src/smt/theory_fpa.cpp
+++ b/src/smt/theory_fpa.cpp
@@ -415,9 +415,7 @@ namespace smt {
         if (ctx.b_internalized(atom))
             return true;
 
-        unsigned num_args = atom->get_num_args();
-        for (unsigned i = 0; i < num_args; i++)
-            ctx.internalize(atom->get_arg(i), false);
+        ctx.internalize(atom->get_args(), atom->get_num_args(), false);
 
         literal l(ctx.mk_bool_var(atom));
         ctx.set_var_theory(l.var(), get_id());
@@ -436,9 +434,7 @@ namespace smt {
         SASSERT(term->get_family_id() == get_family_id());
         SASSERT(!ctx.e_internalized(term));
 
-        unsigned num_args = term->get_num_args();
-        for (unsigned i = 0; i < num_args; i++)
-            ctx.internalize(term->get_arg(i), false);
+        ctx.internalize(term->get_args(), term->get_num_args(), false);
 
         enode * e = ctx.mk_enode(term, false, false, true);
 
@@ -697,9 +693,7 @@ namespace smt {
     }
 
     enode* theory_fpa::ensure_enode(expr* e) {
-        if (!ctx.e_internalized(e)) {
-            ctx.internalize(e, false);
-        }
+        ctx.ensure_internalized(e);
         enode* n = ctx.get_enode(e);
         ctx.mark_as_relevant(n);
         return n;


### PR DESCRIPTION
Gives 2x speedup on the example of #4192
This shares the overhead of top-sort over multiple expressions.

Trying out more benchmarks to check if it regresses.