### PR TITLE
Fix ocaml link and load

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2013,8 +2013,9 @@ class MLComponent(Component):
                 LIBZ3 = z3linkdep
 
             LIBZ3 = LIBZ3 + ' ' + ' '.join(map(lambda x: '-cclib ' + x, LDFLAGS.split()))
+
+            stubs_install_path = '$$(%s printconf path)/stublibs' % OCAMLFIND
             if not STATIC_LIB:
-                stubs_install_path = '$$(%s printconf path)/stublibs' % OCAMLFIND
                 loadpath = '-ccopt -L' + stubs_install_path
                 dllpath = '-dllpath ' + stubs_install_path
                 LIBZ3 = LIBZ3 + ' ' + loadpath + ' ' + dllpath
@@ -2038,6 +2039,9 @@ class MLComponent(Component):
 
             out.write('\n')
             out.write('ml: %s.cma %s.cmxa %s.cmxs\n' % (z3mls, z3mls, z3mls))
+            if IS_OSX:
+                out.write('\tinstall_name_tool -id libz3.dylib %s/libz3.dylib libz3.dylib\n' % (stubs_install_path))
+                out.write('\tinstall_name_tool -change libz3.dylib %s/libz3.dylib api/ml/dllz3ml.so\n' % (stubs_install_path))                
             out.write('\n')
 
             if IS_WINDOWS:


### PR DESCRIPTION
This is the continuation of #5616 (I had some unclean workspace then). I think this would finish this issue. The test is in $5617 which is based on this PR.

Line 2015-2021, for the shared library in ubuntu, flags on where the z3 is installed are used for both the linker and the loader.

Line 2042-2044, for the shared library in osx, this is the ultimate beat-'em-up fix for all the subtleties from osx/z3/ocaml/opam.

**what's wrong with osx and z3 on osx**

One difference between osx (Mach-O) and ubuntu(ELF) on shared libraries is macos stores the id of a library inside the library. See #4840: the library id is stored in the section for `LC_ID_DYLIB`, which is `libz3.dylib`.
To our surprise, a filename with no path always means the current path (and only `~/lib`, `/usr/local/lib`, and `/usr/lib`) of any action, nothing to do with `rpath` at all. See the apple official [doc](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/UsingDynamicLibraries.html) on the dynamic library.

The id `name: libz3.dylib` in the `LC_ID_DYLIB` section of `libz3.dylib` will also propagate to any other shared or executable objects who uses it via (`-lz3 -L/path/to/libz3.dylib`), stored in their `LC_LOAD_DYLIB` section. Therefore, the stublib `dllz3ml.so` (making within z3 src via `ocamlmklib`) and executables make with `ocamlopt` will have this.

These can be checked by `otool -L <so_or_exe>` or `otool -l <so_or_exe> | grep LC_ -A2`.

The idea of #4840 is to change the id from `libz3.dylib` to `@rpath/libz3.dylib`. After the propagation from either linking or compiling, the executable will search `@rpath/libz3.dylib` under `@rpath` (which works like `rpath` in ubuntu). However,
I randomly checked several other installed libraries, including [z3 in homebrew](https://formulae.brew.sh/formula/z3), after installing, the hardcoded absolute path is in it. I am thinking using the install path may be better. Line 2042-2044 is for this.

**what's wrong with ocaml/opam/ocamlfind**

`ocamlfind` installs `libz3.dylib` into `opam-site-lib/z3` rather than `opam-site-lib/stublibs` by default. `opam` doesn't set `opam-site-lib/stublibs` in any form of `ld.conf`. `ocamlmklib -dllpath ..` is no use on osx. ... it is not related to the fix, through. Now the associated [opam] files (https://github.com/arbipher/z3/commit/a863689c47337ee24d5c3264da21551df12e2271) explicitly to point out the z3lib and to ensure it's installed into the stublib.

**another idea to fix this**
`install_name_tool` occurs at the end of building the before the installing. We can also install `libz3.dylib` first to give it an absolute path (then change `-L.` to `-L/path/to/stublibs`) , or change it before building.