### PR TITLE
Correcting 'String' to 'STRING' to resolve CMake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ else()
   if(NOT CMAKE_BUILD_TYPE)
     message(STATUS "CMAKE_BUILD_TYPE is not set. Setting default")
     message(STATUS "The available build types are: ${available_build_types}")
-    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE String
+    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
         "Options are ${available_build_types}"
         FORCE)
     # Provide drop down menu options in cmake-gui


### PR DESCRIPTION
With CMake `3.19.5` on openSUSE Tumbleweed (20210223), running `cmake ..` gives the following:

```
CMake Warning (dev) at CMakeLists.txt:143 (set):
  implicitly converting 'String' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This PR corrects the warning.


Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>