### PR TITLE
z3str3: continue instead of incorrectly giving up in solve_regex_automata

### DIFF
--- a/src/smt/theory_str_regex.cpp
+++ b/src/smt/theory_str_regex.cpp
@@ -203,7 +203,7 @@ namespace smt {
                         continue;
                     } else {
                         // fixed-length model construction handles path constraints on our behalf, and with a better reduction
-                        return false;
+                        continue;
                     }
                 } else {
                     // no automata available, or else all bounds assumptions are invalid


### PR DESCRIPTION
Fixes an issue where this method incorrectly returned `false` when continuing was the more appropriate action.