### PR TITLE
Cpp api general minor improvements

### DIFF
--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -85,6 +85,7 @@ namespace z3 {
     class exception : public std::exception {
         std::string m_msg;
     public:
+        virtual ~exception() throw() {}
         exception(char const * msg):m_msg(msg) {}
         char const * msg() const { return m_msg.c_str(); }
         char const * what() const throw() { return m_msg.c_str(); }


### PR DESCRIPTION
Marked classes as final, added `noexcept` in a few obvious places, deleted copy functions that could be implicitly generated, since explicitly defining them has rule of 5 side effects in C++11+.