### PR TITLE
Update coverage github action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,10 +6,6 @@ on:
   schedule:
     - cron: "0 11 * * *"
 
-env:
-  BUILD_TYPE: Debug
-  CMAKE_GENERATOR: Ninja
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,6 +13,9 @@ jobs:
     env:
       CC: clang
       CXX: clang++
+      BUILD_TYPE: Debug
+      CMAKE_GENERATOR: Ninja
+      COV_DETAILS_PATH: ${{github.workspace}}/cov-details
 
     steps:
     - uses: actions/checkout@v2
@@ -25,14 +24,13 @@ jobs:
       run: |
         sudo apt-get remove -y --purge man-db
         sudo apt-get update -y
-        sudo apt-get install -y gcovr ninja-build
+        sudo apt-get install -y gcovr ninja-build llvm clang
 
     ## Building
     - name: Configure CMake Z3
       run: CFLAGS=="--coverage" CXXFLAGS="--coverage" LDFLAGS="-lgcov" cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=./install
 
     - name: Build Z3
-      # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --target install --config ${{env.BUILD_TYPE}}
 
     - name: Build test-z3
@@ -75,8 +73,14 @@ jobs:
     - name: Gather coverage
       run: |
         cd ${{github.workspace}}
-        gcovr
-        #gcovr --html -o coverage.html .
+        gcovr --html coverage.html --gcov-executable "llvm-cov gcov" .
+        cd -
+
+    - name: Gather detailed coverage
+      run: |
+        cd ${{github.workspace}}
+        mkdir cov-details
+        gcovr --html-details ${{env.COV_DETAILS_PATH}}/coverage.html --gcov-executable "llvm-cov gcov" -r `pwd`/src --object-directory `pwd`/build
         cd -
 
     - name: Get date
@@ -86,5 +90,11 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: coverage-${{steps.date.outputs.date}}
-        path: coverage.html
-        retention-days: 10
+        path: ${{github.workspace}}/coverage.html
+        retention-days: 4
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: coverage-details-${{steps.date.outputs.date}}
+        path: ${{env.COV_DETAILS_PATH}}
+        retention-days: 4


### PR DESCRIPTION
I've managed to fix up the issue. I was using pre-installed `clang`, which seems to have been incompatible with `llvm` from the repos. In addition, I've added the generation of a detailed report to be produced and uploaded. You can check a sample on my fork [1]. They're zipped, as that's what the action does, but they could be further unzipped and placed somewhere accessible, via a subsequent dependent job and using the `download-artifact` action [2], as they're `html` files.

The total execution time seems to be around the hour mark, and I've added everything that I found sensible to be executed for coverage. This means: `z3-test -a`, the four examples, `smt2`, `smt2-debug`, and `smt2-extra` regression suites from `z3test`, and the coverage tests from `z3test` (to which I'll add more PRs for shortly).

[1] https://github.com/0152la/z3/actions/runs/1124141648
[2] https://github.com/actions/download-artifact