### PR TITLE
Fix: QF_UFDT has UF

### DIFF
--- a/src/solver/smt_logics.cpp
+++ b/src/solver/smt_logics.cpp
@@ -148,7 +148,7 @@ bool smt_logics::logic_has_fpa(symbol const & s) {
 }
 
 bool smt_logics::logic_has_uf(symbol const & s) {
-    return s == "QF_UF" || s == "UF" || s == "QF_DT" || s == "SMTFD";
+    return s == "QF_UF" || s == "UF" || s == "QF_UFDT" || s == "SMTFD";
 }
 
 bool smt_logics::logic_has_horn(symbol const& s) {


### PR DESCRIPTION
This request enable the support of `uninterpreted functions` for the `QF_UFDT` logic, which is missing.
It also disable this support for `QF_DT` (cf. #4754).