### PR TITLE
Add access to builtin special relations (`Context::mkLinearOrder` and `Context::mkPartialOrder` ) to Java API

### DIFF
--- a/src/api/java/Context.java
+++ b/src/api/java/Context.java
@@ -4038,6 +4038,16 @@ public class Context implements AutoCloseable {
         return new BitVecExpr(this, Native.mkFpaToFpIntReal(nCtx(), rm.getNativeObject(), exp.getNativeObject(), sig.getNativeObject(), s.getNativeObject()));
     }
 
+    public <R extends Sort> FuncDecl<R> mkLinearOrder(int index, R sort) {
+        return (FuncDecl<R>) FuncDecl.create(
+                this,
+                Native.mkLinearOrder(
+                        nCtx(),
+                        index,
+                        sort.getNativeObject()
+                )
+        );
+    }
 
     /**
      * Wraps an AST.

--- a/src/api/java/Context.java
+++ b/src/api/java/Context.java
@@ -4054,6 +4054,17 @@ public class Context implements AutoCloseable {
         );
     }
 
+    public <R extends Sort> FuncDecl<BoolSort> mkPartialOrder(R sort, int index) {
+        return (FuncDecl<BoolSort>) FuncDecl.create(
+                this,
+                Native.mkPartialOrder(
+                    nCtx(),
+                    sort.getNativeObject(),
+                    index
+                )
+        );
+    }
+
     /**
      * Wraps an AST.
      * Remarks: This function is used for transitions between

--- a/src/api/java/Context.java
+++ b/src/api/java/Context.java
@@ -4038,13 +4038,18 @@ public class Context implements AutoCloseable {
         return new BitVecExpr(this, Native.mkFpaToFpIntReal(nCtx(), rm.getNativeObject(), exp.getNativeObject(), sig.getNativeObject(), s.getNativeObject()));
     }
 
-    public <R extends Sort> FuncDecl<R> mkLinearOrder(int index, R sort) {
-        return (FuncDecl<R>) FuncDecl.create(
+    /**
+     * Creates or accesses a linear order.
+     * @param index The index of the order.
+     * @param sort The sort of the order.
+     */
+    public <R extends Sort> FuncDecl<BoolSort> mkLinearOrder(R sort, int index) {
+        return (FuncDecl<BoolSort>) FuncDecl.create(
                 this,
                 Native.mkLinearOrder(
                         nCtx(),
-                        index,
-                        sort.getNativeObject()
+                        sort.getNativeObject(),
+                        index
                 )
         );
     }

--- a/src/api/java/Context.java
+++ b/src/api/java/Context.java
@@ -4039,7 +4039,7 @@ public class Context implements AutoCloseable {
     }
 
     /**
-     * Creates or accesses a linear order.
+     * Creates or a linear order.
      * @param index The index of the order.
      * @param sort The sort of the order.
      */
@@ -4054,6 +4054,11 @@ public class Context implements AutoCloseable {
         );
     }
 
+    /**
+     * Creates or a partial order.
+     * @param index The index of the order.
+     * @param sort The sort of the order.
+     */
     public <R extends Sort> FuncDecl<BoolSort> mkPartialOrder(R sort, int index) {
         return (FuncDecl<BoolSort>) FuncDecl.create(
                 this,


### PR DESCRIPTION
Adds member functions to `Context.java` to access the builtin special relations linear and partial order from the Java API, previously only exposed via corresponding Native functions.