### PR TITLE
Allow to skip System.loadLibrary() calls from Java Native class

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -542,8 +542,13 @@ def mk_java(java_dir, package_name):
     java_native.write('  public static native void setInternalErrorHandler(long ctx);\n\n')
 
     java_native.write('  static {\n')
-    java_native.write('    try { System.loadLibrary("z3java"); }\n')
-    java_native.write('    catch (UnsatisfiedLinkError ex) { System.loadLibrary("libz3java"); }\n')
+    java_native.write('    if (null == System.getProperty("z3.skipLibraryLoad")) {\n')
+    java_native.write('      try {\n')
+    java_native.write('        System.loadLibrary("z3java");\n')
+    java_native.write('      } catch (UnsatisfiedLinkError ex) {\n')
+    java_native.write('        System.loadLibrary("libz3java");\n')
+    java_native.write('      }\n')
+    java_native.write('    }\n')
     java_native.write('  }\n')
 
     java_native.write('\n')


### PR DESCRIPTION
It's not hard for client code to write a couple of lines for System.loadLibrary()

But it is very very hard for client code to embed Z3 code into JAR file where libraries are need to be loaded from JAR file (as resource). The problem here that System.loadLibrary() works only if libraries are placed in java.library.path and does not allow to load it from temporary folder/file.