### PR TITLE
rewrite bit-blaster multiplier

### DIFF
--- a/src/ast/rewriter/bit_blaster/CMakeLists.txt
+++ b/src/ast/rewriter/bit_blaster/CMakeLists.txt
@@ -1,6 +1,7 @@
 z3_add_component(bit_blaster
   SOURCES
     bit_blaster.cpp
+    bit_blaster_adder.cpp
     bit_blaster_rewriter.cpp
   COMPONENT_DEPENDENCIES
     rewriter

--- a/src/ast/rewriter/bit_blaster/bit_blaster_adder.cpp
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_adder.cpp
@@ -1,0 +1,112 @@
+#include "ast/rewriter/bit_blaster/bit_blaster_adder.h"
+
+bit_blaster_adder::bit_blaster_adder(bool_rewriter & rewriter, unsigned sz, numeral const & value):
+    m_rewriter(rewriter),
+    m_constant(value)
+{
+    reduce();
+    expr_ref_vector empty(m());
+    m_variable.resize(sz, empty);
+}
+
+bit_blaster_adder::bit_blaster_adder(bool_rewriter & rewriter, unsigned sz, expr * const * bits):
+    bit_blaster_adder(rewriter, sz)
+{
+    for (unsigned i = 0; i < sz; i++)
+        add_bit(i, bits[i]);
+}
+
+expr_ref bit_blaster_adder::sum_bits(vector< expr_ref_vector > & columns, expr_ref_vector & out_bits) const {
+    SASSERT(out_bits.empty());
+
+    expr_ref_vector carries(m());
+    expr_ref tmp1(m()), tmp2(m()), tmp3(m());
+
+    for (auto & column : columns) {
+        column.append(carries);
+        carries.reset();
+
+        while (column.size() >= 3) {
+            expr * a = column.back();
+            column.pop_back();
+            expr * b = column.back();
+            column.pop_back();
+            expr * c = column.back();
+            column.pop_back();
+
+            m_rewriter.mk_xor(a, b, tmp1);
+            m_rewriter.mk_xor(tmp1, c, tmp2);
+            column.push_back(tmp2);
+
+            m_rewriter.mk_and(a, b, tmp2);
+            m_rewriter.mk_and(tmp1, c, tmp3);
+            // tmp2 and tmp3 can't be true at the same time, so use
+            // whichever of mk_or vs mk_xor makes the most sense here.
+            m_rewriter.mk_or(tmp2, tmp3, tmp1);
+            carries.push_back(tmp1);
+        }
+
+        if (column.size() == 2) {
+            expr * a = column.back();
+            column.pop_back();
+            expr * b = column.back();
+            column.pop_back();
+
+            m_rewriter.mk_xor(a, b, tmp1);
+            column.push_back(tmp1);
+
+            m_rewriter.mk_and(a, b, tmp1);
+            carries.push_back(tmp1);
+        }
+
+        out_bits.push_back(column.get(0, m().mk_false()));
+    }
+
+    SASSERT(out_bits.size() == size());
+
+    // We return the carry separately in case the caller wants it.
+    tmp1 = m().mk_false();
+    for (auto & carry : carries) {
+        m_rewriter.mk_xor(tmp1, carry, tmp2);
+        tmp1 = tmp2;
+    }
+    return tmp1;
+}
+
+expr_ref bit_blaster_adder::variable_bits(expr_ref_vector & out_bits) const {
+    vector< expr_ref_vector > columns(m_variable);
+    return sum_bits(columns, out_bits);
+}
+
+expr_ref bit_blaster_adder::total_bits(expr_ref_vector & out_bits) const {
+    vector< expr_ref_vector > columns(m_variable);
+
+    expr_ref one(m());
+    one = m().mk_true();
+    for (unsigned i = 0; i < size(); i++)
+        if (m_constant.get_bit(i))
+            columns[i].push_back(one);
+
+    expr_ref carry(m());
+    carry = sum_bits(columns, out_bits);
+    if (m_constant.get_bit(size())) {
+        m_rewriter.mk_not(carry, one);
+        carry = one;
+    }
+    return carry;
+}
+
+bit_blaster_adder & bit_blaster_adder::add_shifted(bit_blaster_adder const & other, unsigned shift) {
+    add_shifted(other.m_constant, shift);
+    for (unsigned i = 0; shift + i < size(); i++)
+        m_variable[shift + i].append(other.m_variable[i]);
+    return *this;
+}
+
+bit_blaster_adder & bit_blaster_adder::add_shifted(unsigned sz, expr * const * bits, unsigned shift) {
+    if (sz > size() - shift)
+        sz = size() - shift;
+    for (unsigned i = 0; i < sz; i++)
+        add_bit(shift + i, bits[i]);
+    return *this;
+}

--- a/src/ast/rewriter/bit_blaster/bit_blaster_adder.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_adder.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "ast/ast.h"
+#include "ast/rewriter/bool_rewriter.h"
+#include "util/rational.h"
+
+class bit_blaster_adder {
+public:
+    typedef rational numeral;
+
+    bit_blaster_adder(bool_rewriter & rewriter, unsigned sz, numeral const & value = numeral::zero());
+    bit_blaster_adder(bool_rewriter & rewriter, unsigned sz, expr * const * bits);
+
+    bit_blaster_adder(bool_rewriter & rewriter, expr_ref_vector & value):
+        bit_blaster_adder(rewriter, value.size(), value.data()) {}
+
+    bit_blaster_adder(bit_blaster_adder const & other):
+        bit_blaster_adder(other.m_rewriter, other.size()) {
+        *this += other;
+    }
+
+    bit_blaster_adder(bit_blaster_adder &&) noexcept = default;
+
+    // The *_bits functions all return the final carry bit out of the addition;
+    // just ignore it if you don't need it.
+
+    // Return the sum of the known-constant inputs to this adder.
+    bool constant_bits(numeral & value) const {
+        value = m_constant % power(size());
+        return m_constant.get_bit(size());
+    }
+
+    // Return the sum of the non-constant inputs to this adder.
+    expr_ref variable_bits(expr_ref_vector & out_bits) const;
+
+    // Return the sum of all inputs to this adder.
+    expr_ref total_bits(expr_ref_vector & out_bits) const;
+
+    unsigned size() const {
+        return m_variable.size();
+    }
+
+    ast_manager & m() const {
+        return m_rewriter.m();
+    }
+
+    bit_blaster_adder & operator+=(bit_blaster_adder const & other) {
+        SASSERT(size() == other.size());
+        return add_shifted(other, 0);
+    }
+
+    bit_blaster_adder & add_bit(unsigned idx, bool bit) {
+        SASSERT(idx < size());
+        if (bit)
+            m_constant += power(idx);
+        return *this;
+    }
+
+    bit_blaster_adder & add_bit(unsigned idx, expr * bit) {
+        SASSERT(idx < size());
+        if (m().is_true(bit))
+            m_constant += power(idx);
+        else if (!m().is_false(bit))
+            m_variable[idx].push_back(bit);
+        return *this;
+    }
+
+    bit_blaster_adder & add_bit(unsigned idx, expr_ref & bit) {
+        return add_bit(idx, bit.get());
+    }
+
+    bit_blaster_adder & add_shifted(bit_blaster_adder const & other, unsigned shift);
+    bit_blaster_adder & add_shifted(unsigned sz, expr * const * bits, unsigned shift);
+
+    bit_blaster_adder & add_shifted(expr_ref_vector const & bits, unsigned shift) {
+        return add_shifted(bits.size(), bits.data(), shift);
+    }
+
+    bit_blaster_adder & add_shifted(numeral const & value, unsigned shift) {
+        m_constant += value * power(shift);
+        reduce();
+        return *this;
+    }
+
+protected:
+    bool_rewriter & m_rewriter;
+    numeral m_constant;
+    vector< expr_ref_vector > m_variable;
+
+    numeral power(unsigned n) const { return numeral::power_of_two(n); }
+
+    void reduce() {
+        // keep one extra bit in case somebody wants the final carry bit
+        m_constant %= power(size() + 1);
+    }
+
+    expr_ref sum_bits(vector< expr_ref_vector > & columns, expr_ref_vector & out_bits) const;
+};

--- a/src/ast/rewriter/bit_blaster/bit_blaster_tpl.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_tpl.h
@@ -18,6 +18,7 @@ Revision History:
 --*/
 #pragma once
 
+#include "ast/rewriter/bit_blaster/bit_blaster_adder.h"
 #include "util/rational.h"
 
 template<typename Cfg>
@@ -73,9 +74,7 @@ public:
     //
 
 
-    bool is_numeral(unsigned sz, expr * const * bits) const;
     bool is_numeral(unsigned sz, expr * const * bits, numeral & r) const;
-    bool is_minus_one(unsigned sz, expr * const * bits) const;
     void num2bits(numeral const & v, unsigned sz, expr_ref_vector & out_bits) const;
     
     void mk_half_adder(expr * a, expr * b, expr_ref & out, expr_ref & cout);
@@ -120,12 +119,8 @@ public:
     void mk_smul_no_underflow(unsigned sz, expr * const * a_bits,  expr * const * b_bits, expr_ref & out);
     void mk_comp(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits);
 
-    void mk_carry_save_adder(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr * const * c_bits, expr_ref_vector & sum_bits, expr_ref_vector & carry_bits);
-    bool mk_const_multiplier(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits);
-    bool mk_const_case_multiplier(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits);
-    void mk_const_case_multiplier(bool is_a, unsigned i, unsigned sz, ptr_buffer<expr, 128>& a_bits, ptr_buffer<expr, 128>& b_bits, expr_ref_vector & out_bits);
+    void mk_const_multiplier(numeral & a, expr_ref_vector & b_bits, bit_blaster_adder & result);
 
-    bool is_bool_const(expr* e) const { return m().is_true(e) || m().is_false(e); }
     void mk_abs(unsigned sz, expr * const * a_bits, expr_ref_vector & out_bits);
 };
 

