### PR TITLE
Add a hacky patch so that Z3 on M1 hardware can link to libs properly

### DIFF
--- a/src/api/python/setup.py
+++ b/src/api/python/setup.py
@@ -187,14 +187,16 @@ def _copy_bins():
     # This hack lets z3 installed libs link on M1 macs; it is a hack, not a proper fix
     # @TODO: Linked issue: https://github.com/Z3Prover/z3/issues/5926
     major_minor = '.'.join(_z3_version().split('.')[:2])
+    link_name = None
     if BUILD_PLATFORM in ('win32', 'cygwin', 'win'):
-        return # TODO: When windows VMs work on M1, fill this in
+        pass # TODO: When windows VMs work on M1, fill this in
     elif BUILD_PLATFORM in ('darwin', 'osx'):
         split = LIBRARY_FILE.split('.')
         link_name = split[0] + '.' + major_minor + '.' + split[1]
     else:
         link_name = LIBRARY_FILE + '.' + major_minor
-    os.symlink(LIBRARY_FILE, os.path.join(LIBS_DIR, link_name), True)
+    if link_name:
+        os.symlink(LIBRARY_FILE, os.path.join(LIBS_DIR, link_name), True)
 
 def _copy_sources():
     """


### PR DESCRIPTION
This is a hacky patch which should ease the effect of: https://github.com/Z3Prover/z3/issues/5926

This is not a fix, it is a hacky patch. It should allow pip installed z3 to be linked to on M1 and unknown hardware (on both macOS and Linux). This will not necessarily work for all situations, but should work for some. It simply creates symlinks to pretend the library is named differently, to match the invalid SONAME in the library header.