### PR TITLE
Updated regex derivative engine

### DIFF
--- a/src/ast/rewriter/seq_axioms.cpp
+++ b/src/ast/rewriter/seq_axioms.cpp
@@ -850,7 +850,7 @@ namespace seq {
             add_clause(~eq, ge10k);
 
         for (unsigned i = 0; i < k; ++i) {
-            expr* ch = seq.str.mk_nth_i(ubvs, i);
+            expr* ch = seq.str.mk_nth_c(ubvs, i);
             is_digit = seq.mk_char_is_digit(ch);
             add_clause(~ge_len, is_digit);
         }

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -3162,6 +3162,13 @@ void seq_rewriter::mk_antimirov_deriv_rec(expr* e, expr* r, expr* path, expr_ref
         result = mk_antimirov_deriv_intersection(
             mk_antimirov_deriv(e, r1, path),
             mk_antimirov_deriv_negate(mk_antimirov_deriv(e, r2, path)), m().mk_true());
+    else if (re().is_of_pred(r, r1)) {
+        array_util array(m());
+        expr* args[2] = { r1, e };
+        result = array.mk_select(2, args);
+        // Use mk_der_cond to normalize
+        result = mk_der_cond(result, e, seq_sort);
+    }
     else
         // stuck cases
         result = re().mk_derivative(e, r);
@@ -4155,7 +4162,7 @@ br_status seq_rewriter::mk_str_in_regexp(expr* a, expr* b, expr_ref& result) {
         //result = re().mk_in_re(tl, re().mk_derivative(hd, b));
         //result = re().mk_in_re(tl, mk_derivative(hd, b));
         result = mk_in_antimirov(tl, mk_antimirov_deriv(hd, b, m().mk_true()));
-        return BR_REWRITE1;
+        return BR_REWRITE_FULL;
     }
 
     if (get_head_tail_reversed(a, hd, tl)) {

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -882,7 +882,7 @@ expr_ref seq_rewriter::mk_seq_first(expr* t) {
     if (str().is_extract(t, s, j, k))
         result = str().mk_nth_i(s, j);
     else
-        result = str().mk_nth_i(t, zero());
+        result = str().mk_nth_c(t, 0);
     return result;
 }
 
@@ -928,7 +928,7 @@ expr_ref seq_rewriter::mk_seq_last(expr* t) {
         str().is_len_sub(k, len_s, s_, i) &&
         s == s_ && jv == i) {
         expr_ref lastpos = mk_sub(len_s, 1);
-        result = str().mk_nth_i(s, lastpos.get());
+        result = str().mk_nth_i(s, lastpos);
     }
     else
         result = str().mk_nth_i(t, m_autil.mk_sub(str().mk_length(t), one()));

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -2992,10 +2992,15 @@ bool seq_rewriter::check_deriv_normal_form(expr* r, int level) {
 #endif
 
 /*
-    Memoized, recursive implementation of the symbolic derivative of r as a transition regex with .
+    Memoized, recursive implementation of the symbolic derivative of r as a transition regex wrt (:var 0).
 */
 expr_ref seq_rewriter::mk_derivative(expr* r) {
-    return mk_antimirov_deriv(ele, r, m().mk_true());
+    sort* seq_sort = nullptr, * elem_sort = nullptr;
+    VERIFY(u().is_re(r, seq_sort));
+    u().is_seq(seq_sort, elem_sort);
+    // Use the canonical variable (:var 0) for derivation
+    // essentially representing the transition regex \lambda x.deriv(x,r)
+    return mk_antimirov_deriv(m().mk_var(0, elem_sort), r, m().mk_true());
 }
 /*
     Memoized, recursive implementation of the symbolic derivative of r.

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -921,7 +921,7 @@ expr_ref seq_rewriter::mk_seq_last(expr* t) {
         expr_ref lastpos(str().is_len_sub(k, l, s_, i) && s == s_ ? 
             m_autil.mk_add(l, m_autil.mk_int(jv.get_int32() - 1 - i)) :
             m_autil.mk_add(k, m_autil.mk_int(jv.get_int32() - 1)), m());
-        result = str().mk_nth_i(s, lastpos);
+        result = str().mk_nth_i(s, lastpos.get());
     }
     else
         result = str().mk_nth_i(t, m_autil.mk_sub(str().mk_length(t), m_autil.mk_int(1)));
@@ -3140,7 +3140,7 @@ void seq_rewriter::mk_antimirov_deriv_rec(expr* e, expr* r, expr* path, expr_ref
         result = mk_antimirov_deriv_intersection(
             mk_antimirov_deriv(e, r1, path),
             mk_antimirov_deriv(e, r2, path), m().mk_true());
-    else if (re().is_star(r, r1) || re().is_plus(r, r1) || re().is_loop(r, r1, lo) && 0 <= lo && lo <= 1)
+    else if (re().is_star(r, r1) || re().is_plus(r, r1) || (re().is_loop(r, r1, lo) && 0 <= lo && lo <= 1))
         result = mk_antimirov_deriv_concat(mk_antimirov_deriv(e, r1, path), re().mk_star(r1));
     else if (re().is_loop(r, r1, lo))
         result = mk_antimirov_deriv_concat(mk_antimirov_deriv(e, r1, path), re().mk_loop(r1, lo - 1));
@@ -3319,6 +3319,7 @@ expr_ref seq_rewriter::mk_regex_concat(expr* r, expr* s) {
         //TODO: perhaps simplifiy some further cases such as .*. = ..* = .*.+ = .+.* = .+
         result = re().mk_concat(r, s);
     }
+    return result;
 }
 
 expr_ref seq_rewriter::mk_in_antimirov(expr* s, expr* d){

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -2996,7 +2996,8 @@ expr_ref seq_rewriter::mk_derivative(expr* r) {
     sort* seq_sort = nullptr, * ele_sort = nullptr;
     VERIFY(m_util.is_re(r, seq_sort));
     VERIFY(m_util.is_seq(seq_sort, ele_sort));
-    return mk_antimirov_deriv(m().mk_var(0, ele_sort), r, m().mk_true());
+    expr_ref v(m().mk_var(0, ele_sort), m());
+    return mk_antimirov_deriv(v, r, m().mk_true());
 }
 
 expr_ref seq_rewriter::mk_derivative(expr* ele, expr* r) {
@@ -3123,7 +3124,7 @@ void seq_rewriter::mk_antimirov_deriv_rec(expr* e, expr* r, expr* path, expr_ref
             SASSERT(u().is_char(c1));
             SASSERT(u().is_char(c2));
             // range represents c1 <= e <= c2
-            range = m().mk_and(u().mk_le(c1, e), u().mk_le(e, c2));
+            range = simplify_path(m().mk_and(u().mk_le(c1, e), u().mk_le(e, c2)));
             psi = simplify_path(m().mk_and(path, range));
             if (m().is_false(psi))
                 result = nothing();
@@ -3356,7 +3357,9 @@ expr_ref  seq_rewriter::simplify_path(expr* path) {
     expr* h = nullptr, * t = nullptr, * lhs = nullptr, * rhs = nullptr, * h1 = nullptr;
     if (m().is_and(path, h, t)) {
         if (m().is_true(h))
-            result = t;
+            result = simplify_path(t);
+        else if (m().is_true(t))
+            result = simplify_path(h);
         else if (m().is_eq(h, lhs, rhs) || m().is_not(h, h1) && m().is_eq(h1, lhs, rhs))
             elim_condition(lhs, result);
     }

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -3082,7 +3082,7 @@ void seq_rewriter::mk_antimirov_deriv_rec(expr* e, expr* r, expr* path, expr_ref
                 result = nothing();
             else
                 // observe that the precondition |r1|>0 of mk_seq_rest is implied by c1
-                result = re().mk_ite_simplify(c1, re().mk_reverse(mk_seq_butlast(r1)), nothing());
+                result = re().mk_ite_simplify(c1, re().mk_reverse(re().mk_to_re(mk_seq_butlast(r1))), nothing());
         }
         else {
             result = mk_regex_reverse(r2);

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -3016,6 +3016,8 @@ expr_ref seq_rewriter::mk_derivative(expr* ele, expr* r) {
 }
 
 expr_ref seq_rewriter::mk_antimirov_deriv(expr* e, expr* r, expr* path) {
+    // Take reference count of path and r
+    expr_ref _path(path, m()), _r(r, m());
     expr_ref result(m_op_cache.find(OP_RE_DERIVATIVE, e, r, path), m());
     if (!result) {
         mk_antimirov_deriv_rec(e, r, path, result);
@@ -3204,6 +3206,8 @@ expr_ref seq_rewriter::mk_antimirov_deriv_intersection(expr* d1, expr* d2, expr*
 
 expr_ref seq_rewriter::mk_antimirov_deriv_concat(expr* d, expr* r) {
     expr_ref result(m());
+    // Take reference count of r and d
+    expr_ref _r(r, m()), _d(d, m());
     expr* c, * t, * e;
     if (m().is_ite(d, c, t, e))
         result = m().mk_ite(c, mk_antimirov_deriv_concat(t, r), mk_antimirov_deriv_concat(e, r));
@@ -4151,7 +4155,7 @@ br_status seq_rewriter::mk_str_in_regexp(expr* a, expr* b, expr_ref& result) {
         //result = re().mk_in_re(tl, re().mk_derivative(hd, b));
         //result = re().mk_in_re(tl, mk_derivative(hd, b));
         result = mk_in_antimirov(tl, mk_antimirov_deriv(hd, b, m().mk_true()));
-        return BR_DONE;
+        return BR_REWRITE1;
     }
 
     if (get_head_tail_reversed(a, hd, tl)) {

--- a/src/ast/rewriter/seq_rewriter.h
+++ b/src/ast/rewriter/seq_rewriter.h
@@ -218,7 +218,6 @@ class seq_rewriter {
     expr_ref mk_antimirov_deriv_concat(expr* d, expr* r);
     expr_ref mk_antimirov_deriv_negate(expr* d);
     expr_ref mk_antimirov_deriv_union(expr* d1, expr* d2);
-    expr_ref mk_ite_simplify(expr* c, expr* t, expr* e);
     expr_ref mk_regex_reverse(expr* r);
     expr_ref mk_regex_concat(expr* r1, expr* r2);
 

--- a/src/ast/rewriter/seq_rewriter.h
+++ b/src/ast/rewriter/seq_rewriter.h
@@ -302,6 +302,8 @@ class seq_rewriter {
     expr_ref zero() { return expr_ref(m_autil.mk_int(0), m()); }
     expr_ref one() { return expr_ref(m_autil.mk_int(1), m()); }
     expr_ref minus_one() { return expr_ref(m_autil.mk_int(-1), m()); }
+    expr_ref mk_sub(expr* a, rational const& n);
+    expr_ref mk_sub(expr* a, unsigned n) { return mk_sub(a, rational(n)); }
 
     bool is_suffix(expr* s, expr* offset, expr* len);
     bool is_prefix(expr* s, expr* offset, expr* len);

--- a/src/ast/rewriter/seq_rewriter.h
+++ b/src/ast/rewriter/seq_rewriter.h
@@ -222,6 +222,8 @@ class seq_rewriter {
     expr_ref mk_regex_reverse(expr* r);
     expr_ref mk_regex_concat(expr* r1, expr* r2);
 
+    expr_ref simplify_path(expr* path);
+
     bool lt_char(expr* ch1, expr* ch2);
     bool eq_char(expr* ch1, expr* ch2);
     bool neq_char(expr* ch1, expr* ch2);
@@ -394,9 +396,18 @@ public:
 
     void add_seqs(expr_ref_vector const& ls, expr_ref_vector const& rs, expr_ref_pair_vector& new_eqs);
 
-    // Expose derivative and nullability check
+    /*
+    create the nullability check for r
+    */
     expr_ref is_nullable(expr* r);
+    /*
+    make the derivative of r wrt the given element ele
+    */
     expr_ref mk_derivative(expr* ele, expr* r);
+    /*
+    make the derivative of r wrt the canonical variable v0 = (:var 0), 
+    for example mk_derivative(a+) = (if (v0 = 'a') then a* else [])
+    */
     expr_ref mk_derivative(expr* r);
 
     // heuristic elimination of element from condition that comes form a derivative.

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -1105,7 +1105,7 @@ app* seq_util::rex::mk_epsilon(sort* seq_sort) {
 /*
   Produces compact view of concrete concatenations such as (abcd).
 */
-void seq_util::rex::pp::print_seq(std::ostream& out, expr* s) const {
+std::ostream& seq_util::rex::pp::print_seq(std::ostream& out, expr* s) const {
     SASSERT(re.u.is_seq(s));
     zstring z;
     expr* x, * j, * k, * l, * i, * x_;
@@ -1158,17 +1158,19 @@ void seq_util::rex::pp::print_seq(std::ostream& out, expr* s) const {
     }
     else 
         out << mk_pp(s, re.m);
+    return out;
 }
 
 /*
   Produces output such as [a-z] for a range.
 */
-void seq_util::rex::pp::print_range(std::ostream& out, expr* s1, expr* s2) const {
+std::ostream& seq_util::rex::pp::print_range(std::ostream& out, expr* s1, expr* s2) const {
     out << "[";
     print_unit(out, s1);
     out << "-";
     print_unit(out, s2);
     out << "]";
+    return out;
 }
 
 /*
@@ -1182,7 +1184,7 @@ bool seq_util::rex::pp::can_skip_parenth(expr* r) const {
 /*
   Specialize output for a unit sequence converting to visible ASCII characters if possible.
 */
-void seq_util::rex::pp::print_unit(std::ostream& out, expr* s) const {
+std::ostream& seq_util::rex::pp::print_unit(std::ostream& out, expr* s) const {
     expr* e, * i;
     unsigned n = 0;
     if ((re.u.str.is_unit(s, e) && re.u.is_const_char(e, n)) || re.u.is_const_char(s, n)) {
@@ -1237,12 +1239,13 @@ void seq_util::rex::pp::print_unit(std::ostream& out, expr* s) const {
     }
     else
         out << mk_pp(s, re.m);
+    return out;
 }
 
 /*
   Pretty prints the regex r into the ostream out
 */
-void seq_util::rex::pp::print(std::ostream& out, expr* e) const {
+std::ostream& seq_util::rex::pp::print(std::ostream& out, expr* e) const {
     expr* r1 = nullptr, * r2 = nullptr, * s = nullptr, * s2 = nullptr;
     unsigned lo = 0, hi = 0;
     rational v;
@@ -1400,6 +1403,7 @@ void seq_util::rex::pp::print(std::ostream& out, expr* e) const {
     else
         // for all remaining cases use the default pretty printer
         out << mk_pp(e, re.m);
+    return out;
 }
 
 std::ostream& seq_util::rex::pp::display(std::ostream& out) const {

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -1231,7 +1231,6 @@ std::ostream& seq_util::rex::pp::print_unit(std::ostream& out, expr* s) const {
         out << mk_pp(e, re.m);
     else if (is_app(e)) {
         out << "(" << to_app(e)->get_decl()->get_name().str();
-        //for (unsigned i = 0; i < to_app(e)->get_num_args(); i++) {
         for (expr * arg : *to_app(e))
             print(out << " ", arg);
         out << ")";

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -1231,10 +1231,9 @@ std::ostream& seq_util::rex::pp::print_unit(std::ostream& out, expr* s) const {
         out << mk_pp(e, re.m);
     else if (is_app(e)) {
         out << "(" << to_app(e)->get_decl()->get_name().str();
-        for (unsigned i = 0; i < to_app(e)->get_num_args(); i++) {
-            out << " ";
-            print(out, to_app(e)->get_arg(i));
-        }
+        //for (unsigned i = 0; i < to_app(e)->get_num_args(); i++) {
+        for (expr * arg : *to_app(e))
+            print(out << " ", arg);
         out << ")";
     }
     else
@@ -1394,10 +1393,8 @@ std::ostream& seq_util::rex::pp::print(std::ostream& out, expr* e) const {
         out << mk_pp(e, re.m);
     else if (is_app(e)) {
         out << "(" << to_app(e)->get_decl()->get_name().str();
-        for (unsigned i = 0; i < to_app(e)->get_num_args(); i++) {
-            out << " ";
-            print(out, to_app(e)->get_arg(i));
-        }
+        for (expr* arg : *to_app(e))
+            print(out << " ", arg);
         out << ")";
     }
     else

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -858,24 +858,24 @@ void seq_util::str::get_concat(expr* e, expr_ref_vector& es) const {
 Returns true if s is an expression of the form (l = |u|) |u|-k or (-k)+|u| or |u|+(-k).
 Also returns true and assigns k=0 and l=s if s is |u|.
 */
-bool seq_util::str::is_len_sub(expr const* s, expr*& l, expr*& u, unsigned& k) const
-{
+bool seq_util::str::is_len_sub(expr const* s, expr*& l, expr*& u, rational& k) const {
     expr* x;
     rational v;
+    arith_util a(m);
     if (is_length(s, l)) {
         k = 0;
         return true;
     }
-    else if (arith_util(m).is_sub(s, l, x) && is_length(l, u) && arith_util(m).is_numeral(x, v) && v.is_nonneg()) {
-        k = v.get_unsigned();
+    else if (a.is_sub(s, l, x) && is_length(l, u) && a.is_numeral(x, v) && v.is_nonneg()) {
+        k = v;
         return true;
     }
-    else if (arith_util(m).is_add(s, l, x) && is_length(l, u) && arith_util(m).is_numeral(x, v) && v.is_nonpos()) {
-        k = (0 - v.get_int32());
+    else if (a.is_add(s, l, x) && is_length(l, u) && a.is_numeral(x, v) && v.is_nonpos()) {
+        k = - v;
         return true;
     }
-    else if (arith_util(m).is_add(s, x, l) && is_length(l, u) && arith_util(m).is_numeral(x, v) && v.is_nonpos()) {
-        k = (0 - v.get_int32());
+    else if (a.is_add(s, x, l) && is_length(l, u) && a.is_numeral(x, v) && v.is_nonpos()) {
+        k = - v;
         return true;
     }
     else

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -1128,21 +1128,21 @@ std::ostream& seq_util::rex::pp::compact_helper_seq(std::ostream& out, expr* s) 
         if (arith_util(re.m).is_numeral(j, jv)) {
             if (arith_util(re.m).is_numeral(k, iv))
                 // output X[j,k]
-                out << pp(re, x) << "[" << jv.get_int32() << "," << jv.get_int32() << "]";
+                out << pp(re, x, html_encode) << "[" << jv.get_int32() << "," << jv.get_int32() << "]";
             else if (arith_util(re.m).is_sub(k, l, i) && re.u.str.is_length(l, x_) && x == x_ &&
                 arith_util(re.m).is_numeral(i, iv) && iv == jv)
                 // case X[j,|X|-j] is denoted by X[j..]
-                out << pp(re, x) << "[" << jv.get_int32() << "..]";
+                out << pp(re, x, html_encode) << "[" << jv.get_int32() << "..]";
             else if (((arith_util(re.m).is_add(k, l, i) && re.u.str.is_length(l, x_)) ||
                     (arith_util(re.m).is_add(k, i, l) && re.u.str.is_length(l, x_))) && x == x_ && 
                 arith_util(re.m).is_numeral(i, iv) && iv.get_int32() + jv.get_int32() == 0)
                 // case X[j,|X|-j] is denoted by X[j..]
-                out << pp(re, x) << "[" << jv.get_int32() << "..]";
+                out << pp(re, x, html_encode) << "[" << jv.get_int32() << "..]";
             else 
-                out << pp(re, x) << "[" << jv.get_int32() << "," << pp(re, k) << "]";
+                out << pp(re, x, html_encode) << "[" << jv.get_int32() << "," << pp(re, k, html_encode) << "]";
         }
         else
-            out << pp(re, x) << "[" << pp(re, j) << "," << pp(re, k) << "]";
+            out << pp(re, x, html_encode) << "[" << pp(re, j, html_encode) << "," << pp(re, k, html_encode) << "]";
     }
     else out << mk_pp(s, re.m);
     return out;
@@ -1181,9 +1181,11 @@ std::ostream& seq_util::rex::pp::seq_unit(std::ostream& out, expr* s) const {
         else if (c == '\f')
             out << "\\f";
         else if (c == ' ')
-            out << "\\s";
+            out << " ";
         else if (c == '(' || c == ')' || c == '{' || c == '}' || c == '[' || c == ']' || c == '.' || c == '\\')
             out << "\\" << c;
+        else if ('A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' || c == '_' || c == '@' || c == ';' || c == ':' || c == '/' || c == '#' || c == '$')
+            out << c;
         else if (32 < n && n < 127) {
             if (html_encode) {
                 if (c == '<')
@@ -1241,79 +1243,79 @@ std::ostream& seq_util::rex::pp::display(std::ostream& out) const {
     else if (re.is_empty(e))
         return out << "[]";
     else if (re.is_concat(e, r1, r2))
-        return out << pp(re, r1) << pp(re, r2);
+        return out << pp(re, r1, html_encode) << pp(re, r2, html_encode);
     else if (re.is_antimorov_union(e, r1, r2) || re.is_union(e, r1, r2))
-        return out << "(" << pp(re, r1) << "|" << pp(re, r2) << ")";
+        return out << "(" << pp(re, r1, html_encode) << "|" << pp(re, r2, html_encode) << ")";
     else if (re.is_intersection(e, r1, r2))
-        return out << "(" << pp(re, r1) << "&amp;" /*(html_encode ? ")&amp;(" : ")&(")*/ << pp(re, r2) << ")";
+        return out << "(" << pp(re, r1, html_encode) << (html_encode ? "&amp;" : "&") << pp(re, r2, html_encode) << ")";
     else if (re.is_complement(e, r1)) {
         if (can_skip_parenth(r1))
-            return out << "~" << pp(re, r1);
+            return out << "~" << pp(re, r1, html_encode);
         else
-            return out << "~(" << pp(re, r1) << ")";
+            return out << "~(" << pp(re, r1, html_encode) << ")";
     }
     else if (re.is_plus(e, r1)) {
         if (can_skip_parenth(r1))
-            return out << pp(re, r1) << "+";
+            return out << pp(re, r1, html_encode) << "+";
         else
-            return out << "(" << pp(re, r1) << ")+";
+            return out << "(" << pp(re, r1, html_encode) << ")+";
     }
     else if (re.is_star(e, r1)) {
         if (can_skip_parenth(r1))
-            return out << pp(re, r1) << "*";
+            return out << pp(re, r1, html_encode) << "*";
         else
-            return out << "(" << pp(re, r1) << ")*";
+            return out << "(" << pp(re, r1, html_encode) << ")*";
     }
     else if (re.is_loop(e, r1, lo)) {
         if (can_skip_parenth(r1))
-            return out << pp(re, r1) << "{" << lo << ",}";
+            return out << pp(re, r1, html_encode) << "{" << lo << ",}";
         else
-            return out << "(" << pp(re, r1) << "){" << lo << ",}";
+            return out << "(" << pp(re, r1, html_encode) << "){" << lo << ",}";
     }
     else if (re.is_loop(e, r1, lo, hi)) {
         if (can_skip_parenth(r1)) {
             if (lo == hi)
-                return out << pp(re, r1) << "{" << lo << "}";
+                return out << pp(re, r1, html_encode) << "{" << lo << "}";
             else
-                return out << pp(re, r1) << "{" << lo << "," << hi << "}";
+                return out << pp(re, r1, html_encode) << "{" << lo << "," << hi << "}";
         }
         else {
             if (lo == hi)
-                return out << "(" << pp(re, r1) << "){" << lo << "}";
+                return out << "(" << pp(re, r1, html_encode) << "){" << lo << "}";
             else
-                return out << "(" << pp(re, r1) << "){" << lo << "," << hi << "}";
+                return out << "(" << pp(re, r1, html_encode) << "){" << lo << "," << hi << "}";
         }
     }
     else if (re.is_diff(e, r1, r2))
-        return out << "(" << pp(re, r1) << ")\\(" << pp(re, r2) << ")";
+        return out << "(" << pp(re, r1, html_encode) << ")\\(" << pp(re, r2, html_encode) << ")";
     else if (re.m.is_ite(e, s, r1, r2))
-        return out << "(if " << pp(re, s) << " then " << pp(re, r1) << " else " << pp(re, r2) << ")";
+        return out << "(if " << pp(re, s, html_encode) << " then " << pp(re, r1, html_encode) << " else " << pp(re, r2, html_encode) << ")";
     else if (re.is_opt(e, r1)) {
         if (can_skip_parenth(r1))
-            return out << pp(re, r1) << "?";
+            return out << pp(re, r1, html_encode) << "?";
         else
-            return out << "(" << pp(re, r1) << ")?";
+            return out << "(" << pp(re, r1, html_encode) << ")?";
     }
     else if (re.is_reverse(e, r1))
-        return out << "rev(" << pp(re, r1) << ")";
+        return out << "rev(" << pp(re, r1, html_encode) << ")";
     else if (re.m.is_eq(e, r1, r2))
-        return out << "(" << pp(re, r1) << "=" << pp(re, r2) << ")";
+        return out << "(" << pp(re, r1, html_encode) << "=" << pp(re, r2, html_encode) << ")";
     else if (re.m.is_not(e, r1))
-        return out << "!" << pp(re, r1);
+        return out << "!" << pp(re, r1, html_encode);
     else if (re.m.is_and(e)) {
         out << "(";
         for (unsigned i = 0; i < to_app(e)->get_num_args(); i++)
-            out << (i > 0 ? " and " : "") << pp(re, to_app(e)->get_arg(i));
+            out << (i > 0 ? " and " : "") << pp(re, to_app(e)->get_arg(i), html_encode);
         out << ")";
     }
     else if (re.m.is_or(e)) {
         out << "(";
         for (unsigned i = 0; i < to_app(e)->get_num_args(); i++)
-            out << (i > 0 ? " or " : "") << pp(re, to_app(e)->get_arg(i));
+            out << (i > 0 ? " or " : "") << pp(re, to_app(e)->get_arg(i), html_encode);
         out << ")";
     }
     else if (re.u.str.is_in_re(e, s, r1))
-        return out << "(" << pp(re, s) << " in " << pp(re, r1) << ")";
+        return out << "(" << pp(re, s, html_encode) << " in " << pp(re, r1, html_encode) << ")";
     //else if (arith_util(re.m).is_add(e, s, r1) && re.u.str.is_length(r1, r2) && arith_util(re.m).is_numeral(s, v) && v.is_neg())
     //    return out << "(|" << pp(re, r2) << "|" << "-" << (0 - v.get_int32()) << ")";
     //else if (arith_util(re.m).is_add(e, r1, s) && re.u.str.is_length(r1, r2) && arith_util(re.m).is_numeral(s, v) && v.is_neg())
@@ -1330,7 +1332,7 @@ std::ostream& seq_util::rex::pp::display(std::ostream& out) const {
 */
 std::string seq_util::rex::to_str(expr* r) const {
     std::ostringstream out;
-    out << pp(u.re, r);
+    out << pp(u.re, r, false);
     return out.str();
 }
 
@@ -1376,7 +1378,7 @@ seq_util::rex::info seq_util::rex::get_info_rec(expr* e) const {
     else 
         result = mk_info_rec(to_app(e));
     m_infos.setx(e->get_id(), result, invalid_info);
-    STRACE("re_info", tout << "compute_info(" << pp(u.re, e) << ")=" << result << std::endl;);
+    STRACE("re_info", tout << "compute_info(" << pp(u.re, e, false) << ")=" << result << std::endl;);
     return result;
 }
 

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -839,7 +839,7 @@ bool seq_util::str::is_nth_i(expr const* n, expr*& s, unsigned& idx) const {
     return arith_util(m).is_unsigned(i, idx);
 }
 
-app* seq_util::str::mk_nth_i(expr* s, unsigned i) const {
+app* seq_util::str::mk_nth_c(expr* s, unsigned i) const {
     return mk_nth_i(s, arith_util(m).mk_int(i));
 }
 

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -614,10 +614,10 @@ public:
             expr* ex;
             bool html_encode;
             bool can_skip_parenth(expr* r) const;
-            void print_unit(std::ostream& out, expr* s) const;
-            void print_seq(std::ostream& out, expr* s) const;
-            void print_range(std::ostream& out, expr* s1, expr* s2) const;
-            void print(std::ostream& out, expr* e) const;
+            std::ostream& print_unit(std::ostream& out, expr* s) const;
+            std::ostream& print_seq(std::ostream& out, expr* s) const;
+            std::ostream& print_range(std::ostream& out, expr* s1, expr* s2) const;
+            std::ostream& print(std::ostream& out, expr* e) const;
 
         public:
             pp(seq_util::rex& re, expr* ex, bool html) : re(re), ex(ex), html_encode(html) {}

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -590,7 +590,7 @@ public:
             std::ostream& compact_helper_range(std::ostream& out, expr* s1, expr* s2) const;
 
         public:
-            pp(seq_util::rex& r, expr* e, bool html = false) : re(r), e(e), html_encode(html) {}
+            pp(seq_util::rex& r, expr* e, bool html) : re(r), e(e), html_encode(html) {}
             std::ostream& display(std::ostream&) const;
         };
     };

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -286,7 +286,7 @@ public:
         app* mk_at(expr* s, expr* i) const { expr* es[2] = { s, i }; return m.mk_app(m_fid, OP_SEQ_AT, 2, es); }
         app* mk_nth(expr* s, expr* i) const { expr* es[2] = { s, i }; return m.mk_app(m_fid, OP_SEQ_NTH, 2, es); }
         app* mk_nth_i(expr* s, expr* i) const { expr* es[2] = { s, i }; return m.mk_app(m_fid, OP_SEQ_NTH_I, 2, es); }
-        app* mk_nth_i(expr* s, unsigned i) const;
+        app* mk_nth_c(expr* s, unsigned i) const;
 
         app* mk_substr(expr* a, expr* b, expr* c) const { expr* es[3] = { a, b, c }; return m.mk_app(m_fid, OP_SEQ_EXTRACT, 3, es); }
         app* mk_contains(expr* a, expr* b) const { expr* es[2] = { a, b }; return m.mk_app(m_fid, OP_SEQ_CONTAINS, 2, es); }

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -593,22 +593,6 @@ public:
             return result;
         }
 
- /*       expr_ref mk_or_simplify(expr* a, expr* b)
-        {
-            expr_ref result(m);
-            if (m.is_true(a) || a == b)
-                result = a;
-            else if (m.is_true(b))
-                result = b;
-            else if (m.is_false(a))
-                result = b;
-            else if (m.is_false(b))
-                result = a;
-            else
-                result = m.mk_or(a, b);
-            return result;
-        }*/
-
         class pp {
             seq_util::rex& re;
             expr* ex;

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -350,7 +350,7 @@ public:
         bool is_from_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_FROM_CODE); }
         bool is_to_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_CODE); }
 
-        bool is_len_sub(expr const* n, expr*& l, expr*& u, unsigned& k) const;
+        bool is_len_sub(expr const* n, expr*& l, expr*& u, rational& k) const;
 
         /*
         tests if s is a single character string(c) or a unit (c)

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -579,18 +579,48 @@ public:
         app* mk_epsilon(sort* seq_sort);
         info get_info(expr* r) const;
         std::string to_str(expr* r) const;
+        std::string to_strh(expr* r) const;
+
+        expr_ref mk_ite_simplify(expr* c, expr* t, expr* e)
+        {
+            expr_ref result(m);
+            if (m.is_true(c) || t == e)
+                result = t;
+            else if (m.is_false(c))
+                result = e;
+            else
+                result = m.mk_ite(c, t, e);
+            return result;
+        }
+
+        expr_ref mk_or_simplify(expr* a, expr* b)
+        {
+            expr_ref result(m);
+            if (m.is_true(a) || a == b)
+                result = a;
+            else if (m.is_true(b))
+                result = b;
+            else if (m.is_false(a))
+                result = b;
+            else if (m.is_false(b))
+                result = a;
+            else
+                result = m.mk_or(a, b);
+            return result;
+        }
 
         class pp {
             seq_util::rex& re;
-            expr* e;
+            expr* ex;
             bool html_encode;
             bool can_skip_parenth(expr* r) const;
-            std::ostream& seq_unit(std::ostream& out, expr* s) const;
-            std::ostream& compact_helper_seq(std::ostream& out, expr* s) const;
-            std::ostream& compact_helper_range(std::ostream& out, expr* s1, expr* s2) const;
+            void print_unit(std::ostream& out, expr* s) const;
+            void print_seq(std::ostream& out, expr* s) const;
+            void print_range(std::ostream& out, expr* s1, expr* s2) const;
+            void print(std::ostream& out, expr* e) const;
 
         public:
-            pp(seq_util::rex& r, expr* e, bool html) : re(r), e(e), html_encode(html) {}
+            pp(seq_util::rex& re, expr* ex, bool html) : re(re), ex(ex), html_encode(html) {}
             std::ostream& display(std::ostream&) const;
         };
     };

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -593,7 +593,7 @@ public:
             return result;
         }
 
-        expr_ref mk_or_simplify(expr* a, expr* b)
+ /*       expr_ref mk_or_simplify(expr* a, expr* b)
         {
             expr_ref result(m);
             if (m.is_true(a) || a == b)
@@ -607,7 +607,7 @@ public:
             else
                 result = m.mk_or(a, b);
             return result;
-        }
+        }*/
 
         class pp {
             seq_util::rex& re;

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -350,6 +350,13 @@ public:
         bool is_from_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_FROM_CODE); }
         bool is_to_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_CODE); }
 
+        bool is_len_sub(expr const* n, expr*& l, expr*& u, unsigned& k) const;
+
+        /*
+        tests if s is a single character string(c) or a unit (c)
+        */
+        bool is_unit_string(expr const* s, expr_ref& c) const;
+
         bool is_string_term(expr const * n) const {
             return u.is_string(n->get_sort());
         }
@@ -530,7 +537,20 @@ public:
         bool is_loop(expr const* n)    const { return is_app_of(n, m_fid, OP_RE_LOOP); }
         bool is_empty(expr const* n)  const { return is_app_of(n, m_fid, OP_RE_EMPTY_SET); }
         bool is_full_char(expr const* n)  const { return is_app_of(n, m_fid, OP_RE_FULL_CHAR_SET); }
-        bool is_full_seq(expr const* n)  const { return is_app_of(n, m_fid, OP_RE_FULL_SEQ_SET); }
+        bool is_full_seq(expr const* n)  const {
+            expr* s;
+            return is_app_of(n, m_fid, OP_RE_FULL_SEQ_SET) || (is_star(n, s) && is_full_char(s));
+        }
+        bool is_dot_plus(expr const* n)  const {
+            expr* s, * t;
+            if (is_plus(n, s) && is_full_char(s))
+                return true;
+            if (is_concat(n, s, t)) {
+                if ((is_full_char(s) && is_full_seq(t)) || (is_full_char(t) && is_full_seq(s)))
+                    return true;
+            }
+            return false;
+        }
         bool is_of_pred(expr const* n) const { return is_app_of(n, m_fid, OP_RE_OF_PRED); }
         bool is_reverse(expr const* n) const { return is_app_of(n, m_fid, OP_RE_REVERSE); }
         bool is_derivative(expr const* n) const { return is_app_of(n, m_fid, OP_RE_DERIVATIVE); }

--- a/src/smt/seq_regex.cpp
+++ b/src/smt/seq_regex.cpp
@@ -12,6 +12,7 @@ Abstract:
 Author:
 
     Nikolaj Bjorner (nbjorner) 2020-5-22
+    Margus Veanes 2021
 
 --*/
 

--- a/src/smt/seq_regex.cpp
+++ b/src/smt/seq_regex.cpp
@@ -636,7 +636,7 @@ namespace smt {
                     // s[i..] in [] <==> false, also: s[i..] in () <==> false when |s|>i
                     re_to_accept.find(e) = m.mk_false();
                 }
-                else if (re().is_full_seq(e) || s_is_longer_than_i && re().is_dot_plus(e))
+                else if (re().is_full_seq(e) || (s_is_longer_than_i && re().is_dot_plus(e)))
                 {
                     // s[i..] in .* <==> true, also: s[i..] in .+ <==> true when |s|>i
                     re_to_accept.find(e) = m.mk_true();

--- a/src/smt/seq_regex.h
+++ b/src/smt/seq_regex.h
@@ -163,7 +163,7 @@ namespace smt {
         // Various support for unfolding derivative expressions that are
         // returned by derivative_wrapper
         expr_ref mk_deriv_accept(expr* s, unsigned i, expr* r);
-        void get_all_derivatives(expr* r, expr_ref_vector& results);
+        void get_targets(expr* r, expr_ref_vector& results);
         void get_cofactors(expr* r, expr_ref_pair_vector& result);
         void get_cofactors_rec(expr* r, expr_ref_vector& conds,
                                expr_ref_pair_vector& result);

--- a/src/smt/seq_regex.h
+++ b/src/smt/seq_regex.h
@@ -158,12 +158,13 @@ namespace smt {
         expr_ref symmetric_diff(expr* r1, expr* r2);
 
         expr_ref is_nullable_wrapper(expr* r);
-        expr_ref derivative_wrapper(expr* hd, expr* r);
+        expr_ref mk_derivative_wrapper(expr* hd, expr* r);
 
         // Various support for unfolding derivative expressions that are
         // returned by derivative_wrapper
         expr_ref mk_deriv_accept(expr* s, unsigned i, expr* r);
-        void get_targets(expr* r, expr_ref_vector& results);
+        expr_ref mk_deriv_accept_rec(expr* s, unsigned i, expr* r);
+        void get_derivative_targets(expr* r, expr_ref_vector& targets);
         void get_cofactors(expr* r, expr_ref_pair_vector& result);
         void get_cofactors_rec(expr* r, expr_ref_vector& conds,
                                expr_ref_pair_vector& result);

--- a/src/smt/seq_regex.h
+++ b/src/smt/seq_regex.h
@@ -163,7 +163,6 @@ namespace smt {
         // Various support for unfolding derivative expressions that are
         // returned by derivative_wrapper
         expr_ref mk_deriv_accept(expr* s, unsigned i, expr* r);
-        expr_ref mk_deriv_accept_rec(expr* s, unsigned i, expr* r);
         void get_derivative_targets(expr* r, expr_ref_vector& targets);
         void get_cofactors(expr* r, expr_ref_pair_vector& result);
         void get_cofactors_rec(expr* r, expr_ref_vector& conds,


### PR DESCRIPTION
Rewrote/updated several derivate related algos both for correctness and performance.
Main changes involve more efficient use of algebraic laws and avoidance of unnecessary rewrites that in many cases were causing orders of magnitude of overhead. 
Several open issues should be addressed by the updated engine.
Some old code is still there for convenience to debug possible regressions, that will eventually be removed, once any new regression bugs have been flushed out.