### PR TITLE
Fix unintentional re-import of package z3 in z3printer, in python3.

### DIFF
--- a/src/api/python/z3/z3printer.py
+++ b/src/api/python/z3/z3printer.py
@@ -5,7 +5,19 @@
 #
 # Author: Leonardo de Moura (leonardo)
 ############################################
-import sys, io, z3
+import sys, io
+
+# We want to import submodule z3 here, but there's no way
+# to do that that works correctly on both Python 2 and 3.
+if sys.version < '3':
+    # In Python 2: an implicit-relative import of submodule z3.
+    # In Python 3: an undesirable import of global package z3.
+    import z3
+else:
+    # In Python 2: an illegal circular import.
+    # In Python 3: an explicit-relative import of submodule z3.
+    from . import z3
+
 from .z3consts import *
 from .z3core import *
 from ctypes import *


### PR DESCRIPTION
This is a second attempt at fixing the problem previously attempted in PR #5079 . 

While attempting to find a fix that _doesn't_ break clients, I did a bit more forensic examination of the root cause, which I believe I've now determined. The sequence of events is:

 - Package `z3` (that is `z3/__init__.py`) does `from .z3 import *` which starts by loading submodule `z3/z3.py`
 - Submodule `z3/z3.py` does `from .z3printer import *` which starts by loading `z3/z3printer.py`
 - Submodule `z3/z3printer.py` does `import z3`. **This is the key event**.
   - This event introduces a binding `z3` in the `z3printer` module, however its semantics are language-version dependent:
     - In Python 2 it's interpreted as an implicit-relative import, so the binding refers to the `z3/z3.py` submodule.
     - In Python 3 implicit-relative imports were removed, so the binding refers to the `z3/__init__.py` package module.
 - That binding for `z3` is copied as part of the `*` from `z3printer` submodule to `z3` submodule.
 - That same binding for `z3` is copied as part of the `*` from `z3` submodule to the `z3` package.

I suspect the desired binding is actually to a submodule (as it meant when the code was written, against Python 2) and it just happens to keep working when it changed to mean a binding to the package in Python 3 -- all the same _public_ symbols show up in both `z3`-the-package and `z3`-the-submodule.

But again: by the time this binding is copied out to the package level, it masks the `z3` submodule so that clients can't see the submodule anymore. That's the bug I'm still interested in fixing, so I think the way to fix it is to switch the import statement down in `z3printer`.

Unfortunately I can't find any single import statement that does the right thing on Python 2 and 3: the semantics of _circular relative imports_ (which this is) changed so I think we need a version-specific switch. Which is what's provided in this patch.

This time I've tested with not only the repl cases I care about but also the python examples in the Z3 repo with both `python2` and `python3`. So hopefully it doesn't introduce new breakage!