### PR TITLE
fixed nullability bug in the if-then-else info

### DIFF
--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -1703,7 +1703,13 @@ seq_util::rex::info seq_util::rex::info::orelse(seq_util::rex::info const& i) co
             // unsigned ite_min_length = std::min(min_length, i.min_length);
             // lbool ite_nullable = (nullable == i.nullable ? nullable : l_undef);
             // TBD: whether ite is interpreted or not depends on whether the condition is interpreted and both branches are interpreted
-            return info(false, false, false, false, normalized && i.normalized, monadic && i.monadic, singleton && i.singleton, nullable, std::min(min_length, i.min_length), std::max(star_height, i.star_height));
+            return info(false, false, false, false, 
+                normalized && i.normalized, 
+                monadic && i.monadic, 
+                singleton && i.singleton, 
+                ((nullable == l_true && i.nullable == l_true) ? l_true : ((nullable == l_false && i.nullable == l_false) ? l_false : l_undef)),
+                std::min(min_length, i.min_length), 
+                std::max(star_height, i.star_height));
         }
         else
             return i;


### PR DESCRIPTION
The computation  of nullability info for if-then-else nodes only kept the then branch info. This caused min-length computation under complement to be wrong (returning 1 when it should have been 0). Addresses issue #5603 