### PR TITLE
Generate bdist wheels for musllinux_1_1

### DIFF
--- a/scripts/nightly.yaml
+++ b/scripts/nightly.yaml
@@ -86,13 +86,23 @@ stages:
         artifactName: 'UbuntuDoc'
         targetPath: $(Build.ArtifactStagingDirectory)
 
-  - job: Manylinux
-    displayName: "Manylinux build"
+  - job: LinuxBuilds
+    strategy:
+      matrix:
+        manyLinux:
+          name: ManyLinux
+          image: "quay.io/pypa/manylinux2010_x86_64:latest"
+          python: "/opt/python/cp37-cp37m/bin/python"
+        muslLinux:
+          name: MuslLinux
+          image: "quay.io/pypa/musllinux_1_1_x86_64:latest"
+          python: "/opt/python/cp310-cp310/bin/python"
+    displayName: "$(name) build"
     pool:
       vmImage: "Ubuntu-18.04"
-    container: "quay.io/pypa/manylinux2010_x86_64:latest"
+    container: $(image)
     variables:
-      python: "/opt/python/cp37-cp37m/bin/python"
+      python: $(python)
     steps:
     - script: $(python) scripts/mk_unix_dist.py --nodotnet --nojava
     - script: git clone https://github.com/z3prover/z3test z3test
