### PR TITLE
array uses unique_ptr

### DIFF
--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -1991,8 +1991,7 @@ namespace z3 {
 
     template<typename T>
     template<typename T2>
-    array<T>::array(ast_vector_tpl<T2> const & v) {
-        m_array.reset(new T[v.size()]);
+    array<T>::array(ast_vector_tpl<T2> const & v):m_array(new T[v.size()]) {
         m_size  = v.size();
         for (unsigned i = 0; i < m_size; i++) {
             m_array[i] = v[i];

--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -405,8 +405,8 @@ namespace z3 {
         unsigned size() const { return m_size; }
         T & operator[](int i) { assert(0 <= i); assert(static_cast<unsigned>(i) < m_size); return m_array[i]; }
         T const & operator[](int i) const { assert(0 <= i); assert(static_cast<unsigned>(i) < m_size); return m_array[i]; }
-        T const * ptr() const { return & m_array[0]; }
-        T * ptr() { return & m_array[0]; }
+        T const * ptr() const { return m_array.get(); }
+        T * ptr() { return m_array.get(); }
     };
 
     class object {


### PR DESCRIPTION
In the C++ API, the array class now uses `unique_ptr` instead of manual memory management