### PR TITLE
added support for saving state graph in dot format

### DIFF
--- a/src/util/state_graph.cpp
+++ b/src/util/state_graph.cpp
@@ -263,10 +263,9 @@ void state_graph::add_state(state s) {
     if (m_seen.contains(s)) return;
     STRACE("state_graph", tout << "[state_graph] adding state " << s << ": ";);
     add_state_core(s);
+    CASSERT("state_graph", write_dgml());
+    CASSERT("state_graph", write_dot());
     CASSERT("state_graph", check_invariant());
-    STRACE("state_graph", 
-        write_dgml(); 
-        write_dot(););
     STRACE("state_graph", tout << std::endl;);
 }
 void state_graph::mark_live(state s) {
@@ -275,10 +274,9 @@ void state_graph::mark_live(state s) {
     SASSERT(m_state_ufind.is_root(s));
     if (m_unexplored.contains(s)) mark_unknown_core(s);
     mark_live_recursive(s);
+    CASSERT("state_graph", write_dgml());
+    CASSERT("state_graph", write_dot());
     CASSERT("state_graph", check_invariant());
-    STRACE("state_graph",
-        write_dgml();
-        write_dot(););
     STRACE("state_graph", tout << std::endl;);
 }
 void state_graph::add_edge(state s1, state s2, bool maybecycle) {
@@ -290,10 +288,9 @@ void state_graph::add_edge(state s1, state s2, bool maybecycle) {
     s2 = m_state_ufind.find(s2);
     add_edge_core(s1, s2, maybecycle);
     if (m_live.contains(s2)) mark_live(s1);
+    CASSERT("state_graph", write_dgml());
+    CASSERT("state_graph", write_dot());
     CASSERT("state_graph", check_invariant());
-    STRACE("state_graph",
-        write_dgml();
-        write_dot(););
     STRACE("state_graph", tout << std::endl;);
 }
 void state_graph::mark_done(state s) {
@@ -304,10 +301,9 @@ void state_graph::mark_done(state s) {
     if (m_unexplored.contains(s)) mark_unknown_core(s);
     s = merge_all_cycles(s);
     mark_dead_recursive(s); // check if dead
+    CASSERT("state_graph", write_dgml());
+    CASSERT("state_graph", write_dot());
     CASSERT("state_graph", check_invariant());
-    STRACE("state_graph",
-        write_dgml();
-        write_dot(););
     STRACE("state_graph", tout << std::endl;);
 }
 
@@ -425,7 +421,7 @@ std::ostream& state_graph::display(std::ostream& o) const {
 /*
     Output the whole state graph in dgml format into the file '.z3-state-graph.dgml'
  */
-void state_graph::write_dgml() {
+bool state_graph::write_dgml() {
     std::ofstream dgml(".z3-state-graph.dgml");
     dgml << "<?xml version=\"1.0\" encoding=\"utf-8\"?>" << std::endl
         << "<DirectedGraph xmlns=\"http://schemas.microsoft.com/vs/2009/dgml\" GraphDirection=\"TopToBottom\">" << std::endl
@@ -500,12 +496,13 @@ void state_graph::write_dgml() {
         << "</Styles>" << std::endl
         << "</DirectedGraph>" << std::endl;
     dgml.close();
+    return true;
 }
 
 /*
     Output the whole state graph in dot format into the file '.z3-state-graph.dot'
  */
-void state_graph::write_dot() {
+bool state_graph::write_dot() {
     std::ofstream dot(".z3-state-graph.dot");
     dot << "digraph \"state_graph\" {" << std::endl
         << "rankdir=TB" << std::endl
@@ -541,5 +538,6 @@ void state_graph::write_dot() {
     }
     dot << "}" << std::endl;
     dot.close();
+    return true;
 }
 #endif

--- a/src/util/state_graph.cpp
+++ b/src/util/state_graph.cpp
@@ -437,10 +437,10 @@ bool state_graph::write_dgml() {
                 r = m_state_ufind.next(r);
             } while (r != s);
             dgml << "\" Category=\"State\">" << std::endl;
-            if (m_live.contains(s))
-                dgml << "<Category Ref=\"Alive\"/>" << std::endl;
             if (m_dead.contains(s))
                 dgml << "<Category Ref=\"Dead\"/>" << std::endl;
+            if (m_live.contains(s))
+                dgml << "<Category Ref=\"Alive\"/>" << std::endl;
             if (m_unexplored.contains(s))
                 dgml << "<Category Ref=\"Unexplored\"/>" << std::endl;
             dgml << "</Node>" << std::endl;
@@ -474,6 +474,7 @@ bool state_graph::write_dgml() {
         << "<Style TargetType=\"Node\" GroupLabel=\"Dead\" ValueLabel=\"True\">" << std::endl
         << "<Condition Expression=\"HasCategory('Dead')\"/>" << std::endl
         << "<Setter Property=\"Background\" Value=\"tomato\"/>" << std::endl
+        << "<Setter Property=\"Stroke\" Value=\"tomato\"/>" << std::endl
         << "</Style>" << std::endl
         << "<Style TargetType=\"Node\" GroupLabel=\"Unexplored\" ValueLabel=\"True\">" << std::endl
         << "<Condition Expression=\"HasCategory('Unexplored')\"/>" << std::endl
@@ -520,10 +521,10 @@ bool state_graph::write_dot() {
             dot << "\"";
             if (m_unexplored.contains(s))
                 dot << ",style=\"dashed,filled\"";
+            if (m_dead.contains(s))
+                dot << ",color=tomato,fillcolor=tomato";
             if (m_live.contains(s))
                 dot << ",fillcolor=green";
-            if (m_dead.contains(s))
-                dot << ",fillcolor=tomato";
             dot << "]" << std::endl;
         }
     }

--- a/src/util/state_graph.h
+++ b/src/util/state_graph.h
@@ -112,9 +112,15 @@ private:
     bool is_subset(state_set set1, state_set set2) const;
     bool is_disjoint(state_set set1, state_set set2) const;
     bool check_invariant() const;
-    #endif
-
+    /*
+    Output the whole state graph in dgml format into the file '.z3-state-graph.dgml'
+    */
     void write_dgml();
+    /*
+    Output the whole state graph in dot format into the file '.z3-state-graph.dot'
+    */
+    void write_dot();
+    #endif
 
     /*
         'Core' functions that modify the plain graph, without

--- a/src/util/state_graph.h
+++ b/src/util/state_graph.h
@@ -115,11 +115,11 @@ private:
     /*
     Output the whole state graph in dgml format into the file '.z3-state-graph.dgml'
     */
-    void write_dgml();
+    bool write_dgml();
     /*
     Output the whole state graph in dot format into the file '.z3-state-graph.dot'
     */
-    void write_dot();
+    bool write_dot();
     #endif
 
     /*


### PR DESCRIPTION
Calling  state_graph::write_dot() outputs the whole state graph in dot format into the file '.z3-state-graph.dot'
The function is called every time when state_graph is updated in debug mode when '/tr:state_graph' is specified.
The output is equivalent dot format of the dgml format.

Moved both state_graph::write_dot() and state_graph::write_dgml() under the Z3DEBUG flag so that 
they are not included in the release build.