### PR TITLE
extended calculation of info for regexes

### DIFF
--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -25,6 +25,7 @@ Revision History:
 #include "ast/ast.h"
 #include "ast/bv_decl_plugin.h"
 #include <string>
+#include "util/lbool.h"
 
 #define Z3_USE_UNICODE 0
 
@@ -411,13 +412,62 @@ public:
     class rex {
     public:
         struct info {
+            /* Value is well-defined. */
             bool valid;
+            /* No complement, no intersection, no difference, and no if-then-else is used. Reverse is allowed. */
+            bool classical;
+            /* Boolean-reverse combination of classical regexes (using reverse, union, complement, intersection or difference). */
+            bool standard;
+            /* There are no uninterpreted symbols. */
+            bool interpreted;
+            /* No if-then-else is used. */
+            bool nonbranching;
+            /* Concatenations are right associative and if a loop body is nullable then the lower bound is zero. */
+            bool normalized;
+            /* All bounded loops have a body that is a singleton. */
+            bool monadic;
+            /* Positive Boolean combination of ranges or predicates or singleton sequences. */
+            bool singleton;
+            /* If l_true then empty word is accepted, if l_false then empty word is not accepted. */
+            lbool nullable;
+            /* Lower bound on the length of all accepted words. */
             unsigned min_length;
-            info() : valid(false), min_length(0) {}
-            info(unsigned k) : valid(true), min_length(k) {}
-            bool is_valid() { return valid; }
+            /* Maximum nesting depth of Kleene stars. */
+            unsigned star_height;
+
+            /* 
+              Constructs an invalid info
+            */
+            info() : valid(false) {}
+
+            /* 
+              General info constructor.
+            */
+            info(bool is_classical, 
+                bool is_standard, 
+                bool is_interpreted, 
+                bool is_nonbranching, 
+                bool is_normalized, 
+                bool is_monadic, 
+                bool is_singleton,
+                lbool is_nullable, 
+                unsigned min_l, 
+                unsigned star_h) :
+                valid(true), classical(is_classical), standard(is_standard), interpreted(is_interpreted), nonbranching(is_nonbranching),
+                normalized(is_normalized), monadic(is_monadic), nullable(is_nullable), singleton(is_singleton), 
+                min_length(min_l), star_height(star_h) {}
+
+            /*
+              Appends a string representation of the info into the stream.
+            */
             std::ostream& display(std::ostream&) const;
+
+            /*
+              Returns a string representation of the info.
+            */
             std::string str() const;
+
+            bool is_valid() const { return valid; }
         };
     private:
         seq_util&    u;
@@ -536,3 +586,4 @@ public:
 inline std::ostream& operator<<(std::ostream& out, seq_util::rex::pp const & p) { return p.display(out); }
 
 inline std::ostream& operator<<(std::ostream& out, seq_util::rex::info const& p) { return p.display(out); }
+

--- a/src/smt/seq_regex.cpp
+++ b/src/smt/seq_regex.cpp
@@ -793,11 +793,12 @@ namespace smt {
         }
         STRACE("seq_regex", tout << "Updating state graph for regex "
                                  << mk_pp(r, m) << ") ";);
-        if (!m_state_graph.is_seen(r_id))
-            STRACE("state_graph", tout << std::endl << "state(" << r_id << ") = " << seq_util::rex::pp(re(), r) << std::endl;);
+        
+        STRACE("state_graph",
+            if (!m_state_graph.is_seen(r_id))
+                tout << std::endl << "state(" << r_id << ") = " << seq_util::rex::pp(re(), r) << std::endl << "info(" << r_id << ") = " << re().get_info(r) << std::endl;);
         // Add state
         m_state_graph.add_state(r_id);
-        STRACE("state_graph", tout << "regex(" << r_id << ") = " << mk_pp(r, m) << std::endl;);
         STRACE("seq_regex", tout << "Updating state graph for regex "
                                  << mk_pp(r, m) << ") " << std::endl;);
         STRACE("seq_regex_brief", tout << std::endl << "USG("
@@ -815,12 +816,12 @@ namespace smt {
             for (auto const& dr: derivatives) {
                 unsigned dr_id = get_state_id(dr);
                 STRACE("seq_regex_verbose", tout
-                    << std::endl << "  traversing deriv: " << dr_id << " ";);
-                if (!m_state_graph.is_seen(dr_id))
-                    STRACE("state_graph", tout << "state(" << dr_id << ") = " << seq_util::rex::pp(re(), dr) << std::endl;);
+                    << std::endl << "  traversing deriv: " << dr_id << " ";);              
+                STRACE("state_graph",
+                    if (!m_state_graph.is_seen(dr_id))
+                        tout << "state(" << dr_id << ") = " << seq_util::rex::pp(re(), dr) << std::endl << "info(" << dr_id << ") = " << re().get_info(dr) << std::endl;);
                 // Add state
                 m_state_graph.add_state(dr_id);
-                STRACE("state_graph", tout << "regex(" << dr_id << ") = " << mk_pp(dr, m) << std::endl;);
                 bool maybecycle = can_be_in_cycle(r, dr);
                 m_state_graph.add_edge(r_id, dr_id, maybecycle);
             }


### PR DESCRIPTION
Added new fields to the info object and implemented their calculation rules.
In particular, this fixes some earlier issues with 
min-length of compl as well as min-length of difference (that was buggy).
Also updated tracing of state_graph with regex info.
Introduced the trace tag "re_info" to trace info calculation of new regex expressions.