### PR TITLE
MANIFEST.in will now include pyproject.toml

### DIFF
--- a/src/api/python/MANIFEST.in
+++ b/src/api/python/MANIFEST.in
@@ -5,3 +5,4 @@ recursive-include core *.cmake
 recursive-include core/src *
 recursive-include core/cmake *
 recursive-include core/scripts *
+include pyproject.toml


### PR DESCRIPTION
This change should ensure that even if your CI is older, the generated sdist z3 publishes to pypi should include `pyproject.toml`. This should ensure that `pyproject.toml` is distributed with the pip sdist, thus whenever `pip` builds the `z3` `wheel` it should honor build dependencies if the user's software is new enough. If their software is too outdated this just adds a couple extra bytes to the size of the package but should otherwise be ignored.

Tested via:
```
FROM alpine
RUN apk add --no-cache make g++ python3 py3-pip git
RUN pip install --upgrade pip

# Clone
RUN git clone --depth 1 https://github.com/Z3Prover/z3 /z3
WORKDIR /z3/src/api/python

# Add change
RUN echo "include pyproject.toml" >> MANIFEST.in

# Gen sdist
RUN python3 setup.py sdist
WORKDIR dist

# Build pip install from sdist to mimic pip install from pypy sdist
RUN tar -xvf *; rm -rf *.gz; mv * dir
WORKDIR dir
RUN pip install .
```