### PR TITLE
Circular seq axioms node

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -976,9 +976,17 @@ class Component:
     # That is, we were looking for fname when processing ownerfile
     def find_file(self, fname, ownerfile, orig_path=None):
         full_fname = os.path.join(self.src_dir, fname)
+
+        # Store all our possible locations
         possibilities = set()
+
+        # If the our file exists in the current directory, then we store it
         if os.path.exists(full_fname):
-            return self
+
+            # We cannot return here, as we might have files with the same
+            # basename, but different include paths
+            possibilities.add(self)
+
         for dep in self.deps:
             c_dep = get_component(dep)
             full_fname = os.path.join(c_dep.src_dir, fname)
@@ -1005,8 +1013,10 @@ class Component:
                         # ... use our new match
                         return possibility
 
-            # This means we didn't make an exact match, but we're no worse than
-            # before
+            # This means we didn't make an exact match ...
+            #
+            # We return any one possibility, just to ensure we don't break Z3's
+            # builds
             return possibilities.pop()
 
         raise MKException("Failed to find include file '%s' for '%s' when processing '%s'." % (fname, ownerfile, self.name))

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -974,7 +974,7 @@ class Component:
     # Find fname in the include paths for the given component.
     # ownerfile is only used for creating error messages.
     # That is, we were looking for fname when processing ownerfile
-    def find_file(self, fname, ownerfile, orig_path=None):
+    def find_file(self, fname, ownerfile, orig_include=None):
         full_fname = os.path.join(self.src_dir, fname)
 
         # Store all our possible locations
@@ -999,10 +999,10 @@ class Component:
             if len(possibilities) > 1:
 
                 # We expect orig_path to be non-None here, so we can disambiguate
-                assert orig_path is not None
+                assert orig_include is not None
 
                 # Get the original directory name
-                orig_dir = os.path.dirname(orig_path)
+                orig_dir = os.path.dirname(orig_include)
 
                 # Iterate through all of the possibilities
                 for possibility in possibilities:
@@ -1026,17 +1026,16 @@ class Component:
     def add_cpp_h_deps(self, out, basename):
         includes = extract_c_includes(os.path.join(self.src_dir, basename))
         out.write(os.path.join(self.to_src_dir, basename))
-        for include in includes:
-            orig_path = includes[include]
-            owner = self.find_file(include, basename, orig_path)
+        for include, orig_include in includes.items():
+            owner = self.find_file(include, basename, orig_include)
             out.write(' %s.node' % os.path.join(owner.build_dir, include))
 
     # Add a rule for each #include directive in the file basename located at the current component.
     def add_rule_for_each_include(self, out, basename):
         fullname = os.path.join(self.src_dir, basename)
         includes = extract_c_includes(fullname)
-        for include, orig_name in includes.items():
-            owner = self.find_file(include, fullname, orig_name)
+        for include, orig_include in includes.items():
+            owner = self.find_file(include, fullname, orig_include)
             owner.add_h_rule(out, include)
 
     # Display a Makefile rule for an include file located in the given component directory.


### PR DESCRIPTION
In master (hash 909808421), the following:

```bash
./configure
make smt/seq_axioms.h.node
```

will give:

```
make: Circular smt/seq_axioms.h.node <- smt/seq_axioms.h.node dependency dropped.
```

This is because the functionality in `find_file` was not written to expect there to be multiple includes with the same base name, and where shared names include each other.

For example, this is a problem with `smt/seq_axioms.h` which itself includes `ast/rewriter/seq_axioms.h`. In the past, when trying to resolve `seq_axioms.h` **in the `src_dir` of `smt`** would give the same file, because it was only using `seq_axioms.h`.

This PR corrects this to endeavour to correct ambiguity by also storing the full `#include` directive (and not just the base name).


