### PR TITLE
Adjust imports so z3.z3 is still available in python3

### DIFF
--- a/src/api/python/z3/__init__.py
+++ b/src/api/python/z3/__init__.py
@@ -1,4 +1,5 @@
-from .z3 import *
+from . import z3
+from z3 import *
 
 from . import z3num
 from . import z3poly


### PR DESCRIPTION
The python package `z3` contains an inner module named `z3` stored in the file `z3/z3.py`.

The package uses a relative import in its `z3/__init__.py` file to import (and re-export) the contents of this inner module, that looks like so:

```
from .z3 import *
```

In python2, the inner module `z3` is still available to clients who `import z3` as the nested name `z3.z3`, for clients to dig around in, in particular if they want access to some of the advisory-private functions (prefixed by underscores) in `z3/z3.py`. This is evidenced by the following python2 session transcript:

```
$ python2
Python 2.7.18 (default, Aug  4 2020, 11:16:42) 
[GCC 9.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import z3
>>> z3
<module 'z3' from '.../z3/__init__.pyc'>
>>> z3.z3
<module 'z3.z3' from '.../z3/z3.pyc'>
>>> z3.z3._to_expr_ref
<function _to_expr_ref at 0x7f1d2dd60cd0>
>>> 
```

In python3, the semantics of imports have changed subtly, and now the inner module is no longer accessible -- it is masked by a (seemingly unintentional) reference to the outer z3 _package_ that is imported from the inner module back to the package, creating a `z3.z3` reference identical to `z3` (and `z3.z3.z3` and so on). This is evidenced by the following python3 transcript:

```
$ python3
Python 3.8.5 (default, Jan 27 2021, 15:41:15) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import z3
>>> z3
<module 'z3' from '.../z3/__init__.py'>
>>> z3.z3
<module 'z3' from '.../z3/__init__.py'>
>>> z3.z3.z3
<module 'z3' from '.../z3/__init__.py'>
>>> z3.z3._to_expr_ref
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'z3' has no attribute '_to_expr_ref'
>>> 
```

The patch in this PR changes the import statements in `__init__.py` slightly to reproduce the old behaviour, even on python3. I believe it has no other effects. It appears to work identically on both python2 and python3.