### PR TITLE
scripts/update_api: Replace Z3_LIBRARY_DIRS with Z3_LIB_DIRS

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1810,7 +1810,7 @@ if _lib is None:
   print("Could not find libz3.%s; consider adding the directory containing it to" % _ext)
   print("  - your system's PATH environment variable,")
   print("  - the Z3_LIBRARY_PATH environment variable, or ")
-  print("  - to the custom Z3_LIBRARY_DIRS Python-builtin before importing the z3 module, e.g. via")
+  print("  - to the custom Z3_LIB_DIRS Python-builtin before importing the z3 module, e.g. via")
   if sys.version < '3':
     print("    import __builtin__")
     print("    __builtin__.Z3_LIB_DIRS = [ '/path/to/libz3.%s' ] " % _ext)


### PR DESCRIPTION
The error message that is printed when libz3.so can't be loaded contains
incorrect instruction to set `Z3_LIBRARY_DIRS` builtin. The correct variable
name is `Z3_LIB_DIRS`.