### PR TITLE
Add cmake setup.py build dep

### DIFF
--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "cmake"]

--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "cmake"]
+requires = ["setuptools>=46.4.0", "wheel", "cmake"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This extends https://github.com/Z3Prover/z3/pull/5971

It additionally adds `cmake` as a pip-installable build dependency. `cmake` is a native dependency, however, pip has a very well (first party?) maintained `cmake` package. This PR would tell the unbuilt `z3-solver` `python` package to depend on pypy's `cmake`; that is, `pip install z3-solver` will `pip install cmake` during build time as needed.

This would have a few benefits:
1. It would allow the python package to be less dependent on what native tooling the user has installed on their system; that is `pip install z3-solver` will no longer fail if `cmake` is not present on the host system. This can be useful in docker, for example, among other scenarios.
2. This will ensure the user is always using a relative new version of cmake; we could also pin the version if desired but cmake maintains backwards compatibility via [cmake_minimum_required](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html) and other functions so I'm not sure why you would want to do this.

Note: This is not (necessarily) a bug fix, but a feature add. It just makes it easier to build in isolated environments, improves the chances of build success / reproducibility, and prefers using the python package manager for distributing packages the python package manager has over leaving installing it to the user natively.