### PR TITLE
Checking sat using check() with assumptions rises AttributeError: 'bool' object has no attribute 'as_ast'

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -6670,11 +6670,12 @@ class Solver(Z3PPObject):
         >>> s.check()
         unknown
         """
+        s = BoolSort(self.ctx)
         assumptions = _get_args(assumptions)
         num = len(assumptions)
         _assumptions = (Ast * num)()
         for i in range(num):
-            _assumptions[i] = assumptions[i].as_ast()
+            _assumptions[i] = s.cast(assumptions[i]).as_ast()
         r = Z3_solver_check_assumptions(self.ctx.ref(), self.solver, num, _assumptions)
         return CheckSatResult(r)
 


### PR DESCRIPTION
I found this problem and reported [here](https://stackoverflow.com/questions/62621990/checking-sat-using-check-with-assumptions-rises-attributeerror-bool-object).

How to reproduce:
```
>>> from z3 import *
>>> s = Solver()
>>> s.check([True])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "$HOME/.local/lib/python3.6/site-packages/z3/z3.py", line 6656, in check
    _assumptions[i] = assumptions[i].as_ast()
AttributeError: 'bool' object has no attribute 'as_ast'
```