### PR TITLE
Use osx-x64 for mac rid rather than macos.

### DIFF
--- a/scripts/mk_nuget_release.py
+++ b/scripts/mk_nuget_release.py
@@ -48,7 +48,7 @@ os_info = {"z64-ubuntu-14" : ('so', 'ubuntu.14.04-x64'),
            'x64-win' : ('dll', 'win-x64'),
 # Skip x86 as I can't get dotnet build to produce AnyCPU TargetPlatform           
 #          'x86-win' : ('dll', 'win-x86'),
-           'osx' : ('dylib', 'macos'),
+           'osx' : ('dylib', 'osx-x64'),
            'debian' : ('so', 'debian.8-x64') }
 
 def classify_package(f):
@@ -69,7 +69,7 @@ def unpack():
     #    +- ubuntu.16.04-x64
     #    +- ubuntu.14.04-x64
     #    +- debian.8-x64
-    #    +- macos
+    #    +- osx-x64
     # +
     for f in os.listdir("packages"):
         print(f)

--- a/scripts/mk_nuget_task.py
+++ b/scripts/mk_nuget_task.py
@@ -28,7 +28,7 @@ os_info = {"z64-ubuntu-14" : ('so', 'ubuntu.14.04-x64'),
            'glibc-2.31' : ('so', 'glibc-x64'),
            'x64-win' : ('dll', 'win-x64'),
            'x86-win' : ('dll', 'win-x86'),
-           'osx' : ('dylib', 'macos'),
+           'osx' : ('dylib', 'osx-x64'),
            'debian' : ('so', 'debian.8-x64') }
 
 def classify_package(f):
@@ -52,7 +52,7 @@ def unpack(packages, symbols):
     #    +- win-x64
     #    +- win-x86
     #    +- ubuntu-x64
-    #    +- macos
+    #    +- osx-x64
     # +
     tmp = "tmp" if not symbols else "tmpsym"
     for f in os.listdir(packages):

--- a/src/api/dotnet/Microsoft.Z3.csproj.in
+++ b/src/api/dotnet/Microsoft.Z3.csproj.in
@@ -84,7 +84,7 @@ ${Z3_DOTNET_COMPILE_ITEMS}
       <PackagePath>runtimes\linux-x64\native</PackagePath>
     </Content>
     <Content Include="${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libz3.dylib" Condition="Exists('${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libz3.dylib')">
-      <PackagePath>runtimes\macos\native</PackagePath>
+      <PackagePath>runtimes\osx-x64\native</PackagePath>
     </Content>
   </ItemGroup>
 


### PR DESCRIPTION
I hit an issue today when using the Microsoft.Z3.x64 package in a .NET 5.0 project and running the tests for my project on mac. Specifically it throws the following exception when running the tests.

```sh
Error Message:
   System.DllNotFoundException : Unable to load shared library 'libz3' or one of its dependencies. In order to help diagnose loading problems, consider setting the DYLD_PRINT_LIBRARIES environment variable: dlopen(liblibz3, 1): image not found
```

After probing about in `MyTestProject/bin/x64/Debug/net5.0/runtimes` I noticed that the `z3lib.dylib` was under a folder called `macos` and that the `MyTestProject.deps.json` file was pointing to this location for the `macos` `rid`. However, checking with the Microsoft documentation on which runtime identifiers are officially supported it seems that `macos` is not a well known value. Instead `osx-x64` is the base rid for mac, as detailed [here](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#macos-rids).

Also running `dotnet --info` on my machine reveals my specific `rid` to be:

```
Runtime Environment:
 OS Name:     Mac OS X
 OS Version:  11.0
 OS Platform: Darwin
 RID:         osx.11.0-x64
 Base Path:   /usr/local/share/dotnet/sdk/5.0.102/
```

It seems that NuGet generates the `MyProject.deps.json` rid mappings based on the folder structure in the NuGet package and that the package is installed at `~/.nuget/packages/microsoft.z3.x64/4.8.10/`. Inspecting that location showed again that under the `runtimes` folder there was a `macos` folder which contained the `libz3.dylib` file. If I copied / renamed this folder to `osx-x64`, and then re-ran the tests in my project it was properly able to locate `liibz3.dylib`. 

Therefore, I think the fix is to ensure that when the nuget package is created the `libz3.dylib` file is placed under `osx-x64` rather than `macos`. 

I've attempted a fix here, but I'm not completely certain I've identified the right places to ensure that the packaging is now done correctly. 