### PR TITLE
Fix bug in coi filter

### DIFF
--- a/src/muz/transforms/dl_mk_coi_filter.cpp
+++ b/src/muz/transforms/dl_mk_coi_filter.cpp
@@ -139,24 +139,12 @@ namespace datalog {
             res = nullptr;
         }
         if (res && m_context.get_model_converter()) {
-            generic_model_converter* mc0 = alloc(generic_model_converter, m, "dl_coi");
+            horn_subsume_model_converter* mc0 = alloc(horn_subsume_model_converter, m);
             for (func_decl* f : pruned_preds) {
                 const rule_vector& rules = source.get_predicate_rules(f);
-                expr_ref_vector fmls(m);
                 for (rule * r : rules) {
-                    app* head = r->get_head();
-                    expr_ref_vector conj(m);
-                    for (unsigned j = 0; j < head->get_num_args(); ++j) {
-                        expr* arg = head->get_arg(j);
-                        if (!is_var(arg)) {
-                            conj.push_back(m.mk_eq(m.mk_var(j, arg->get_sort()), arg));
-                        }
-                    }
-                    fmls.push_back(mk_and(conj));
+                    datalog::del_rule(mc0, *r, false);
                 }
-                expr_ref fml(m);
-                fml = m.mk_or(fmls.size(), fmls.data());
-                mc0->add(f, fml);
             }
             m_context.add_model_converter(mc0);
         }


### PR DESCRIPTION

Current implementation of coi filter ignores rule bodies during model constructions phase.
For instance, when coi filter remove rule with non empty body like this one 
```
P_error(#2,#3,#1,#0,4,#5,#4) :- 
 (= (:var 4) (+ 1 (:var 1))),
 (= (:var 5) (+ 2 (:var 3))).
```
it results in a model which is incorrect in [provided sample (debug.txt)](https://github.com/Z3Prover/z3/files/8082143/debug.txt).
```
  (define-fun P_error ((x!0 Int)
   (x!1 Int)
   (x!2 Int)
   (x!3 Int)
   (x!4 Int)
   (x!5 Int)
   (x!6 Int)) Bool
    (= x!4 4))
```

The correct model is
```
  (define-fun P_error ((x!0 Int)
   (x!1 Int)
   (x!2 Int)
   (x!3 Int)
   (x!4 Int)
   (x!5 Int)
   (x!6 Int)) Bool
    (and (= x!6 (+ 1 x!2)) (= x!5 (+ 2 x!1)) (= x!4 4)))

```
