### PR TITLE
Fix multiple argument array select/store for Java generics

### DIFF
--- a/src/api/java/Context.java
+++ b/src/api/java/Context.java
@@ -229,7 +229,7 @@ public class Context implements AutoCloseable {
     /**
      * Create a new array sort.
      **/
-    public <R extends Sort> ArraySort<?, R> mkArraySort(Sort[] domains, R range)
+    public <R extends Sort> ArraySort<Sort, R> mkArraySort(Sort[] domains, R range)
     {
         checkContextMatch(domains);
         checkContextMatch(range);
@@ -1725,7 +1725,7 @@ public class Context implements AutoCloseable {
      * @see #mkArraySort
      * @see #mkStore
      **/
-    public <R extends Sort> Expr<R> mkSelect(Expr<ArraySort<?, R>> a, Expr<?>[] args)
+    public <R extends Sort> Expr<R> mkSelect(Expr<ArraySort<Sort, R>> a, Expr<?>[] args)
     {
         checkContextMatch(a);
         checkContextMatch(args);
@@ -1775,7 +1775,7 @@ public class Context implements AutoCloseable {
      * @see #mkSelect
 
      **/
-    public <R extends Sort> ArrayExpr<?, R> mkStore(Expr<ArraySort<?, R>> a, Expr<?>[] args, Expr<R> v)
+    public <R extends Sort> ArrayExpr<Sort, R> mkStore(Expr<ArraySort<Sort, R>> a, Expr<?>[] args, Expr<R> v)
     {
         checkContextMatch(a);
         checkContextMatch(args);


### PR DESCRIPTION
There was an issue with my generics implementation that I found in some actual application.

Using a `?` capture for the mkArraySort domain with an array of Sort as an index made it impossible for the compiler to determine which method to use for mkSelect/mkStore in some versions of Java. This fixes that.