### PR TITLE
tweak GC in OCaml bindings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,15 +43,15 @@ jobs:
     - ${{if eq(variables['runRegressions'], 'True')}}:
       - template: scripts/test-regressions.yml
 
-- job: "Ubuntu18Python"
-  displayName: "Ubuntu 18 with ocaml"
+- job: "Ubuntu20OCaml"
+  displayName: "Ubuntu 20 with ocaml"
   pool:
-    vmImage: "Ubuntu-18.04"
+    vmImage: "Ubuntu-20.04"
   steps:
     - script: sudo apt-get install ocaml opam libgmp-dev
     - script: opam init -y
     - script: eval `opam config env`; opam install zarith ocamlfind -y
-    - script: python scripts/mk_make.py --ml --staticlib
+    - script: eval `opam config env`; python scripts/mk_make.py --ml --staticlib
     - script: |
         set -e
         cd build

--- a/src/api/ml/z3.ml
+++ b/src/api/ml/z3.ml
@@ -59,7 +59,6 @@ let mk_context (settings:(string * string) list) =
   Z3native.del_config cfg;
   Z3native.set_ast_print_mode res (Z3enums.int_of_ast_print_mode PRINT_SMTLIB2_COMPLIANT);
   Z3native.set_internal_error_handler res;
-  Gc.finalise Z3native.del_context res;
   res
 
 module Symbol =

--- a/src/api/ml/z3.ml
+++ b/src/api/ml/z3.ml
@@ -59,6 +59,7 @@ let mk_context (settings:(string * string) list) =
   Z3native.del_config cfg;
   Z3native.set_ast_print_mode res (Z3enums.int_of_ast_print_mode PRINT_SMTLIB2_COMPLIANT);
   Z3native.set_internal_error_handler res;
+  Gc.finalise Z3native.del_context res;
   res
 
 module Symbol =

--- a/src/api/ml/z3native_stubs.c.pre
+++ b/src/api/ml/z3native_stubs.c.pre
@@ -76,14 +76,14 @@ int compare_pointers(void* pt1, void* pt2) {
     return +1;
 }
 
-#define MK_CTX_OF(X, USED, MAX)                                         \
+#define MK_CTX_OF(X, USED)                                         \
   CAMLprim DLL_PUBLIC value n_context_of_ ## X(value v) {               \
     CAMLparam1(v);                                                      \
     CAMLlocal1(result);                                                 \
     Z3_context_plus cp;                                                 \
     Z3_ ## X ## _plus * p = (Z3_ ## X ## _plus *) Data_custom_val(v);   \
     cp = p->cp;                                                         \
-    result = caml_alloc_custom(&Z3_context_plus_custom_ops, sizeof(Z3_context_plus), USED, MAX); \
+    result = caml_alloc_custom_mem(&Z3_context_plus_custom_ops, sizeof(Z3_context_plus), USED); \
     *(Z3_context_plus *)Data_custom_val(result) = cp;                   \
     /* We increment the usage counter of the context, as we just        \
        created a second custom block holding that context        */     \
