### PR TITLE
scoped_timer: deadlock in thread pool based implementation since 4.8.10

### DIFF
--- a/src/util/scoped_timer.cpp
+++ b/src/util/scoped_timer.cpp
@@ -51,6 +51,7 @@ static int working = WORKING;
 static void thread_func(scoped_timer_state *s) {
     workers.lock();
     while (true) {
+    start:
         s->cv.wait(workers, [=]{ return s->work > 0; });
         workers.unlock();
 
@@ -66,7 +67,7 @@ static void thread_func(scoped_timer_state *s) {
                     s->eh->operator()(TIMEOUT_EH_CALLER);
                     s->work = IDLE;
                     workers.lock();
-                    goto end;
+                    goto start;
                 }
                 goto next;
             }
@@ -77,8 +78,6 @@ static void thread_func(scoped_timer_state *s) {
     next:
         workers.lock();
         available_workers.push_back(s);
-
-    end:
     }
 }
 

--- a/src/util/scoped_timer.cpp
+++ b/src/util/scoped_timer.cpp
@@ -51,7 +51,6 @@ static atomic<unsigned> num_workers(0);
 static void thread_func(scoped_timer_state *s) {
     workers.lock();
     while (true) {
-    start:
         s->cv.wait(workers, [=]{ return s->work > IDLE; });
         workers.unlock();
 
@@ -71,8 +70,8 @@ static void thread_func(scoped_timer_state *s) {
         s->m_mutex.unlock();
 
     next:
+        s->work = IDLE;
         workers.lock();
-        available_workers.push_back(s);
     }
 }
 


### PR DESCRIPTION
When scoped_timer expires, the lock isn't released before it is returned to the thread pool, which could cause reenter deadlock and data race.