### PR TITLE
Update setup.py to use cmake build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ doc/code
 .vs
 examples/**/obj
 CMakeSettings.json
+# Editor temp files
+*.swp

--- a/src/api/python/MANIFEST.in
+++ b/src/api/python/MANIFEST.in
@@ -1,4 +1,7 @@
 include core/LICENSE.txt
+include core/z3.pc.cmake.in
+recursive-include core CMakeLists.txt
+recursive-include core *.cmake
 recursive-include core/src *
+recursive-include core/cmake *
 recursive-include core/scripts *
-recursive-include core/examples *


### PR DESCRIPTION
This also allows future PRs to more easily distribute the CMake config files generated by the CMake build system.