@@ -102,7 +102,7 @@ int compare_pointers(void* pt1, void* pt2) {
     CAMLlocal1(result);                                                 \
     Z3_context_plus cp = *(Z3_context_plus*)(Data_custom_val(v));       \
     Z3_ ## X ## _plus a = Z3_ ## X ## _plus_mk(cp, NULL);               \
-    result = caml_alloc_custom(&Z3_ ## X ## _plus_custom_ops, sizeof(Z3_ ## X ## _plus), USED, MAX); \
+    result = caml_alloc_custom_mem(&Z3_ ## X ## _plus_custom_ops, sizeof(Z3_ ## X ## _plus), USED); \
     *(Z3_ ## X ## _plus*)(Data_custom_val(result)) = a;                 \
     CAMLreturn(result);                                                 \
   }
@@ -294,9 +294,9 @@ static struct custom_operations Z3_ast_plus_custom_ops = {
   Z3_ast_compare_ext
 };
 
-MK_CTX_OF(ast, 1, 100000)
+MK_CTX_OF(ast, 16) // let's say 16 bytes per ast
 
-#define MK_PLUS_OBJ_NO_REF(X, USED, MAX)                                \
+#define MK_PLUS_OBJ_NO_REF(X, USED)                                \
   typedef struct {                                                      \
     Z3_context_plus cp;                                                 \
     Z3_ ## X p;                                                         \
@@ -349,9 +349,9 @@ MK_CTX_OF(ast, 1, 100000)
     Z3_ ## X ## _compare_ext                                            \
   };                                                                    \
                                                                         \
-  MK_CTX_OF(X, USED, MAX)
+  MK_CTX_OF(X, USED)
 
-#define MK_PLUS_OBJ(X, USED, MAX)                                       \
+#define MK_PLUS_OBJ(X, USED)                                            \
   typedef struct {                                                      \
     Z3_context_plus cp;                                                 \
     Z3_ ## X p;                                                         \
@@ -408,27 +408,27 @@ MK_CTX_OF(ast, 1, 100000)
     Z3_ ## X ## _compare_ext                                            \
   };                                                                    \
                                                                         \
-  MK_CTX_OF(X, USED, MAX)
+  MK_CTX_OF(X, USED)
 
-MK_PLUS_OBJ_NO_REF(symbol, 1, 5000)
-MK_PLUS_OBJ_NO_REF(constructor, 0, 1)
-MK_PLUS_OBJ_NO_REF(constructor_list, 0, 1)
-MK_PLUS_OBJ_NO_REF(rcf_num, 0, 1)
-MK_PLUS_OBJ(params, 0, 1)
-MK_PLUS_OBJ(param_descrs, 0, 1)
-MK_PLUS_OBJ(model, 1, 100)
-MK_PLUS_OBJ(func_interp, 0, 1)
-MK_PLUS_OBJ(func_entry, 0, 1)
-MK_PLUS_OBJ(goal, 0, 1)
-MK_PLUS_OBJ(tactic, 0, 1)
-MK_PLUS_OBJ(probe, 0, 1)
-MK_PLUS_OBJ(apply_result, 0, 1)
-MK_PLUS_OBJ(solver, 1, 5) // at most 5 dead solvers before GC
-MK_PLUS_OBJ(stats, 0, 1)
-MK_PLUS_OBJ(ast_map, 0, 1)
-MK_PLUS_OBJ(ast_vector, 0, 1)
-MK_PLUS_OBJ(fixedpoint, 1, 5)
-MK_PLUS_OBJ(optimize, 1, 5)
+MK_PLUS_OBJ_NO_REF(symbol, 32)
+MK_PLUS_OBJ_NO_REF(constructor, 32)
+MK_PLUS_OBJ_NO_REF(constructor_list, 32)
+MK_PLUS_OBJ_NO_REF(rcf_num, 32)
+MK_PLUS_OBJ(params, 128)
+MK_PLUS_OBJ(param_descrs, 128)
+MK_PLUS_OBJ(model, 512)
+MK_PLUS_OBJ(func_interp, 128)
+MK_PLUS_OBJ(func_entry, 128)
+MK_PLUS_OBJ(goal, 128)
+MK_PLUS_OBJ(tactic, 128)
+MK_PLUS_OBJ(probe, 128)
+MK_PLUS_OBJ(apply_result, 128)
+MK_PLUS_OBJ(solver, 20 * 1000 * 1000) // pretend a solver is 20MB
+MK_PLUS_OBJ(stats, 128)
+MK_PLUS_OBJ(ast_map, 1024 * 2)
+MK_PLUS_OBJ(ast_vector, 128)
+MK_PLUS_OBJ(fixedpoint, 20 * 1000 * 1000)
+MK_PLUS_OBJ(optimize, 20 * 1000 * 1000)
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/api/ml/z3native_stubs.c.pre
+++ b/src/api/ml/z3native_stubs.c.pre
@@ -76,14 +76,14 @@ int compare_pointers(void* pt1, void* pt2) {
     return +1;
 }
 
-#define MK_CTX_OF(X)                                                    \
+#define MK_CTX_OF(X, USED, MAX)                                         \
   CAMLprim DLL_PUBLIC value n_context_of_ ## X(value v) {               \
     CAMLparam1(v);                                                      \
     CAMLlocal1(result);                                                 \
     Z3_context_plus cp;                                                 \
     Z3_ ## X ## _plus * p = (Z3_ ## X ## _plus *) Data_custom_val(v);   \
     cp = p->cp;                                                         \
-    result = caml_alloc_custom(&Z3_context_plus_custom_ops, sizeof(Z3_context_plus), 0, 1); \
+    result = caml_alloc_custom(&Z3_context_plus_custom_ops, sizeof(Z3_context_plus), USED, MAX); \
     *(Z3_context_plus *)Data_custom_val(result) = cp;                   \
     /* We increment the usage counter of the context, as we just        \
        created a second custom block holding that context        */     \
@@ -102,7 +102,7 @@ int compare_pointers(void* pt1, void* pt2) {
     CAMLlocal1(result);                                                 \
     Z3_context_plus cp = *(Z3_context_plus*)(Data_custom_val(v));       \
     Z3_ ## X ## _plus a = Z3_ ## X ## _plus_mk(cp, NULL);               \
-    result = caml_alloc_custom(&Z3_ ## X ## _plus_custom_ops, sizeof(Z3_ ## X ## _plus), 0, 1); \
+    result = caml_alloc_custom(&Z3_ ## X ## _plus_custom_ops, sizeof(Z3_ ## X ## _plus), USED, MAX); \
     *(Z3_ ## X ## _plus*)(Data_custom_val(result)) = a;                 \
     CAMLreturn(result);                                                 \
   }
@@ -294,9 +294,9 @@ static struct custom_operations Z3_ast_plus_custom_ops = {
   Z3_ast_compare_ext
 };
 
-MK_CTX_OF(ast)
+MK_CTX_OF(ast, 0, 1)
 
-#define MK_PLUS_OBJ_NO_REF(X)                                           \
+#define MK_PLUS_OBJ_NO_REF(X, USED, MAX)                                \
   typedef struct {                                                      \
     Z3_context_plus cp;                                                 \
     Z3_ ## X p;                                                         \
@@ -349,9 +349,9 @@ MK_CTX_OF(ast)
     Z3_ ## X ## _compare_ext                                            \
   };                                                                    \
                                                                         \
-  MK_CTX_OF(X)
+  MK_CTX_OF(X, USED, MAX)
 
-#define MK_PLUS_OBJ(X)                                                  \
+#define MK_PLUS_OBJ(X, USED, MAX)                                       \
   typedef struct {                                                      \
     Z3_context_plus cp;                                                 \
     Z3_ ## X p;                                                         \
@@ -408,27 +408,27 @@ MK_CTX_OF(ast)
     Z3_ ## X ## _compare_ext                                            \
   };                                                                    \
                                                                         \
-  MK_CTX_OF(X)
+  MK_CTX_OF(X, USED, MAX)
 
-MK_PLUS_OBJ_NO_REF(symbol)
-MK_PLUS_OBJ_NO_REF(constructor)
-MK_PLUS_OBJ_NO_REF(constructor_list)
-MK_PLUS_OBJ_NO_REF(rcf_num)
-MK_PLUS_OBJ(params)
-MK_PLUS_OBJ(param_descrs)
-MK_PLUS_OBJ(model)
-MK_PLUS_OBJ(func_interp)
-MK_PLUS_OBJ(func_entry)
-MK_PLUS_OBJ(goal)
-MK_PLUS_OBJ(tactic)
-MK_PLUS_OBJ(probe)
-MK_PLUS_OBJ(apply_result)
-MK_PLUS_OBJ(solver)
-MK_PLUS_OBJ(stats)
-MK_PLUS_OBJ(ast_map)
-MK_PLUS_OBJ(ast_vector)
-MK_PLUS_OBJ(fixedpoint)
-MK_PLUS_OBJ(optimize)
+MK_PLUS_OBJ_NO_REF(symbol, 0, 1)
+MK_PLUS_OBJ_NO_REF(constructor, 0, 1)
+MK_PLUS_OBJ_NO_REF(constructor_list, 0, 1)
+MK_PLUS_OBJ_NO_REF(rcf_num, 0, 1)
+MK_PLUS_OBJ(params, 0, 1)
+MK_PLUS_OBJ(param_descrs, 0, 1)
+MK_PLUS_OBJ(model, 1, 100)
+MK_PLUS_OBJ(func_interp, 0, 1)
+MK_PLUS_OBJ(func_entry, 0, 1)
+MK_PLUS_OBJ(goal, 0, 1)
+MK_PLUS_OBJ(tactic, 0, 1)
+MK_PLUS_OBJ(probe, 0, 1)
+MK_PLUS_OBJ(apply_result, 0, 1)
+MK_PLUS_OBJ(solver, 1, 5) // at most 5 dead solvers before GC
+MK_PLUS_OBJ(stats, 0, 1)
+MK_PLUS_OBJ(ast_map, 0, 1)
+MK_PLUS_OBJ(ast_vector, 0, 1)
+MK_PLUS_OBJ(fixedpoint, 1, 5)
+MK_PLUS_OBJ(optimize, 1, 5)
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/api/ml/z3native_stubs.c.pre
+++ b/src/api/ml/z3native_stubs.c.pre
@@ -294,7 +294,7 @@ static struct custom_operations Z3_ast_plus_custom_ops = {
   Z3_ast_compare_ext
 };
 
-MK_CTX_OF(ast, 0, 1)
+MK_CTX_OF(ast, 1, 100000)
 
 #define MK_PLUS_OBJ_NO_REF(X, USED, MAX)                                \
   typedef struct {                                                      \
@@ -410,7 +410,7 @@ MK_CTX_OF(ast, 0, 1)
                                                                         \
   MK_CTX_OF(X, USED, MAX)
 
-MK_PLUS_OBJ_NO_REF(symbol, 0, 1)
+MK_PLUS_OBJ_NO_REF(symbol, 1, 5000)
 MK_PLUS_OBJ_NO_REF(constructor, 0, 1)
 MK_PLUS_OBJ_NO_REF(constructor_list, 0, 1)
 MK_PLUS_OBJ_NO_REF(rcf_num, 0, 1)


### PR DESCRIPTION
at Imandra we've had issues with recent versions of OCaml, where Z3 objects wouldn't be collected and would accumulate in RAM, eventually taking multiple GBs. There's some related issues for .NET I believe. This patch uses a different version of custom blocks (OCaml heap values that wrap foreign objects, such as a Z3 solver, expr, or context) with more explicit resource limits. I've hand picked limits that seem reasonable but it's subject to discussion. Pinging @ivg if he's interested.