### PR TITLE
Add GitHub Action for automated Android builds

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,35 @@
+name: Android Build
+
+on:
+  push:
+    branches: [ master ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        android-abi: [arm64-v8a, armeabi-v7a, x86, x86_64]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Configure CMake and build
+      run:  |
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=21 -DCMAKE_ANDROID_ARCH_ABI=${{ matrix.android-abi }} -DCMAKE_ANDROID_NDK=$ANDROID_NDK_HOME -DZ3_BUILD_JAVA_BINDINGS=TRUE -G "Unix Makefiles" -DJAVA_AWT_LIBRARY=NotNeeded -DJAVA_JVM_LIBRARY=NotNeeded -DJAVA_INCLUDE_PATH2=NotNeeded -DJAVA_AWT_INCLUDE_PATH=NotNeeded ../
+        make -j $(nproc)
+        tar -cvf z3-build-${{ matrix.android-abi }}.tar *.jar *.so
+        
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: android-build-${{ matrix.android-abi }}
+        path: build/z3-build-${{ matrix.android-abi }}.tar


### PR DESCRIPTION
Related to #5586 - this adds an automated GitHub Action to build Z3 for Android with the four ABIs `arm64-v8a` , `armeabi-v7a`, `x86` and `x86_64`. An artefact of the `.so` and `.jar` files is created for each so that users can get the binaries without performing their own build.

Example output from a run here: https://github.com/jamiecollinson/z3/actions/runs/1329522794

@NikolajBjorner - I imagine you'll want to make some tweaks, and you might want to consider automating releases via something like https://github.com/marketplace/actions/git-release, though I don't know how that would tie into the existing pipeline for other builds.