### PR TITLE
fix is_char(s) being applied to non-sort s

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -4238,7 +4238,7 @@ void seq_rewriter::elim_condition(expr* elem, expr_ref& cond) {
     expr_ref_vector conds(m());
     flatten_and(cond, conds);
     expr* lhs = nullptr, *rhs = nullptr, *e1 = nullptr; 
-    if (u().is_char(elem)) {
+    if (u().is_char(elem->get_sort())) {
         unsigned ch = 0;
         svector<std::pair<unsigned, unsigned>> ranges, ranges1;
         ranges.push_back(std::make_pair(0, u().max_char()));


### PR DESCRIPTION
@NikolajBjorner one minor addition to your fix in
https://github.com/Z3Prover/z3/commit/bdcfba1324ec834bd194d28f017798fdbb390322
(`is_char` was being applied to an `expr*` rather than a `sort*`)