### PR TITLE
Setup.py fix dependencies

### DIFF
--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=46.4.0", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Z3 pip install requires `wheel` to build; it is a build dependency so we use `pyproject.toml` to declare it as such. Newer versions of pip will recognize this and auto-install build dependencies for the user.