@@ -100,7 +110,7 @@ stages:
     - script: cp dist/*.zip $(Build.ArtifactStagingDirectory)/
     - task: PublishPipelineArtifact@0
       inputs:
-        artifactName: 'Manylinux'
+        artifactName: '$(name)Build'
         targetPath: $(Build.ArtifactStagingDirectory)
 
   - job: Windows32
@@ -396,6 +406,11 @@ stages:
         artifactName: 'Manylinux'
         targetPath: $(Agent.TempDirectory)
     - task: DownloadPipelineArtifact@2
+      displayName: 'Download MuslLinux Build'
+      inputs:
+        artifact: 'MuslLinuxBuild'
+        path: $(Agent.TempDirectory)
+    - task: DownloadPipelineArtifact@2
       inputs:
         artifactName: 'Mac'
         targetPath: $(Agent.TempDirectory)
@@ -405,13 +420,15 @@ stages:
         targetPath: $(Agent.TempDirectory)
     - script: cd $(Agent.TempDirectory); mkdir osx-x64-bin; cd osx-x64-bin; unzip ../*x64-osx*.zip
     - script: cd $(Agent.TempDirectory); mkdir osx-arm64-bin; cd osx-arm64-bin; unzip ../*arm64-osx*.zip
-    - script: cd $(Agent.TempDirectory); mkdir linux-bin; cd linux-bin; unzip ../*glibc*.zip
+    - script: cd $(Agent.TempDirectory); mkdir libc-bin; cd libc-bin; unzip ../*glibc*.zip
+    - script: cd $(Agent.TempDirectory); mkdir musl-bin; cd musl-bin; unzip ../*-linux.zip
     - script: cd $(Agent.TempDirectory); mkdir win32-bin; cd win32-bin; unzip ../*x86-win*.zip
     - script: cd $(Agent.TempDirectory); mkdir win64-bin; cd win64-bin; unzip ../*x64-win*.zip
     - script: python3 -m pip install --user -U setuptools wheel
     - script: cd src/api/python; python3 setup.py sdist
     # take a look at this PREMIUM HACK I came up with to get around the fact that the azure variable syntax overloads the bash syntax for subshells
-    - script: cd src/api/python; echo $(Agent.TempDirectory)/linux-bin/* | xargs printf 'PACKAGE_FROM_RELEASE=%s\n' | xargs -I '{}' env '{}' python3 setup.py bdist_wheel
+    - script: cd src/api/python; echo $(Agent.TempDirectory)/libc-bin/* | xargs printf 'PACKAGE_FROM_RELEASE=%s\n' | xargs -I '{}' env '{}' python3 setup.py bdist_wheel
+    - script: cd src/api/python; echo $(Agent.TempDirectory)/musl-bin/* | xargs printf 'PACKAGE_FROM_RELEASE=%s\n' | xargs -I '{}' env '{}' python3 setup.py bdist_wheel
     - script: cd src/api/python; echo $(Agent.TempDirectory)/win32-bin/* | xargs printf 'PACKAGE_FROM_RELEASE=%s\n' | xargs -I '{}' env '{}' python3 setup.py bdist_wheel
     - script: cd src/api/python; echo $(Agent.TempDirectory)/win64-bin/* | xargs printf 'PACKAGE_FROM_RELEASE=%s\n' | xargs -I '{}' env '{}' python3 setup.py bdist_wheel
     - script: cd src/api/python; echo $(Agent.TempDirectory)/osx-x64-bin/* | xargs printf 'PACKAGE_FROM_RELEASE=%s\n' | xargs -I '{}' env '{}' python3 setup.py bdist_wheel

--- a/scripts/release.yml
+++ b/scripts/release.yml
@@ -129,13 +129,23 @@ stages:
         artifactName: 'UbuntuDoc'
         targetPath: $(Build.ArtifactStagingDirectory)
 
-  - job: ManyLinuxBuild
-    displayName: "ManyLinux build"
+  - job: LinuxBuilds
+    strategy:
+      matrix:
+        manyLinux:
+          name: ManyLinux
+          image: "quay.io/pypa/manylinux2010_x86_64:latest"
+          python: "/opt/python/cp37-cp37m/bin/python"
+        muslLinux:
+          name: MuslLinux
+          image: "quay.io/pypa/musllinux_1_1_x86_64:latest"
+          python: "/opt/python/cp310-cp310/bin/python"
+    displayName: "$(name) build"
     pool:
       vmImage: "ubuntu-latest"
-    container: "quay.io/pypa/manylinux2010_x86_64:latest"
+    container: $(image)
     variables:
-      python: "/opt/python/cp37-cp37m/bin/python"
+      python: $(python)
     steps:
     - task: PythonScript@0
       displayName: Build
@@ -160,7 +170,7 @@ stages:
         targetFolder: $(Build.ArtifactStagingDirectory)
     - task: PublishPipelineArtifact@0
       inputs:
-        artifactName: 'ManyLinuxBuild'
+        artifactName: '$(name)Build'
         targetPath: $(Build.ArtifactStagingDirectory)
   
   - template: build-win-signed.yml
@@ -401,6 +411,11 @@ stages:
         artifact: 'ManyLinuxBuild'
         path: $(Agent.TempDirectory)
     - task: DownloadPipelineArtifact@2
+      displayName: 'Download MuslLinux Build'
+      inputs:
+        artifact: 'MuslLinuxBuild'
+        path: $(Agent.TempDirectory)
+    - task: DownloadPipelineArtifact@2
       displayName: 'Download Win32 Build'
       inputs:
         artifact: 'WindowsBuild-x86'
@@ -411,14 +426,16 @@ stages:
         artifact: 'WindowsBuild-x64'
         path: $(Agent.TempDirectory)
     - script: cd $(Agent.TempDirectory); mkdir osx-bin; cd osx-bin; unzip ../*osx*.zip
-    - script: cd $(Agent.TempDirectory); mkdir linux-bin; cd linux-bin; unzip ../*glibc*.zip
+    - script: cd $(Agent.TempDirectory); mkdir libc-bin; cd libc-bin; unzip ../*glibc*.zip
+    - script: cd $(Agent.TempDirectory); mkdir musl-bin; cd musl-bin; unzip ../*-linux.zip
     - script: cd $(Agent.TempDirectory); mkdir win32-bin; cd win32-bin; unzip ../*x86-win*.zip
     - script: cd $(Agent.TempDirectory); mkdir win64-bin; cd win64-bin; unzip ../*x64-win*.zip
     - script: python3 -m pip install --user -U setuptools wheel
     - script: cd src/api/python; python3 setup.py sdist
     # take a look at this PREMIUM HACK I came up with to get around the fact that the azure variable syntax overloads the bash syntax for subshells
     - script: cd src/api/python; echo $(Agent.TempDirectory)/osx-bin/* | xargs printf 'PACKAGE_FROM_RELEASE=%s\n' | xargs -I '{}' env '{}' python3 setup.py bdist_wheel
-    - script: cd src/api/python; echo $(Agent.TempDirectory)/linux-bin/* | xargs printf 'PACKAGE_FROM_RELEASE=%s\n' | xargs -I '{}' env '{}' python3 setup.py bdist_wheel
+    - script: cd src/api/python; echo $(Agent.TempDirectory)/libc-bin/* | xargs printf 'PACKAGE_FROM_RELEASE=%s\n' | xargs -I '{}' env '{}' python3 setup.py bdist_wheel
+    - script: cd src/api/python; echo $(Agent.TempDirectory)/musl-bin/* | xargs printf 'PACKAGE_FROM_RELEASE=%s\n' | xargs -I '{}' env '{}' python3 setup.py bdist_wheel
     - script: cd src/api/python; echo $(Agent.TempDirectory)/win32-bin/* | xargs printf 'PACKAGE_FROM_RELEASE=%s\n' | xargs -I '{}' env '{}' python3 setup.py bdist_wheel
     - script: cd src/api/python; echo $(Agent.TempDirectory)/win64-bin/* | xargs printf 'PACKAGE_FROM_RELEASE=%s\n' | xargs -I '{}' env '{}' python3 setup.py bdist_wheel
     - task: PublishPipelineArtifact@0

--- a/src/api/python/setup.py
+++ b/src/api/python/setup.py
@@ -250,6 +250,16 @@ class clean(_clean):
 #try: os.makedirs(os.path.join(ROOT_DIR, 'build'))
 #except OSError: pass
 
+# platform.freedesktop_os_release was added in 3.10
+os_id = ''
+if hasattr(platform, 'freedesktop_os_release'):
+    try:
+        osr = platform.freedesktop_os_release()
+        print(osr)
+        os_id = osr['ID']
+    except OSError:
+        pass
+
 if 'bdist_wheel' in sys.argv and '--plat-name' not in sys.argv:
     if RELEASE_DIR is None:
         name = get_platform()
@@ -271,13 +281,20 @@ if 'bdist_wheel' in sys.argv and '--plat-name' not in sys.argv:
         # extract the architecture of the release from the directory name
         arch = RELEASE_METADATA[1]
         distos = RELEASE_METADATA[2]
-        if distos in ('debian', 'ubuntu') or 'linux' in distos:
-            raise Exception("Linux binary distributions must be built on centos to conform to PEP 513")
+        if distos in ('debian', 'ubuntu'):
+            raise Exception(
+                "Linux binary distributions must be built on centos to conform to PEP 513 or alpine if targetting musl"
+            )
         elif distos == 'glibc':
             if arch == 'x64':
                 plat_name = 'manylinux1_x86_64'
             else:
                 plat_name = 'manylinux1_i686'
+        elif distos == 'linux' and os_id == 'alpine':
+            if arch == 'x64':
+                plat_name = 'musllinux_1_1_x86_64'
+            else:
+                plat_name = 'musllinux_1_1_i686'
         elif distos == 'win':
             if arch == 'x64':
                 plat_name = 'win_amd64'


### PR DESCRIPTION
This PR adds steps to the release scripts to package bdist wheels for musllinux, saving users of musl based distros the hassle of waiting for z3 to compile. I expect this is largely identical to the efforts of the Alpine `z3` and `py3-z3` packages but fully contained in pip instead of relying on system packages. The setup.py changes are probably the sketchiest part of this as they require Python 3.10+. I wasn't sure how big of a concern that is and the other solutions that came to mind were uglier so I left it as is, please let me know if there's a better approach. :)