### PR TITLE
Specify and document value for environment variable for loading native library in Java bindings

### DIFF
--- a/examples/java/README
+++ b/examples/java/README
@@ -12,3 +12,9 @@ On Linux and FreeBSD, we must use
    LD_LIBRARY_PATH=. java -cp com.microsoft.z3.jar:. JavaExample
 On macOS, the corresponding option is DYLD_LIBRARY_PATH:
    DYLD_LIBRARY_PATH=. java -cp com.microsoft.z3.jar:. JavaExample  
+
+By default, Z3 Java bindings are automatically loading the required native library for Z3 from the default library path.
+In certain environments, depending on the developing process, the Z3 library is not available in the given library path.
+To disable the automated loading process, the user can set the environment variable "z3.skipLibraryLoad=true".
+In that case, the calling application should directly load the corresponding libraries before any interaction with Z3.
+

--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -545,7 +545,7 @@ def mk_java(java_dir, package_name):
     java_native.write('  public static native void setInternalErrorHandler(long ctx);\n\n')
 
     java_native.write('  static {\n')
-    java_native.write('    if (null == System.getProperty("z3.skipLibraryLoad")) {\n')
+    java_native.write('    if (!Boolean.parseBoolean(System.getProperty("z3.skipLibraryLoad"))) {\n')
     java_native.write('      try {\n')
     java_native.write('        System.loadLibrary("z3java");\n')
     java_native.write('      } catch (UnsatisfiedLinkError ex) {\n')


### PR DESCRIPTION
This is a follow-up PR for #4667.
Now the allowed values for the environment variable is specified as "true" (case-insensitive) or not.
And some documentation is added in the example directory for Java API usage.