### PR TITLE
Cpp api fp to bv

### DIFF
--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -1308,6 +1308,15 @@ namespace z3 {
         friend expr fma(expr const& a, expr const& b, expr const& c, expr const& rm);
 
         /**
+           \brief Conversion of a floating-point term into a signed bit-vector
+        */
+        friend expr fpa_to_sbv(expr const& rm, expr const& fp, unsigned bv_len);
+        /**
+           \brief Conversion of a floating-point term into a unsigned bit-vector
+        */
+        friend expr fpa_to_ubv(expr const& rm, expr const& fp, unsigned bv_len);
+
+        /**
            \brief sequence and regular expression operations.
            + is overloaded as sequence concatenation and regular expression union.
            concat is overloaded to handle sequences and regular expressions
@@ -1802,6 +1811,21 @@ namespace z3 {
         Z3_ast r = Z3_mk_fpa_fma(a.ctx(), rm, a, b, c);
         a.check_error();
         return expr(a.ctx(), r);
+    }
+
+    inline expr fpa_to_sbv(expr const& rm, expr const& fp, unsigned bv_len) {
+        check_context(rm, fp);
+        assert(fp.is_fpa());
+        Z3_ast r = Z3_mk_fpa_to_sbv(fp.ctx(), rm, fp, bv_len);
+        fp.check_error();
+        return expr(fp.ctx(), r);
+    }
+    inline expr fpa_to_ubv(expr const& rm, expr const& fp, unsigned bv_len) {
+        check_context(rm, fp);
+        assert(fp.is_fpa());
+        Z3_ast r = Z3_mk_fpa_to_ubv(fp.ctx(), rm, fp, bv_len);
+        fp.check_error();
+        return expr(fp.ctx(), r);
     }
 
 

--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -1308,6 +1308,10 @@ namespace z3 {
         friend expr fma(expr const& a, expr const& b, expr const& c, expr const& rm);
 
         /**
+           \brief Create an expression of FloatingPoint sort from three bit-vector expressions.
+        */
+        friend expr fpa_fp(expr const& rm, expr const& fp, unsigned bv_len);
+        /**
            \brief Conversion of a floating-point term into a signed bit-vector
         */
         friend expr fpa_to_sbv(expr const& rm, expr const& fp, unsigned bv_len);
@@ -1813,6 +1817,12 @@ namespace z3 {
         return expr(a.ctx(), r);
     }
 
+    inline expr fpa_fp(expr const& sgn, expr const& exp, expr const & sig) {
+        check_context(sgn, exp); check_context(exp, sig);
+        Z3_ast r = Z3_mk_fpa_fp(sgn.ctx(), sgn, exp, sig)
+        sgn.check_error();
+        return expr(sgn.ctx(), r);
+    }
     inline expr fpa_to_sbv(expr const& rm, expr const& fp, unsigned bv_len) {
         check_context(rm, fp);
         assert(fp.is_fpa());

--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -1314,11 +1314,11 @@ namespace z3 {
         /**
            \brief Conversion of a floating-point term into a signed bit-vector
         */
-        friend expr fpa_to_sbv(expr const& rm, expr const& fp, unsigned bv_len);
+        friend expr fpa_to_sbv(sort const& rm, expr const& fp, unsigned bv_len);
         /**
            \brief Conversion of a floating-point term into a unsigned bit-vector
         */
-        friend expr fpa_to_ubv(expr const& rm, expr const& fp, unsigned bv_len);
+        friend expr fpa_to_ubv(sort const& rm, expr const& fp, unsigned bv_len);
 
         /**
            \brief sequence and regular expression operations.
@@ -1819,21 +1819,21 @@ namespace z3 {
 
     inline expr fpa_fp(expr const& sgn, expr const& exp, expr const & sig) {
         check_context(sgn, exp); check_context(exp, sig);
-        Z3_ast r = Z3_mk_fpa_fp(sgn.ctx(), sgn, exp, sig)
+        Z3_ast r = Z3_mk_fpa_fp(sgn.ctx(), sgn, exp, sig);
         sgn.check_error();
         return expr(sgn.ctx(), r);
     }
-    inline expr fpa_to_sbv(expr const& rm, expr const& fp, unsigned bv_len) {
+    inline expr fpa_to_sbv(sort const& rm, expr const& fp, unsigned bv_len) {
         check_context(rm, fp);
         assert(fp.is_fpa());
-        Z3_ast r = Z3_mk_fpa_to_sbv(fp.ctx(), rm, fp, bv_len);
+        Z3_ast r = Z3_mk_fpa_to_sbv(fp.ctx(), rm.m_ast, fp.m_ast, bv_len);
         fp.check_error();
         return expr(fp.ctx(), r);
     }
-    inline expr fpa_to_ubv(expr const& rm, expr const& fp, unsigned bv_len) {
+    inline expr fpa_to_ubv(sort const& rm, expr const& fp, unsigned bv_len) {
         check_context(rm, fp);
         assert(fp.is_fpa());
-        Z3_ast r = Z3_mk_fpa_to_ubv(fp.ctx(), rm, fp, bv_len);
+        Z3_ast r = Z3_mk_fpa_to_ubv(fp.ctx(), rm.m_ast, fp.m_ast, bv_len);
         fp.check_error();
         return expr(fp.ctx(), r);
     }

--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -895,7 +895,7 @@ namespace z3 {
         */
         expr mk_to_ieee_bv() const {
             assert(is_fpa());
-            Z3_ast r = Z3_mk_fpa_to_ieee_bv(ctx(), m_ast),
+            Z3_ast r = Z3_mk_fpa_to_ieee_bv(ctx(), m_ast);
             check_error();
             return expr(ctx(), r);
         }


### PR DESCRIPTION
Add missing API methods `fpa_to_ubv` and `sbv`.
Bug fix of missing semi-colon.