### PR TITLE
thread pool for scoped_timer

### DIFF
--- a/src/util/scoped_timer.cpp
+++ b/src/util/scoped_timer.cpp
@@ -83,6 +83,7 @@ public:
         } else {
             s = available_workers.back();
             available_workers.pop_back();
+            workers.unlock();
         }
         s->ms = ms;
         s->eh = eh;
@@ -93,7 +94,6 @@ public:
             s->m_thread->detach();
         } else {
             s->cv.notify_one();
-            workers.unlock();
         }
     }
 

--- a/src/util/scoped_timer.cpp
+++ b/src/util/scoped_timer.cpp
@@ -20,7 +20,6 @@ Revision History:
 --*/
 
 #include "util/scoped_timer.h"
-#include "util/mutex.h"
 #include "util/util.h"
 #include <chrono>
 #include <climits>
@@ -46,7 +45,7 @@ struct state {
  * deadlock.
  */
 static std::vector<state *> available_workers;
-static mutex workers;
+static std::mutex workers;
 
 static void thread_func(state *s) {
     while (true) {
@@ -68,7 +67,7 @@ static void thread_func(state *s) {
     next:
         s->work = 0;
         {
-            lock_guard lock(workers);
+            std::lock_guard<std::mutex> lock(workers);
             available_workers.push_back(s);
         }
     }

--- a/src/util/scoped_timer.cpp
+++ b/src/util/scoped_timer.cpp
@@ -68,7 +68,7 @@ static void thread_func(state *s) {
     next:
         s->work = 0;
         {
-            lock_guard(workers);
+            lock_guard lock(workers);
             available_workers.push_back(s);
         }
     }


### PR DESCRIPTION
creating a fresh thread for every scoped_timer has significant overhead
in some use cases. this patch creates a persistent pool of worker threads
to do this job, resulting in 20-30% speedup of some alive2 jobs on a
large multicore