### PR TITLE
Z3str3: add str.to_code and str.from_code

### DIFF
--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -340,8 +340,8 @@ public:
         bool is_lt(expr const* n)       const { return is_app_of(n, m_fid, OP_STRING_LT); }
         bool is_le(expr const* n)       const { return is_app_of(n, m_fid, OP_STRING_LE); }
         bool is_is_digit(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_IS_DIGIT); }
-        bool is_from_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_CODE); }
-        bool is_to_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_FROM_CODE); }
+        bool is_from_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_FROM_CODE); }
+        bool is_to_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_CODE); }
 
         bool is_string_term(expr const * n) const {
             return u.is_string(n->get_sort());

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -1843,17 +1843,24 @@ namespace smt {
 
         expr * arg;
         u.str.is_from_code(ex, arg);
-        // (str.from_code N) == "" if N is not in the range [0, 196607].
+        // (str.from_code N) == "" if N is not in the range [0, max_char].
         {
-	  expr_ref premise(m.mk_or(m_autil.mk_le(ex, mk_int(-1)), m_autil.mk_ge(ex, mk_int(u.max_char() + 1))), m);
+	        expr_ref premise(m.mk_or(m_autil.mk_le(arg, mk_int(-1)), m_autil.mk_ge(arg, mk_int(u.max_char() + 1))), m);
             expr_ref conclusion(ctx.mk_eq_atom(ex, mk_string("")), m);
             expr_ref axiom(rewrite_implication(premise, conclusion), m);
             assert_axiom_rw(axiom);
         }
-        // len (str.from_code N) == 1 if N is in the range [0, 196607].
+        // len (str.from_code N) == 1 if N is in the range [0, max_char].
         {
-	  expr_ref premise(m.mk_and(m_autil.mk_ge(ex, mk_int(0)), m_autil.mk_le(ex, mk_int(u.max_char() + 1))), m);
+	        expr_ref premise(m.mk_and(m_autil.mk_ge(arg, mk_int(0)), m_autil.mk_le(arg, mk_int(u.max_char() + 1))), m);
             expr_ref conclusion(ctx.mk_eq_atom(mk_strlen(ex), mk_int(1)), m);
+            expr_ref axiom(rewrite_implication(premise, conclusion), m);
+            assert_axiom_rw(axiom);
+        }
+        // If N is in the range [0, max_char], then to_code(from_code(e)) == e.
+        {
+            expr_ref premise(m.mk_and(m_autil.mk_ge(arg, mk_int(0)), m_autil.mk_le(arg, mk_int(u.max_char() + 1))), m);
+            expr_ref conclusion(ctx.mk_eq_atom(u.str.mk_to_code(ex), arg), m);
             expr_ref axiom(rewrite_implication(premise, conclusion), m);
             assert_axiom_rw(axiom);
         }
@@ -1879,7 +1886,7 @@ namespace smt {
             expr_ref axiom(rewrite_implication(premise, conclusion), m);
             assert_axiom_rw(axiom);
         }
-        // (str.to_code S) is in [0, 196607] if len(S) == 1.
+        // (str.to_code S) is in [0, max_char] if len(S) == 1.
         {
             expr_ref premise(ctx.mk_eq_atom(mk_strlen(arg), mk_int(1)), m);
             expr_ref conclusion(m.mk_and(m_autil.mk_ge(ex, mk_int(0)), m_autil.mk_le(ex, mk_int(u.max_char()))), m);

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -8701,8 +8701,6 @@ namespace smt {
                     if (axiomAdd) {
                         addedStrIntAxioms = true;
                     }
-                } else {
-                    UNREACHABLE();
                 }
             }
             if (addedStrIntAxioms) {

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -1845,14 +1845,14 @@ namespace smt {
         u.str.is_from_code(ex, arg);
         // (str.from_code N) == "" if N is not in the range [0, 196607].
         {
-            expr_ref premise(m.mk_or(m_autil.mk_le(ex, mk_int(-1)), m_autil.mk_ge(ex, mk_int(196608))), m);
+	  expr_ref premise(m.mk_or(m_autil.mk_le(ex, mk_int(-1)), m_autil.mk_ge(ex, mk_int(u.max_char() + 1))), m);
             expr_ref conclusion(ctx.mk_eq_atom(ex, mk_string("")), m);
             expr_ref axiom(rewrite_implication(premise, conclusion), m);
             assert_axiom_rw(axiom);
         }
         // len (str.from_code N) == 1 if N is in the range [0, 196607].
         {
-            expr_ref premise(m.mk_and(m_autil.mk_ge(ex, mk_int(0)), m_autil.mk_le(ex, mk_int(196607))), m);
+	  expr_ref premise(m.mk_and(m_autil.mk_ge(ex, mk_int(0)), m_autil.mk_le(ex, mk_int(u.max_char() + 1))), m);
             expr_ref conclusion(ctx.mk_eq_atom(mk_strlen(ex), mk_int(1)), m);
             expr_ref axiom(rewrite_implication(premise, conclusion), m);
             assert_axiom_rw(axiom);
@@ -1882,7 +1882,7 @@ namespace smt {
         // (str.to_code S) is in [0, 196607] if len(S) == 1.
         {
             expr_ref premise(ctx.mk_eq_atom(mk_strlen(arg), mk_int(1)), m);
-            expr_ref conclusion(m.mk_and(m_autil.mk_ge(ex, mk_int(0)), m_autil.mk_le(ex, mk_int(196607))), m);
+            expr_ref conclusion(m.mk_and(m_autil.mk_ge(ex, mk_int(0)), m_autil.mk_le(ex, mk_int(u.max_char()))), m);
             expr_ref axiom(rewrite_implication(premise, conclusion), m);
             assert_axiom_rw(axiom);
         }

--- a/src/smt/theory_str.cpp
+++ b/src/smt/theory_str.cpp
@@ -833,6 +833,10 @@ namespace smt {
                         instantiate_axiom_Replace(e);
                     } else if (u.str.is_in_re(a)) {
                         instantiate_axiom_RegexIn(e);
+                    } else if (u.str.is_from_code(a)) {
+                        instantiate_axiom_str_from_code(e);
+                    } else if (u.str.is_to_code(a)) {
+                        instantiate_axiom_str_to_code(e);
                     } else {
                         TRACE("str", tout << "BUG: unhandled library-aware term " << mk_pp(e->get_owner(), get_manager()) << std::endl;);
                         NOT_IMPLEMENTED_YET();
@@ -1823,6 +1827,64 @@ namespace smt {
             // encoding: the result does NOT start with a "0" (~p) xor the result is "0" (q)
             // ~p xor q == (~p or q) and (p or ~q)
             assert_axiom(m.mk_and(m.mk_or(m.mk_not(starts_with_zero), is_zero), m.mk_or(starts_with_zero, m.mk_not(is_zero))));
+        }
+    }
+
+    void theory_str::instantiate_axiom_str_from_code(enode * e) {
+        ast_manager & m = get_manager();
+
+        app * ex = e->get_owner();
+        if (axiomatized_terms.contains(ex)) {
+            TRACE("str", tout << "already set up str.from_code axiom for " << mk_pp(ex, m) << std::endl;);
+            return;
+        }
+        axiomatized_terms.insert(ex);
+        TRACE("str", tout << "instantiate str.from_code axiom for " << mk_pp(ex, m) << std::endl;);
+
+        expr * arg;
+        u.str.is_from_code(ex, arg);
+        // (str.from_code N) == "" if N is not in the range [0, 196607].
+        {
+            expr_ref premise(m.mk_or(m_autil.mk_le(ex, mk_int(-1)), m_autil.mk_ge(ex, mk_int(196608))), m);
+            expr_ref conclusion(ctx.mk_eq_atom(ex, mk_string("")), m);
+            expr_ref axiom(rewrite_implication(premise, conclusion), m);
+            assert_axiom_rw(axiom);
+        }
+        // len (str.from_code N) == 1 if N is in the range [0, 196607].
+        {
+            expr_ref premise(m.mk_and(m_autil.mk_ge(ex, mk_int(0)), m_autil.mk_le(ex, mk_int(196607))), m);
+            expr_ref conclusion(ctx.mk_eq_atom(mk_strlen(ex), mk_int(1)), m);
+            expr_ref axiom(rewrite_implication(premise, conclusion), m);
+            assert_axiom_rw(axiom);
+        }
+    }
+
+    void theory_str::instantiate_axiom_str_to_code(enode * e) {
+        ast_manager & m = get_manager();
+
+        app * ex = e->get_owner();
+        if (axiomatized_terms.contains(ex)) {
+            TRACE("str", tout << "already set up str.to_code axiom for " << mk_pp(ex, m) << std::endl;);
+            return;
+        }
+        axiomatized_terms.insert(ex);
+        TRACE("str", tout << "instantiate str.to_code axiom for " << mk_pp(ex, m) << std::endl;);
+
+        expr * arg;
+        u.str.is_to_code(ex, arg);
+        // (str.to_code S) == -1 if len(S) != 1.
+        {
+            expr_ref premise(m.mk_not(ctx.mk_eq_atom(mk_strlen(arg), mk_int(1))), m);
+            expr_ref conclusion(ctx.mk_eq_atom(ex, mk_int(-1)), m);
+            expr_ref axiom(rewrite_implication(premise, conclusion), m);
+            assert_axiom_rw(axiom);
+        }
+        // (str.to_code S) is in [0, 196607] if len(S) == 1.
+        {
+            expr_ref premise(ctx.mk_eq_atom(mk_strlen(arg), mk_int(1)), m);
+            expr_ref conclusion(m.mk_and(m_autil.mk_ge(ex, mk_int(0)), m_autil.mk_le(ex, mk_int(196607))), m);
+            expr_ref axiom(rewrite_implication(premise, conclusion), m);
+            assert_axiom_rw(axiom);
         }
     }
 
@@ -6777,7 +6839,7 @@ namespace smt {
         if (ex_sort != str_sort) return false;
         // string constants cannot be variables
         if (u.str.is_string(e)) return false;
-        if (u.str.is_concat(e) || u.str.is_at(e) || u.str.is_extract(e) || u.str.is_replace(e) || u.str.is_itos(e))
+        if (u.str.is_concat(e) || u.str.is_at(e) || u.str.is_extract(e) || u.str.is_replace(e) || u.str.is_itos(e) || u.str.is_from_code(e))
             return false;
         if (m.is_ite(e))
             return false;
@@ -6801,8 +6863,7 @@ namespace smt {
         sort * int_sort = m.mk_sort(m_arith_fid, INT_SORT);
 
         // reject unhandled expressions
-        if (u.str.is_replace_all(ex) || u.str.is_replace_re(ex) || u.str.is_replace_re_all(ex) || u.str.is_from_code(ex)
-            || u.str.is_to_code(ex) || u.str.is_is_digit(ex)) {
+        if (u.str.is_replace_all(ex) || u.str.is_replace_re(ex) || u.str.is_replace_re_all(ex) || u.str.is_is_digit(ex)) {
             TRACE("str", tout << "ERROR: Z3str3 has encountered an unsupported operator. Aborting." << std::endl;);
             m.raise_exception("Z3str3 encountered an unsupported operator.");
         }
@@ -6830,6 +6891,11 @@ namespace smt {
                     m_library_aware_trail_stack.push(push_back_trail<theory_str, enode*, false>(m_library_aware_axiom_todo));
                 } else if (u.str.is_itos(ap)) {
                     TRACE("str", tout << "found string-integer conversion term: " << mk_pp(ex, get_manager()) << std::endl;);
+                    string_int_conversion_terms.push_back(ap);
+                    m_library_aware_axiom_todo.push_back(n);
+                    m_library_aware_trail_stack.push(push_back_trail<theory_str, enode*, false>(m_library_aware_axiom_todo));
+                } else if (u.str.is_from_code(ap)) {
+                    TRACE("str", tout << "found string-codepoint conversion term: " << mk_pp(ex, get_manager()) << std::endl;);
                     string_int_conversion_terms.push_back(ap);
                     m_library_aware_axiom_todo.push_back(n);
                     m_library_aware_trail_stack.push(push_back_trail<theory_str, enode*, false>(m_library_aware_axiom_todo));
@@ -6881,6 +6947,11 @@ namespace smt {
                     m_library_aware_trail_stack.push(push_back_trail<theory_str, enode*, false>(m_library_aware_axiom_todo));
                 } else if (u.str.is_stoi(ap)) {
                     TRACE("str", tout << "found string-integer conversion term: " << mk_pp(ex, get_manager()) << std::endl;);
+                    string_int_conversion_terms.push_back(ap);
+                    m_library_aware_axiom_todo.push_back(n);
+                    m_library_aware_trail_stack.push(push_back_trail<theory_str, enode*, false>(m_library_aware_axiom_todo));
+                } else if (u.str.is_to_code(ex)) {
+                    TRACE("str", tout << "found string-codepoint conversion term: " << mk_pp(ex, get_manager()) << std::endl;);
                     string_int_conversion_terms.push_back(ap);
                     m_library_aware_axiom_todo.push_back(n);
                     m_library_aware_trail_stack.push(push_back_trail<theory_str, enode*, false>(m_library_aware_axiom_todo));

--- a/src/smt/theory_str.h
+++ b/src/smt/theory_str.h
@@ -606,6 +606,8 @@ protected:
     void instantiate_axiom_Replace(enode * e);
     void instantiate_axiom_str_to_int(enode * e);
     void instantiate_axiom_int_to_str(enode * e);
+    void instantiate_axiom_str_to_code(enode * e);
+    void instantiate_axiom_str_from_code(enode * e);
 
     void add_persisted_axiom(expr * a);
 


### PR DESCRIPTION
Fixes #4409 and completes Unicode support for Z3str3