### PR TITLE
Fix build failure on riscv64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,7 @@ endif()
 ################################################################################
 # Threading support
 ################################################################################
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads)
 list(APPEND Z3_DEPENDENT_LIBS ${CMAKE_THREAD_LIBS_INIT})
 


### PR DESCRIPTION
The Debian package for z3 required this small patch in order to build on riscv64; origin:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=948109#75

The CMake variable in question is documented [here](https://cmake.org/cmake/help/latest/module/FindThreads.html).