### PR TITLE
Fixed ModelRef translate method in Python API

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -6266,7 +6266,7 @@ class ModelRef(Z3PPObject):
         if z3_debug():
             _z3_assert(isinstance(target, Context), "argument must be a Z3 context")
         model = Z3_model_translate(self.ctx.ref(), self.model, target.ref())
-        return Model(model, target)
+        return ModelRef(model, target)
 
     def __copy__(self):
         return self.translate(self.ctx)


### PR DESCRIPTION
This fixes a bug in the translate method of the ModelRef class in the Python API. Without this fix, calling the translate method causes an exception because the wrong function is called.

Here's a simple test program I used. Without the fix, `s1.model().translate(c2)` raises an exception, with the fix, the program prints `sat`, `True`, and `True`.
```python
import z3

c1 = z3.Context()
c2 = z3.Context()
a1, b1 = z3.Bools('a b', c1)
a2, b2 = z3.Bools('a b', c2)

s1 = z3.Solver(ctx=c1)
s1.add(z3.And(a1,b1))
print(s1.check())
m2 = s1.model().translate(c2)
print(m2[a2])
print(m2[b2])
```