### PR TITLE
Use `Stdlib.` instead of `Pervasives.` due to deprecation

### DIFF
--- a/src/api/ml/z3.ml
+++ b/src/api/ml/z3.ml
@@ -203,7 +203,7 @@ end = struct
   let equal = (=)
 
   (* The standard comparison uses the custom operations of the C layer *)
-  let compare = Pervasives.compare
+  let compare = Stdlib.compare
 
   let translate (x:ast) (to_ctx:context) =
     if gc x = to_ctx then


### PR DESCRIPTION
Recent versions of OCaml (> 4.07) have deprecated the module **Pervasives** in favor of **Stdlib**:

- https://ocaml.org/releases/4.08/htmlman/libref/Pervasives.html

Fixes the following warning:
```
ocamlfind ocamlopt -package zarith  -I api/ml -o api/ml/z3.cmx -c ../src/api/ml/z3.ml
File "../src/api/ml/z3.ml", line 206, characters 16-34:
206 |   let compare = Pervasives.compare
                      ^^^^^^^^^^^^^^^^^^
Alert deprecated: module Stdlib.Pervasives
Use Stdlib instead.

If you need to stay compatible with OCaml < 4.07, you can use the 
stdlib-shims library: https://github.com/ocaml/stdlib-shims
```
https://dev.azure.com/Z3Public/Z3/_build/results?buildId=2801&view=logs&j=60487b59-e8f4-5a1c-7805-8cc27f5a1dc1&t=ca2a1193-486e-5e6c-d734-b6804764b299&l=76