### PR TITLE
switch expr_safe_replace to std::unordered_map

### DIFF
--- a/src/ast/rewriter/expr_safe_replace.h
+++ b/src/ast/rewriter/expr_safe_replace.h
@@ -28,13 +28,9 @@ class expr_safe_replace {
     ast_manager& m;
     expr_ref_vector m_src;
     expr_ref_vector m_dst;
-    obj_map<expr, expr*> m_subst;
     ptr_vector<expr> m_todo, m_args;
     expr_ref_vector m_refs;
     std::unordered_map<expr*,expr*> m_cache;
-
-    void cache_insert(expr* a, expr* b);
-    expr* cache_find(expr* a);
 
 public:
     expr_safe_replace(ast_manager& m): m(m), m_src(m), m_dst(m), m_refs(m) {}
@@ -51,6 +47,6 @@ public:
 
     void reset();
 
-    bool empty() const { return m_subst.empty(); }
+    bool empty() const { return m_src.empty(); }
 };
 

--- a/src/ast/rewriter/expr_safe_replace.h
+++ b/src/ast/rewriter/expr_safe_replace.h
@@ -22,6 +22,7 @@ Revision History:
 #pragma once
 
 #include "ast/ast.h"
+#include <unordered_map>
 
 class expr_safe_replace {
     ast_manager& m;
@@ -30,7 +31,7 @@ class expr_safe_replace {
     obj_map<expr, expr*> m_subst;
     ptr_vector<expr> m_todo, m_args;
     expr_ref_vector m_refs;
-    obj_map<expr,expr*> m_cache;
+    std::unordered_map<expr*,expr*> m_cache;
 
     void cache_insert(expr* a, expr* b);
     expr* cache_find(expr* a);


### PR DESCRIPTION
`Z3_substitute` is extremely slow. I profiled it and one of the culprits is hash collisions in `expr_safe_replace`'s hash table. Z3's hash table is not particularly smart in handling collisions and goes into linear scan very quickly.

I tried several alternatives and the best one gives a nice 35% speedup in some crazy Alive2 benchmarks:

![speedup](https://user-images.githubusercontent.com/2998477/107155174-d1140000-696e-11eb-9ce0-a87f789c6cb9.png)

This PR is the top performing alternative.
I know that Z3 has traditionally avoid using std:: containers, but there's precedence in the new lp code, for example. Moreover, it's unlikely any std:: implementation performs worse than Z3's 😅