### PR TITLE
Fix show parameter in `prove`, `solve`, and `solve_using`

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -8469,7 +8469,7 @@ def PbEq(args, k, ctx = None):
     return BoolRef(Z3_mk_pbeq(ctx.ref(), sz, _args, _coeffs, k), ctx)
 
 
-def solve(*args, show=False, **keywords):
+def solve(*args, **keywords):
     """Solve the constraints `*args`.
 
     This is a simple function for creating demonstrations. It creates a solver,
@@ -8480,6 +8480,7 @@ def solve(*args, show=False, **keywords):
     >>> solve(a > 0, a < 2)
     [a = 1]
     """
+    show = keywords.pop("show")
     s = Solver()
     s.set(**keywords)
     s.add(*args)
@@ -8497,7 +8498,7 @@ def solve(*args, show=False, **keywords):
     else:
         print(s.model())
 
-def solve_using(s, *args, show=False, **keywords):
+def solve_using(s, *args, **keywords):
     """Solve the constraints `*args` using solver `s`.
 
     This is a simple function for creating demonstrations. It is similar to `solve`,
@@ -8505,6 +8506,7 @@ def solve_using(s, *args, show=False, **keywords):
     It configures solver `s` using the options in `keywords`, adds the constraints
     in `args`, and invokes check.
     """
+    show = keywords.pop("show")
     if z3_debug():
         _z3_assert(isinstance(s, Solver), "Solver object expected")
     s.set(**keywords)
@@ -8553,8 +8555,9 @@ def prove(claim, show=False, **keywords):
         print("counterexample")
         print(s.model())
 
-def _solve_html(*args, show=False, **keywords):
+def _solve_html(*args, **keywords):
     """Version of function `solve` used in RiSE4Fun."""
+    show = keywords.pop("show")
     s = Solver()
     s.set(**keywords)
     s.add(*args)
@@ -8575,8 +8578,9 @@ def _solve_html(*args, show=False, **keywords):
             print("<b>Solution:</b>")
         print(s.model())
 
-def _solve_using_html(s, *args, show=False, **keywords):
+def _solve_using_html(s, *args, **keywords):
     """Version of function `solve_using` used in RiSE4Fun."""
+    show = keywords.pop("show")
     if z3_debug():
         _z3_assert(isinstance(s, Solver), "Solver object expected")
     s.set(**keywords)

--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -8469,7 +8469,7 @@ def PbEq(args, k, ctx = None):
     return BoolRef(Z3_mk_pbeq(ctx.ref(), sz, _args, _coeffs, k), ctx)
 
 
-def solve(*args, **keywords):
+def solve(*args, show=False, **keywords):
     """Solve the constraints `*args`.
 
     This is a simple function for creating demonstrations. It creates a solver,
@@ -8483,7 +8483,7 @@ def solve(*args, **keywords):
     s = Solver()
     s.set(**keywords)
     s.add(*args)
-    if keywords.get('show', False):
+    if show:
         print(s)
     r = s.check()
     if r == unsat:
@@ -8497,7 +8497,7 @@ def solve(*args, **keywords):
     else:
         print(s.model())
 
-def solve_using(s, *args, **keywords):
+def solve_using(s, *args, show=False, **keywords):
     """Solve the constraints `*args` using solver `s`.
 
     This is a simple function for creating demonstrations. It is similar to `solve`,
@@ -8509,7 +8509,7 @@ def solve_using(s, *args, **keywords):
         _z3_assert(isinstance(s, Solver), "Solver object expected")
     s.set(**keywords)
     s.add(*args)
-    if keywords.get('show', False):
+    if show:
         print("Problem:")
         print(s)
     r = s.check()
@@ -8522,7 +8522,7 @@ def solve_using(s, *args, **keywords):
         except Z3Exception:
             return
     else:
-        if keywords.get('show', False):
+        if show:
             print("Solution:")
         print(s.model())
 
@@ -8553,12 +8553,12 @@ def prove(claim, show=False, **keywords):
         print("counterexample")
         print(s.model())
 
-def _solve_html(*args, **keywords):
+def _solve_html(*args, show=False, **keywords):
     """Version of function `solve` used in RiSE4Fun."""
     s = Solver()
     s.set(**keywords)
     s.add(*args)
-    if keywords.get('show', False):
+    if show:
         print("<b>Problem:</b>")
         print(s)
     r = s.check()
@@ -8571,17 +8571,17 @@ def _solve_html(*args, **keywords):
         except Z3Exception:
             return
     else:
-        if keywords.get('show', False):
+        if show:
             print("<b>Solution:</b>")
         print(s.model())
 
-def _solve_using_html(s, *args, **keywords):
+def _solve_using_html(s, *args, show=False, **keywords):
     """Version of function `solve_using` used in RiSE4Fun."""
     if z3_debug():
         _z3_assert(isinstance(s, Solver), "Solver object expected")
     s.set(**keywords)
     s.add(*args)
-    if keywords.get('show', False):
+    if show:
         print("<b>Problem:</b>")
         print(s)
     r = s.check()
