### PR TITLE
Z3str3: Add consistency checks for string-integer conversion terms in model construction

### DIFF
--- a/src/smt/theory_str.h
+++ b/src/smt/theory_str.h
@@ -753,6 +753,7 @@ protected:
 
     bool finalcheck_str2int(app * a);
     bool finalcheck_int2str(app * a);
+    bool string_integer_conversion_valid(zstring str, rational& converted) const;
 
     lbool fixed_length_model_construction(expr_ref_vector formulas, expr_ref_vector &precondition,
             expr_ref_vector& free_variables,


### PR DESCRIPTION
Fixes an issue with instances like the following:

```
(declare-const var1 String) (declare-const var5 String)
(assert (> (str.to.int var5) (str.to.int var1)))
(check-sat)
```

where this would be answered with an invalid model.