### PR TITLE
Fix z3.pc file template

### DIFF
--- a/z3.pc.cmake.in
+++ b/z3.pc.cmake.in
@@ -1,12 +1,12 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_LIBDIR@
-sharedlibdir=@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+sharedlibdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: z3
 Description: The Z3 Theorem Prover
-Version: @VERSION@
+Version: @Z3_VERSION@
 
 Requires:
 Libs: -L${libdir} -L${sharedlibdir} -lz3


### PR DESCRIPTION
The `z3.pc` file that is currently generated contains wrong paths, because the prefix is not taken into account, and the version is wrong, too. This simple patch fixes those issues; I don't see any copyrightable contribution in it.