### PR TITLE
either use non-adjacent form instead of Booth encoding, or delete it

### DIFF
--- a/src/ast/rewriter/bit_blaster/bit_blaster_tpl.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_tpl.h
@@ -116,7 +116,6 @@ public:
     void mk_smul_no_underflow(unsigned sz, expr * const * a_bits,  expr * const * b_bits, expr_ref & out);
     void mk_comp(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits);
 
-    void mk_carry_save_adder(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr * const * c_bits, expr_ref_vector & sum_bits, expr_ref_vector & carry_bits);
     bool mk_const_case_multiplier(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits);
     void mk_const_case_multiplier(bool is_a, unsigned i, unsigned sz, ptr_buffer<expr, 128>& a_bits, ptr_buffer<expr, 128>& b_bits, expr_ref_vector & out_bits);
 

--- a/src/ast/rewriter/bit_blaster/bit_blaster_tpl.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_tpl.h
@@ -71,7 +71,6 @@ public:
 
     bool is_numeral(unsigned sz, expr * const * bits) const;
     bool is_numeral(unsigned sz, expr * const * bits, numeral & r) const;
-    bool is_minus_one(unsigned sz, expr * const * bits) const;
     void num2bits(numeral const & v, unsigned sz, expr_ref_vector & out_bits) const;
     
     void mk_half_adder(expr * a, expr * b, expr_ref & out, expr_ref & cout);
@@ -80,6 +79,7 @@ public:
     void mk_adder(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits);
     void mk_subtracter(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits, expr_ref & cout);
     void mk_multiplier(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits);
+    void mk_multiplier_core(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits);
     void mk_udiv_urem(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & q_bits, expr_ref_vector & r_bits);
     void mk_udiv(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & q_bits);
     void mk_urem(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & r_bits);
@@ -118,6 +118,7 @@ public:
 
     bool mk_const_case_multiplier(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits);
     void mk_const_case_multiplier(bool is_a, unsigned i, unsigned sz, ptr_buffer<expr, 128>& a_bits, ptr_buffer<expr, 128>& b_bits, expr_ref_vector & out_bits);
+    bool mk_const_multiplier(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits);
 
     bool is_bool_const(expr* e) const { return m().is_true(e) || m().is_false(e); }
     void mk_abs(unsigned sz, expr * const * a_bits, expr_ref_vector & out_bits);

--- a/src/ast/rewriter/bit_blaster/bit_blaster_tpl_def.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_tpl_def.h
@@ -1101,17 +1101,6 @@ void bit_blaster_tpl<Cfg>::mk_comp(unsigned sz, expr * const * a_bits, expr * co
 }
 
 template<typename Cfg>
-void bit_blaster_tpl<Cfg>::mk_carry_save_adder(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr * const * c_bits, expr_ref_vector & sum_bits, expr_ref_vector & carry_bits) {    
-    expr_ref t(m());
-    for (unsigned i = 0; i < sz; i++) {            
-        mk_xor3(a_bits[i], b_bits[i], c_bits[i], t);
-        sum_bits.push_back(t);
-        mk_carry(a_bits[i], b_bits[i], c_bits[i], t);
-        carry_bits.push_back(t);
-    }
-}
-
-template<typename Cfg>
 bool bit_blaster_tpl<Cfg>::mk_const_case_multiplier(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref_vector & out_bits) {
     unsigned case_size = 1;
     unsigned circuit_size = sz*sz*5;


### PR DESCRIPTION
There's been a Booth encoding implementation of multiplying by a constant in the bit blaster for as long as there's git history, but I don't think it's been turned on in any release during that time. Booth encoding is sometimes worse than straightforward long multiplication, but non-adjacent form is always at least as good. So in this PR I'm trying to give non-adjacent form every opportunity to shine, by using it unconditionally but making an effort to produce the same circuit as long multiplication in case NAF is only equally as good. If it doesn't actually help, then instead of merging this PR I propose to remove the implementation.

@NikolajBjorner, would you mind running a performance comparison of this patch versus master?