@@ -8594,7 +8594,7 @@ def _solve_using_html(s, *args, **keywords):
         except Z3Exception:
             return
     else:
-        if keywords.get('show', False):
+        if show:
             print("<b>Solution:</b>")
         print(s.model())
 

--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -8526,7 +8526,7 @@ def solve_using(s, *args, **keywords):
             print("Solution:")
         print(s.model())
 
-def prove(claim, **keywords):
+def prove(claim, show=False, **keywords):
     """Try to prove the given claim.
 
     This is a simple function for creating demonstrations.  It tries to prove
@@ -8541,7 +8541,7 @@ def prove(claim, **keywords):
     s = Solver()
     s.set(**keywords)
     s.add(Not(claim))
-    if keywords.get('show', False):
+    if show:
         print(s)
     r = s.check()
     if r == unsat:
@@ -8598,14 +8598,14 @@ def _solve_using_html(s, *args, **keywords):
             print("<b>Solution:</b>")
         print(s.model())
 
-def _prove_html(claim, **keywords):
+def _prove_html(claim, show=False, **keywords):
     """Version of function `prove` used in RiSE4Fun."""
     if z3_debug():
         _z3_assert(is_bool(claim), "Z3 Boolean expression expected")
     s = Solver()
     s.set(**keywords)
     s.add(Not(claim))
-    if keywords.get('show', False):
+    if show:
         print(s)
     r = s.check()
     if r == unsat:

--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -8480,7 +8480,7 @@ def solve(*args, **keywords):
     >>> solve(a > 0, a < 2)
     [a = 1]
     """
-    show = keywords.pop("show")
+    show = keywords.pop("show", False)
     s = Solver()
     s.set(**keywords)
     s.add(*args)
@@ -8506,7 +8506,7 @@ def solve_using(s, *args, **keywords):
     It configures solver `s` using the options in `keywords`, adds the constraints
     in `args`, and invokes check.
     """
-    show = keywords.pop("show")
+    show = keywords.pop("show", False)
     if z3_debug():
         _z3_assert(isinstance(s, Solver), "Solver object expected")
     s.set(**keywords)
@@ -8557,7 +8557,7 @@ def prove(claim, show=False, **keywords):
 
 def _solve_html(*args, **keywords):
     """Version of function `solve` used in RiSE4Fun."""
-    show = keywords.pop("show")
+    show = keywords.pop("show", False)
     s = Solver()
     s.set(**keywords)
     s.add(*args)
@@ -8580,7 +8580,7 @@ def _solve_html(*args, **keywords):
 
 def _solve_using_html(s, *args, **keywords):
     """Version of function `solve_using` used in RiSE4Fun."""
-    show = keywords.pop("show")
+    show = keywords.pop("show", False)
     if z3_debug():
         _z3_assert(isinstance(s, Solver), "Solver object expected")
     s.set(**keywords)


### PR DESCRIPTION
I noticed that the `prove` function contains a check for the parameter `show`. However, when I tried to use it, I got an error:

Input:
```python
x = Int('x')
prove(x == x, show=True)
```
Output:
```
Z3Exception: b"unknown parameter 'show'\nLegal parameters are:\n  abce (bool) (default: false)\n  acce (bool) (default: false)\n  add_bound_lower (rational)\n  add_bound_upper (rational)\n  aig_per_assertion (bool)\n  algebraic_number_evaluator (bool) (default: true)\n  anf (bool) (default: false)\n  anf.delay (unsigned int) (default: 2)\n  anf.exlin (bool) (default: false)\n  arith.auto_config_simplex (bool) (default: false)\n  arith.bprop_on_pivoted_rows (bool) (default: true)\n  arith.branch_cut_ratio (unsigned int) (default: 2)\n  arith.dump_lemmas (bool) (default: false)\n  arith.eager_eq_axioms (bool) (default: true)\n  arith.enable_hnf (bool) (default: true)\n  arith.greatest_error_pivot (bool) (default: false)\n  arith.ignore_int (bool) (default: false)\n  arith.int_eq_branch (bool) (default: false)\n  arith.min (bool) (default: false)\n  arith.nl (bool) (default: true)\n  arith.nl.branching (bool) (default: true)\n  arith.nl.expp (bool) (default: false)\n  arith.nl.gr_q (unsigned int) (default: 10)\n  arith.nl.grobner (bool) (default: true)\n  arith.nl.grobner_cnfl_to_report (unsigned int) (default: 1)\n  arith.nl.grobner_eqs_growth (unsigned int) (default: 10)\n  arith.nl.grobner_expr_degree_growth (unsigned int) (default: 2)\n  arith.nl.grobner_expr_size_growth (unsigned int) (default: 2)\n  arith.nl.grobner_frequency (unsigned int) (default: 4)\n  arith.nl.grobner_max_simplified (unsigned int) (default: 10000)\n  arith.nl.grobner_subs_fixed (unsigned...
```

The problem is that `show` is passed to `Solver`. I fixed it by adding a default parameter `show=False`.
