### PR TITLE
scoped_timer: deadlock in thread pool based implementation since 4.8.10

### DIFF
--- a/src/util/scoped_timer.cpp
+++ b/src/util/scoped_timer.cpp
@@ -60,17 +60,22 @@ static void thread_func(scoped_timer_state *s) {
 
         while (!s->m_mutex.try_lock_until(end)) {
             if (std::chrono::steady_clock::now() >= end) {
-                s->eh->operator()(TIMEOUT_EH_CALLER);
-                goto next;
+                if (s->work.compare_exchange_strong(1, 0)) {
+                    s->eh->operator()(TIMEOUT_EH_CALLER);
+                    workers.lock();
+                    goto next;
+                }
+                s->m_mutex.lock();
+                break;
             }
         }
 
+        s->cv.notify_one();
         s->m_mutex.unlock();
-
-    next:
-        s->work = 0;
         workers.lock();
         available_workers.push_back(s);
+
+    next:
     }
 }
 
@@ -107,9 +112,15 @@ public:
     }
 
     ~imp() {
-        s->m_mutex.unlock();
-        while (s->work == 1)
-            std::this_thread::yield();
+        if (s->work.compare_exchange_strong(1, 0)) {
+            s->cv.wait(s->m_mutex);
+            s->m_mutex.unlock();
+        } else {
+            s->m_mutex.unlock();
+            workers.lock();
+            available_workers.push_back(s);
+            workers.unlock();
+        }
     }
 };
 


### PR DESCRIPTION
When scoped_timer expires, the lock isn't released before it is returned to the thread pool, which could cause reenter deadlock.