### PR TITLE
string to regex approximation used to strengthen membership constraints

### DIFF
--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -1454,8 +1454,8 @@ bool seq_util::re::is_loop(expr const* n, expr*& body, expr*& lo) const {
    Returns true iff e is the epsilon regex.
  */
 bool seq_util::re::is_epsilon(expr* r) const {
-    expr* r1;
-    return is_to_re(r, r1) && u.str.is_empty(r1);
+    expr* s;
+    return is_to_re(r, s) && u.str.is_empty(s);
 }
 /**
    Makes the epsilon regex for a given sequence sort.

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -1449,3 +1449,17 @@ bool seq_util::re::is_loop(expr const* n, expr*& body, expr*& lo) const {
     }
     return false;
 }
+
+/**
+   Returns true iff e is the epsilon regex.
+ */
+bool seq_util::re::is_epsilon(expr* r) const {
+    expr* r1;
+    return is_to_re(r, r1) && u.str.is_empty(r1);
+}
+/**
+   Makes the epsilon regex for a given sequence sort.
+ */
+app* seq_util::re::mk_epsilon(sort* seq_sort) {
+    return mk_to_re(u.str.mk_empty(seq_sort));
+}

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -474,6 +474,8 @@ public:
         bool is_loop(expr const* n, expr*& body, expr*& lo) const;
         unsigned min_length(expr* r) const;
         unsigned max_length(expr* r) const;
+        bool is_epsilon(expr* r) const;
+        app* mk_epsilon(sort* seq_sort);
     };
     str str;
     re  re;

--- a/src/smt/seq_regex.h
+++ b/src/smt/seq_regex.h
@@ -75,6 +75,9 @@ namespace smt {
 
         bool is_string_equality(literal lit);
 
+        // Get a regex which overapproximates a given string
+        expr_ref get_overapprox_regex(expr* s);
+
         void rewrite(expr_ref& e);
 
         bool coallesce_in_re(literal lit);


### PR DESCRIPTION
As a preprocessing step of regex membership constraints.
Converts a non-ground sequence into an additional regex and strengthens the original regex constraint into an intersection.
For example  (x ++ "a" ++ y) in b* is converted to (x ++ "a" ++ y) in intersect((.* ++ "a" ++ .*), b*).
This will guarantee termination  for some unsat cases that would otherwise not terminate.