### PR TITLE
Fix return type of as_int64

### DIFF
--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -834,7 +834,7 @@ namespace z3 {
 
         double as_double() const { double d = 0; is_numeral(d); return d; }
         uint64_t as_uint64() const { uint64_t r = 0; is_numeral_u64(r); return r; }
-        uint64_t as_int64() const { int64_t r = 0; is_numeral_i64(r); return r; }
+        int64_t as_int64() const { int64_t r = 0; is_numeral_i64(r); return r; }
         
 
         /**


### PR DESCRIPTION
As written, this method always casts its return value to `uint64_t`, resulting in incorrect values when the output would have been negative.