### PR TITLE
Update coverage CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -76,14 +76,14 @@ jobs:
     - name: Gather coverage
       run: |
         cd ${{github.workspace}}
-        gcovr --html coverage.html --gcov-executable "llvm-cov gcov" .
+        gcovr --html coverage.html --gcov-ignore-parse-errors --gcov-executable "llvm-cov gcov" .
         cd -
 
     - name: Gather detailed coverage
       run: |
         cd ${{github.workspace}}
         mkdir cov-details
-        gcovr --html-details ${{env.COV_DETAILS_PATH}}/coverage.html --gcov-executable "llvm-cov gcov" -r `pwd`/src --object-directory `pwd`/build
+        gcovr --html-details ${{env.COV_DETAILS_PATH}}/coverage.html --gcov-ignore-parse-errors --gcov-executable "llvm-cov gcov" -r `pwd`/src --object-directory `pwd`/build
         cd -
 
     - name: Get date


### PR DESCRIPTION
Ignore errors within `gcov` when using `gcovr`, as per
https://github.com/gcovr/gcovr/issues/627.