### PR TITLE
dgml output generation for regex state graphs

### DIFF
--- a/src/util/state_graph.h
+++ b/src/util/state_graph.h
@@ -112,8 +112,9 @@ private:
     bool is_subset(state_set set1, state_set set2) const;
     bool is_disjoint(state_set set1, state_set set2) const;
     bool check_invariant() const;
-    void write_dgml();
     #endif
+
+    void write_dgml();
 
     /*
         'Core' functions that modify the plain graph, without

--- a/src/util/state_graph.h
+++ b/src/util/state_graph.h
@@ -112,6 +112,7 @@ private:
     bool is_subset(state_set set1, state_set set2) const;
     bool is_disjoint(state_set set1, state_set set2) const;
     bool check_invariant() const;
+    void write_dgml();
     #endif
 
     /*


### PR DESCRIPTION
Added support for directed graph markup language (dgml) generation support when debugging with option /tr:state_graph. The output will be saved in the file '.z3-state-graph.dgml' every time state_graph is changed in regex solver. The file can be viewed using VS 2019 and some earlier versions like VS 2017 and VS 2015 (dgml viewing is not supported in VS Code).