### PR TITLE
Update the mkConstant parameter type

### DIFF
--- a/src/api/java/Context.java
+++ b/src/api/java/Context.java
@@ -2018,7 +2018,7 @@ public class Context implements AutoCloseable {
     /**
      * Concatenate sequences.
      */
-    public <R extends Sort> SeqExpr<R> mkConcat(SeqSort<R>... t)
+    public <R extends Sort> SeqExpr<R> mkConcat(Expr<SeqSort<R>>... t)
     {
         checkContextMatch(t);
         return (SeqExpr<R>) Expr.create(this, Native.mkSeqConcat(nCtx(), t.length, AST.arrayToNative(t)));


### PR DESCRIPTION
I tried to adapt [jconstraints-z3](https://github.com/tudo-aqua/jconstraints-z3) to Z3 4.8.10 as the new performance is awesome.

I got stuck on the `str.++` operator.

Assume the following problem:
```
(declare-fun x () String)
(declare-fun y () String)
(assert (= (str.++ x y) "test"))
(check-sat)
```

I expected that a method encoding this problem in the Java API would look like:
```
@Test
public void nativeConcatTest() {
Context ctx = new Context();
Expr<SeqSort<BitVecSort>> a = ctx.mkConst("a", ctx.getStringSort());
Expr<SeqSort<BitVecSort>> b = ctx.mkConst("b", ctx.getStringSort());
SeqExpr<BitVecSort> constant = ctx.mkString("test");
Expr concat = ctx.mkConcat(a, b);
Expr eq = ctx.mkEq(concat, constant);
Solver s = ctx.mkSolver();
assertEquals(s.check(eq), Status.SATISFIABLE);
}
```

This does only compile and execute successful, if I adapt the parameter type in mkConcat.

The example works with the proposed change in the Java API.