### PR TITLE
Migrate from deprecated `distutils.sysconfig` in scripts

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -15,7 +15,7 @@ import shutil
 from mk_exception import *
 import mk_genfile_common
 from fnmatch import fnmatch
-import distutils.sysconfig
+import sysconfig
 import compileall
 import subprocess
 
@@ -48,7 +48,7 @@ CXX_COMPILERS=['g++', 'clang++']
 C_COMPILERS=['gcc', 'clang']
 JAVAC=None
 JAR=None
-PYTHON_PACKAGE_DIR=distutils.sysconfig.get_python_lib(prefix=getenv("PREFIX", None))
+PYTHON_PACKAGE_DIR=sysconfig.get_path('purelib')
 BUILD_DIR='build'
 REV_BUILD_DIR='..'
 SRC_DIR='src'
@@ -1611,7 +1611,7 @@ class PythonInstallComponent(Component):
                                       os.path.join(self.pythonPkgDir,'z3'),
                                       in_prefix=self.in_prefix_install)
 
-        if PYTHON_PACKAGE_DIR != distutils.sysconfig.get_python_lib():
+        if PYTHON_PACKAGE_DIR != sysconfig.get_path('purelib'):
             out.write('\t@echo Z3Py was installed at \'%s\', make sure this directory is in your PYTHONPATH environment variable.' % PYTHON_PACKAGE_DIR)
 
     def mk_uninstall(self, out):
@@ -2692,7 +2692,7 @@ def mk_config():
             print("Python pkg dir: %s" % PYTHON_PACKAGE_DIR)
             if GPROF:
                 print('gprof:          enabled')
-            print('Python version: %s' % distutils.sysconfig.get_python_version())
+            print('Python version: %s' % sysconfig.get_python_version())
             if is_java_enabled():
                 print('JNI Bindings:   %s' % JNI_HOME)
                 print('Java Compiler:  %s' % JAVAC)

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -99,7 +99,7 @@ if (Z3_INSTALL_PYTHON_BINDINGS)
     message(STATUS "CMAKE_INSTALL_PYTHON_PKG_DIR not set. Trying to guess")
     execute_process(
       COMMAND "${PYTHON_EXECUTABLE}" "-c"
-        "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib())"
+        "import sysconfig; print(sysconfig.get_path('purelib'))"
       RESULT_VARIABLE exit_code
       OUTPUT_VARIABLE CMAKE_INSTALL_PYTHON_PKG_DIR
       OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
Python module `distutils.sysconfig` was deprecated via [PEP-632](https://www.python.org/dev/peps/pep-0632/) since Python 3.10 and will be removed in 3.12. The recommended alternative to use the `sysconfig` module. Instead of [`get_python_lib()`](https://docs.python.org/3/distutils/apiref.html#distutils.sysconfig.get_python_lib) the recommended alternative is [`get_path('purelib')`](https://docs.python.org/3/library/sysconfig.html#sysconfig.get_path).

- https://www.python.org/dev/peps/pep-0632/
- https://docs.python.org/3/distutils/apiref.html#module-distutils.sysconfig
- https://docs.python.org/3/library/sysconfig.html#module-sysconfig
- https://bugs.gentoo.org/794166

Tested with Python 3.10 on Fedora 35 x86_64