### PR TITLE
Fix Z3Config.cmake.in when generating a static library

### DIFF
--- a/cmake/Z3Config.cmake.in
+++ b/cmake/Z3Config.cmake.in
@@ -10,6 +10,21 @@
 # This file was built for the @CONFIG_FILE_TYPE@.
 ################################################################################
 
+
+# Handle dependencies (necessary when compiling the static library)
+if(NOT @Z3_BUILD_LIBZ3_SHARED@)
+  include(CMakeFindDependencyMacro)
+
+  # Threads::Threads
+  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+  find_dependency(Threads)
+
+  # GMP::GMP
+  if(@Z3_USE_LIB_GMP@)
+    find_dependency(GMP)
+  endif()
+endif()
+
 # Exported targets
 include("${CMAKE_CURRENT_LIST_DIR}/Z3Targets.cmake")
 


### PR DESCRIPTION
If you use `-DZ3_BUILD_LIBZ3_SHARED=OFF` and then the following `CMakeLists.txt` to find the installed Z3:

```cmake
cmake_minimum_required(VERSION 3.15)

project(z3_static_test)

find_package(Z3 REQUIRED CONFIG)

add_executable(z3_static_test src/main.cpp)

target_link_libraries(z3_static_test PRIVATE z3::libz3)
```

You will get the following error:

```
-- Configuring done
CMake Error at CMakeLists.txt:51 (add_executable):
  Target "z3_static_test" links to target "Threads::Threads" but the target
  was not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?


-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

This is because the `find_dependency` calls for `Threads` (and `GMP`) are missing. When building a shared library this is no problem because these are not part of the `IMPORTED` target, but when you build a static library these dependencies will be propagated to the final executable you link.