### PR TITLE
C++ API add missing FP methods

### DIFF
--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -891,6 +891,16 @@ namespace z3 {
         }
 
         /**
+           \brief Convert this fpa into an IEEE BV
+        */
+        bool to_ieee_bv() const {
+            assert(is_fpa());
+            Z3_ast r = Z3_mk_fpa_to_ieee_bv(ctx(), m_ast),
+            check_error();
+            return expr(ctx(), r);
+        }
+
+        /**
            \brief Return string representation of numeral or algebraic number
            This method assumes the expression is numeral or algebraic
 

--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -871,6 +871,26 @@ namespace z3 {
         bool is_well_sorted() const { bool r = Z3_is_well_sorted(ctx(), m_ast); check_error(); return r; }
 
         /**
+           \brief Return true if this expression is an fpa and is inf
+        */
+        bool is_inf() const {
+            assert(is_fpa());
+            Z3_ast r = Z3_mk_fpa_is_infinite(ctx(), m_ast);
+            check_error();
+            return expr(ctx(), r);
+        }
+
+        /**
+           \brief Return true if this expression is an fpa and is NaN
+        */
+        bool is_nan() const {
+            assert(is_fpa());
+            Z3_ast r = Z3_mk_fpa_is_nan(ctx(), m_ast);
+            check_error();
+            return expr(ctx(), r);
+        }
+
+        /**
            \brief Return string representation of numeral or algebraic number
            This method assumes the expression is numeral or algebraic
 


### PR DESCRIPTION
The C++ API was lacking these methods before; furthermore since `m_ast` cannot be trivially exposed, these methods could not be invoked using the lower level functions like `Z3_mk_fpa_is_infinite`. This PR added 3 functions to the C++ API to expose these fp methods that were otherwise not accessible.