--- a/src/test/bit_blaster.cpp
+++ b/src/test/bit_blaster.cpp
@@ -17,9 +17,12 @@ Revision History:
 
 --*/
 
-#include "ast/rewriter/bit_blaster/bit_blaster.h"
 #include "ast/ast_pp.h"
 #include "ast/ast_ll_pp.h"
+#include "ast/reg_decl_plugins.h"
+#include "ast/rewriter/bit_blaster/bit_blaster.h"
+#include "model/model.h"
+#include "model/model_evaluator.h"
 
 void mk_bits(ast_manager & m, char const * prefix, unsigned sz, expr_ref_vector & r) {
     sort_ref b(m);
@@ -36,38 +39,153 @@ void mk_bits(ast_manager & m, char const * prefix, unsigned sz, expr_ref_vector 
 }
 
 void display(std::ostream & out, expr_ref_vector & r, bool ll=true) {
-    ast_mark v;
     for (unsigned i = 0; i < r.size(); i++) {
+        out << "bit " << i << ":\n";
         if (ll)
-            ast_ll_pp(out, r.get_manager(), r.get(i), v);
+            ast_ll_pp(out, r.get_manager(), r.get(i));
         else
-            out << mk_pp(r.get(i), r.get_manager());
-        out << "\n";
+            out << mk_pp(r.get(i), r.get_manager()) << "\n";
     }
 }
 
-void tst_adder(ast_manager & m, unsigned sz) {
-//     expr_ref_vector a(m);
-//     expr_ref_vector b(m);
-//     expr_ref_vector c(m);
-//     mk_bits(m, "a", sz, a);
-//     mk_bits(m, "b", sz, b);
-//     bool t = true;
-//     bit_blaster blaster(m, t);
-//     blaster.mk_adder(sz, a.c_ptr(), b.c_ptr(), c);
-//     TRACE("bit_blaster", display(tout, c););
+static unsigned to_int(model_core & mdl, expr_ref_vector & out) {
+    SASSERT(out.size() <= sizeof unsigned * 8);
+    ast_manager & m = mdl.get_manager();
+    model_evaluator eval(mdl);
+    expr_ref bit(m);
+    unsigned actual = 0;
+    for (unsigned i = 0; i < out.size(); i++) {
+        eval(out.get(i), bit);
+        if (m.is_true(bit))
+            actual |= 1 << i;
+        else
+            ENSURE(m.is_false(bit));
+    }
+    return actual;
 }
 
-void tst_multiplier(ast_manager & m, unsigned sz) {
-//     expr_ref_vector a(m);
-//     expr_ref_vector b(m);
-//     expr_ref_vector c(m);
-//     mk_bits(m, "a", sz, a);
-//     mk_bits(m, "b", sz, b);
-//     bool t = true;
-//     bit_blaster blaster(m, t);
-//     blaster.mk_multiplier(sz, a.c_ptr(), b.c_ptr(), c);
-//     TRACE("bit_blaster", display(tout, c););
+#define ENSURE_INT(mdl, out, expected) \
+    do { \
+        unsigned actual = to_int(mdl, out); \
+        TRACE("bit_blaster", \
+            display(tout, out); \
+            tout << "expected=" << (expected) << ", actual=" << actual << "\n"; \
+        ); \
+        ENSURE(actual == (expected)); \
+    } while (0)
+
+void tst_adder(ast_manager & m, bit_blaster & blaster) {
+    model mdl(m);
+    expr_ref_vector c(m);
+    app_ref b1(m.mk_const("b1", m.mk_bool_sort()), m);
+    app_ref b2(m.mk_const("b2", m.mk_bool_sort()), m);
+    expr_ref not_b1(m.mk_not(b1), m);
+
+    {
+        expr * const a[] = { b1, b1, b1 };
+        expr * const b[] = { m.mk_false(), m.mk_true(), m.mk_true() };
+        c.reset();
+        blaster.mk_adder(3, a, b, c);
+    }
+
+    mdl.register_decl(b1->get_decl(), m.mk_false());
+    ENSURE_INT(mdl, c, 6); // b000 + b110
+
+    mdl.register_decl(b1->get_decl(), m.mk_true());
+    ENSURE_INT(mdl, c, 5); // b111 + b110
+
+    {
+        expr * const a[] = { m.mk_false(), m.mk_true(), m.mk_true() };
+        expr * const b[] = { b1, not_b1, m.mk_false() };
+        c.reset();
+        blaster.mk_adder(3, a, b, c);
+    }
+
+    mdl.register_decl(b1->get_decl(), m.mk_false());
+    ENSURE_INT(mdl, c, 0); // b110 + b010
+
+    mdl.register_decl(b1->get_decl(), m.mk_true());
+    ENSURE_INT(mdl, c, 7); // b110 + b001
+
+    {
+        expr * const a[] = { b1, b2, m.mk_true() };
+        expr * const b[] = { b1, not_b1, m.mk_false() };
+        c.reset();
+        blaster.mk_adder(3, a, b, c);
+    }
+
+    mdl.register_decl(b1->get_decl(), m.mk_false());
+    mdl.register_decl(b2->get_decl(), m.mk_false());
+    ENSURE_INT(mdl, c, 6); // b100 + b010
+
+    mdl.register_decl(b1->get_decl(), m.mk_false());
+    mdl.register_decl(b2->get_decl(), m.mk_true());
+    ENSURE_INT(mdl, c, 0); // b110 + b010
+
+    mdl.register_decl(b1->get_decl(), m.mk_true());
+    mdl.register_decl(b2->get_decl(), m.mk_false());
+    ENSURE_INT(mdl, c, 6); // b101 + b001
+
+    mdl.register_decl(b1->get_decl(), m.mk_true());
+    mdl.register_decl(b2->get_decl(), m.mk_true());
+    ENSURE_INT(mdl, c, 0); // b111 + b001
+}
+
+void tst_multiplier(ast_manager & m, bit_blaster & blaster) {
+    model mdl(m);
+    expr_ref_vector c(m);
+    app_ref b1(m.mk_const("b1", m.mk_bool_sort()), m);
+    app_ref b2(m.mk_const("b2", m.mk_bool_sort()), m);
+    expr_ref not_b1(m.mk_not(b1), m);
+
+    {
+        expr * const a[] = { b1, b1, b1 };
+        expr * const b[] = { m.mk_false(), m.mk_true(), m.mk_true() };
+        c.reset();
+        blaster.mk_multiplier(3, a, b, c);
+    }
+
+    mdl.register_decl(b1->get_decl(), m.mk_false());
+    ENSURE_INT(mdl, c, 0); // b000 * b110
+
+    mdl.register_decl(b1->get_decl(), m.mk_true());
+    ENSURE_INT(mdl, c, 2); // b111 * b110
+
+    {
+        expr * const a[] = { m.mk_false(), m.mk_true(), m.mk_true() };
+        expr * const b[] = { b1, not_b1, m.mk_false() };
+        c.reset();
+        blaster.mk_multiplier(3, a, b, c);
+    }
+
+    mdl.register_decl(b1->get_decl(), m.mk_false());
+    ENSURE_INT(mdl, c, 4); // b110 * b010
+
+    mdl.register_decl(b1->get_decl(), m.mk_true());
+    ENSURE_INT(mdl, c, 6); // b110 * b001
+
+    {
+        expr * const a[] = { b1, b2, m.mk_true() };
+        expr * const b[] = { b1, not_b1, m.mk_false() };
+        c.reset();
+        blaster.mk_multiplier(3, a, b, c);
+    }
+
+    mdl.register_decl(b1->get_decl(), m.mk_false());
+    mdl.register_decl(b2->get_decl(), m.mk_false());
+    ENSURE_INT(mdl, c, 0); // b100 * b010
+
+    mdl.register_decl(b1->get_decl(), m.mk_false());
+    mdl.register_decl(b2->get_decl(), m.mk_true());
+    ENSURE_INT(mdl, c, 4); // b110 * b010
+
+    mdl.register_decl(b1->get_decl(), m.mk_true());
+    mdl.register_decl(b2->get_decl(), m.mk_false());
+    ENSURE_INT(mdl, c, 5); // b101 * b001
+
+    mdl.register_decl(b1->get_decl(), m.mk_true());
+    mdl.register_decl(b2->get_decl(), m.mk_true());
+    ENSURE_INT(mdl, c, 7); // b111 * b001
 }
 
 void tst_le(ast_manager & m, unsigned sz) {
@@ -115,8 +233,12 @@ void tst_sh(ast_manager & m, unsigned sz) {
 
 void tst_bit_blaster() {
     ast_manager m;
-    tst_adder(m, 4);
-    tst_multiplier(m, 4);
+    reg_decl_plugins(m);
+    bit_blaster_params params;
+    bit_blaster blaster(m, params);
+
+    tst_adder(m, blaster);
+    tst_multiplier(m, blaster);
     tst_le(m, 4);
     tst_eqs(m, 8);
     tst_sh(m, 4);


### PR DESCRIPTION
This version handles more special cases efficiently, with less code, and introduces some basic unit tests.

I deleted a bunch of code that wasn't being invoked, specifically the Wallace tree multiplier and Booth constant multiplier. As far as I can tell, there was no existing way to turn either of these on without recompiling z3, and they were not turned on at either use site.

Instead of the inline Wallace adder, I isolated into a separate class the choice of how to add together many terms. I hope that class will be reused by the rest of the bit-blaster at some point, because it could produce a smaller expression graph for bit-vector problems containing linear operations, especially when some bits are constant.

I think it was good that the Booth constant multiplier was not turned on, because it is sometimes worse than long multiplication. For example, multiplying by 010101... adds a term for every bit after Booth encoding, when it only needs a term every other bit in long multiplication. The commented-out radix-4 Booth multiplier isn't better, because although it would handle that example correctly, in a case like 001001001... it still needs three terms per six bits, instead of two.

But using non-adjacent form (NAF) instead is always at least as good as long multiplication and also at least as good as either form of Booth encoding, so it's worth doing unconditionally.

Optimizing multiplication by constants also subsumes the check for multiplication by -1, so I deleted that too. That optimization falls out automatically from either NAF or Booth encoding, along with other cases such as the negation of any power of two.

I also deleted the constant case multiplier, which was called but its result was ignored: it always returned false, indicating the caller should skip it and complete the multiply a different way.

I tried just fixing up the constant case multiplier, and did some experiments with different implementations. I got worse results in some cases, and in other cases I think more general optimizations in either the adder or the boolean rewriter will get the same result. So I think at best it's not worth the extra code complexity; at worst it might be actively harmful.