### PR TITLE
added regex simplification rules ~() = .+ and .+* = .*

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -3950,6 +3950,7 @@ br_status seq_rewriter::mk_re_union(expr* a, expr* b, expr_ref& result) {
     comp(none) -> all
     comp(all) -> none
     comp(comp(e1)) -> e1
+    comp(epsilon) -> .+
 */
 br_status seq_rewriter::mk_re_complement(expr* a, expr_ref& result) {
     expr *e1 = nullptr, *e2 = nullptr;
@@ -3971,6 +3972,10 @@ br_status seq_rewriter::mk_re_complement(expr* a, expr_ref& result) {
     }
     if (re().is_complement(a, e1)) {
         result = e1;
+        return BR_DONE;
+    }
+    if (re().is_to_re(a, e1) && str().is_empty(e1)) {
+        result = re().mk_plus(re().mk_full_char(a->get_sort()));
         return BR_DONE;
     }
     return BR_FAILED;
@@ -4160,6 +4165,7 @@ br_status seq_rewriter::mk_re_power(func_decl* f, expr* a, expr_ref& result) {
    a+* = a*
    emp* = ""
    all* = all   
+   .+* = all
 */
 br_status seq_rewriter::mk_re_star(expr* a, expr_ref& result) {
     expr* b, *c, *b1, *c1;
@@ -4182,7 +4188,10 @@ br_status seq_rewriter::mk_re_star(expr* a, expr_ref& result) {
         return BR_DONE;
     }
     if (re().is_plus(a, b)) {
-        result = re().mk_star(b);
+        if (re().is_full_char(b))
+            result = re().mk_full_seq(a->get_sort());
+        else
+            result = re().mk_star(b);
         return BR_DONE;
     }
     if (re().is_union(a, b, c)) {


### PR DESCRIPTION
This fixes the wrong unsat result in the following example reported in issue #1540, 
here the condition 'a in (~())star' of the ite becomes trivially true: (ite (a in .star) (a = "") ...)
and the correct model a="" is generated

(declare-fun a () String)
(assert (str.in_re a (re.* (str.to_re "a"))))
(assert (str.in_re a (re.* (str.to_re "b"))))
(assert
 (ite (str.in_re a (re.* (re.comp (str.to_re ""))))
  (= a "")
  (str.in_re (str.++ "aaab" a)
   (re.*
    (re.++ (re.comp (re.* (str.to_re "b")))
     (str.to_re (str.from_int (str.len a))))))))
(check-sat)
(get-model)
