### PR TITLE
Better error message for mismatching sorts in substitutions

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -8773,8 +8773,12 @@ def substitute(t, *m):
             m = m1
     if z3_debug():
         _z3_assert(is_expr(t), "Z3 expression expected")
-        _z3_assert(all([isinstance(p, tuple) and is_expr(p[0]) and is_expr(p[1]) and p[0].sort().eq(
-            p[1].sort()) for p in m]), "Z3 invalid substitution, expression pairs expected.")
+        _z3_assert(
+            all([isinstance(p, tuple) and is_expr(p[0]) and is_expr(p[1]) for p in m]),
+            "Z3 invalid substitution, expression pairs expected.")
+        _z3_assert(
+            all([p[0].sort().eq(p[1].sort()) for p in m]),
+            'Z3 invalid substitution, mismatching "from" and "to" sorts.')
     num = len(m)
     _from = (Ast * num)()
     _to = (Ast * num)()


### PR DESCRIPTION
When substituting expressions in the Z3 API, the error message in case of a sort mismatch was confusing:

```python
import z3

# x * y
expr = z3.Int('x') * z3.Int('y')

# (x * y)[z / x]
subst_expr = z3.substitute(expr, (z3.Int('x'), z3.Int('z')))

# Wrong type:
try:
    subst_expr = z3.substitute(expr, (z3.String('x'), z3.Int('z')))
except z3.z3types.Z3Exception as exc:
    print(exc)  # -> "Z3 invalid substitution, expression pairs expected."
```

In the above example, expression pairs *were* passed, only with the wrong type. This issue confused me a lot in my beginner times with Z3, and currently, it's confusing my students ;) 

This pull request leads to the, in my opinion more meaningful, error message 'Z3 invalid substitution, mismatching "from" and "to" sorts.' in that case.