### PR TITLE
Use more generic linux-x64 for NuGet rid.

### DIFF
--- a/scripts/mk_nuget_release.py
+++ b/scripts/mk_nuget_release.py
@@ -43,13 +43,13 @@ def download_installs():
         sys.stdout.flush()
         urllib.request.urlretrieve(url, "packages/%s" % name)
 
-os_info = {"z64-ubuntu-14" : ('so', 'ubuntu.14.04-x64'),
-           'ubuntu-16' : ('so', 'ubuntu-x64'),
+os_info = {"z64-ubuntu-14" : ('so', 'linux-x64'),
+           'ubuntu-16' : ('so', 'linux-x64'),
            'x64-win' : ('dll', 'win-x64'),
 # Skip x86 as I can't get dotnet build to produce AnyCPU TargetPlatform           
 #          'x86-win' : ('dll', 'win-x86'),
            'osx' : ('dylib', 'osx-x64'),
-           'debian' : ('so', 'debian.8-x64') }
+           'debian' : ('so', 'linux-x64') }
 
 def classify_package(f):
     for os_name in os_info:
@@ -66,9 +66,7 @@ def unpack():
     # +- runtimes
     #    +- win-x64
     #    +- win-x86
-    #    +- ubuntu.16.04-x64
-    #    +- ubuntu.14.04-x64
-    #    +- debian.8-x64
+    #    +- linux-x64
     #    +- osx-x64
     # +
     for f in os.listdir("packages"):

--- a/scripts/mk_nuget_task.py
+++ b/scripts/mk_nuget_task.py
@@ -22,14 +22,14 @@ def mk_dir(d):
         os.makedirs(d)
 
 
-os_info = {"z64-ubuntu-14" : ('so', 'ubuntu.14.04-x64'),
-           'ubuntu-18' : ('so', 'ubuntu-x64'),
-           'ubuntu-20' : ('so', 'ubuntu-x64'),
-           'glibc-2.31' : ('so', 'ubuntu-x64'),
+os_info = {"z64-ubuntu-14" : ('so', 'linux-x64'),
+           'ubuntu-18' : ('so', 'linux-x64'),
+           'ubuntu-20' : ('so', 'linux-x64'),
+           'glibc-2.31' : ('so', 'linux-x64'),
            'x64-win' : ('dll', 'win-x64'),
            'x86-win' : ('dll', 'win-x86'),
            'osx' : ('dylib', 'osx-x64'),
-           'debian' : ('so', 'debian.8-x64') }
+           'debian' : ('so', 'linux-x64') }
 
 def classify_package(f):
     for os_name in os_info:
@@ -51,7 +51,7 @@ def unpack(packages, symbols):
     # +- runtimes
     #    +- win-x64
     #    +- win-x86
-    #    +- ubuntu-x64
+    #    +- linux-x64
     #    +- osx-x64
     # +
     tmp = "tmp" if not symbols else "tmpsym"


### PR DESCRIPTION
The more generic 'linux-x64' should be used as the linux rid for NuGet packages, because at the moment only 'ubuntu-x64' is included in the package. Therefore, loading in dotnet on e.g. 'debian-x64' does not work, even though there seems to be no fundamental reason it should not. As a minimal test, manually changing the rid and the associated directory path in the build output to 'linux-x64' makes everything work as expected on 'debian-x64'.

It does not appear that different shared objects (per specific distribution) are being produced anyway, so this change should have no regressions, as far as I understand it. At the very least, the rid should be changed to 'debian-x64' since this is a parent of 'ubuntu-x64' in the [hierarchy](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json), but I don't see any reason not to go to the further ancestor 'linux-x64'.