### PR TITLE
wait for timer thread before main thread continues

### DIFF
--- a/src/util/scoped_timer.cpp
+++ b/src/util/scoped_timer.cpp
@@ -34,7 +34,7 @@ struct scoped_timer_state {
     std::timed_mutex m_mutex;
     event_handler * eh;
     unsigned ms;
-    int work;
+    std::atomic<int> work;
     std::condition_variable_any cv;
 };
 
@@ -102,6 +102,8 @@ public:
 
     ~imp() {
         s->m_mutex.unlock();
+        while (s->work == 1)
+            std::this_thread::yield();
     }
 };
 


### PR DESCRIPTION
ok-- the thread pool in the scoped_timer works, but there's an interaction going on where the worker thread(s) sometimes don't get added back to the queue of available workers in time, causing the main thread to spawn another timer thread. I do not know what is the reason for this delay, perhaps some scheduler quirk, or @nunoplopes speculates that it's mutex contention. regardless, sometimes this goes on and on and we get up to ~100 worker threads when there clearly should be just one. this patch forces the main thread to busy-wait for the timer thread to finish, before continuing. it has been tested and verified to fix the problem, and incurs only a tiny amount of overhead (like 0.2%) on large Alive2 runs.

I'm compelled to add that even with this patch, I believe there's still a short window where extra timer threads can be spawned. this is because the patch makes `work` atomic instead of doing proper locking in the busy-wait loop. I do not believe this to be a big risk (and I did not see this window getting exploited in practice -- this patch does fix the timing-related leak of worker threads).