### PR TITLE
Ensure that the 'OUTPUT' locations in CMake for Python examples is accurate

### DIFF
--- a/examples/python/CMakeLists.txt
+++ b/examples/python/CMakeLists.txt
@@ -13,17 +13,18 @@ set(z3py_bindings_build_dest "${PROJECT_BINARY_DIR}/python")
 
 set(build_z3_python_examples_target_depends "")
 foreach (example_file ${python_example_files})
-  add_custom_command(OUTPUT "${z3py_bindings_build_dest}/${example_file}"
+  get_filename_component(example_file_name "${example_file}" NAME)
+  add_custom_command(OUTPUT "${z3py_bindings_build_dest}/${example_file_name}"
     COMMAND "${CMAKE_COMMAND}" "-E" "copy"
       "${CMAKE_CURRENT_SOURCE_DIR}/${example_file}"
       # We flatten the hierarchy so that all python files have
       # the `z3` directory in their directory so that their import
       # statements "just work".
-      "${z3py_bindings_build_dest}/"
+      "${z3py_bindings_build_dest}/${example_file_name}"
     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${example_file}"
-    COMMENT "Copying \"${example_file}\" to ${z3py_bindings_build_dest}/${example_file}"
+    COMMENT "Copying \"${example_file}\" to ${z3py_bindings_build_dest}/${example_file_name}"
   )
-  list(APPEND build_z3_python_examples_target_depends "${z3py_bindings_build_dest}/${example_file}")
+  list(APPEND build_z3_python_examples_target_depends "${z3py_bindings_build_dest}/${example_file_name}")
 endforeach()
 
 add_custom_target(build_z3_python_examples


### PR DESCRIPTION
## Issue

It would be nice if Z3's builds were "no op" (i.e., if you make no changes, the build system does nothing), however this isn't currently the case.

Immediately after doing the first build, if I do `ninja` again:

```
[avj@tempvm build]$ ninja -d stats -d explain
ninja explain: output src/test/lp/all of phony edge with no inputs doesn't exist
ninja explain: src/test/lp/all is dirty
ninja explain: src/test/all is dirty
ninja explain: src/all is dirty
ninja explain: output python/complex/complex.py doesn't exist
ninja explain: python/complex/complex.py is dirty
ninja explain: output python/hamiltonian/hamiltonian.py doesn't exist
ninja explain: python/hamiltonian/hamiltonian.py is dirty
ninja explain: output python/mus/marco.py doesn't exist
ninja explain: python/mus/marco.py is dirty
ninja explain: output python/mus/mss.py doesn't exist
ninja explain: python/mus/mss.py is dirty
ninja explain: examples/python/CMakeFiles/build_z3_python_examples is dirty
ninja explain: python/complex/complex.py is dirty
ninja explain: python/hamiltonian/hamiltonian.py is dirty
ninja explain: python/mus/marco.py is dirty
ninja explain: python/mus/mss.py is dirty
ninja explain: examples/python/build_z3_python_examples is dirty
ninja explain: examples/python/all is dirty
ninja explain: examples/all is dirty
[4/4] Copying "mus/mss.py" to /home/avj/working/z3/build/python/mus/mss.py
metric           	count 	avg (us) 	total (ms)
.ninja parse     	2     	18093.5 	36.2
canonicalize str 	13831 	0.2     	2.9
canonicalize path	13831 	0.2     	2.2
lookup node      	16756 	0.2     	3.6
.ninja_log load  	1     	841.0   	0.8
.ninja_deps load 	1     	5793.0  	5.8
node stat        	3104  	1.3     	4.0
StartEdge        	7     	93.3    	0.7
FinishCommand    	4     	34.8    	0.1

path->node hash load 0.66 (4251 entries / 6427 buckets)
```

The reason for this is the `OUTPUT` locations in CMake for the Python examples incorrectly tells CMake that we are generating a file in one location, and then it does a copy to another.

## Solution

This PR fixes the `OUTPUT` locations of the Python examples such that Z3 has no-op builds:

```
[avj@tempvm build]$ ninja -d stats -d explain
ninja explain: output src/test/lp/all of phony edge with no inputs doesn't exist
ninja explain: src/test/lp/all is dirty
ninja explain: src/test/all is dirty
ninja explain: src/all is dirty
ninja: no work to do.
metric           	count 	avg (us) 	total (ms)
.ninja parse     	2     	17834.5 	35.7
canonicalize str 	13831 	0.2     	2.9
canonicalize path	13831 	0.2     	2.3
lookup node      	16756 	0.2     	3.4
.ninja_log load  	1     	817.0   	0.8
.ninja_deps load 	1     	5565.0  	5.6
node stat        	3092  	1.2     	3.7

path->node hash load 0.66 (4251 entries / 6427 buckets)
```
