### PR TITLE
Remove x64 suffix from NuGet package names.

### DIFF
--- a/scripts/mk_nuget_release.py
+++ b/scripts/mk_nuget_release.py
@@ -94,7 +94,7 @@ def create_nuget_spec():
     contents = """<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-        <id>Microsoft.Z3.x64</id>
+        <id>Microsoft.Z3</id>
         <version>{0}</version>
         <authors>Microsoft</authors>
         <description>

--- a/scripts/mk_nuget_task.py
+++ b/scripts/mk_nuget_task.py
@@ -89,7 +89,7 @@ def create_nuget_spec(version, repo, branch, commit, symbols):
     contents = """<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-        <id>Microsoft.Z3.x64</id>
+        <id>Microsoft.Z3</id>
         <version>{0}</version>
         <authors>Microsoft</authors>
         <description>


### PR DESCRIPTION
Since the NuGet package name was deliberately shortened in https://github.com/Z3Prover/z3/pull/5021 it should not have been changed back in https://github.com/Z3Prover/z3/pull/5290 after all. This change simply removes the x64 suffix again.