### PR TITLE
Fix: Prove and Disprove methods are exactly the same

### DIFF
--- a/examples/dotnet/Program.cs
+++ b/examples/dotnet/Program.cs
@@ -256,7 +256,7 @@ namespace test_mapi
             s.Parameters = p;
             foreach (BoolExpr a in assumptions)
                 s.Assert(a);
-            s.Assert(ctx.MkNot(f));
+            s.Assert(f);
             Status q = s.Check();
 
             switch (q)


### PR DESCRIPTION
Seems like a cut 'n' paste issue with Prove and Disprove.  

There's a spurious `MkNot` in the main boolean expression assertion for Prove.  This has been removed.

There are other build issues with this project, but this seems like a particularly misleading example, so I figured I'd fix it in isolation.