### PR TITLE
Mixing Integers and Rational in the new Java API #5085

### DIFF
--- a/examples/java/JavaGenericExample.java
+++ b/examples/java/JavaGenericExample.java
@@ -829,6 +829,29 @@ class JavaGenericExample
         } catch (Z3Exception ignored)
         {
         }
+
+        // Coercing type change in Z3
+        Expr<IntSort> integerDivision = ctx.mkDiv(ctx.mkInt(1), ctx.mkInt(2));
+        System.out.printf("%s -> %s%n", integerDivision, integerDivision.simplify()); // (div 1 2) -> 0
+
+        Expr<RealSort> realDivision = ctx.mkDiv(ctx.mkReal(1), ctx.mkReal(2));
+        System.out.printf("%s -> %s%n", realDivision, realDivision.simplify()); // (/ 1.0 2.0) -> 1/2
+
+        var mixedDivision1 = ctx.mkDiv(ctx.mkReal(1), ctx.mkInt(2));
+        Expr<ArithSort> tmp = mixedDivision1;
+        // the return type is a Expr<ArithSort> here but since we know it is a
+        // real we can declare that.
+        Expr<RealSort> mixedDivision2 = ctx.mkDiv(ctx.mkReal(1), ctx.mkInt(2));
+        System.out.printf("%s -> %s%n", mixedDivision2, mixedDivision2.simplify()); // (/ 1.0 (to_real 2)) -> 1/2
+
+        // this does work but should not be done
+        Expr<IntSort> mixedDivision3 = ctx.mkDiv(ctx.mkReal(1), ctx.mkInt(2));
+        
+        Expr<BoolSort> eq1 = ctx.mkEq(realDivision, integerDivision);
+        System.out.printf("%s -> %s%n", eq1, eq1.simplify()); // (= (/ 1.0 2.0) (to_real (div 1 2))) -> false
+
+        Expr<BoolSort> eq2 = ctx.mkEq(realDivision, mixedDivision2);
+        System.out.printf("%s -> %s%n", eq2, eq2.simplify()); // (= (/ 1.0 2.0) (/ 1.0 (to_real 2))) -> true
     }
 
     // / Shows how to use Solver(logic)

--- a/examples/java/JavaGenericExample.java
+++ b/examples/java/JavaGenericExample.java
@@ -837,7 +837,7 @@ class JavaGenericExample
         Expr<RealSort> realDivision = ctx.mkDiv(ctx.mkReal(1), ctx.mkReal(2));
         System.out.printf("%s -> %s%n", realDivision, realDivision.simplify()); // (/ 1.0 2.0) -> 1/2
 
-        var mixedDivision1 = ctx.mkDiv(ctx.mkReal(1), ctx.mkInt(2));
+        Expr<ArithSort> mixedDivision1 = ctx.mkDiv(ctx.mkReal(1), ctx.mkInt(2));
         Expr<ArithSort> tmp = mixedDivision1;
         // the return type is a Expr<ArithSort> here but since we know it is a
         // real view it as such.

--- a/examples/java/JavaGenericExample.java
+++ b/examples/java/JavaGenericExample.java
@@ -840,12 +840,20 @@ class JavaGenericExample
         var mixedDivision1 = ctx.mkDiv(ctx.mkReal(1), ctx.mkInt(2));
         Expr<ArithSort> tmp = mixedDivision1;
         // the return type is a Expr<ArithSort> here but since we know it is a
-        // real we can declare that.
-        Expr<RealSort> mixedDivision2 = ctx.mkDiv(ctx.mkReal(1), ctx.mkInt(2));
+        // real view it as such.
+        Expr<RealSort> mixedDivision2 = mixedDivision1.distillSort(RealSort.class);
         System.out.printf("%s -> %s%n", mixedDivision2, mixedDivision2.simplify()); // (/ 1.0 (to_real 2)) -> 1/2
 
