### PR TITLE
Revert "doc: update readme"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python scripts/mk_make.py -x
 then:
 
 ```bash
-mkdir build && cd build
+cd build
 nmake
 ```
 
@@ -54,7 +54,7 @@ Execute:
 
 ```bash
 python scripts/mk_make.py
-mkdir build && cd build
+cd build
 make
 sudo make install
 ```
@@ -86,7 +86,7 @@ the ``--prefix=`` command line option to change the install prefix. For example:
 
 ```bash
 python scripts/mk_make.py --prefix=/home/leo
-mkdir build && cd build
+cd build
 make
 make install
 ```


### PR DESCRIPTION
Reverts Z3Prover/z3#5898
I am sorry that the commit [https://github.com/Z3Prover/z3/pull/5898/commits/54780da90581db7d010575fb3319b17b1bce597f](url) was wrong. 
The code `python scripts/mk_make.py` has create the directory `build`, so there is no need to `mkdir build`. We can just `cd build`.