### PR TITLE
[WIP] Suggestion: build .NET package for both x86 and x64 and rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Z3 has bindings for various programming languages.
 
 ### ``.NET``
 
-You can install a nuget package for the latest release Z3 from [nuget.org](https://www.nuget.org/packages/Microsoft.Z3.x64/).
+You can install a nuget package for the latest release Z3 from [nuget.org](https://www.nuget.org/packages/Microsoft.Z3/).
 
 Use the ``--dotnet`` command line flag with ``mk_make.py`` to enable building these.
 

--- a/scripts/mk_nuget_release.py
+++ b/scripts/mk_nuget_release.py
@@ -94,7 +94,7 @@ def create_nuget_spec():
     contents = """<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-        <id>Microsoft.Z3.x64</id>
+        <id>Microsoft.Z3</id>
         <version>{0}</version>
         <authors>Microsoft</authors>
         <description>
@@ -119,7 +119,7 @@ Linux Dependencies:
     </metadata>
 </package>""".format(release_version, release_commit)
 
-    with open("out/Microsoft.Z3.x64.nuspec", 'w') as f:
+    with open("out/Microsoft.Z3.nuspec", 'w') as f:
         f.write(contents)
         
 def create_nuget_package():

--- a/scripts/mk_nuget_task.py
+++ b/scripts/mk_nuget_task.py
@@ -26,8 +26,7 @@ os_info = {"z64-ubuntu-14" : ('so', 'ubuntu.14.04-x64'),
            'ubuntu-18' : ('so', 'ubuntu-x64'),
            'ubuntu-20' : ('so', 'ubuntu-x64'),
            'x64-win' : ('dll', 'win-x64'),
-# Skip x86 as I can't get dotnet build to produce AnyCPU TargetPlatform           
-#          'x86-win' : ('dll', 'win-x86'),
+           'x86-win' : ('dll', 'win-x86'),
            'osx' : ('dylib', 'macos'),
            'debian' : ('so', 'debian.8-x64') }
 
@@ -79,7 +78,7 @@ def unpack(packages, symbols):
 
 def mk_targets(source_root):
     mk_dir("out/build")
-    shutil.copy(f"{source_root}/src/api/dotnet/Microsoft.Z3.targets.in", "out/build/Microsoft.Z3.x64.targets")
+    shutil.copy(f"{source_root}/src/api/dotnet/Microsoft.Z3.targets.in", "out/build/Microsoft.Z3.targets")
 
 def mk_icon(source_root):
     mk_dir("out/content")
@@ -90,7 +89,7 @@ def create_nuget_spec(version, repo, branch, commit, symbols):
     contents = """<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-        <id>Microsoft.Z3.x64</id>
+        <id>Microsoft.Z3</id>
         <version>{0}</version>
         <authors>Microsoft</authors>
         <description>
@@ -114,7 +113,7 @@ Linux Dependencies:
 </package>""".format(version, repo, branch, commit)
     print(contents)
     sym = "sym." if symbols else ""
-    file = f"out/Microsoft.Z3.x64.{sym}nuspec"
+    file = f"out/Microsoft.Z3.{sym}nuspec"
     print(file)
     with open(file, 'w') as f:
         f.write(contents)

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2157,18 +2157,11 @@ class DotNetExampleComponent(ExampleComponent):
 
             mk_dir(os.path.join(BUILD_DIR, 'dotnet_example'))
             csproj = os.path.join('dotnet_example', proj_name)
-            if VS_X64:
-                platform = 'x64'
-            elif VS_ARM:
-                platform = 'ARM'
-            else:
-                platform = 'x86'
 
             dotnet_proj_str = """<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <PlatformTarget>%s</PlatformTarget>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\%s/*.cs" />
@@ -2176,7 +2169,7 @@ class DotNetExampleComponent(ExampleComponent):
       <HintPath>..\Microsoft.Z3.dll</HintPath>
     </Reference>
   </ItemGroup>
-</Project>""" % (platform, self.to_ex_dir)
+</Project>""" % (self.to_ex_dir)
 
             with open(os.path.join(BUILD_DIR, csproj), 'w') as ous:
                 ous.write(dotnet_proj_str)

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2157,11 +2157,17 @@ class DotNetExampleComponent(ExampleComponent):
 
             mk_dir(os.path.join(BUILD_DIR, 'dotnet_example'))
             csproj = os.path.join('dotnet_example', proj_name)
+            if VS_X64:
+                platform = 'x64'
+            elif VS_ARM:
+                platform = 'ARM'
+            else:
+                platform = 'x86'
 
             dotnet_proj_str = """<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\%s/*.cs" />
@@ -2169,7 +2175,7 @@ class DotNetExampleComponent(ExampleComponent):
       <HintPath>..\Microsoft.Z3.dll</HintPath>
     </Reference>
   </ItemGroup>
-</Project>""" % (self.to_ex_dir)
+</Project>""" % (platform, self.to_ex_dir)
 
             with open(os.path.join(BUILD_DIR, csproj), 'w') as ous:
                 ous.write(dotnet_proj_str)

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2168,6 +2168,7 @@ class DotNetExampleComponent(ExampleComponent):
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PlatformTarget>%s</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\%s/*.cs" />

--- a/scripts/nightly.yaml
+++ b/scripts/nightly.yaml
@@ -181,13 +181,13 @@ stages:
       displayName: 'NuGet Pack Symbols'
       inputs:
         command: custom
-        arguments: 'pack $(Agent.TempDirectory)\package\out\Microsoft.Z3.x64.sym.nuspec -OutputDirectory $(Build.ArtifactStagingDirectory) -Verbosity detailed -Symbols -SymbolPackageFormat snupkg -BasePath $(Agent.TempDirectory)\package\out' 
+        arguments: 'pack $(Agent.TempDirectory)\package\out\Microsoft.Z3.sym.nuspec -OutputDirectory $(Build.ArtifactStagingDirectory) -Verbosity detailed -Symbols -SymbolPackageFormat snupkg -BasePath $(Agent.TempDirectory)\package\out' 
     - task: EsrpCodeSigning@1
       displayName: 'Sign Package'
       inputs:
         ConnectedServiceName: 'z3-esrp-signing'
         FolderPath: $(Build.ArtifactStagingDirectory)
-        Pattern: Microsoft.Z3.x64.$(ReleaseVersion).nupkg
+        Pattern: Microsoft.Z3.$(ReleaseVersion).nupkg
         signConfigType: 'inlineSignParams'
         inlineOperation: |
           [
@@ -214,7 +214,7 @@ stages:
       inputs:
         ConnectedServiceName: 'z3-esrp-signing'
         FolderPath: $(Build.ArtifactStagingDirectory)
-        Pattern: Microsoft.Z3.x64.$(ReleaseVersion).snupkg
+        Pattern: Microsoft.Z3.$(ReleaseVersion).snupkg
         signConfigType: 'inlineSignParams'
         inlineOperation: |
           [

--- a/scripts/release.yml
+++ b/scripts/release.yml
@@ -168,13 +168,13 @@ stages:
       displayName: 'NuGet Pack Symbols'
       inputs:
         command: custom
-        arguments: 'pack $(Agent.TempDirectory)\package\out\Microsoft.Z3.x64.sym.nuspec -OutputDirectory $(Build.ArtifactStagingDirectory) -Verbosity detailed -Symbols -SymbolPackageFormat snupkg -BasePath $(Agent.TempDirectory)\package\out' 
+        arguments: 'pack $(Agent.TempDirectory)\package\out\Microsoft.Z3.sym.nuspec -OutputDirectory $(Build.ArtifactStagingDirectory) -Verbosity detailed -Symbols -SymbolPackageFormat snupkg -BasePath $(Agent.TempDirectory)\package\out' 
     - task: EsrpCodeSigning@1
       displayName: 'Sign Package'
       inputs:
         ConnectedServiceName: 'z3-esrp-signing'
         FolderPath: $(Build.ArtifactStagingDirectory)
-        Pattern: Microsoft.Z3.x64.$(ReleaseVersion).nupkg
+        Pattern: Microsoft.Z3.$(ReleaseVersion).nupkg
         signConfigType: 'inlineSignParams'
         inlineOperation: |
           [
@@ -201,7 +201,7 @@ stages:
       inputs:
         ConnectedServiceName: 'z3-esrp-signing'
         FolderPath: $(Build.ArtifactStagingDirectory)
-        Pattern: Microsoft.Z3.x64.$(ReleaseVersion).snupkg
+        Pattern: Microsoft.Z3.$(ReleaseVersion).snupkg
         signConfigType: 'inlineSignParams'
         inlineOperation: |
           [


### PR DESCRIPTION
The Z3 .NET package is 64-bit only, however I don't see any real reason why

This proposes to rename the package in the obvious way and include the x86 bits in the build:

    Microsoft.Z3.x64 --> Microsoft.Z3

Advice welcome - in particular are you open to renaming the nuget package?

Apart from the rename the only change is removing this line: https://github.com/Z3Prover/z3/pull/5021/files#diff-56aeb133db14143ea8b4d74e24d17aafd198b6233d27676ed0ee951acf53062cL30.  The comment in that line doesn't make any sense to me - the `Microsoft.Z3.dll` is already an AnyCPU DLL as far as I can see.   However I don't yet understand whether the necessary x86 bits will be available when assembling the release package.