### PR TITLE
fix one typo and two misunderstandings for doxygen

### DIFF
--- a/src/muz/rel/dl_mk_simple_joins.cpp
+++ b/src/muz/rel/dl_mk_simple_joins.cpp
@@ -42,7 +42,7 @@ namespace datalog {
             /**
                \brief Number of rules longer than two that contain this pair.
 
-               This number is being updated by \c add_rule and \remove rule. Even though between
+               This number is being updated by \c add_rule and \c remove_rule. Even though between
                adding a rule and removing it, the length of a rule can decrease without this pair
                being notified about it, it will surely see the decrease from length 3 to 2 which
                the threshold for rule being counted in this counter.

--- a/src/qe/nlarith_util.h
+++ b/src/qe/nlarith_util.h
@@ -96,8 +96,6 @@ namespace nlarith {
         bool create_branches(app* x, unsigned nl, expr* const* lits, branch_conditions& bc);
         /**
            \brief Extract non-linear variables from ground formula.
-           
-           \requires a ground formula.
         */
         void extract_non_linear(expr* e, ptr_vector<app>& nl_vars);
 

--- a/src/sat/smt/sat_th.h
+++ b/src/sat/smt/sat_th.h
@@ -52,7 +52,7 @@ namespace euf {
         virtual void apply_sort_cnstr(enode* n, sort* s) {}
 
         /**
-           \record that an equality has been internalized.
+           \brief Record that an equality has been internalized.
          */
         virtual void eq_internalized(enode* n) {}
 


### PR DESCRIPTION
There is no doxygen command ‘record’. The author of commit 8691ef1 forgot [brief](https://www.doxygen.nl/manual/commands.html#cmdbrief).
There is no doxygen command ‘requires’. The author was about creating a new line but the line does not add much info.
There is no doxygen command ‘remove’. The author of commit c8f9535 forgot [c](https://www.doxygen.nl/manual/commands.html#cmdc) and in the text an underscore.