### PR TITLE
support bit-blasting bvand

### DIFF
--- a/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.cpp
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.cpp
@@ -285,6 +285,7 @@ void OP(unsigned num_args, expr * const * args, expr_ref & result) {    \
     MK_BIN_AC_REDUCE(reduce_add, reduce_bin_add, mk_adder);
     MK_BIN_AC_REDUCE(reduce_mul, reduce_bin_mul, mk_multiplier);
 
+    MK_BIN_AC_REDUCE(reduce_and, reduce_bin_and, mk_and);
     MK_BIN_AC_REDUCE(reduce_or, reduce_bin_or, mk_or);
     MK_BIN_AC_REDUCE(reduce_xor, reduce_bin_xor, mk_xor);
 
@@ -471,6 +472,9 @@ MK_PARAMETRIC_UNARY_REDUCE(reduce_sign_extend, mk_sign_extend);
             case OP_SLEQ:
                 SASSERT(num == 2);
                 reduce_sle(args[0], args[1], result);
+                return BR_DONE;
+            case OP_BAND:
+                reduce_and(num, args, result);
                 return BR_DONE;
             case OP_BOR:
                 reduce_or(num, args, result);


### PR DESCRIPTION
The bit-blast rewriter didn't support `bvand`. It did support `bvor` and `bvnot`, so I rewrote my problem instance to use those instead. But that seemed like a silly thing to have to do, and looked easy to fix, so here's an attempt at it.

I've tested this patch using the following input:

```
(declare-const x (_ BitVec 2))
(assert (= (bvand x x) (_ bv3 2)))
(check-sat-using (and-then bit-blast sat))
```