### PR TITLE
updates related to issue #5140

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -1974,8 +1974,7 @@ br_status seq_rewriter::mk_seq_replace_all(expr* a, expr* b, expr* c, expr_ref& 
     }
     expr_ref_vector a_vals(m());
     expr_ref_vector b_vals(m());
-    if (try_get_unit_values(a, a_vals) && try_get_unit_values(b, b_vals))
-    {
+    if (try_get_unit_values(a, a_vals) && try_get_unit_values(b, b_vals)) {
         replace_all_subvectors(a_vals, b_vals, c, strs);
         result = str().mk_concat(strs, a->get_sort());
         return BR_REWRITE_FULL;
@@ -2011,8 +2010,8 @@ bool seq_rewriter::try_get_unit_values(expr* s, expr_ref_vector& vals) {
 * Replace all subvectors of b in a by c
 */
 void seq_rewriter::replace_all_subvectors(expr_ref_vector const& a, expr_ref_vector const& b, expr* c, expr_ref_vector& result) {
-    int i = 0;
-    int k = b.size();
+    unsigned int i = 0;
+    unsigned int k = b.size();
     while (i + k <= a.size()) {
         //if a[i..i+k-1] equals b then replace it by c and inceremnt i by k
         int j = 0;

--- a/src/ast/rewriter/seq_rewriter.h
+++ b/src/ast/rewriter/seq_rewriter.h
@@ -180,6 +180,16 @@ class seq_rewriter {
 
     expr_ref mk_seq_concat(expr* a, expr* b);    
 
+    // Construct the expressions for taking the first element, the last element, the rest, and the butlast element
+    expr_ref mk_seq_first(expr* s);
+    expr_ref mk_seq_rest(expr* s);
+    expr_ref mk_seq_last(expr* s);
+    expr_ref mk_seq_butlast(expr* s);
+
+    bool try_get_unit_values(expr* s, expr_ref_vector& result);
+    //replace b in a by c into result
+    void replace_all_subvectors(expr_ref_vector const& as, expr_ref_vector const& bs, expr* c, expr_ref_vector& result);
+
     // Calculate derivative, memoized and enforcing a normal form
     expr_ref is_nullable_rec(expr* r);
     expr_ref mk_derivative_rec(expr* ele, expr* r);

--- a/src/ast/rewriter/seq_rewriter.h
+++ b/src/ast/rewriter/seq_rewriter.h
@@ -354,6 +354,16 @@ public:
         return result;
     }
 
+    /*
+    * makes concat and simplifies
+    */
+    expr_ref mk_re_append(expr* r1, expr* r2) {
+        expr_ref result(m());
+        if (mk_re_concat(r1, r2, result) == BR_FAILED)
+            result = re().mk_concat(r1, r2);
+        return result;
+    }
+
     /**
      * check if regular expression is of the form all ++ s ++ all ++ t + u ++ all, where, s, t, u are sequences
      */

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -1070,7 +1070,7 @@ std::ostream& seq_util::rex::pp::compact_helper_seq(std::ostream& out, expr* s) 
             compact_helper_seq(out, e);
     }
     else if (re.u.str.is_string(s, z)) {
-        for (int i=0; i < z.length(); i++)
+        for (int i = 0; i < z.length(); i++)
             out << (char)z[i];
     }
     //using braces to indicate 'full' output

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -911,7 +911,7 @@ unsigned seq_util::str::max_length(expr* s) const {
             return UINT_MAX;
     };
     while (is_concat(s, s1, s2)) {
-        result = u.max_plus(get_length(s), result);
+        result = u.max_plus(get_length(s1), result);
         s = s2;
     }
     result = u.max_plus(get_length(s), result);

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -1058,6 +1058,7 @@ app* seq_util::rex::mk_epsilon(sort* seq_sort) {
 */
 std::ostream& seq_util::rex::pp::compact_helper_seq(std::ostream& out, expr* s) const {
     SASSERT(re.u.is_seq(s));
+    zstring z;
     if (re.u.str.is_empty(s))
         out << "()";
     else if (re.u.str.is_unit(s))
@@ -1067,6 +1068,10 @@ std::ostream& seq_util::rex::pp::compact_helper_seq(std::ostream& out, expr* s) 
         re.u.str.get_concat(s, es);
         for (expr* e : es)
             compact_helper_seq(out, e);
+    }
+    else if (re.u.str.is_string(s, z)) {
+        for (int i=0; i < z.length(); i++)
+            out << (char)z[i];
     }
     //using braces to indicate 'full' output
     //for example an uninterpreted constant X will be printed as {X}
@@ -1100,7 +1105,7 @@ bool seq_util::rex::pp::can_skip_parenth(expr* r) const {
 std::ostream& seq_util::rex::pp::seq_unit(std::ostream& out, expr* s) const {
     expr* e;
     unsigned n = 0;
-    if (re.u.str.is_unit(s, e) && re.u.is_const_char(e, n)) {
+    if ((re.u.str.is_unit(s, e) && re.u.is_const_char(e, n)) || re.u.is_const_char(s, n)) {
         char c = (char)n;
         if (c == '\n')
             out << "\\n";
@@ -1148,7 +1153,11 @@ std::ostream& seq_util::rex::pp::seq_unit(std::ostream& out, expr* s) const {
 std::ostream& seq_util::rex::pp::display(std::ostream& out) const {
     expr* r1 = nullptr, * r2 = nullptr, * s = nullptr, * s2 = nullptr;
     unsigned lo = 0, hi = 0;
-    if (re.is_full_char(e))
+    if (re.u.is_char(e))
+        return seq_unit(out, e);
+    else if (re.u.is_seq(e))
+        return compact_helper_seq(out, e);
+    else if (re.is_full_char(e))
         return out << ".";
     else if (re.is_full_seq(e))
         return out << ".*";
@@ -1163,9 +1172,9 @@ std::ostream& seq_util::rex::pp::display(std::ostream& out) const {
     else if (re.is_concat(e, r1, r2)) 
         return out << pp(re, r1) << pp(re, r2);
     else if (re.is_union(e, r1, r2)) 
-        return out << pp(re, r1) << "|" << pp(re, r2);
+        return out << "(" << pp(re, r1) << "|" << pp(re, r2) << ")";
     else if (re.is_intersection(e, r1, r2)) 
-        return out << "(" << pp(re, r1) << (html_encode ? ")&amp;(": ")&(" ) << pp(re, r2) << ")";
+        return out << "(" << pp(re, r1) << "&amp;" /*(html_encode ? ")&amp;(" : ")&(")*/ << pp(re, r2) << ")";
     else if (re.is_complement(e, r1)) {
         if (can_skip_parenth(r1))
             return out << "~" << pp(re, r1);

--- a/src/util/state_graph.cpp
+++ b/src/util/state_graph.cpp
@@ -13,7 +13,7 @@ Abstract:
 Author:
 
     Caleb Stanford (calebstanford-msr / cdstanford) 2020-7
-
+    Margus Veanes 2020-8
 --*/
 
 #include "state_graph.h"


### PR DESCRIPTION
Fixed some bugs in issue #5140 (work in progress, not all are fixed yet).

Added functionality for dealing with derivatives over nonground sequences s without introducing the mkderivative OP in the ast.
Essentially D(e,s) = ite(s!=()& first(s)=e, rest(s), [])
This avoids stuck-situations -- that I believe lead to unsound unsat results in some cases.

Also, if s in uninterpreted, then 
D(e,reverse(s)) = ite(s!=()& last(s)=e, reverse(butlast(s)), [])

Currently:
butlast(s) = substr(s,0,|s|-1) 
and the pattern butlast(butlast(s)) is simplified to substr(s,0,|s|-2)

Similarly:
rest(s) = substr(s,1,|s|-1) 
rest(rest(s)) = ..TBD.. =  substr(s,2,|s|-2)

first(rest(s)) = nth(2,s) 

etc..

Fixed also some rex:pp issues (still some TBD).
