### PR TITLE
fix of bug #5343 and some related edits

### DIFF
--- a/src/smt/seq_regex.cpp
+++ b/src/smt/seq_regex.cpp
@@ -272,13 +272,15 @@ namespace smt {
                                        << "PA(" << mk_pp(s, m) << "@" << idx
                                        << "," << state_str(r) << ") ";);
 
-        if (re().is_empty(r)) {
+        auto info = re().get_info(r);
+
+        //if the minlength of the regex is UINT_MAX then the regex is a deadend
+        if (re().is_empty(r) || info.min_length == UINT_MAX) {
             STRACE("seq_regex_brief", tout << "(empty) ";);
             th.add_axiom(~lit);
             return;
         }
 
-        auto info = re().get_info(r);
         if (info.interpreted) {
             update_state_graph(r);
             


### PR DESCRIPTION
A deadend loop was not detected in the context of an uninterpreted regex because the state-graph is not enabled for regexes that contain uninterpreted symbols.
The fix was in this case to detect that the loop is actually a dead-end by seeing that its minlength in the regex info object is UINT_MAX. In this particular case the minlength of a loop []+ is UINT_MAX because the minlength of [] is UINT_MAX and thus the minlength of any regex R, ++ []+ is also UINT_MAX.

Added a couple of other small related simplifications of derivatives.

The correct result is unsat (was sat in the bugreport).