### PR TITLE
Ensure that Z3 uses the correct SMT-LIB2 syntax for `push` and `pop`

### DIFF
--- a/src/api/api_solver.cpp
+++ b/src/api/api_solver.cpp
@@ -61,7 +61,7 @@ extern "C" {
     }
 
     void solver2smt2_pp::push() {
-        m_out << "(push)\n";
+        m_out << "(push 1)\n";
         m_pp_util.push();
         m_tracked_lim.push_back(m_tracked.size());
     }

--- a/src/muz/base/dl_context.cpp
+++ b/src/muz/base/dl_context.cpp
@@ -1231,7 +1231,7 @@ namespace datalog {
         }
         else {
             for (unsigned i = 0; i < queries.size(); ++i) {
-                if (queries.size() > 1) out << "(push)\n";
+                if (queries.size() > 1) out << "(push 1)\n";
                 out << "(assert ";
                 expr_ref q(m);
                 q = m.mk_not(queries[i].get());

--- a/src/muz/base/dl_context.cpp
+++ b/src/muz/base/dl_context.cpp
@@ -1238,7 +1238,7 @@ namespace datalog {
                 PP(q);
                 out << ")\n";
                 out << "(check-sat)\n";
-                if (queries.size() > 1) out << "(pop)\n";
+                if (queries.size() > 1) out << "(pop 1)\n";
             }
         }
     }

--- a/src/muz/spacer/spacer_manager.cpp
+++ b/src/muz/spacer/spacer_manager.cpp
@@ -141,7 +141,7 @@ void inductive_property::display(datalog::rule_manager& rm, ptr_vector<datalog::
 
     out << to_string() << "\n";
     for (auto* r : rules) {
-        out << "(push)\n";
+        out << "(push 1)\n";
         out << "(assert (not\n";
         rm.display_smt2(*r, out);
         out << "))\n";

--- a/src/muz/spacer/spacer_manager.cpp
+++ b/src/muz/spacer/spacer_manager.cpp
@@ -146,7 +146,7 @@ void inductive_property::display(datalog::rule_manager& rm, ptr_vector<datalog::
         rm.display_smt2(*r, out);
         out << "))\n";
         out << "(check-sat)\n";
-        out << "(pop)\n";
+        out << "(pop 1)\n";
     }
 }
 

--- a/src/muz/spacer/spacer_util.cpp
+++ b/src/muz/spacer/spacer_util.cpp
@@ -124,7 +124,7 @@ namespace spacer {
         out << "(define-fun mbp_benchmark_fml () Bool\n  ";
         out << mk_pp(fml, m) << ")\n\n";
 
-        out << "(push)\n"
+        out << "(push 1)\n"
             << "(assert mbp_benchmark_fml)\n"
             << "(check-sat)\n"
             << "(mbp mbp_benchmark_fml (";

--- a/src/muz/spacer/spacer_util.cpp
+++ b/src/muz/spacer/spacer_util.cpp
@@ -130,7 +130,7 @@ namespace spacer {
             << "(mbp mbp_benchmark_fml (";
         for (auto v : vars) {out << mk_pp(v, m) << " ";}
         out << "))\n"
-            << "(pop)\n"
+            << "(pop 1)\n"
             << "(exit)\n";
     }
 

--- a/src/qe/qe.cpp
+++ b/src/qe/qe.cpp
@@ -1208,7 +1208,7 @@ namespace qe {
                 fml = mk_not(m, m.mk_iff(q, fml));
                 ast_smt_pp pp(m);
                 out << "; eliminate " << mk_pp(m_var, m) << "\n";
-                out << "(push)\n";
+                out << "(push 1)\n";
                 pp.display_smt2(out, fml);                
                 out << "(pop)\n\n";      
 #if 0

--- a/src/qe/qe.cpp
+++ b/src/qe/qe.cpp
@@ -1210,7 +1210,7 @@ namespace qe {
                 out << "; eliminate " << mk_pp(m_var, m) << "\n";
                 out << "(push 1)\n";
                 pp.display_smt2(out, fml);                
-                out << "(pop)\n\n";      
+                out << "(pop 1)\n\n";
 #if 0
                 DEBUG_CODE(
                     smt_params params;

--- a/src/test/theory_pb.cpp
+++ b/src/test/theory_pb.cpp
@@ -105,7 +105,7 @@ private:
         num_rounds = r;
         std::cout << "; number of rounds: " << num_rounds << " level: " << lvl << "\n";
         ctx.pop(1);
-        std::cout << "(pop)\n";
+        std::cout << "(pop 1)\n";
     }
 
 };

--- a/src/test/theory_pb.cpp
+++ b/src/test/theory_pb.cpp
@@ -90,7 +90,7 @@ private:
     void fuzz_round(unsigned& num_rounds, unsigned lvl) {
         unsigned num_rounds2 = 0;
         lbool is_sat = l_true;    
-        std::cout << "(push)\n";
+        std::cout << "(push 1)\n";
         ctx.push();
         unsigned r = 0;
         while (is_sat == l_true && r <= num_rounds + 1) {


### PR DESCRIPTION
## Issue

According to [The SMT-LIB Standard Version 2.6](http://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2017-07-18.pdf), the operators `push` and `pop` are defined as follows:

```
| ( pop ⟨numeral ⟩ )
| ( push ⟨numeral ⟩ )
```

That is, they take an unsigned integer value for the number of "assertion levels" to push and pop.

However, if you ask Z3 to dump the SMT2 from the current instance (e.g., using the `logFile` kwarg in Python for a `Solver`) then this instance will contain `(push)` and `(pop)` with no integer arguments.

This makes it hard to re-use these SMT-LIB2 instances against other solvers (e.g., to submit benchmarks to [SMT-LIB benchmarks](https://clc-gitlab.cs.uiowa.edu:2443/explore/groups)) because the instances are not well-formed.

## Solution

This PR changes all instance of `(push)` and `(pop)` with no arguments to be `(push 1)` and `(pop 1)`, therefore making the instances usable across other SMT solvers, which are more strict on the syntax they accept.
