### PR TITLE
Fixing build errors when building test-z3

### DIFF
--- a/src/math/hilbert/heap_trie.h
+++ b/src/math/hilbert/heap_trie.h
@@ -37,12 +37,12 @@ Notes:
 #ifndef HEAP_TRIE_H_
 #define HEAP_TRIE_H_
 
+#include <cstring>
 #include "util/map.h"
 #include "util/vector.h"
 #include "util/buffer.h"
 #include "util/statistics.h"
 #include "util/small_object_allocator.h"
-
 
 template<typename Key, typename KeyLE, typename KeyHash, typename Value>
 class heap_trie {

--- a/src/test/mpff.cpp
+++ b/src/test/mpff.cpp
@@ -16,7 +16,8 @@ Author:
 Revision History:
 
 --*/
-#include<sstream>
+#include <sstream>
+#include <cstring>
 #include "util/mpff.h"
 #include "util/mpz.h"
 #include "util/mpq.h"


### PR DESCRIPTION
## Issue

On a stock CentOS 8 install, I can't build `test-z3`:

```
../src/test/mpff.cpp:550:12: error: ‘strcmp’ was not declared in this scope
     ENSURE(strcmp(expected, buffer.str().c_str()) == 0);
            ^~~~~~
../src/util/debug.h:78:27: note: in definition of macro ‘VERIFY’
 #define VERIFY(_x_) if (!(_x_)) {                                                       \
                           ^~~
../src/test/mpff.cpp:550:5: note: in expansion of macro ‘ENSURE’
     ENSURE(strcmp(expected, buffer.str().c_str()) == 0);
     ^~~~~~
../src/test/mpff.cpp:550:12: note: ‘strcmp’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
../src/test/mpff.cpp:23:1:
+#include <cstring>
```

and

```
../src/test/heap_trie.cpp:37:22:   required from here
../src/math/hilbert/heap_trie.h:57:30: error: ‘memset’ was not declared in this scope
         void reset() { memset(this, 0, sizeof(*this)); }
                        ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
../src/math/hilbert/heap_trie.h:57:30: note: ‘memset’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
../src/math/hilbert/heap_trie.h:45:1:
+#include <cstring>
```

## Machine specifics

```
[avj@tempvm build]$ /usr/bin/lsb_release -a
LSB Version:	:core-4.1-amd64:core-4.1-ia32:core-4.1-noarch:cxx-4.1-amd64:cxx-4.1-noarch:desktop-4.1-amd64:desktop-4.1-noarch:languages-4.1-amd64:languages-4.1-noarch:printing-4.1-amd64:printing-4.1-noarch
Distributor ID:	CentOS
Description:	CentOS Linux release 8.1.1911 (Core)
Release:	8.1.1911
Codename:	Core
[avj@tempvm build]$ gcc --version
gcc (GCC) 8.3.1 20190507 (Red Hat 8.3.1-4)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

## Resolution

This PR simply applies the fixes as suggested by gcc.
