### PR TITLE
get rid of threads in the scoped_timer thread pool prior to forking, on non-Windows

### DIFF
--- a/src/util/scoped_timer.h
+++ b/src/util/scoped_timer.h
@@ -26,5 +26,10 @@ class scoped_timer {
 public:
     scoped_timer(unsigned ms, event_handler * eh);
     ~scoped_timer();
+    static void initialize();
     static void finalize();
 };
+
+/*
+    ADD_INITIALIZER('scoped_timer::initialize();')
+*/


### PR DESCRIPTION
on POSIX systems, fork() is dangerous in the presence of a thread
pool, because the child process inherits only the thread from the
parent that actually called fork().

this patch winds down the scoped_timer thread pool in preparation for
forking; workers will get freshly created again following the fork
call.

this has been tested using a hacked version of Alive2 that forks, and it appears to work.

NB @nunoplopes -- this absolutely needs review, particularly the #ifndef _WINDOWS bit. does that mean this code will be inoperative under Cygwin and WSL? I did not see a MSVC-specific or Win32-specific CPP symbol that would be a better choice than _WINDOWS.