### PR TITLE
Fix is_from_code() and is_to_code()

### DIFF
--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -340,8 +340,8 @@ public:
         bool is_lt(expr const* n)       const { return is_app_of(n, m_fid, OP_STRING_LT); }
         bool is_le(expr const* n)       const { return is_app_of(n, m_fid, OP_STRING_LE); }
         bool is_is_digit(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_IS_DIGIT); }
-        bool is_from_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_CODE); }
-        bool is_to_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_FROM_CODE); }
+        bool is_from_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_FROM_CODE); }
+        bool is_to_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_CODE); }
 
         bool is_string_term(expr const * n) const {
             return u.is_string(n->get_sort());


### PR DESCRIPTION
While implementing `str.from_code` and `str.to_code` in Z3str3 I ran into some weird problems matching against these operators and wondered what was going on -- turns out they are backwards in `seq_util::str`!

As a bonus, `theory_seq` correctly solves the instance in #4409 with this patch (support for it in `theory_str` will be on the way)