### PR TITLE
Set the ocaml environment each line.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,16 +60,20 @@ jobs:
         make -j3 examples
         make -j3 test-z3
         cd ..
-    - script: eval `opam config env`; ocamlfind install z3 build/api/ml/* -dll build/libz3.*
+    - script: eval `opam config env`; ocamlfind install z3 build/api/ml/* -dll build/libz3.*        
     - script: |
         set -e
+        set -x
         cd build
-        eval `opam config env`
+        eval `opam config env`;
         make -j3
+        ocamlopt -config
         make -j3 _ex_ml_example_post_install
+        ocamlopt -config
+        ldd ./ml_example_shared
+        ./ml_example_shared
         ./ml_example_shared.byte
         ./ml_example_shared_custom.byte
-        ./ml_example_shared
         cd ..
     - template: scripts/test-z3.yml
     - template: scripts/test-regressions.yml
@@ -93,16 +97,18 @@ jobs:
         make -j3 examples
         make -j3 test-z3
         cd ..
-    - script: eval `opam config env`; ocamlfind install z3-static build/api/ml/* build/libz3-static.a
+    - script: eval `opam config env`; ocamlfind install z3-static build/api/ml/* -dll build/libz3.*
     - script: |
         set -e
+        set -x
         cd build
-        eval `opam config env`
+        eval `opam config env`; 
         make -j3
         make -j3 _ex_ml_example_post_install
+        ldd ./ml_example_static
+        ./ml_example_static
         ./ml_example_static.byte
         ./ml_example_static_custom.byte
-        ./ml_example_static
         cd ..
     - template: scripts/test-z3.yml
     - template: scripts/test-regressions.yml

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2322,7 +2322,7 @@ class MLExampleComponent(ExampleComponent):
             for mlfile in get_ml_files(self.ex_dir):
                 out.write(' %s' % os.path.join(self.to_ex_dir, mlfile))
             out.write('\n')
-            out.write('\tocamlfind %s -o %s %s %s ' % (ocaml_compiler, debug_opt, testname, opam_z3_opts))
+            out.write('\teval `opam config env` ; ocamlfind %s -o %s %s %s ' % (ocaml_compiler, debug_opt, testname, opam_z3_opts))
             for mlfile in get_ml_files(self.ex_dir):
                 out.write(' %s/%s' % (self.to_ex_dir, mlfile))
             out.write('\n')


### PR DESCRIPTION
I guess from the previous error [report](https://dev.azure.com/Z3Public/Z3/_build/results?buildId=2526&view=logs&jobId=a37fbfb7-285e-5a66-1cd0-9d89456717f9&j=a37fbfb7-285e-5a66-1cd0-9d89456717f9&t=51218d1b-06ce-5e91-ab7d-ed0bbd713769) that the script section in `azure-pipeline.yml` may be split into separate bash [processes](https://dev.azure.com/Z3Public/Z3/_build/results?buildId=2526&view=logs&j=a37fbfb7-285e-5a66-1cd0-9d89456717f9&t=51218d1b-06ce-5e91-ab7d-ed0bbd713769&l=11).

Maybe the OCaml binding is correct but the bash is broken.