### PR TITLE
Dispose of intermediate Z3Objects created in dotnet api.

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -1682,6 +1682,7 @@ class DotNetDLLComponent(Component):
 
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <DefineConstants>$(DefineConstants);DOTNET_CORE</DefineConstants>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Z3</AssemblyName>

--- a/src/api/dotnet/ASTMap.cs
+++ b/src/api/dotnet/ASTMap.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Z3
         {
             get
             {
-                ASTVector res = new ASTVector(Context, Native.Z3_ast_map_keys(Context.nCtx, NativeObject));
+                using ASTVector res = new ASTVector(Context, Native.Z3_ast_map_keys(Context.nCtx, NativeObject));
                 return res.ToArray();
             }
         }

--- a/src/api/dotnet/ArithExpr.cs
+++ b/src/api/dotnet/ArithExpr.cs
@@ -57,30 +57,30 @@ namespace Microsoft.Z3
 
         /// <summary> Operator overloading for arithmetical operator </summary>
         public static ArithExpr operator /(ArithExpr a, int b) 
-        { 
+        {
             using var denominator = MkNum(a, b);
-            return a / denominator; 
+            return a / denominator;
         }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
         public static ArithExpr operator /(ArithExpr a, double b) 
-        { 
-            using var denomintor = MkNum(a, b);
-            return a / denominator; 
+        {
+            using var denominator = MkNum(a, b);
+            return a / denominator;
         }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
         public static ArithExpr operator /(int a, ArithExpr b) 
-        { 
+        {
             using var numerator = MkNum(b, a);
             return numerator / b;
         }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
         public static ArithExpr operator /(double a, ArithExpr b) 
-        { 
+        {
             using var numerator = MkNum(b, a);
-            return numerator / b; 
+            return numerator / b;
         }
 
         /// <summary> Operator overloading for arithmetical operator </summary>

--- a/src/api/dotnet/ArithExpr.cs
+++ b/src/api/dotnet/ArithExpr.cs
@@ -22,7 +22,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-
 namespace Microsoft.Z3
 {
     /// <summary>
@@ -41,24 +40,48 @@ namespace Microsoft.Z3
 
         #region Operators
 
-        private static ArithExpr MkNum(ArithExpr e, int i) { return (ArithExpr)e.Context.MkNumeral(i, e.Context.MkIntSort()); }        
+        private static ArithExpr MkNum(ArithExpr e, int i)
+        { 
+            using var sort = e.Context.MkIntSort();
+            return (ArithExpr)e.Context.MkNumeral(i, sort); 
+        }        
 
-        private static ArithExpr MkNum(ArithExpr e, double d) { return (ArithExpr)e.Context.MkNumeral(d.ToString(), e.Context.MkRealSort()); }        
+        private static ArithExpr MkNum(ArithExpr e, double d) 
+        { 
+            using var sort = e.Context.MkRealSort();
+            return (ArithExpr)e.Context.MkNumeral(d.ToString(), sort); 
+        }        
 
         /// <summary> Operator overloading for arithmetical division operator (over reals) </summary>
         public static ArithExpr operator /(ArithExpr a, ArithExpr b) { return a.Context.MkDiv(a, b); }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator /(ArithExpr a, int b) { return a / MkNum(a, b); }
+        public static ArithExpr operator /(ArithExpr a, int b) 
+        { 
+            using var denominator = MkNum(a, b);
+            return a / denominator; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator /(ArithExpr a, double b) { return a / MkNum(a, b); }
+        public static ArithExpr operator /(ArithExpr a, double b) 
+        { 
+            using var denomintor = MkNum(a, b);
+            return a / denominator; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator /(int a, ArithExpr b) { return MkNum(b, a) / b; }
+        public static ArithExpr operator /(int a, ArithExpr b) 
+        { 
+            using var numerator = MkNum(b, a);
+            return numerator / b;
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator /(double a, ArithExpr b) { return MkNum(b, a) / b; }
+        public static ArithExpr operator /(double a, ArithExpr b) 
+        { 
+            using var numerator = MkNum(b, a);
+            return numerator / b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
         public static ArithExpr operator -(ArithExpr a) { return a.Context.MkUnaryMinus(a); }        
@@ -67,106 +90,218 @@ namespace Microsoft.Z3
         public static ArithExpr operator -(ArithExpr a, ArithExpr b) { return a.Context.MkSub(a, b); }        
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator -(ArithExpr a, int b) { return a - MkNum(a, b); }        
+        public static ArithExpr operator -(ArithExpr a, int b) 
+        { 
+            using var rhs = MkNum(a, b);
+            return a - rhs; 
+        }        
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator -(ArithExpr a, double b) { return a - MkNum(a, b); }
+        public static ArithExpr operator -(ArithExpr a, double b) 
+        {
+            using var rhs = MkNum(a, b);
+            return a - rhs; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator -(int a, ArithExpr b) { return MkNum(b, a) - b; }
+        public static ArithExpr operator -(int a, ArithExpr b) 
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs - b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator -(double a, ArithExpr b) { return MkNum(b, a) - b; }
+        public static ArithExpr operator -(double a, ArithExpr b) 
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs - b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
         public static ArithExpr operator +(ArithExpr a, ArithExpr b) { return a.Context.MkAdd(a, b); }        
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator +(ArithExpr a, int b) { return a + MkNum(a, b); }
+        public static ArithExpr operator +(ArithExpr a, int b) 
+        { 
+            using var rhs = MkNum(a, b);
+            return a + rhs; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator +(ArithExpr a, double b) { return a + MkNum(a, b); }
+        public static ArithExpr operator +(ArithExpr a, double b)
+        { 
+            using var rhs = MkNum(a, b);
+            return a + rhs; 
+        }
  
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator +(int a, ArithExpr b) { return MkNum(b, a) + b; }
+        public static ArithExpr operator +(int a, ArithExpr b) 
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs + b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator +(double a, ArithExpr b) { return MkNum(b, a) + b; }
+        public static ArithExpr operator +(double a, ArithExpr b) 
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs + b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
         public static ArithExpr operator *(ArithExpr a, ArithExpr b) { return a.Context.MkMul(a, b); }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator *(ArithExpr a, int b) { return a * MkNum(a, b); }
+        public static ArithExpr operator *(ArithExpr a, int b) 
+        { 
+            using var rhs = MkNum(a, b);
+            return a * rhs; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator *(ArithExpr a, double b) { return a * MkNum(a, b); }
+        public static ArithExpr operator *(ArithExpr a, double b) 
+        { 
+            using var rhs = MkNum(a, b);
+            return a * rhs; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator *(int a, ArithExpr b) { return MkNum(b, a) * b; }
+        public static ArithExpr operator *(int a, ArithExpr b) 
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs * b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static ArithExpr operator *(double a, ArithExpr b) { return MkNum(b, a) * b; }
+        public static ArithExpr operator *(double a, ArithExpr b) 
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs * b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
         public static BoolExpr operator <=(ArithExpr a, ArithExpr b) { return a.Context.MkLe(a, b); }         
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator <=(ArithExpr a, int b) { return a <= MkNum(a, b); }
+        public static BoolExpr operator <=(ArithExpr a, int b) 
+        { 
+            using var rhs = MkNum(a, b);
+            return a <= rhs; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator <=(ArithExpr a, double b) { return a <= MkNum(a, b); }
+        public static BoolExpr operator <=(ArithExpr a, double b) 
+        { 
+            using var rhs = MkNum(a, b);
+            return a <= rhs; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator <=(int a, ArithExpr b) { return MkNum(b, a) <= b; }
+        public static BoolExpr operator <=(int a, ArithExpr b) 
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs <= b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator <=(double a, ArithExpr b) { return MkNum(b, a) <= b; }
+        public static BoolExpr operator <=(double a, ArithExpr b) 
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs <= b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
         public static BoolExpr operator <(ArithExpr a, ArithExpr b) { return a.Context.MkLt(a, b); }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator <(ArithExpr a, int b) { return a < MkNum(a, b); }
+        public static BoolExpr operator <(ArithExpr a, int b) 
+        {
+            using var rhs = MkNum(a, b);
+            return a < rhs; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator <(ArithExpr a, double b) { return a < MkNum(a, b); }
+        public static BoolExpr operator <(ArithExpr a, double b) 
+        { 
+            using var rhs = MkNum(a, b);
+            return a < rhs; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator <(int a, ArithExpr b) { return MkNum(b, a) < b; }
+        public static BoolExpr operator <(int a, ArithExpr b) 
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs < b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator <(double a, ArithExpr b) { return MkNum(b, a) < b; }
+        public static BoolExpr operator <(double a, ArithExpr b) 
+        {
+            using var lhs = MkNum(b, a);
+            return lhs < b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
         public static BoolExpr operator >(ArithExpr a, ArithExpr b) { return a.Context.MkGt(a, b); }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator >(ArithExpr a, int b) { return a > MkNum(a, b); }
+        public static BoolExpr operator >(ArithExpr a, int b) 
+        { 
+            using var rhs = MkNum(a, b);
+            return a > rhs; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator >(ArithExpr a, double b) { return a > MkNum(a, b); }
+        public static BoolExpr operator >(ArithExpr a, double b) 
+        { 
+            using var rhs = MkNum(a, b);
+            return a > rhs; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator >(int a, ArithExpr b) { return MkNum(b, a) > b; }
+        public static BoolExpr operator >(int a, ArithExpr b) 
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs > b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator >(double a, ArithExpr b) { return MkNum(b, a) > b; }
+        public static BoolExpr operator >(double a, ArithExpr b) 
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs > b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
         public static BoolExpr operator >=(ArithExpr a, ArithExpr b) { return a.Context.MkGe(a, b); }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator >=(ArithExpr a, int b) { return a >= MkNum(a, b); }
+        public static BoolExpr operator >=(ArithExpr a, int b) 
+        { 
+            using var rhs = MkNum(a, b);
+            return a >= rhs; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator >=(ArithExpr a, double b) { return a >= MkNum(a, b); }
+        public static BoolExpr operator >=(ArithExpr a, double b) 
+        { 
+            using var rhs = MkNum(a, b);
+            return a >= rhs; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator >=(int a, ArithExpr b) { return MkNum(b, a) >= b; }
+        public static BoolExpr operator >=(int a, ArithExpr b)
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs >= b; 
+        }
 
         /// <summary> Operator overloading for arithmetical operator </summary>
-        public static BoolExpr operator >=(double a, ArithExpr b) { return MkNum(b, a) >= b; }
+        public static BoolExpr operator >=(double a, ArithExpr b) 
+        { 
+            using var lhs = MkNum(b, a);
+            return lhs >= b; 
+        }
 
         #endregion
     }

--- a/src/api/dotnet/Context.cs
+++ b/src/api/dotnet/Context.cs
@@ -312,9 +312,18 @@ namespace Microsoft.Z3
         public EnumSort MkEnumSort(string name, params string[] enumNames)
         {
             Debug.Assert(enumNames != null);
-	    using var sname = MkSymbol(name);
-	    using var snames = MkSymbols(enumNames);
-            return new EnumSort(this, sname, snames);
+
+            using var symbol = MkSymbol(name);
+            var symbols = MkSymbols(enumNames);
+            try 
+            {
+                return new EnumSort(this, symbol, symbols);
+            }
+            finally
+            {
+                foreach (var symbol in symbols)
+                    symbol.Dispose();
+            }
         }
 
         /// <summary>
@@ -338,8 +347,8 @@ namespace Microsoft.Z3
             Debug.Assert(elemSort != null);
 
             CheckContextMatch(elemSort);
-	    using var sname = MkSymbol(name);
-            return new ListSort(this, sname, elemSort);
+            using var symbol = MkSymbol(name);
+            return new ListSort(this, symbol, elemSort);
         }
 
         /// <summary>
@@ -366,8 +375,8 @@ namespace Microsoft.Z3
         /// <param name="size">The size of the sort</param>
         public FiniteDomainSort MkFiniteDomainSort(string name, ulong size)
         {
-	    using var sname = MkSymbol(name);
-            return new FiniteDomainSort(this, sname, size);
+            using var symbol = MkSymbol(name);
+            return new FiniteDomainSort(this, symbol, size);
         }
 
 
@@ -401,10 +410,19 @@ namespace Microsoft.Z3
         /// <returns></returns>
         public Constructor MkConstructor(string name, string recognizer, string[] fieldNames = null, Sort[] sorts = null, uint[] sortRefs = null)
         {
-	    using var sname = MkSymbol(name);
-	    using var srecognizer = MkSymbol(recognizer);
-	    using var sfieldNames = MkSymbols(fieldNames);
-            return new Constructor(this, sname, srecognizer, sfieldNames, sorts, sortRefs);
+
+            using var nameSymbol = MkSymbol(name);
+            using var recognizerSymbol = MkSymbol(recognizer);
+            var fieldSymbols = MkSymbols(fieldNames);
+            try
+            {
+                return new Constructor(this, nameSymbol, recognizerSymbol, fieldSymbols, sorts, sortRefs);
+            }
+            finally
+            {
+                foreach (var fieldSymbol in fieldSymbols)
+                    fieldSymbol.Dispose();
+            }
         }
 
         /// <summary>
@@ -431,8 +449,8 @@ namespace Microsoft.Z3
             Debug.Assert(constructors.All(c => c != null));
 
             CheckContextMatch<Constructor>(constructors);
-	    using var sname = MkSymbol(name);
-            return new DatatypeSort(this, sname, constructors);
+            using var symbol = MkSymbol(name);
+            return new DatatypeSort(this, symbol, constructors);
         }
 
         /// <summary>
@@ -480,8 +498,17 @@ namespace Microsoft.Z3
             Debug.Assert(names.Length == c.Length);
             //Debug.Assert(Contract.ForAll(0, c.Length, j => c[j] != null));
             //Debug.Assert(names.All(name => name != null));
-            var snames = MkSymbols(names);
-            return MkDatatypeSorts(snames, c);
+
+            var symbols = MkSymbols(names);
+            try
+            {
+                return MkDatatypeSorts(symbols, c);
+            }
+            finally
+            {
+                foreach (var symbol in symbols)
+                    symbol.Dispose();
+            }
         }
 
         /// <summary>
@@ -542,8 +569,8 @@ namespace Microsoft.Z3
 
             CheckContextMatch<Sort>(domain);
             CheckContextMatch(range);
-	    using var sname = MkSymbol(name);
-            return new FuncDecl(this, sname, domain, range);
+            using var symbol = MkSymbol(name);
+            return new FuncDecl(this, symbol, domain, range);
         }
 
         /// <summary>
@@ -556,8 +583,8 @@ namespace Microsoft.Z3
 
             CheckContextMatch<Sort>(domain);
             CheckContextMatch(range);
-    	    using var sname = MkSymbol(name);
-            return new FuncDecl(this, sname, domain, range, true);
+            using var symbol = MkSymbol(name);
+            return new FuncDecl(this, symbol, domain, range, true);
         }
 
         /// <summary>
@@ -585,9 +612,9 @@ namespace Microsoft.Z3
 
             CheckContextMatch(domain);
             CheckContextMatch(range);
-       	    using var sname = MkSymbol(name);
+            using var symbol = MkSymbol(name);
             Sort[] q = new Sort[] { domain };
-            return new FuncDecl(this, sname, q, range);
+            return new FuncDecl(this, symbol, q, range);
         }
 
         /// <summary>
@@ -626,8 +653,8 @@ namespace Microsoft.Z3
             Debug.Assert(range != null);
 
             CheckContextMatch(range);
-       	    using var sname = MkSymbol(name);
-            return new FuncDecl(this, sname, null, range);
+            using var symbol = MkSymbol(name);
+            return new FuncDecl(this, symbol, null, range);
         }
 
         /// <summary>
@@ -694,8 +721,9 @@ namespace Microsoft.Z3
         public Expr MkConst(string name, Sort range)
         {
             Debug.Assert(range != null);
-            using var sname = MkSymbol(name);
-            return MkConst(sname, range);
+
+            using var symbol = MkSymbol(name);
+            return MkConst(symbol, range);
         }
 
         /// <summary>
@@ -736,8 +764,8 @@ namespace Microsoft.Z3
         /// </summary>
         public BoolExpr MkBoolConst(string name)
         {
-            using var sname = MkSymbol(name);
-            return (BoolExpr)MkConst(sname, BoolSort);
+            using var symbol = MkSymbol(name);
+            return (BoolExpr)MkConst(symbol, BoolSort);
         }
 
         /// <summary>
@@ -785,8 +813,9 @@ namespace Microsoft.Z3
         public BitVecExpr MkBVConst(Symbol name, uint size)
         {
             Debug.Assert(name != null);
-	    using var sort = MkBitVecSort(size);
-            return (BitVecExpr)MkConst(name, sort);	    
+
+            using var sort = MkBitVecSort(size);
+            return (BitVecExpr)MkConst(name, sort);
         }
 
         /// <summary>
@@ -794,7 +823,7 @@ namespace Microsoft.Z3
         /// </summary>
         public BitVecExpr MkBVConst(string name, uint size)
         {
-	    using var sort = MkBitVecSort(size);
+            using var sort = MkBitVecSort(size);
             return (BitVecExpr)MkConst(name, sort);
         }
         #endregion
@@ -962,11 +991,10 @@ namespace Microsoft.Z3
                 if (r == null)
                     r = t;
                 else
-                    r = MkXor(r, t);
+                    using var left = r;
+                    r = MkXor(left, t);
             }
-            if (r == null)
-                r = MkTrue();
-            return r;
+            return r ?? MkTrue();
         }
 
         /// <summary>
@@ -2041,7 +2069,8 @@ namespace Microsoft.Z3
             Debug.Assert(domain != null);
             Debug.Assert(range != null);
 
-            return (ArrayExpr)MkConst(name, MkArraySort(domain, range));
+            using var sort = MkArraySort(domain, range);
+            return (ArrayExpr)MkConst(name, sort);
         }
 
         /// <summary>
@@ -2051,9 +2080,10 @@ namespace Microsoft.Z3
         {
             Debug.Assert(domain != null);
             Debug.Assert(range != null);
-	    using var sort = MkArraySort(domain, range);
-	    using var sname = MkSymbol(name);
-            return (ArrayExpr)MkConst(sname, sort);
+
+            using var symbol = MkSymbol(name);
+            using var sort = MkArraySort(domain, range);
+            return (ArrayExpr)MkConst(symbol, sort);
         }
 
 
@@ -3051,8 +3081,8 @@ namespace Microsoft.Z3
         /// <param name="size">the size of the bit-vector</param>
         public BitVecNum MkBV(string v, uint size)
         {
-
-            return (BitVecNum)MkNumeral(v, MkBitVecSort(size));
+            using var sort = MkBitVecSort(size);
+            return (BitVecNum)MkNumeral(v, sort);
         }
 
         /// <summary>
@@ -3062,8 +3092,8 @@ namespace Microsoft.Z3
         /// <param name="size">the size of the bit-vector</param>
         public BitVecNum MkBV(int v, uint size)
         {
-
-            return (BitVecNum)MkNumeral(v, MkBitVecSort(size));
+            using var sort = MkBitVecSort(size);
+            return (BitVecNum)MkNumeral(v, sort);
         }
 
         /// <summary>
@@ -3073,8 +3103,8 @@ namespace Microsoft.Z3
         /// <param name="size">the size of the bit-vector</param>
         public BitVecNum MkBV(uint v, uint size)
         {
-
-            return (BitVecNum)MkNumeral(v, MkBitVecSort(size));
+            using var sort = MkBitVecSort(size);
+            return (BitVecNum)MkNumeral(v, sort);
         }
 
         /// <summary>
@@ -3084,8 +3114,8 @@ namespace Microsoft.Z3
         /// <param name="size">the size of the bit-vector</param>
         public BitVecNum MkBV(long v, uint size)
         {
-
-            return (BitVecNum)MkNumeral(v, MkBitVecSort(size));
+            using var sort = MkBitVecSort(size);
+            return (BitVecNum)MkNumeral(v, sort);
         }
 
         /// <summary>
@@ -3095,8 +3125,8 @@ namespace Microsoft.Z3
         /// <param name="size">the size of the bit-vector</param>
         public BitVecNum MkBV(ulong v, uint size)
         {
-
-            return (BitVecNum)MkNumeral(v, MkBitVecSort(size));
+            using var sort = MkBitVecSort(size);
+            return (BitVecNum)MkNumeral(v, sort);
         }
 
         /// <summary>
@@ -3343,7 +3373,7 @@ namespace Microsoft.Z3
             uint cd = AST.ArrayLength(decls);
             if (csn != cs || cdn != cd)
                 throw new Z3Exception("Argument size mismatch");
-            ASTVector assertions = new ASTVector(this, Native.Z3_parse_smtlib2_string(nCtx, str,
+            using ASTVector assertions = new ASTVector(this, Native.Z3_parse_smtlib2_string(nCtx, str,
                 AST.ArrayLength(sorts), Symbol.ArrayToNative(sortNames), AST.ArrayToNative(sorts),
                 AST.ArrayLength(decls), Symbol.ArrayToNative(declNames), AST.ArrayToNative(decls)));
             return assertions.ToBoolExprArray();
@@ -3362,7 +3392,7 @@ namespace Microsoft.Z3
             uint cd = AST.ArrayLength(decls);
             if (csn != cs || cdn != cd)
                 throw new Z3Exception("Argument size mismatch");
-            ASTVector assertions = new ASTVector(this, Native.Z3_parse_smtlib2_file(nCtx, fileName,
+            using ASTVector assertions = new ASTVector(this, Native.Z3_parse_smtlib2_file(nCtx, fileName,
                 AST.ArrayLength(sorts), Symbol.ArrayToNative(sortNames), AST.ArrayToNative(sorts),
                 AST.ArrayLength(decls), Symbol.ArrayToNative(declNames), AST.ArrayToNative(decls)));
             return assertions.ToBoolExprArray();
@@ -3847,8 +3877,8 @@ namespace Microsoft.Z3
         /// <seealso cref="MkSolver(Symbol)"/>
         public Solver MkSolver(string logic)
         {
-	    using var slogic = MkSymbol(logic);
-            return MkSolver(slogic);
+            using var symbol = MkSymbol(logic);
+            return MkSolver(symbol);
         }
 
         /// <summary>

--- a/src/api/dotnet/Context.cs
+++ b/src/api/dotnet/Context.cs
@@ -18,10 +18,10 @@ Notes:
 --*/
 
 using System;
-using System.Diagnostics;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Z3
 {
@@ -202,7 +202,7 @@ namespace Microsoft.Z3
         /// </summary>
         public UninterpretedSort MkUninterpretedSort(string str)
         {
-	    using var sym = MkSymbol(str);
+            using var sym = MkSymbol(str);
             return MkUninterpretedSort(sym);
         }
 
@@ -314,7 +314,7 @@ namespace Microsoft.Z3
             Debug.Assert(enumNames != null);
 
             var enumSymbols = MkSymbols(enumNames);
-            try 
+            try
             {
                 using var symbol = MkSymbol(name);
                 return new EnumSort(this, symbol, enumSymbols);
@@ -991,8 +991,8 @@ namespace Microsoft.Z3
                 if (r == null)
                     r = t;
                 else
-                    using(r);
-                    r = MkXor(r, t);
+                    using (r)
+                        r = MkXor(r, t);
             }
             return r ?? MkTrue();
         }
@@ -4967,16 +4967,16 @@ namespace Microsoft.Z3
             Fixedpoint_DRQ.Clear(this);
             Optimize_DRQ.Clear(this);
 
-	    if (m_boolSort != null) m_boolSort.Dispose();
-	    if (m_intSort != null) m_intSort.Dispose();
-	    if (m_realSort != null) m_realSort.Dispose();
-	    if (m_stringSort != null) m_stringSort.Dispose();
-	    if (m_charSort != null) m_charSort.Dispose();
+            if (m_boolSort != null) m_boolSort.Dispose();
+            if (m_intSort != null) m_intSort.Dispose();
+            if (m_realSort != null) m_realSort.Dispose();
+            if (m_stringSort != null) m_stringSort.Dispose();
+            if (m_charSort != null) m_charSort.Dispose();
             m_boolSort = null;
             m_intSort = null;
             m_realSort = null;
             m_stringSort = null;
-	    m_charSort = null;
+            m_charSort = null;
             if (refCount == 0 && m_ctx != IntPtr.Zero)
             {
                 m_n_err_handler = null;

--- a/src/api/dotnet/Context.cs
+++ b/src/api/dotnet/Context.cs
@@ -985,16 +985,15 @@ namespace Microsoft.Z3
             Debug.Assert(ts != null);
             Debug.Assert(ts.All(a => a != null));
             CheckContextMatch<BoolExpr>(ts);
-            BoolExpr r = null;
-            foreach (var t in ts)
-            {
-                if (r == null)
-                    r = t;
-                else
-                    using (r)
-                        r = MkXor(r, t);
-            }
-            return r ?? MkTrue();
+
+            return ts.Any()
+                ? ts
+                    .Aggregate(MkFalse(), (r, t) =>
+                    {
+                        using (r)
+                            return MkXor(r, t);
+                    })
+                : MkTrue();
         }
 
         /// <summary>

--- a/src/api/dotnet/Context.cs
+++ b/src/api/dotnet/Context.cs
@@ -313,16 +313,16 @@ namespace Microsoft.Z3
         {
             Debug.Assert(enumNames != null);
 
-            using var symbol = MkSymbol(name);
-            var symbols = MkSymbols(enumNames);
+            var enumSymbols = MkSymbols(enumNames);
             try 
             {
-                return new EnumSort(this, symbol, symbols);
+                using var symbol = MkSymbol(name);
+                return new EnumSort(this, symbol, enumSymbols);
             }
             finally
             {
-                foreach (var symbol in symbols)
-                    symbol.Dispose();
+                foreach (var enumSymbol in enumSymbols)
+                    enumSymbol.Dispose();
             }
         }
 
@@ -991,8 +991,8 @@ namespace Microsoft.Z3
                 if (r == null)
                     r = t;
                 else
-                    using var left = r;
-                    r = MkXor(left, t);
+                    using(r);
+                    r = MkXor(r, t);
             }
             return r ?? MkTrue();
         }

--- a/src/api/dotnet/DatatypeSort.cs
+++ b/src/api/dotnet/DatatypeSort.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Z3
                 FuncDecl[][] res = new FuncDecl[n][];
                 for (uint i = 0; i < n; i++)
                 {
-                    FuncDecl fd = new FuncDecl(Context, Native.Z3_get_datatype_sort_constructor(Context.nCtx, NativeObject, i));
+                    using FuncDecl fd = new FuncDecl(Context, Native.Z3_get_datatype_sort_constructor(Context.nCtx, NativeObject, i));
                     uint ds = fd.DomainSize;
                     FuncDecl[] tmp = new FuncDecl[ds];
                     for (uint j = 0; j < ds; j++)

--- a/src/api/dotnet/EnumSort.cs
+++ b/src/api/dotnet/EnumSort.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Z3
         /// <returns></returns>
         public Expr Const(uint inx)
         {
-            return Context.MkApp(ConstDecl(inx));
+            using var decl = ConstDecl(inx);
+            return Context.MkApp(decl);
         }
 
         /// <summary>

--- a/src/api/dotnet/Fixedpoint.cs
+++ b/src/api/dotnet/Fixedpoint.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Z3
             get
             {
 
-                ASTVector av = new ASTVector(Context, Native.Z3_fixedpoint_get_rules(Context.nCtx, NativeObject));
+                using ASTVector av = new ASTVector(Context, Native.Z3_fixedpoint_get_rules(Context.nCtx, NativeObject));
                 return av.ToBoolExprArray();
             }
         }
@@ -268,7 +268,7 @@ namespace Microsoft.Z3
             get
             {
 
-                ASTVector av = new ASTVector(Context, Native.Z3_fixedpoint_get_assertions(Context.nCtx, NativeObject));
+                using ASTVector av = new ASTVector(Context, Native.Z3_fixedpoint_get_assertions(Context.nCtx, NativeObject));
                 return av.ToBoolExprArray();
             }
         }
@@ -292,7 +292,7 @@ namespace Microsoft.Z3
         /// </summary>                
         public BoolExpr[] ParseFile(string file)
         {
-            ASTVector av = new ASTVector(Context, Native.Z3_fixedpoint_from_file(Context.nCtx, NativeObject, file));
+            using ASTVector av = new ASTVector(Context, Native.Z3_fixedpoint_from_file(Context.nCtx, NativeObject, file));
             return av.ToBoolExprArray();
         }
 
@@ -301,7 +301,7 @@ namespace Microsoft.Z3
         /// </summary>
         public BoolExpr[] ParseString(string s)
         {
-            ASTVector av = new ASTVector(Context, Native.Z3_fixedpoint_from_string(Context.nCtx, NativeObject, s));
+            using ASTVector av = new ASTVector(Context, Native.Z3_fixedpoint_from_string(Context.nCtx, NativeObject, s));
             return av.ToBoolExprArray();
         }
 

--- a/src/api/dotnet/Goal.cs
+++ b/src/api/dotnet/Goal.cs
@@ -203,8 +203,8 @@ namespace Microsoft.Z3
         /// <remarks>Essentially invokes the `simplify' tactic on the goal.</remarks>
         public Goal Simplify(Params p = null)
         {
-            Tactic t = Context.MkTactic("simplify");
-            ApplyResult res = t.Apply(this, p);
+            using Tactic t = Context.MkTactic("simplify");
+            using ApplyResult res = t.Apply(this, p);
 
             if (res.NumSubgoals == 0)
                 throw new Z3Exception("No subgoals");

--- a/src/api/dotnet/Microsoft.Z3.csproj.in
+++ b/src/api/dotnet/Microsoft.Z3.csproj.in
@@ -32,6 +32,8 @@
 
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
+
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <!-- Code contract & signing properties -->

--- a/src/api/dotnet/Model.cs
+++ b/src/api/dotnet/Model.cs
@@ -87,7 +87,8 @@ namespace Microsoft.Z3
                         if (Native.Z3_is_as_array(Context.nCtx, n) == 0)
                             throw new Z3Exception("Argument was not an array constant");
                         IntPtr fd = Native.Z3_get_as_array_func_decl(Context.nCtx, n);
-                        return FuncInterp(new FuncDecl(Context, fd));
+                        using var decl = new FuncDecl(Context, fd);
+                        return FuncInterp(decl);
                     }
                 }
                 else
@@ -241,7 +242,7 @@ namespace Microsoft.Z3
         /// Evaluate expression to a double, assuming it is a numeral already.
         /// </summary>
         public double Double(Expr t) {
-            var r = Eval(t, true);
+            using var r = Eval(t, true);
             return Native.Z3_get_numeral_double(Context.nCtx, r.NativeObject);
         }
 
@@ -283,7 +284,7 @@ namespace Microsoft.Z3
         {
             Debug.Assert(s != null);
 
-            ASTVector av = new ASTVector(Context, Native.Z3_model_get_sort_universe(Context.nCtx, NativeObject, s.NativeObject));            
+            using ASTVector av = new ASTVector(Context, Native.Z3_model_get_sort_universe(Context.nCtx, NativeObject, s.NativeObject));            
             return av.ToExprArray();
         }
 

--- a/src/api/dotnet/Optimize.cs
+++ b/src/api/dotnet/Optimize.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Z3
         public Handle AssertSoft(BoolExpr constraint, uint weight, string group)
         {
             Context.CheckContextMatch(constraint);
-            Symbol s = Context.MkSymbol(group);
+            using Symbol s = Context.MkSymbol(group);
             return new Handle(this, Native.Z3_optimize_assert_soft(Context.nCtx, NativeObject, constraint.NativeObject, weight.ToString(), s.NativeObject));
         }
 
@@ -289,7 +289,7 @@ namespace Microsoft.Z3
             get
             {
 
-                ASTVector core = new ASTVector(Context, Native.Z3_optimize_get_unsat_core(Context.nCtx, NativeObject));                
+                using ASTVector core = new ASTVector(Context, Native.Z3_optimize_get_unsat_core(Context.nCtx, NativeObject));                
                 return core.ToBoolExprArray();
             }
         }
@@ -337,7 +337,7 @@ namespace Microsoft.Z3
         /// </summary>            
         private Expr[] GetLowerAsVector(uint index)
         {
-            ASTVector v = new ASTVector(Context, Native.Z3_optimize_get_lower_as_vector(Context.nCtx, NativeObject, index));
+            using ASTVector v = new ASTVector(Context, Native.Z3_optimize_get_lower_as_vector(Context.nCtx, NativeObject, index));
             return v.ToExprArray();
         }
 
@@ -347,7 +347,7 @@ namespace Microsoft.Z3
         /// </summary>            
         private Expr[] GetUpperAsVector(uint index)
         {
-            ASTVector v = new ASTVector(Context, Native.Z3_optimize_get_upper_as_vector(Context.nCtx, NativeObject, index));
+            using ASTVector v = new ASTVector(Context, Native.Z3_optimize_get_upper_as_vector(Context.nCtx, NativeObject, index));
             return v.ToExprArray();
         }
 
@@ -396,7 +396,7 @@ namespace Microsoft.Z3
             get
             {
 
-                ASTVector assertions = new ASTVector(Context, Native.Z3_optimize_get_assertions(Context.nCtx, NativeObject));
+                using ASTVector assertions = new ASTVector(Context, Native.Z3_optimize_get_assertions(Context.nCtx, NativeObject));
                 return assertions.ToBoolExprArray();
             }
         }
@@ -409,7 +409,7 @@ namespace Microsoft.Z3
             get
             {
 
-                ASTVector objectives = new ASTVector(Context, Native.Z3_optimize_get_objectives(Context.nCtx, NativeObject));
+                using ASTVector objectives = new ASTVector(Context, Native.Z3_optimize_get_objectives(Context.nCtx, NativeObject));
                 return objectives.ToExprArray();
             }
         }

--- a/src/api/dotnet/RatNum.cs
+++ b/src/api/dotnet/RatNum.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Z3
         {
             get
             {
-                IntNum n = Numerator;
+                using IntNum n = Numerator;
                 return BigInteger.Parse(n.ToString());
             }
         }
@@ -74,7 +74,7 @@ namespace Microsoft.Z3
         {
             get
             {
-                IntNum n = Denominator;
+                using IntNum n = Denominator;
                 return BigInteger.Parse(n.ToString());
             }
         }

--- a/src/api/dotnet/Solver.cs
+++ b/src/api/dotnet/Solver.cs
@@ -58,43 +58,92 @@ namespace Microsoft.Z3
 	/// <summary>
 	/// Sets parameter on the solver
 	/// </summary>
-	public void Set(string name, bool value) { Parameters = Context.MkParams().Add(name, value); }
+	public void Set(string name, bool value) 
+    { 
+        using var parameters = Context.MkParams().Add(name, value);
+        Parameters = parameters; 
+    }
+
 	/// <summary>
 	/// Sets parameter on the solver
 	/// </summary>
-	public void Set(string name, uint value) { Parameters = Context.MkParams().Add(name, value); }
+	public void Set(string name, uint value)
+    { 
+        using var parameters = Context.MkParams().Add(name, value);
+        Parameters = parameters; 
+    }
+
 	/// <summary>
 	/// Sets parameter on the solver
 	/// </summary>
-	public void Set(string name, double value) { Parameters = Context.MkParams().Add(name, value); }
+	public void Set(string name, double value)
+    { 
+        using var parameters = Context.MkParams().Add(name, value);
+        Parameters = parameters; 
+    }
+
 	/// <summary>
 	/// Sets parameter on the solver
 	/// </summary>
-	public void Set(string name, string value) { Parameters = Context.MkParams().Add(name, value); }
+	public void Set(string name, string value)
+    {
+        using var parameters = Context.MkParams().Add(name, value);
+        Parameters = parameters; 
+    }
+
 	/// <summary>
 	/// Sets parameter on the solver
 	/// </summary>
-	public void Set(string name, Symbol value) { Parameters = Context.MkParams().Add(name, value); }
+	public void Set(string name, Symbol value)
+    {
+        using var parameters = Context.MkParams().Add(name, value);
+        Parameters = parameters; 
+    }
+
 	/// <summary>
 	/// Sets parameter on the solver
 	/// </summary>
-	public void Set(Symbol name, bool value) { Parameters = Context.MkParams().Add(name, value); }
+	public void Set(Symbol name, bool value)
+    { 
+        using var parameters = Context.MkParams().Add(name, value);
+        Parameters = parameters; 
+    }
+
 	/// <summary>
 	/// Sets parameter on the solver
 	/// </summary>
-	public void Set(Symbol name, uint value) { Parameters = Context.MkParams().Add(name, value); }
+	public void Set(Symbol name, uint value)
+    { 
+        using var parameters = Context.MkParams().Add(name, value);
+        Parameters = parameters; 
+    }
+
 	/// <summary>
 	/// Sets parameter on the solver
 	/// </summary>
-	public void Set(Symbol name, double value) { Parameters = Context.MkParams().Add(name, value); }
+	public void Set(Symbol name, double value)
+    { 
+        using var parameters = Context.MkParams().Add(name, value);
+        Parameters = parameters; 
+    }
+
 	/// <summary>
 	/// Sets parameter on the solver
 	/// </summary>
-	public void Set(Symbol name, string value) { Parameters = Context.MkParams().Add(name, value); }
+	public void Set(Symbol name, string value)
+    { 
+        using var parameters = Context.MkParams().Add(name, value);
+        Parameters = parameters; 
+    }
+
 	/// <summary>
 	/// Sets parameter on the solver
 	/// </summary>
-	public void Set(Symbol name, Symbol value) { Parameters = Context.MkParams().Add(name, value); }
+	public void Set(Symbol name, Symbol value) 
+    { 
+        using var parameters = Context.MkParams().Add(name, value);
+        Parameters = parameters; 
+    }
 
 
 
@@ -245,7 +294,7 @@ namespace Microsoft.Z3
         {
             get
             {
-                ASTVector assertions = new ASTVector(Context, Native.Z3_solver_get_assertions(Context.nCtx, NativeObject));
+                using ASTVector assertions = new ASTVector(Context, Native.Z3_solver_get_assertions(Context.nCtx, NativeObject));
                 return assertions.Size;
             }
         }
@@ -258,7 +307,7 @@ namespace Microsoft.Z3
             get
             {
 
-                ASTVector assertions = new ASTVector(Context, Native.Z3_solver_get_assertions(Context.nCtx, NativeObject));
+                using ASTVector assertions = new ASTVector(Context, Native.Z3_solver_get_assertions(Context.nCtx, NativeObject));
                 return assertions.ToBoolExprArray();
             }
         }
@@ -271,7 +320,7 @@ namespace Microsoft.Z3
             get
             {
 
-                ASTVector assertions = new ASTVector(Context, Native.Z3_solver_get_units(Context.nCtx, NativeObject));
+                using ASTVector assertions = new ASTVector(Context, Native.Z3_solver_get_units(Context.nCtx, NativeObject));
                 return assertions.ToBoolExprArray();
             }
         }
@@ -330,9 +379,9 @@ namespace Microsoft.Z3
         /// </remarks>    
         public Status Consequences(IEnumerable<BoolExpr> assumptions, IEnumerable<Expr> variables, out BoolExpr[] consequences) 
         {
-            ASTVector result = new ASTVector(Context);
-            ASTVector asms = new ASTVector(Context);
-            ASTVector vars = new ASTVector(Context);
+            using ASTVector result = new ASTVector(Context);
+            using ASTVector asms = new ASTVector(Context);
+            using ASTVector vars = new ASTVector(Context);
             foreach (var asm in assumptions) asms.Push(asm);
             foreach (var v in variables) vars.Push(v);
             Z3_lbool r = (Z3_lbool)Native.Z3_solver_get_consequences(Context.nCtx, NativeObject, asms.NativeObject, vars.NativeObject, result.NativeObject);
@@ -391,7 +440,7 @@ namespace Microsoft.Z3
             get
             {
 
-                ASTVector core = new ASTVector(Context, Native.Z3_solver_get_unsat_core(Context.nCtx, NativeObject));                
+                using ASTVector core = new ASTVector(Context, Native.Z3_solver_get_unsat_core(Context.nCtx, NativeObject));                
                 return core.ToBoolExprArray();
             }
         }
@@ -424,14 +473,14 @@ namespace Microsoft.Z3
 	/// </summary>
 	public IEnumerable<BoolExpr[]> Cube()
 	{
-             ASTVector cv = new ASTVector(Context);
+             using ASTVector cv = new ASTVector(Context);
              if (CubeVariables != null) 
                 foreach (var b in CubeVariables) cv.Push(b);
 
 	     while (true) {
                 var lvl = BacktrackLevel;
                 BacktrackLevel = uint.MaxValue;
-                ASTVector r = new ASTVector(Context, Native.Z3_solver_cube(Context.nCtx, NativeObject, cv.NativeObject, lvl));
+                using ASTVector r = new ASTVector(Context, Native.Z3_solver_cube(Context.nCtx, NativeObject, cv.NativeObject, lvl));
                 var v = r.ToBoolExprArray();
                 CubeVariables = cv.ToBoolExprArray();
                 if (v.Length == 1 && v[0].IsFalse) {


### PR DESCRIPTION
Addresses #5900 by ensuring that any intermediate objects created in the dotnet API that inherit from `Z3Object` are wrapped in a using statement so that they are deterministically disposed.