### PR TITLE
Remove __DATE__ to make the build more reproducible

### DIFF
--- a/src/api/api_log.cpp
+++ b/src/api/api_log.cpp
@@ -54,7 +54,7 @@ extern "C" {
             res = false;
         }
         else {
-            *g_z3_log << "V \"" << Z3_MAJOR_VERSION << "." << Z3_MINOR_VERSION << "." << Z3_BUILD_NUMBER << "." << Z3_REVISION_NUMBER << " " << __DATE__ << "\"\n";
+            *g_z3_log << "V \"" << Z3_MAJOR_VERSION << "." << Z3_MINOR_VERSION << "." << Z3_BUILD_NUMBER << "." << Z3_REVISION_NUMBER << "\"\n";
             g_z3_log->flush();
             g_z3_log_enabled = true;
         }


### PR DESCRIPTION
Most of z3 builds reproducibly already; by dropping this unnecessary occurrence of `__DATE__`, we can make the build even more reproducible (see [here](https://reproducible-builds.org/) for why reproducibility is desirable).