-        // this does work but should not be done
-        Expr<IntSort> mixedDivision3 = ctx.mkDiv(ctx.mkReal(1), ctx.mkInt(2));
+        // empty distillSort
+        mixedDivision1.distillSort(ArithSort.class);
+
+        try {
+            mixedDivision1.distillSort(IntSort.class);
+            throw new TestFailedException(); // unreachable
+        } catch (Z3Exception exception) {
+            System.out.println(exception); // com.microsoft.z3.Z3Exception: Cannot cast expression of sort
+                                           // com.microsoft.z3.RealSort to com.microsoft.z3.IntSort.
+        }
         
         Expr<BoolSort> eq1 = ctx.mkEq(realDivision, integerDivision);
         System.out.printf("%s -> %s%n", eq1, eq1.simplify()); // (= (/ 1.0 2.0) (to_real (div 1 2))) -> false

--- a/src/api/java/Context.java
+++ b/src/api/java/Context.java
@@ -723,7 +723,7 @@ public class Context implements AutoCloseable {
     /**
      * Creates the equality {@code x = y}
      **/
-    public <R extends Sort> BoolExpr mkEq(Expr<R> x, Expr<R> y)
+    public BoolExpr mkEq(Expr<?> x, Expr<?> y)
     {
         checkContextMatch(x);
         checkContextMatch(y);
@@ -735,7 +735,7 @@ public class Context implements AutoCloseable {
      * Creates a {@code distinct} term.
      **/
     @SafeVarargs
-    public final <R extends Sort> BoolExpr mkDistinct(Expr<R>... args)
+    public final BoolExpr mkDistinct(Expr<?>... args)
     {
         checkContextMatch(args);
         return new BoolExpr(this, Native.mkDistinct(nCtx(), args.length,
@@ -758,7 +758,7 @@ public class Context implements AutoCloseable {
      * @param t2 An expression  
      * @param t3 An expression with the same sort as {@code t2}
      **/
-    public <R extends Sort> Expr<R> mkITE(Expr<BoolSort> t1, Expr<R> t2, Expr<R> t3)
+    public <R extends Sort> Expr<R> mkITE(Expr<BoolSort> t1, Expr<? extends R> t2, Expr<? extends R> t3)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);
@@ -826,10 +826,10 @@ public class Context implements AutoCloseable {
      * Create an expression representing {@code t[0] + t[1] + ...}.
      **/
     @SafeVarargs
-    public final <R extends ArithSort> ArithExpr<R> mkAdd(Expr<R>... t)
+    public final <R extends ArithSort, R1 extends R> ArithExpr<R1> mkAdd(Expr<? extends R>... t)
     {
         checkContextMatch(t);
-        return (ArithExpr<R>) Expr.create(this,
+        return (ArithExpr<R1>) Expr.create(this,
                 Native.mkAdd(nCtx(), t.length, AST.arrayToNative(t)));
     }
 
@@ -837,10 +837,10 @@ public class Context implements AutoCloseable {
      * Create an expression representing {@code t[0] * t[1] * ...}.
      **/
     @SafeVarargs
-    public final <R extends ArithSort> ArithExpr<R> mkMul(Expr<R>... t)
+    public final <R extends ArithSort, R1 extends R> ArithExpr<R1> mkMul(Expr<? extends R>... t)
     {
         checkContextMatch(t);
-        return (ArithExpr<R>) Expr.create(this,
+        return (ArithExpr<R1>) Expr.create(this,
                 Native.mkMul(nCtx(), t.length, AST.arrayToNative(t)));
     }
 
@@ -848,10 +848,10 @@ public class Context implements AutoCloseable {
      * Create an expression representing {@code t[0] - t[1] - ...}.
      **/
     @SafeVarargs
-    public final <R extends ArithSort> ArithExpr<R> mkSub(Expr<R>... t)
+    public final <R extends ArithSort, R1 extends R> ArithExpr<R1> mkSub(Expr<? extends R>... t)
     {
         checkContextMatch(t);
-        return (ArithExpr<R>) Expr.create(this,
+        return (ArithExpr<R1>) Expr.create(this,
                 Native.mkSub(nCtx(), t.length, AST.arrayToNative(t)));
     }
 
@@ -868,11 +868,11 @@ public class Context implements AutoCloseable {
     /**
      * Create an expression representing {@code t1 / t2}.
      **/
-    public <R extends ArithSort> ArithExpr<R> mkDiv(Expr<R> t1, Expr<R> t2)
+    public <R extends ArithSort, R1 extends R> ArithExpr<R1> mkDiv(Expr<? extends R> t1, Expr<? extends R> t2)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);
-        return (ArithExpr<R>) Expr.create(this, Native.mkDiv(nCtx(),
+        return (ArithExpr<R1>) Expr.create(this, Native.mkDiv(nCtx(),
                 t1.getNativeObject(), t2.getNativeObject()));
     }
 
@@ -905,11 +905,12 @@ public class Context implements AutoCloseable {
     /**
      * Create an expression representing {@code t1 ^ t2}.
      **/
-    public <R extends ArithSort> ArithExpr<R> mkPower(Expr<R> t1, Expr<R> t2)
+    public <R extends ArithSort, R1 extends ArithSort> ArithExpr<R1> mkPower(Expr<? extends R> t1,
+            Expr<? extends R> t2)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);
-        return (ArithExpr<R>) Expr.create(
+        return (ArithExpr<R1>) Expr.create(
                 this,
                 Native.mkPower(nCtx(), t1.getNativeObject(),
                         t2.getNativeObject()));
@@ -918,7 +919,7 @@ public class Context implements AutoCloseable {
     /**
      * Create an expression representing {@code t1 &lt; t2}
      **/
-    public <R extends ArithSort> BoolExpr mkLt(Expr<R> t1, Expr<R> t2)
+    public <R extends ArithSort> BoolExpr mkLt(Expr<? extends R> t1, Expr<? extends R> t2)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);
@@ -929,7 +930,7 @@ public class Context implements AutoCloseable {
     /**
      * Create an expression representing {@code t1 &lt;= t2}
      **/
-    public <R extends ArithSort> BoolExpr mkLe(Expr<R> t1, Expr<R> t2)
+    public <R extends ArithSort> BoolExpr mkLe(Expr<? extends R> t1, Expr<? extends R> t2)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);
@@ -940,7 +941,7 @@ public class Context implements AutoCloseable {
     /**
      * Create an expression representing {@code t1 &gt; t2}
      **/
-    public <R extends ArithSort> BoolExpr mkGt(Expr<R> t1, Expr<R> t2)
+    public <R extends ArithSort> BoolExpr mkGt(Expr<? extends R> t1, Expr<? extends R> t2)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);
@@ -951,7 +952,7 @@ public class Context implements AutoCloseable {
     /**
      * Create an expression representing {@code t1 &gt;= t2}
      **/
-    public <R extends ArithSort> BoolExpr mkGe(Expr<R> t1, Expr<R> t2)
+    public <R extends ArithSort> BoolExpr mkGe(Expr<? extends R> t1, Expr<? extends R> t2)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);

--- a/src/api/java/Context.java
+++ b/src/api/java/Context.java
@@ -826,10 +826,10 @@ public class Context implements AutoCloseable {
      * Create an expression representing {@code t[0] + t[1] + ...}.
      **/
     @SafeVarargs
-    public final <R extends ArithSort, R1 extends R> ArithExpr<R1> mkAdd(Expr<? extends R>... t)
+    public final <R extends ArithSort> ArithExpr<R> mkAdd(Expr<? extends R>... t)
     {
         checkContextMatch(t);
-        return (ArithExpr<R1>) Expr.create(this,
+        return (ArithExpr<R>) Expr.create(this,
                 Native.mkAdd(nCtx(), t.length, AST.arrayToNative(t)));
     }
 
@@ -837,10 +837,10 @@ public class Context implements AutoCloseable {
      * Create an expression representing {@code t[0] * t[1] * ...}.
      **/
     @SafeVarargs
-    public final <R extends ArithSort, R1 extends R> ArithExpr<R1> mkMul(Expr<? extends R>... t)
+    public final <R extends ArithSort> ArithExpr<R> mkMul(Expr<? extends R>... t)
     {
         checkContextMatch(t);
-        return (ArithExpr<R1>) Expr.create(this,
+        return (ArithExpr<R>) Expr.create(this,
                 Native.mkMul(nCtx(), t.length, AST.arrayToNative(t)));
     }
 
@@ -848,10 +848,10 @@ public class Context implements AutoCloseable {
      * Create an expression representing {@code t[0] - t[1] - ...}.
      **/
     @SafeVarargs
-    public final <R extends ArithSort, R1 extends R> ArithExpr<R1> mkSub(Expr<? extends R>... t)
+    public final <R extends ArithSort> ArithExpr<R> mkSub(Expr<? extends R>... t)
     {
         checkContextMatch(t);
-        return (ArithExpr<R1>) Expr.create(this,
+        return (ArithExpr<R>) Expr.create(this,
                 Native.mkSub(nCtx(), t.length, AST.arrayToNative(t)));
     }
 
@@ -868,11 +868,11 @@ public class Context implements AutoCloseable {
     /**
      * Create an expression representing {@code t1 / t2}.
      **/
-    public <R extends ArithSort, R1 extends R> ArithExpr<R1> mkDiv(Expr<? extends R> t1, Expr<? extends R> t2)
+    public <R extends ArithSort> ArithExpr<R> mkDiv(Expr<? extends R> t1, Expr<? extends R> t2)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);
-        return (ArithExpr<R1>) Expr.create(this, Native.mkDiv(nCtx(),
+        return (ArithExpr<R>) Expr.create(this, Native.mkDiv(nCtx(),
                 t1.getNativeObject(), t2.getNativeObject()));
     }
 
@@ -905,12 +905,12 @@ public class Context implements AutoCloseable {
     /**
      * Create an expression representing {@code t1 ^ t2}.
      **/
-    public <R extends ArithSort, R1 extends ArithSort> ArithExpr<R1> mkPower(Expr<? extends R> t1,
+    public <R extends ArithSort> ArithExpr<R> mkPower(Expr<? extends R> t1,
             Expr<? extends R> t2)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);
-        return (ArithExpr<R1>) Expr.create(
+        return (ArithExpr<R>) Expr.create(
                 this,
                 Native.mkPower(nCtx(), t1.getNativeObject(),
                         t2.getNativeObject()));
@@ -919,7 +919,7 @@ public class Context implements AutoCloseable {
     /**
      * Create an expression representing {@code t1 &lt; t2}
      **/
-    public <R extends ArithSort> BoolExpr mkLt(Expr<? extends R> t1, Expr<? extends R> t2)
+    public BoolExpr mkLt(Expr<? extends ArithSort> t1, Expr<? extends ArithSort> t2)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);
@@ -930,7 +930,7 @@ public class Context implements AutoCloseable {
     /**
      * Create an expression representing {@code t1 &lt;= t2}
      **/
-    public <R extends ArithSort> BoolExpr mkLe(Expr<? extends R> t1, Expr<? extends R> t2)
+    public BoolExpr mkLe(Expr<? extends ArithSort> t1, Expr<? extends ArithSort> t2)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);
@@ -941,7 +941,7 @@ public class Context implements AutoCloseable {
     /**
      * Create an expression representing {@code t1 &gt; t2}
      **/
-    public <R extends ArithSort> BoolExpr mkGt(Expr<? extends R> t1, Expr<? extends R> t2)
+    public BoolExpr mkGt(Expr<? extends ArithSort> t1, Expr<? extends ArithSort> t2)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);
@@ -952,7 +952,7 @@ public class Context implements AutoCloseable {
     /**
      * Create an expression representing {@code t1 &gt;= t2}
      **/
-    public <R extends ArithSort> BoolExpr mkGe(Expr<? extends R> t1, Expr<? extends R> t2)
+    public BoolExpr mkGe(Expr<? extends ArithSort> t1, Expr<? extends ArithSort> t2)
     {
         checkContextMatch(t1);
         checkContextMatch(t2);


### PR DESCRIPTION
This should fix #5085 

The idea is to allow `Expr` to the have sort `ArithSort`, which could be integers or reals.
The problem in Java with this is that is does not support covariance, i.e., `Expr<ArithSort>` is not a supertype of `Expr<RealSort>`.
To overcome this, create the function `Expr.distillSort` which can do this cast.

Please let me know what you think.