### PR TITLE
Explicitly delete private constructors

### DIFF
--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -105,8 +105,8 @@ namespace z3 {
     */
     class config {
         Z3_config    m_cfg;
-        config(config const & s);
-        config & operator=(config const & s);
+        config(config const & s) = delete;
+        config & operator=(config const & s) = delete;
     public:
         config() { m_cfg = Z3_mk_config(); }
         ~config() { Z3_del_config(m_cfg); }
@@ -169,8 +169,8 @@ namespace z3 {
         }
 
 
-        context(context const & s);
-        context & operator=(context const & s);
+        context(context const & s) = delete;
+        context & operator=(context const & s) = delete;
 
         friend class scoped_context;
         context(Z3_context c) { set_context(c); }
@@ -394,8 +394,8 @@ namespace z3 {
     class array {
         T *      m_array;
         unsigned m_size;
-        array(array const & s);
-        array & operator=(array const & s);
+        array(array const & s) = delete;
+        array & operator=(array const & s) = delete;
     public:
         array(unsigned sz):m_size(sz) { m_array = new T[sz]; }
         template<typename T2>


### PR DESCRIPTION
This requires `C++11` or later.