### PR TITLE
Clean up intrinsics handling in mpz.cpp

### DIFF
--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -49,17 +49,21 @@ Revision History:
 
 
 #if defined(_WINDOWS) && !defined(_M_ARM) && !defined(_M_ARM64)
-// This is needed for _tzcnt_u32 and friends.
-#include <immintrin.h>
-#define _trailing_zeros32(X) _tzcnt_u32(X)
-#endif
-
-#if defined(__GNUC__)
-#define _trailing_zeros32(X) __builtin_ctz(X)
+ // This is needed for _tzcnt_u32 and friends.
+ #include <immintrin.h>
+ #define _trailing_zeros32(X) _tzcnt_u32(X)
+#elif defined(__GNUC__) || defined(__clang__)
+ #define _trailing_zeros32(X) __builtin_ctz(X)
+#else
+inline uint32_t _trailing_zeros32(uint32_t x) {
+    uint32_t r = 0;
+    for (; 0 == (x & 1) && r < 32; ++r, x >>= 1);
+    return r;
+}
 #endif
 
 #if (defined(__LP64__) || defined(_WIN64)) && !defined(_M_ARM) && !defined(_M_ARM64)
- #if defined(__GNUC__)
+ #if defined(__GNUC__) || defined(__clang__)
  #define _trailing_zeros64(X) __builtin_ctzll(X)
  #else
  #define _trailing_zeros64(X) _tzcnt_u64(X)
@@ -70,20 +74,7 @@ inline uint64_t _trailing_zeros64(uint64_t x) {
     for (; 0 == (x & 1) && r < 64; ++r, x >>= 1);
     return r;
 }
-
-#if defined(_WINDOWS) && !defined(_M_ARM) && !defined(_M_ARM64)
-// _trailing_zeros32 already defined using intrinsics
-#elif defined(__GNUC__)
-// _trailing_zeros32 already defined using intrinsics
-#else
-inline uint32_t _trailing_zeros32(uint32_t x) {
-    uint32_t r = 0;
-    for (; 0 == (x & 1) && r < 32; ++r, x >>= 1);
-    return r;
-}
 #endif
-#endif
-
 
 #define _bit_min(x, y) (y + ((x - y) & ((int)(x - y) >> 31)))
 #define _bit_max(x, y) (x - ((x - y) & ((int)(x - y) >> 31)))


### PR DESCRIPTION
The way conditional compilation for intrinsics support is implemented in `src/util/mpz.cpp` is somewhat confusing, because it's split across two `#if` blocks; this PR merges them into one and adds support for clang (which also [supports](https://github.com/llvm-mirror/clang/blob/aa231e4be75ac4759c236b755c57876f76e3cf05/include/clang/Basic/Builtins.def#L427) these intrinsics by now).

Since this PR mostly only reorders a few lines, it is not a copyrightable contribution, and thus I won't deem it necessary to sign your CLA.

The intrinsics implementation in `src/util/hwf.cpp` also looks fishy, because in line 34, you have
```C
#if defined(__x86_64__) || defined(_M_X64) ||    \
    defined(__i386) || defined(_M_IX86)
#define USE_INTRINSICS
#endif
```
and then, in line 51:
```C
#if defined(__clang__) || defined(_M_ARM) && defined(_M_ARM64)
#undef USE_INTRINSICS
#endif
```
But if we're on ARM, `USE_INTRINSICS` would not have been defined in the first place (lines 34-37), right? Also, I'm pretty sure clang [supports](https://clang.llvm.org/doxygen/emmintrin_8h.html) the intrinsics in question by now (but you may want to check this for yourselves by removing lines 51-53 and then compiling with clang).