### PR TITLE
operator= checks this equality before moving

### DIFF
--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -511,9 +511,11 @@ namespace z3 {
             return *this;
         }
         ast & operator=(ast && s) noexcept {
-            object::operator=(std::forward<object>(s));
-            m_ast = s.m_ast;
-            s.m_ast = nullptr;
+            if (this != &s) {
+                object::operator=(std::forward<object>(s));
+                m_ast = s.m_ast;
+                s.m_ast = nullptr;
+            }
             return *this;
         }
         Z3_ast_kind kind() const { Z3_ast_kind r = Z3_get_ast_kind(ctx(), m_ast); check_error(); return r; }


### PR DESCRIPTION
Without this, invoking this would leave a memory leak and leave the both (they are the same) objects in a state with a null AST pointer.