### PR TITLE
Make high-level JS API more idiomatic/type-safe

### DIFF
--- a/src/api/js/examples/high-level/miracle-sudoku.ts
+++ b/src/api/js/examples/high-level/miracle-sudoku.ts
@@ -1,0 +1,206 @@
+import { init } from '../../build/node';
+
+import type { Solver, Arith } from '../../build/node';
+
+// solve the "miracle sudoku"
+// https://www.youtube.com/watch?v=yKf9aUIxdb4
+// most of the interesting stuff is in `solve`
+// the process is:
+// - parse the board
+// - create a Solver
+// - create a Z3.Int variable for each square
+// - for known cells, add a constraint which says the variable for that cell equals that value
+// - add the usual uniqueness constraints
+// - add the special "miracle sudoku" constraints
+// - call `await solver.check()`
+// - if the result is "sat", the board is solvable
+//   - call `solver.model()` to get a model, i.e. a concrete assignment of variables which satisfies the model
+//   - for each variable, call `model.evaluate(v)` to recover its value
+
+function parseSudoku(str: string) {
+  // derive a list of { row, col, val } records, one for each specified position
+  // from a string like
+  // ....1..3.
+  // ..9..5..8
+  // 8.4..6.25
+  // ......6..
+  // ..8..4...
+  // 12..87...
+  // 3..9..2..
+  // .65..8...
+  // 9........
+
+  let cells = [];
+
+  let lines = str.trim().split('\n');
+  if (lines.length !== 9) {
+    throw new Error(`expected 9 lines, got ${lines.length}`);
+  }
+  for (let row = 0; row < 9; ++row) {
+    let line = lines[row].trim();
+    if (line.length !== 9) {
+      throw new Error(`expected line of length 9, got length ${line.length}`);
+    }
+    for (let col = 0; col < 9; ++col) {
+      let char = line[col];
+      if (char === '.') {
+        continue;
+      }
+      if (char < '1' || char > '9') {
+        throw new Error(`expected digit or '.', got ${char}`);
+      }
+      cells.push({ row, col, value: char.codePointAt(0)! - 48 /* '0' */ });
+    }
+  }
+  return cells;
+}
+
+(async () => {
+  let { Context, em } = await init();
+
+  // if you use 'main' as your context name, you won't need to name it in types like Solver
+  // if you're creating multiple contexts, give them different names
+  // then the type system will prevent you from mixing them
+  let Z3 = Context('main');
+
+  function addSudokuConstraints(solver: Solver, cells: Arith[][]) {
+    // the usual constraints:
+
+    // every square is between 1 and 9
+    for (let row of cells) {
+      for (let cell of row) {
+        solver.add(cell.ge(1));
+        solver.add(cell.le(9));
+      }
+    }
+
+    // values in each row are unique
+    for (let row of cells) {
+      solver.add(Z3.Distinct(...row));
+    }
+
+    // values in each column are unique
+    for (let col = 0; col < 9; ++col) {
+      solver.add(Z3.Distinct(...cells.map(row => row[col])));
+    }
+
+    // values in each 3x3 subdivision are unique
+    for (let suprow = 0; suprow < 3; ++suprow) {
+      for (let supcol = 0; supcol < 3; ++supcol) {
+        let square = [];
+        for (let row = 0; row < 3; ++row) {
+          for (let col = 0; col < 3; ++col) {
+            square.push(cells[suprow * 3 + row][supcol * 3 + col]);
+          }
+        }
+        solver.add(Z3.Distinct(...square));
+      }
+    }
+  }
+
+  function applyOffsets(x: number, y: number, offsets: [number, number][]) {
+    let out = [];
+    for (let offset of offsets) {
+      let rx = x + offset[0];
+      let ry = y + offset[1];
+      if (rx >= 0 && rx < 9 && ry >= 0 && ry < 8) {
+        out.push({ x: rx, y: ry });
+      }
+    }
+    return out;
+  }
+
+  function addMiracleConstraints(s: Solver, cells: Arith[][]) {
+    // the special "miracle sudoku" constraints
+
+    // any two cells separated by a knight's move or a kings move cannot contain the same digit
+    let knightOffets: [number, number][] = [
+      [1, -2],
+      [2, -1],
+      [2, 1],
+      [1, 2],
+      [-1, 2],
+      [-2, 1],
+      [-2, -1],
+      [-1, -2],
+    ];
+    let kingOffsets: [number, number][] = [
+      [1, 1],
+      [1, -1],
+      [-1, 1],
+      [-1, -1],
+    ]; // skipping immediately adjacent because those are covered by normal sudoku rules
+    let allOffets = [...knightOffets, ...kingOffsets];
+    for (let row = 0; row < 9; ++row) {
+      for (let col = 0; col < 9; ++col) {
+        for (let { x, y } of applyOffsets(row, col, allOffets)) {
+          s.add(cells[row][col].neq(cells[x][y]));
+        }
+      }
+    }
+
+    // any two orthogonally adjacent cells cannot contain consecutive digits
+    let orthoOffsets: [number, number][] = [
+      [0, 1],
+      [0, -1],
+      [1, 0],
+      [-1, 0],
+    ];
+    for (let row = 0; row < 9; ++row) {
+      for (let col = 0; col < 9; ++col) {
+        for (let { x, y } of applyOffsets(row, col, orthoOffsets)) {
+          s.add(cells[row][col].sub(cells[x][y]).neq(1));
+        }
+      }
+    }
+  }
+
+  async function solve(str: string) {
+    let solver = new Z3.Solver();
+    let cells = Array.from({ length: 9 }, (_, col) => Array.from({ length: 9 }, (_, row) => Z3.Int.const(`c_${row}_${col}`)));
+    for (let { row, col, value } of parseSudoku(str)) {
+      solver.add(cells[row][col].eq(value));
+    }
+    addSudokuConstraints(solver, cells);
+    addMiracleConstraints(solver, cells); // remove this line to solve normal sudokus
+
+    let start = Date.now();
+    console.log('starting... this may take a minute or two');
+    let check = await solver.check();
+    console.log(`problem was determined to be ${check} in ${Date.now() - start} ms`);
+    if (check === 'sat') {
+      let model = solver.model();
+      let str = '';
+      for (let row = 0; row < 9; ++row) {
+        for (let col = 0; col < 9; ++col) {
+          str += model.eval(cells[row][col]).toString() + (col === 8 ? '' : ' ');
+          if (col === 2 || col === 5) {
+            str += ' ';
+          }
+        }
+        str += '\n';
+        if (row === 2 || row === 5) {
+          str += '\n';
+        }
+      }
+      console.log(str);
+    }
+  }
+
+  await solve(`
+.........
+.........
+.........
+.........
+..1......
+......2..
+.........
+.........
+.........
+`);
+
+  em.PThread.terminateAllThreads();
+})().catch(e => {
+  console.error('error', e);
+  process.exit(1);
+});

--- a/src/api/js/src/high-level/high-level.test.ts
+++ b/src/api/js/src/high-level/high-level.test.ts
@@ -96,7 +96,7 @@ describe('high-level', () => {
   });
 
   it('proves x = y implies g(x) = g(y)', async () => {
-    const { Solver, Int, Function, Implies, Not } = new api.Context('main');
+    const { Solver, Int, Function, Implies, Not } = api.Context('main');
     const solver = new Solver();
 
     const sort = Int.sort();
@@ -110,7 +110,7 @@ describe('high-level', () => {
   });
 
   it('disproves x = y implies g(g(x)) = g(y)', async () => {
-    const { Solver, Int, Function, Implies, Not } = new api.Context('main');
+    const { Solver, Int, Function, Implies, Not } = api.Context('main');
     const solver = new Solver();
 
     const sort = Int.sort();
@@ -123,10 +123,10 @@ describe('high-level', () => {
   });
 
   it('checks that Context matches', () => {
-    const c1 = new api.Context('context');
-    const c2 = new api.Context('context');
-    const c3 = new api.Context('foo');
-    const c4 = new api.Context('bar');
+    const c1 = api.Context('context');
+    const c2 = api.Context('context');
+    const c3 = api.Context('foo');
+    const c4 = api.Context('bar');
 
     // Contexts with the same name don't do type checking during compile time.
     // We need to check for different context dynamically
@@ -144,7 +144,7 @@ describe('high-level', () => {
 
   describe('booleans', () => {
     it("proves De Morgan's Law", async () => {
-      const { Bool, Not, And, Eq, Or } = new api.Context('main');
+      const { Bool, Not, And, Eq, Or } = api.Context('main');
       const [x, y] = [Bool.const('x'), Bool.const('y')];
 
       const conjecture = Eq(Not(And(x, y)), Or(Not(x), Not(y)));
@@ -155,7 +155,7 @@ describe('high-level', () => {
 
   describe('ints', () => {
     it('finds a model', async () => {
-      const { Solver, Int, isIntVal } = new api.Context('main');
+      const { Solver, Int, isIntVal } = api.Context('main');
       const solver = new Solver();
       const x = Int.const('x');
       const y = Int.const('y');
@@ -225,7 +225,7 @@ describe('high-level', () => {
         541972386
       `);
 
-      const { Solver, Int, Distinct, isIntVal } = new api.Context('main');
+      const { Solver, Int, Distinct, isIntVal } = api.Context('main');
 
       const cells: Arith[][] = [];
       // 9x9 matrix of integer variables
@@ -308,7 +308,7 @@ describe('high-level', () => {
 
   describe('reals', () => {
     it('can work with numerals', async () => {
-      const { Real, And } = new api.Context('main');
+      const { Real, And } = api.Context('main');
       const n1 = Real.val('1/2');
       const n2 = Real.val('0.5');
       const n3 = Real.val(0.5);
@@ -322,7 +322,7 @@ describe('high-level', () => {
     it('can do non-linear arithmetic', async () => {
       api.setParam('pp.decimal', true);
       api.setParam('pp.decimal_precision', 20);
-      const { Real, Solver, isReal, isRealVal } = new api.Context('main');
+      const { Real, Solver, isReal, isRealVal } = api.Context('main');
       const x = Real.const('x');
       const y = Real.const('y');
       const z = Real.const('z');
@@ -344,7 +344,7 @@ describe('high-level', () => {
 
   describe('bitvectors', () => {
     it('can do simple proofs', async () => {
-      const { BitVec, Concat, Implies, isBitVecVal } = new api.Context('main');
+      const { BitVec, Concat, Implies, isBitVecVal } = api.Context('main');
 
       const x = BitVec.const('x', 32);
 
@@ -363,7 +363,7 @@ describe('high-level', () => {
     });
 
     it('finds x and y such that: x ^ y - 103 == x * y', async () => {
-      const { BitVec, isBitVecVal } = new api.Context('main');
+      const { BitVec, isBitVecVal } = api.Context('main');
 
       const x = BitVec.const('x', 32);
       const y = BitVec.const('y', 32);
@@ -382,7 +382,7 @@ describe('high-level', () => {
 
   describe('Solver', () => {
     it('can use push and pop', async () => {
-      const { Solver, Int } = new api.Context('main');
+      const { Solver, Int } = api.Context('main');
       const solver = new Solver();
       const x = Int.const('x');
 
@@ -403,7 +403,7 @@ describe('high-level', () => {
     });
 
     it('can find multiple solutions', async () => {
-      const { Int, isIntVal } = new api.Context('main');
+      const { Int, isIntVal } = api.Context('main');
 
       const x = Int.const('x');
 
@@ -431,7 +431,7 @@ describe('high-level', () => {
 
   describe('AstVector', () => {
     it('can use basic methods', async () => {
-      const { Solver, AstVector, Int } = new api.Context('main');
+      const { Solver, AstVector, Int } = api.Context('main');
       const solver = new Solver();
 
       const vector = new AstVector<Arith>();

--- a/src/api/js/src/high-level/high-level.test.ts
+++ b/src/api/js/src/high-level/high-level.test.ts
@@ -166,7 +166,7 @@ describe('high-level', () => {
       expect(await solver.check()).toStrictEqual('sat');
 
       const model = solver.model();
-      expect(model.length).toStrictEqual(2);
+      expect(model.length()).toStrictEqual(2);
 
       for (const decl of model) {
         expect(decl.arity()).toStrictEqual(0);
@@ -175,8 +175,8 @@ describe('high-level', () => {
       const yValueExpr = model.get(y);
       assert(isIntVal(xValueExpr));
       assert(isIntVal(yValueExpr));
-      const xValue = xValueExpr.value;
-      const yValue = yValueExpr.value;
+      const xValue = xValueExpr.value();
+      const yValue = yValueExpr.value();
       assert(typeof xValue === 'bigint');
       assert(typeof yValue === 'bigint');
       expect(xValue).toBeGreaterThanOrEqual(1n);
@@ -293,7 +293,7 @@ describe('high-level', () => {
         for (let j = 0; j < 9; j++) {
           const cell = model.eval(cells[i][j]);
           assert(isIntVal(cell));
-          const value = cell.value;
+          const value = cell.value();
           assert(typeof value === 'bigint');
           expect(value).toBeGreaterThanOrEqual(0n);
           expect(value).toBeLessThanOrEqual(9n);
@@ -354,7 +354,7 @@ describe('high-level', () => {
       assert(isBitVecVal(sSol) && isBitVecVal(uSol));
       let v = sSol.asSignedValue();
       expect(v - 10n <= 0n === v <= 10n).toStrictEqual(true);
-      v = uSol.value;
+      v = uSol.value();
       expect(v - 10n <= 0n === v <= 10n).toStrictEqual(true);
 
       const y = BitVec.const('y', 32);
@@ -413,7 +413,7 @@ describe('high-level', () => {
         .map(solution => {
           const expr = solution.eval(x);
           assert(isIntVal(expr));
-          return expr.value;
+          return expr.value();
         })
         .sort((a, b) => {
           assert(a !== null && b !== null && typeof a === 'bigint' && typeof b === 'bigint');
@@ -439,7 +439,7 @@ describe('high-level', () => {
         vector.push(Int.const(`int__${i}`));
       }
 
-      const length = vector.length;
+      const length = vector.length();
       for (let i = 0; i < length; i++) {
         solver.add(vector.get(i).gt(1));
       }

--- a/src/api/js/src/high-level/high-level.ts
+++ b/src/api/js/src/high-level/high-level.ts
@@ -456,7 +456,15 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
     function from(value: CoercibleToExpr<Name>): AnyExpr<Name> {
       if (typeof value === 'boolean') {
         return Bool.val(value);
-      } else if (typeof value === 'number' || isCoercibleRational(value)) {
+      } else if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+          throw new Error(`cannot represent infinity/NaN (got ${value})`);
+        }
+        if (Math.floor(value) === value) {
+          return Int.val(value);
+        }
+        return Real.val(value);
+      } else if (isCoercibleRational(value)) {
         return Real.val(value);
       } else if (typeof value === 'bigint') {
         return Int.val(value);

--- a/src/api/js/src/high-level/high-level.ts
+++ b/src/api/js/src/high-level/high-level.ts
@@ -62,13 +62,10 @@ import {
   Model,
   Probe,
   RatNum,
-  sat,
   Solver,
   Sort,
   SortToExprMap,
   Tactic,
-  unknown,
-  unsat,
   Z3Error,
   Z3HighLevel,
 } from './types';
@@ -469,11 +466,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       assert(false);
     }
 
-    async function solve(...assertions: Bool<Name>[]): Promise<Model<Name> | typeof unsat | typeof unknown> {
+    async function solve(...assertions: Bool<Name>[]): Promise<Model<Name> | 'unsat' | 'unknown'> {
       const solver = new ctx.Solver();
       solver.add(...assertions);
       const result = await solver.check();
-      if (result === sat) {
+      if (result === 'sat') {
         return solver.model();
       }
       return result;
@@ -955,11 +952,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         );
         switch (result) {
           case Z3_lbool.Z3_L_FALSE:
-            return unsat;
+            return 'unsat';
           case Z3_lbool.Z3_L_TRUE:
-            return sat;
+            return 'sat';
           case Z3_lbool.Z3_L_UNDEF:
-            return unknown;
+            return 'unknown';
           default:
             assertExhaustive(result);
         }

--- a/src/api/js/src/high-level/high-level.ts
+++ b/src/api/js/src/high-level/high-level.ts
@@ -892,6 +892,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       hash() {
         return Z3.get_ast_hash(contextPtr, this.ast);
       }
+
+      toString() {
+        let str = Z3.ast_to_string(ctx.ptr, this.ast);
+        return str;
+      }
     }
 
     class SolverImpl implements Solver<Name> {
@@ -964,6 +969,10 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
 
       model() {
         return new ModelImpl(Z3.solver_get_model(contextPtr, this.ptr));
+      }
+
+      toString() {
+        return Z3.solver_to_string(contextPtr, this.ptr);
       }
     }
 

--- a/src/api/js/src/high-level/high-level.ts
+++ b/src/api/js/src/high-level/high-level.ts
@@ -72,7 +72,7 @@ import {
   Z3Error,
   Z3HighLevel,
 } from './types';
-import { allSatisfy, assert, assertExhaustive, autoBind } from './utils';
+import { allSatisfy, assert, assertExhaustive } from './utils';
 
 const FALLBACK_PRECISION = 17;
 
@@ -150,257 +150,327 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
     return Z3.global_param_get(name);
   }
 
-  function isContext(obj: unknown): obj is Context {
-    return obj instanceof ContextImpl;
-  }
+  function createContext<Name extends string>(name: Name, options?: Record<string, any>): Context<Name> {
+    const cfg = Z3.mk_config();
+    if (options != null) {
+      Object.entries(options).forEach(([key, value]) => Z3.set_param_value(cfg, key, value.toString()));
+    }
+    const contextPtr = Z3.mk_context_rc(cfg); // TODO rename
+    Z3.set_ast_print_mode(contextPtr, Z3_ast_print_mode.Z3_PRINT_SMTLIB2_COMPLIANT);
+    Z3.del_config(cfg);
 
-  class ContextImpl implements Context {
-    declare readonly __typename: Context['__typename'];
+    function _assertContext(...ctxs: (Context | { ctx: Context })[]) {
+      ctxs.forEach(other => assert('ctx' in other ? ctx === other.ctx : ctx === other, 'Context mismatch'));
+    }
 
-    readonly ptr: Z3_context;
-    readonly name: string;
+    /////////////
+    // Private //
+    /////////////
+    function _toSymbol(s: string | number) {
+      if (typeof s === 'number') {
+        return Z3.mk_int_symbol(contextPtr, s);
+      } else {
+        return Z3.mk_string_symbol(contextPtr, s);
+      }
+    }
 
-    constructor(name: string, params: Record<string, any> = {}) {
-      const cfg = Z3.mk_config();
-      Object.entries(params).forEach(([key, value]) => Z3.set_param_value(cfg, key, value.toString()));
-      const context = Z3.mk_context_rc(cfg);
+    function _fromSymbol(sym: Z3_symbol) {
+      const kind = Z3.get_symbol_kind(contextPtr, sym);
+      switch (kind) {
+        case Z3_symbol_kind.Z3_INT_SYMBOL:
+          return Z3.get_symbol_int(contextPtr, sym);
+        case Z3_symbol_kind.Z3_STRING_SYMBOL:
+          return Z3.get_symbol_string(contextPtr, sym);
+        default:
+          assertExhaustive(kind);
+      }
+    }
 
-      this.ptr = context;
-      this.name = name;
+    function _toAst(ast: Z3_ast): AnyAst {
+      switch (Z3.get_ast_kind(contextPtr, ast)) {
+        case Z3_ast_kind.Z3_SORT_AST:
+          return _toSort(ast as Z3_sort);
+        case Z3_ast_kind.Z3_FUNC_DECL_AST:
+          return new FuncDeclImpl(ast as Z3_func_decl);
+        default:
+          return _toExpr(ast);
+      }
+    }
 
-      Z3.set_ast_print_mode(this.ptr, Z3_ast_print_mode.Z3_PRINT_SMTLIB2_COMPLIANT);
-      Z3.del_config(cfg);
+    function _toSort(ast: Z3_sort): AnySort {
+      switch (Z3.get_sort_kind(contextPtr, ast)) {
+        case Z3_sort_kind.Z3_BOOL_SORT:
+          return new BoolSortImpl(ast);
+        case Z3_sort_kind.Z3_INT_SORT:
+        case Z3_sort_kind.Z3_REAL_SORT:
+          return new ArithSortImpl(ast);
+        case Z3_sort_kind.Z3_BV_SORT:
+          return new BitVecSortImpl(ast);
+        default:
+          return new SortImpl(ast);
+      }
+    }
 
-      // We want to bind functions and operations to `this` inside Context
-      // So that the user can write things like this and have it work:
-      // ```
-      // const { And, Or } = new Context('main');
-      // ```
-      //
-      // Typescript doesn't handle overloading of method fields, only
-      // methods. We can't use closures to bind this, so we use auto-bind library
-      // ```
-      // class {
-      //   // This works
-      //   test(a: boolean): boolean;
-      //   test(a: number): number;
-      //   test(a: boolean | number): boolean | number {
-      //     return 0;
-      //   }
-      //
-      //   // This fails to compile
-      //   test2: (a: boolean) => boolean;
-      //   test2: (a: number) => number;
-      //   test2 = (a: boolean | number): boolean | number => {
-      //     return 0;
-      //   }
-      // }
-      // ```
-      autoBind(this);
+    function _toExpr(ast: Z3_ast): Bool | IntNum | RatNum | Arith | Expr {
+      const kind = Z3.get_ast_kind(contextPtr, ast);
+      if (kind === Z3_ast_kind.Z3_QUANTIFIER_AST) {
+        assert(false);
+      }
+      const sortKind = Z3.get_sort_kind(contextPtr, Z3.get_sort(contextPtr, ast));
+      switch (sortKind) {
+        case Z3_sort_kind.Z3_BOOL_SORT:
+          return new BoolImpl(ast);
+        case Z3_sort_kind.Z3_INT_SORT:
+          if (kind === Z3_ast_kind.Z3_NUMERAL_AST) {
+            return new IntNumImpl(ast);
+          }
+          return new ArithImpl(ast);
+        case Z3_sort_kind.Z3_REAL_SORT:
+          if (kind === Z3_ast_kind.Z3_NUMERAL_AST) {
+            return new RatNumImpl(ast);
+          }
+          return new ArithImpl(ast);
+        case Z3_sort_kind.Z3_BV_SORT:
+          if (kind === Z3_ast_kind.Z3_NUMERAL_AST) {
+            return new BitVecNumImpl(ast);
+          }
+          return new BitVecImpl(ast);
+        default:
+          return new ExprImpl(ast);
+      }
+    }
 
-      cleanup.register(this, () => Z3.del_context(context));
+    function _flattenArgs<T extends AnyAst = AnyAst>(args: (T | AstVector<T>)[]): T[] {
+      const result: T[] = [];
+      for (const arg of args) {
+        if (isAstVector(arg)) {
+          result.push(...arg.values());
+        } else {
+          result.push(arg);
+        }
+      }
+      return result;
+    }
+
+    function _toProbe(p: Probe | Z3_probe): Probe {
+      if (isProbe(p)) {
+        return p;
+      }
+      return new ProbeImpl(p);
+    }
+
+    function _probeNary(
+      f: (ctx: Z3_context, left: Z3_probe, right: Z3_probe) => Z3_probe,
+      args: [Probe | Z3_probe, ...(Probe | Z3_probe)[]],
+    ) {
+      assert(args.length > 0, 'At least one argument expected');
+      let r = _toProbe(args[0]);
+      for (let i = 1; i < args.length; i++) {
+        r = new ProbeImpl(f(contextPtr, r.ptr, _toProbe(args[i]).ptr));
+      }
+      return r;
     }
 
     ///////////////
     // Functions //
     ///////////////
-    interrupt(): void {
-      Z3.interrupt(this.ptr);
+    function interrupt(): void {
+      Z3.interrupt(contextPtr);
     }
 
-    isModel(obj: unknown): obj is Model {
+    function isModel(obj: unknown): obj is Model {
       const r = obj instanceof ModelImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isAst(obj: unknown): obj is Ast {
+    function isAst(obj: unknown): obj is Ast {
       const r = obj instanceof AstImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isSort(obj: unknown): obj is Sort {
+    function isSort(obj: unknown): obj is Sort {
       const r = obj instanceof SortImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isFuncDecl(obj: unknown): obj is FuncDecl {
+    function isFuncDecl(obj: unknown): obj is FuncDecl {
       const r = obj instanceof FuncDeclImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isApp(obj: unknown): boolean {
-      if (!this.isExpr(obj)) {
+    function isApp(obj: unknown): boolean {
+      if (!isExpr(obj)) {
         return false;
       }
-      const kind = Z3.get_ast_kind(this.ptr, obj.ast);
+      const kind = Z3.get_ast_kind(contextPtr, obj.ast);
       return kind === Z3_ast_kind.Z3_NUMERAL_AST || kind === Z3_ast_kind.Z3_APP_AST;
     }
 
-    isConst(obj: unknown): boolean {
-      return this.isExpr(obj) && this.isApp(obj) && obj.numArgs() === 0;
+    function isConst(obj: unknown): boolean {
+      return isExpr(obj) && isApp(obj) && obj.numArgs() === 0;
     }
 
-    isExpr(obj: unknown): obj is Expr {
+    function isExpr(obj: unknown): obj is Expr {
       const r = obj instanceof ExprImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isVar(obj: unknown): boolean {
-      return this.isExpr(obj) && Z3.get_ast_kind(this.ptr, obj.ast) === Z3_ast_kind.Z3_VAR_AST;
+    function isVar(obj: unknown): boolean {
+      return isExpr(obj) && Z3.get_ast_kind(contextPtr, obj.ast) === Z3_ast_kind.Z3_VAR_AST;
     }
 
-    isAppOf(obj: unknown, kind: Z3_decl_kind): boolean {
-      return this.isExpr(obj) && this.isApp(obj) && obj.decl().kind() === kind;
+    function isAppOf(obj: unknown, kind: Z3_decl_kind): boolean {
+      return isExpr(obj) && isApp(obj) && obj.decl().kind() === kind;
     }
 
-    isBool(obj: unknown): obj is Bool {
+    function isBool(obj: unknown): obj is Bool {
       const r = obj instanceof BoolImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isTrue(obj: unknown): boolean {
-      return this.isAppOf(obj, Z3_decl_kind.Z3_OP_TRUE);
+    function isTrue(obj: unknown): boolean {
+      return isAppOf(obj, Z3_decl_kind.Z3_OP_TRUE);
     }
 
-    isFalse(obj: unknown): boolean {
-      return this.isAppOf(obj, Z3_decl_kind.Z3_OP_FALSE);
+    function isFalse(obj: unknown): boolean {
+      return isAppOf(obj, Z3_decl_kind.Z3_OP_FALSE);
     }
 
-    isAnd(obj: unknown): boolean {
-      return this.isAppOf(obj, Z3_decl_kind.Z3_OP_AND);
+    function isAnd(obj: unknown): boolean {
+      return isAppOf(obj, Z3_decl_kind.Z3_OP_AND);
     }
 
-    isOr(obj: unknown): boolean {
-      return this.isAppOf(obj, Z3_decl_kind.Z3_OP_OR);
+    function isOr(obj: unknown): boolean {
+      return isAppOf(obj, Z3_decl_kind.Z3_OP_OR);
     }
 
-    isImplies(obj: unknown): boolean {
-      return this.isAppOf(obj, Z3_decl_kind.Z3_OP_IMPLIES);
+    function isImplies(obj: unknown): boolean {
+      return isAppOf(obj, Z3_decl_kind.Z3_OP_IMPLIES);
     }
 
-    isNot(obj: unknown): boolean {
-      return this.isAppOf(obj, Z3_decl_kind.Z3_OP_NOT);
+    function isNot(obj: unknown): boolean {
+      return isAppOf(obj, Z3_decl_kind.Z3_OP_NOT);
     }
 
-    isEq(obj: unknown): boolean {
-      return this.isAppOf(obj, Z3_decl_kind.Z3_OP_EQ);
+    function isEq(obj: unknown): boolean {
+      return isAppOf(obj, Z3_decl_kind.Z3_OP_EQ);
     }
 
-    isDistinct(obj: unknown): boolean {
-      return this.isAppOf(obj, Z3_decl_kind.Z3_OP_DISTINCT);
+    function isDistinct(obj: unknown): boolean {
+      return isAppOf(obj, Z3_decl_kind.Z3_OP_DISTINCT);
     }
 
-    isArith(obj: unknown): obj is Arith {
+    function isArith(obj: unknown): obj is Arith {
       const r = obj instanceof ArithImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isArithSort(obj: unknown): obj is ArithSort {
+    function isArithSort(obj: unknown): obj is ArithSort {
       const r = obj instanceof ArithSortImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isInt(obj: unknown): boolean {
-      return this.isArith(obj) && this.isIntSort(obj.sort);
+    function isInt(obj: unknown): boolean {
+      return isArith(obj) && isIntSort(obj.sort);
     }
 
-    isIntVal(obj: unknown): obj is IntNum {
+    function isIntVal(obj: unknown): obj is IntNum {
       const r = obj instanceof IntNumImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isIntSort(obj: unknown): boolean {
-      return this.isSort(obj) && obj.kind() === Z3_sort_kind.Z3_INT_SORT;
+    function isIntSort(obj: unknown): boolean {
+      return isSort(obj) && obj.kind() === Z3_sort_kind.Z3_INT_SORT;
     }
 
-    isReal(obj: unknown): boolean {
-      return this.isArith(obj) && this.isRealSort(obj.sort);
+    function isReal(obj: unknown): boolean {
+      return isArith(obj) && isRealSort(obj.sort);
     }
 
-    isRealVal(obj: unknown): obj is RatNum {
+    function isRealVal(obj: unknown): obj is RatNum {
       const r = obj instanceof RatNumImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isRealSort(obj: unknown): boolean {
-      return this.isSort(obj) && obj.kind() === Z3_sort_kind.Z3_REAL_SORT;
+    function isRealSort(obj: unknown): boolean {
+      return isSort(obj) && obj.kind() === Z3_sort_kind.Z3_REAL_SORT;
     }
 
-    isBitVecSort(obj: unknown): obj is BitVecSort {
+    function isBitVecSort(obj: unknown): obj is BitVecSort {
       const r = obj instanceof BitVecSortImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isBitVec(obj: unknown): obj is BitVec {
+    function isBitVec(obj: unknown): obj is BitVec {
       const r = obj instanceof BitVecImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isBitVecVal(obj: unknown): obj is BitVecNum {
+    function isBitVecVal(obj: unknown): obj is BitVecNum {
       const r = obj instanceof BitVecNumImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isProbe(obj: unknown): obj is Probe {
+    function isProbe(obj: unknown): obj is Probe {
       const r = obj instanceof ProbeImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isTactic(obj: unknown): obj is Tactic {
+    function isTactic(obj: unknown): obj is Tactic {
       const r = obj instanceof TacticImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    isAstVector(obj: unknown): obj is AstVector {
+    function isAstVector(obj: unknown): obj is AstVector {
       const r = obj instanceof AstVectorImpl;
-      r && this._assertContext(obj);
+      r && _assertContext(obj);
       return r;
     }
 
-    eqIdentity(a: Ast, b: Ast): boolean {
+    function eqIdentity(a: Ast, b: Ast): boolean {
       return a.eqIdentity(b);
     }
 
-    getVarIndex(obj: Expr): number {
-      assert(this.isVar(obj), 'Z3 bound variable expected');
-      return Z3.get_index_value(this.ptr, obj.ast);
+    function getVarIndex(obj: Expr): number {
+      assert(isVar(obj), 'Z3 bound variable expected');
+      return Z3.get_index_value(contextPtr, obj.ast);
     }
 
-    from(primitive: boolean): Bool;
-    from(primitive: number | CoercibleRational): RatNum;
-    from(primitive: bigint): IntNum;
-    from<T extends Expr>(expr: T): T;
-    from(expr: CoercibleToExpr): AnyExpr;
-    from(value: CoercibleToExpr): AnyExpr {
+    function from(primitive: boolean): Bool;
+    function from(primitive: number | CoercibleRational): RatNum;
+    function from(primitive: bigint): IntNum;
+    function from<T extends Expr>(expr: T): T;
+    function from(expr: CoercibleToExpr): AnyExpr;
+    function from(value: CoercibleToExpr): AnyExpr {
       if (typeof value === 'boolean') {
-        return this.Bool.val(value);
+        return Bool.val(value);
       } else if (typeof value === 'number' || isCoercibleRational(value)) {
-        return this.Real.val(value);
+        return Real.val(value);
       } else if (typeof value === 'bigint') {
-        return this.Int.val(value);
-      } else if (this.isExpr(value)) {
+        return Int.val(value);
+      } else if (isExpr(value)) {
         return value;
       }
       assert(false);
     }
 
-    async solve(...assertions: Bool[]): Promise<Model | typeof unsat | typeof unknown> {
-      const solver = new this.Solver();
+    async function solve(...assertions: Bool[]): Promise<Model | typeof unsat | typeof unknown> {
+      const solver = new ctx.Solver();
       solver.add(...assertions);
       const result = await solver.check();
       if (result === sat) {
@@ -410,171 +480,158 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
     }
 
     /////////////
-    // Classes //
-    /////////////
-    readonly Solver = SolverImpl.bind(SolverImpl, this);
-    readonly Model = ModelImpl.bind(ModelImpl, this);
-    readonly Tactic = TacticImpl.bind(TacticImpl, this);
-    readonly AstVector = AstVectorImpl.bind(AstVectorImpl, this) as AstVectorCtor<any>;
-    readonly AstMap = AstMapImpl.bind(AstMapImpl, this) as AstMapCtor<any>;
-
-    /////////////
     // Objects //
     /////////////
-    readonly Sort = {
-      declare: (name: string) => new SortImpl(this, Z3.mk_uninterpreted_sort(this.ptr, this._toSymbol(name))),
+    const Sort = {
+      declare: (name: string) => new SortImpl(Z3.mk_uninterpreted_sort(contextPtr, _toSymbol(name))),
     };
-    readonly Function = {
+    const Function = {
       declare: (name: string, ...signature: FuncDeclSignature<any>) => {
         const arity = signature.length - 1;
         const rng = signature[arity];
-        this._assertContext(rng);
+        _assertContext(rng);
         const dom = [];
         for (let i = 0; i < arity; i++) {
-          this._assertContext(signature[i]);
+          _assertContext(signature[i]);
           dom.push(signature[i].ptr);
         }
-        return new FuncDeclImpl(this, Z3.mk_func_decl(this.ptr, this._toSymbol(name), dom, rng.ptr));
+        return new FuncDeclImpl(Z3.mk_func_decl(contextPtr, _toSymbol(name), dom, rng.ptr));
       },
       fresh: (...signature: FuncDeclSignature<any>) => {
         const arity = signature.length - 1;
         const rng = signature[arity];
-        this._assertContext(rng);
+        _assertContext(rng);
         const dom = [];
         for (let i = 0; i < arity; i++) {
-          this._assertContext(signature[i]);
+          _assertContext(signature[i]);
           dom.push(signature[i].ptr);
         }
-        return new FuncDeclImpl(this, Z3.mk_fresh_func_decl(this.ptr, 'f', dom, rng.ptr));
+        return new FuncDeclImpl(Z3.mk_fresh_func_decl(contextPtr, 'f', dom, rng.ptr));
       },
     };
-    readonly RecFunc = {
+    const RecFunc = {
       declare: (name: string, ...signature: FuncDeclSignature<any>) => {
         const arity = signature.length - 1;
         const rng = signature[arity];
-        this._assertContext(rng);
+        _assertContext(rng);
         const dom = [];
         for (let i = 0; i < arity; i++) {
-          this._assertContext(signature[i]);
+          _assertContext(signature[i]);
           dom.push(signature[i].ptr);
         }
-        return new FuncDeclImpl(this, Z3.mk_rec_func_decl(this.ptr, this._toSymbol(name), dom, rng.ptr));
+        return new FuncDeclImpl(Z3.mk_rec_func_decl(contextPtr, _toSymbol(name), dom, rng.ptr));
       },
 
       addDefinition: (f: FuncDecl, args: Expr[], body: Expr) => {
-        this._assertContext(f, ...args, body);
+        _assertContext(f, ...args, body);
         Z3.add_rec_def(
-          this.ptr,
+          contextPtr,
           f.ptr,
           args.map(arg => arg.ast),
           body.ast,
         );
       },
     };
-    readonly Bool = {
-      sort: () => new BoolSortImpl(this, Z3.mk_bool_sort(this.ptr)),
+    const Bool = {
+      sort: () => new BoolSortImpl(Z3.mk_bool_sort(contextPtr)),
 
-      const: (name: string) => new BoolImpl(this, Z3.mk_const(this.ptr, this._toSymbol(name), this.Bool.sort().ptr)),
+      const: (name: string) => new BoolImpl(Z3.mk_const(contextPtr, _toSymbol(name), Bool.sort().ptr)),
       consts: (names: string | string[]) => {
         if (typeof names === 'string') {
           names = names.split(' ');
         }
-        return names.map(name => this.Bool.const(name));
+        return names.map(name => Bool.const(name));
       },
       vector: (prefix: string, count: number) => {
         const result = [];
         for (let i = 0; i < count; i++) {
-          result.push(this.Bool.const(`${prefix}__${i}`));
+          result.push(Bool.const(`${prefix}__${i}`));
         }
         return result;
       },
-      fresh: (prefix = 'b') => new BoolImpl(this, Z3.mk_fresh_const(this.ptr, prefix, this.Bool.sort().ptr)),
+      fresh: (prefix = 'b') => new BoolImpl(Z3.mk_fresh_const(contextPtr, prefix, Bool.sort().ptr)),
 
       val: (value: boolean) => {
         if (value) {
-          return new BoolImpl(this, Z3.mk_true(this.ptr));
+          return new BoolImpl(Z3.mk_true(contextPtr));
         }
-        return new BoolImpl(this, Z3.mk_false(this.ptr));
+        return new BoolImpl(Z3.mk_false(contextPtr));
       },
     };
-    readonly Int = {
-      sort: () => new ArithSortImpl(this, Z3.mk_int_sort(this.ptr)),
+    const Int = {
+      sort: () => new ArithSortImpl(Z3.mk_int_sort(contextPtr)),
 
-      const: (name: string) => new ArithImpl(this, Z3.mk_const(this.ptr, this._toSymbol(name), this.Int.sort().ptr)),
+      const: (name: string) => new ArithImpl(Z3.mk_const(contextPtr, _toSymbol(name), Int.sort().ptr)),
       consts: (names: string | string[]) => {
         if (typeof names === 'string') {
           names = names.split(' ');
         }
-        return names.map(name => this.Int.const(name));
+        return names.map(name => Int.const(name));
       },
       vector: (prefix: string, count: number) => {
         const result = [];
         for (let i = 0; i < count; i++) {
-          result.push(this.Int.const(`${prefix}__${i}`));
+          result.push(Int.const(`${prefix}__${i}`));
         }
         return result;
       },
-      fresh: (prefix = 'x') => new ArithImpl(this, Z3.mk_fresh_const(this.ptr, prefix, this.Int.sort().ptr)),
+      fresh: (prefix = 'x') => new ArithImpl(Z3.mk_fresh_const(contextPtr, prefix, Int.sort().ptr)),
 
       val: (value: number | bigint | string) => {
         assert(typeof value === 'bigint' || typeof value === 'string' || Number.isSafeInteger(value));
-        return new IntNumImpl(this, Z3.mk_numeral(this.ptr, value.toString(), this.Int.sort().ptr));
+        return new IntNumImpl(Z3.mk_numeral(contextPtr, value.toString(), Int.sort().ptr));
       },
     };
-    readonly Real = {
-      sort: () => new ArithSortImpl(this, Z3.mk_real_sort(this.ptr)),
+    const Real = {
+      sort: () => new ArithSortImpl(Z3.mk_real_sort(contextPtr)),
 
-      const: (name: string) => new ArithImpl(this, Z3.mk_const(this.ptr, this._toSymbol(name), this.Real.sort().ptr)),
+      const: (name: string) => new ArithImpl(Z3.mk_const(contextPtr, _toSymbol(name), Real.sort().ptr)),
       consts: (names: string | string[]) => {
         if (typeof names === 'string') {
           names = names.split(' ');
         }
-        return names.map(name => this.Real.const(name));
+        return names.map(name => Real.const(name));
       },
       vector: (prefix: string, count: number) => {
         const result = [];
         for (let i = 0; i < count; i++) {
-          result.push(this.Real.const(`${prefix}__${i}`));
+          result.push(Real.const(`${prefix}__${i}`));
         }
         return result;
       },
-      fresh: (prefix = 'b') => new ArithImpl(this, Z3.mk_fresh_const(this.ptr, prefix, this.Real.sort().ptr)),
+      fresh: (prefix = 'b') => new ArithImpl(Z3.mk_fresh_const(contextPtr, prefix, Real.sort().ptr)),
 
       val: (value: number | bigint | string | CoercibleRational) => {
         if (isCoercibleRational(value)) {
           value = `${value.numerator}/${value.denominator}`;
         }
-        return new RatNumImpl(this, Z3.mk_numeral(this.ptr, value.toString(), this.Real.sort().ptr));
+        return new RatNumImpl(Z3.mk_numeral(contextPtr, value.toString(), Real.sort().ptr));
       },
     };
-    readonly BitVec = {
+    const BitVec = {
       sort: (bits: number): BitVecSort<any> => {
         assert(Number.isSafeInteger(bits), 'number of bits must be an integer');
-        return new BitVecSortImpl(this, Z3.mk_bv_sort(this.ptr, bits));
+        return new BitVecSortImpl(Z3.mk_bv_sort(contextPtr, bits));
       },
 
       const: (name: string, bits: number | BitVecSort): BitVec<any> =>
-        new BitVecImpl(
-          this,
-          Z3.mk_const(this.ptr, this._toSymbol(name), this.isBitVecSort(bits) ? bits.ptr : this.BitVec.sort(bits).ptr),
-        ),
+        new BitVecImpl(Z3.mk_const(contextPtr, _toSymbol(name), isBitVecSort(bits) ? bits.ptr : BitVec.sort(bits).ptr)),
 
       consts: (names: string | string[], bits: number | BitVecSort): BitVec<any>[] => {
         if (typeof names === 'string') {
           names = names.split(' ');
         }
-        return names.map(name => this.BitVec.const(name, bits));
+        return names.map(name => BitVec.const(name, bits));
       },
 
       val: (value: bigint | number | boolean, bits: number | BitVecSort): BitVecNum<any> => {
         if (value === true) {
-          return this.BitVec.val(1, bits);
+          return BitVec.val(1, bits);
         } else if (value === false) {
-          return this.BitVec.val(0, bits);
+          return BitVec.val(0, bits);
         }
         return new BitVecNumImpl(
-          this,
-          Z3.mk_numeral(this.ptr, value.toString(), this.isBitVecSort(bits) ? bits.ptr : this.BitVec.sort(bits).ptr),
+          Z3.mk_numeral(contextPtr, value.toString(), isBitVecSort(bits) ? bits.ptr : BitVec.sort(bits).ptr),
         );
       },
     };
@@ -582,521 +639,1074 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
     ////////////////
     // Operations //
     ////////////////
-    If(condition: Probe, onTrue: Tactic, onFalse: Tactic): Tactic;
-    If<OnTrueRef extends CoercibleToExpr, OnFalseRef extends CoercibleToExpr>(
+    function If(condition: Probe, onTrue: Tactic, onFalse: Tactic): Tactic;
+    function If<OnTrueRef extends CoercibleToExpr, OnFalseRef extends CoercibleToExpr>(
       condition: Bool | boolean,
       onTrue: OnTrueRef,
       onFalse: OnFalseRef,
     ): CoercibleToExprMap<OnTrueRef | OnFalseRef>;
-    If(
+    function If(
       condition: Bool | Probe | boolean,
       onTrue: CoercibleToExpr | Tactic,
       onFalse: CoercibleToExpr | Tactic,
     ): Expr | Tactic {
-      if (this.isProbe(condition) && this.isTactic(onTrue) && this.isTactic(onFalse)) {
-        return this.Cond(condition, onTrue, onFalse);
+      if (isProbe(condition) && isTactic(onTrue) && isTactic(onFalse)) {
+        return Cond(condition, onTrue, onFalse);
       }
-      assert(
-        !this.isProbe(condition) && !this.isTactic(onTrue) && !this.isTactic(onFalse),
-        'Mixed expressions and goals',
-      );
+      assert(!isProbe(condition) && !isTactic(onTrue) && !isTactic(onFalse), 'Mixed expressions and goals');
       if (typeof condition === 'boolean') {
-        condition = this.Bool.val(condition);
+        condition = Bool.val(condition);
       }
-      onTrue = this.from(onTrue);
-      onFalse = this.from(onFalse);
-      return this._toExpr(Z3.mk_ite(this.ptr, condition.ptr, onTrue.ast, onFalse.ast));
+      onTrue = from(onTrue);
+      onFalse = from(onFalse);
+      return _toExpr(Z3.mk_ite(contextPtr, condition.ptr, onTrue.ast, onFalse.ast));
     }
 
-    Distinct(...exprs: CoercibleToExpr[]): Bool {
+    function Distinct(...exprs: CoercibleToExpr[]): Bool {
       assert(exprs.length > 0, "Can't make Distinct ouf of nothing");
 
       return new BoolImpl(
-        this,
         Z3.mk_distinct(
-          this.ptr,
+          contextPtr,
           exprs.map(expr => {
-            expr = this.from(expr);
-            this._assertContext(expr);
+            expr = from(expr);
+            _assertContext(expr);
             return expr.ast;
           }),
         ),
       );
     }
 
-    Const<S extends Sort>(name: string, sort: S): SortToExprMap<S> {
-      this._assertContext(sort);
-      return this._toExpr(Z3.mk_const(this.ptr, this._toSymbol(name), sort.ptr)) as SortToExprMap<S>;
+    function Const<S extends Sort>(name: string, sort: S): SortToExprMap<S> {
+      _assertContext(sort);
+      return _toExpr(Z3.mk_const(contextPtr, _toSymbol(name), sort.ptr)) as SortToExprMap<S>;
     }
 
-    Consts<S extends Sort>(names: string | string[], sort: S): SortToExprMap<S>[] {
-      this._assertContext(sort);
+    function Consts<S extends Sort>(names: string | string[], sort: S): SortToExprMap<S>[] {
+      _assertContext(sort);
       if (typeof names === 'string') {
         names = names.split(' ');
       }
-      return names.map(name => this.Const(name, sort));
+      return names.map(name => Const(name, sort));
     }
 
-    FreshConst<S extends Sort>(sort: S, prefix: string = 'c'): SortToExprMap<S> {
-      this._assertContext(sort);
-      return this._toExpr(Z3.mk_fresh_const(sort.ctx.ptr, prefix, sort.ptr)) as SortToExprMap<S>;
+    function FreshConst<S extends Sort>(sort: S, prefix: string = 'c'): SortToExprMap<S> {
+      _assertContext(sort);
+      return _toExpr(Z3.mk_fresh_const(sort.ctx.ptr, prefix, sort.ptr)) as SortToExprMap<S>;
     }
 
-    Var<S extends Sort>(idx: number, sort: S): SortToExprMap<S> {
-      this._assertContext(sort);
-      return this._toExpr(Z3.mk_bound(sort.ctx.ptr, idx, sort.ptr)) as SortToExprMap<S>;
+    function Var<S extends Sort>(idx: number, sort: S): SortToExprMap<S> {
+      _assertContext(sort);
+      return _toExpr(Z3.mk_bound(sort.ctx.ptr, idx, sort.ptr)) as SortToExprMap<S>;
     }
 
-    Implies(a: Bool | boolean, b: Bool | boolean): Bool {
-      a = this.from(a) as Bool;
-      b = this.from(b) as Bool;
-      this._assertContext(a, b);
-      return new BoolImpl(this, Z3.mk_implies(this.ptr, a.ptr, b.ptr));
+    function Implies(a: Bool | boolean, b: Bool | boolean): Bool {
+      a = from(a) as Bool;
+      b = from(b) as Bool;
+      _assertContext(a, b);
+      return new BoolImpl(Z3.mk_implies(contextPtr, a.ptr, b.ptr));
     }
 
-    Eq(a: CoercibleToExpr, b: CoercibleToExpr): Bool {
-      a = this.from(a);
-      b = this.from(b);
-      this._assertContext(a, b);
+    function Eq(a: CoercibleToExpr, b: CoercibleToExpr): Bool {
+      a = from(a);
+      b = from(b);
+      _assertContext(a, b);
       return a.eq(b);
     }
 
-    Xor(a: Bool | boolean, b: Bool | boolean): Bool {
-      a = this.from(a) as Bool;
-      b = this.from(b) as Bool;
-      this._assertContext(a, b);
-      return new BoolImpl(this, Z3.mk_xor(this.ptr, a.ptr, b.ptr));
+    function Xor(a: Bool | boolean, b: Bool | boolean): Bool {
+      a = from(a) as Bool;
+      b = from(b) as Bool;
+      _assertContext(a, b);
+      return new BoolImpl(Z3.mk_xor(contextPtr, a.ptr, b.ptr));
     }
 
-    Not(a: Probe): Probe;
-    Not(a: Bool | boolean): Bool;
-    Not(a: Bool | boolean | Probe): Bool | Probe {
+    function Not(a: Probe): Probe;
+    function Not(a: Bool | boolean): Bool;
+    function Not(a: Bool | boolean | Probe): Bool | Probe {
       if (typeof a === 'boolean') {
-        a = this.from(a);
+        a = from(a);
       }
-      this._assertContext(a);
-      if (this.isProbe(a)) {
-        return new ProbeImpl(this, Z3.probe_not(this.ptr, a.ptr));
+      _assertContext(a);
+      if (isProbe(a)) {
+        return new ProbeImpl(Z3.probe_not(contextPtr, a.ptr));
       }
-      return new BoolImpl(this, Z3.mk_not(this.ptr, a.ptr));
+      return new BoolImpl(Z3.mk_not(contextPtr, a.ptr));
     }
 
-    And(): Bool;
-    And(vector: AstVector<Bool>): Bool;
-    And(...args: (Bool | boolean)[]): Bool;
-    And(...args: Probe[]): Probe;
-    And(...args: (AstVector<Bool> | Probe | Bool | boolean)[]): Bool | Probe {
-      if (args.length == 1 && args[0] instanceof this.AstVector) {
+    function And(): Bool;
+    function And(vector: AstVector<Bool>): Bool;
+    function And(...args: (Bool | boolean)[]): Bool;
+    function And(...args: Probe[]): Probe;
+    function And(...args: (AstVector<Bool> | Probe | Bool | boolean)[]): Bool | Probe {
+      if (args.length == 1 && args[0] instanceof ctx.AstVector) {
         args = [...args[0].values()];
-        assert(allSatisfy(args, this.isBool.bind(this)) ?? true, 'AstVector containing not bools');
+        assert(allSatisfy(args, isBool) ?? true, 'AstVector containing not bools');
       }
 
-      const allProbes = allSatisfy(args, this.isProbe.bind(this)) ?? false;
+      const allProbes = allSatisfy(args, isProbe) ?? false;
       if (allProbes) {
-        return this._probeNary(Z3.probe_and, args as [Probe, ...Probe[]]);
+        return _probeNary(Z3.probe_and, args as [Probe, ...Probe[]]);
       } else {
-        args = args.map(this.from.bind(this)) as Bool[];
-        this._assertContext(...(args as Bool[]));
+        args = args.map(from) as Bool[];
+        _assertContext(...(args as Bool[]));
         return new BoolImpl(
-          this,
           Z3.mk_and(
-            this.ptr,
+            contextPtr,
             args.map(arg => (arg as Bool).ptr),
           ),
         );
       }
     }
 
-    Or(): Bool;
-    Or(vector: AstVector<Bool>): Bool;
-    Or(...args: (Bool | boolean)[]): Bool;
-    Or(...args: Probe[]): Probe;
-    Or(...args: (AstVector<Bool> | Probe | Bool | boolean)[]): Bool | Probe {
-      if (args.length == 1 && args[0] instanceof this.AstVector) {
+    function Or(): Bool;
+    function Or(vector: AstVector<Bool>): Bool;
+    function Or(...args: (Bool | boolean)[]): Bool;
+    function Or(...args: Probe[]): Probe;
+    function Or(...args: (AstVector<Bool> | Probe | Bool | boolean)[]): Bool | Probe {
+      if (args.length == 1 && args[0] instanceof ctx.AstVector) {
         args = [...args[0].values()];
-        assert(allSatisfy(args, this.isBool.bind(this)) ?? true, 'AstVector containing not bools');
+        assert(allSatisfy(args, isBool) ?? true, 'AstVector containing not bools');
       }
 
-      const allProbes = allSatisfy(args, this.isProbe.bind(this)) ?? false;
+      const allProbes = allSatisfy(args, isProbe) ?? false;
       if (allProbes) {
-        return this._probeNary(Z3.probe_or, args as [Probe, ...Probe[]]);
+        return _probeNary(Z3.probe_or, args as [Probe, ...Probe[]]);
       } else {
-        args = args.map(this.from.bind(this)) as Bool[];
-        this._assertContext(...(args as Bool[]));
+        args = args.map(from) as Bool[];
+        _assertContext(...(args as Bool[]));
         return new BoolImpl(
-          this,
           Z3.mk_or(
-            this.ptr,
+            contextPtr,
             args.map(arg => (arg as Bool).ptr),
           ),
         );
       }
     }
 
-    ToReal(expr: Arith | bigint): Arith {
-      expr = this.from(expr) as Arith;
-      this._assertContext(expr);
-      assert(this.isInt(expr), 'Int expression expected');
-      return new ArithImpl(this, Z3.mk_int2real(this.ptr, expr.ast));
+    function ToReal(expr: Arith | bigint): Arith {
+      expr = from(expr) as Arith;
+      _assertContext(expr);
+      assert(isInt(expr), 'Int expression expected');
+      return new ArithImpl(Z3.mk_int2real(contextPtr, expr.ast));
     }
 
-    ToInt(expr: Arith | number | CoercibleRational | string): Arith {
-      if (!this.isExpr(expr)) {
-        expr = this.Real.val(expr);
+    function ToInt(expr: Arith | number | CoercibleRational | string): Arith {
+      if (!isExpr(expr)) {
+        expr = Real.val(expr);
       }
-      this._assertContext(expr);
-      assert(this.isReal(expr), 'Real expression expected');
-      return new ArithImpl(this, Z3.mk_real2int(this.ptr, expr.ast));
+      _assertContext(expr);
+      assert(isReal(expr), 'Real expression expected');
+      return new ArithImpl(Z3.mk_real2int(contextPtr, expr.ast));
     }
 
-    IsInt(expr: Arith | number | CoercibleRational | string): Bool {
-      if (!this.isExpr(expr)) {
-        expr = this.Real.val(expr);
+    function IsInt(expr: Arith | number | CoercibleRational | string): Bool {
+      if (!isExpr(expr)) {
+        expr = Real.val(expr);
       }
-      this._assertContext(expr);
-      assert(this.isReal(expr), 'Real expression expected');
-      return new BoolImpl(this, Z3.mk_is_int(this.ptr, expr.ast));
+      _assertContext(expr);
+      assert(isReal(expr), 'Real expression expected');
+      return new BoolImpl(Z3.mk_is_int(contextPtr, expr.ast));
     }
 
-    Sqrt(a: Arith | number | bigint | string | CoercibleRational): Arith {
-      if (!this.isExpr(a)) {
-        a = this.Real.val(a);
+    function Sqrt(a: Arith | number | bigint | string | CoercibleRational): Arith {
+      if (!isExpr(a)) {
+        a = Real.val(a);
       }
       return a.pow('1/2');
     }
 
-    Cbrt(a: Arith | number | bigint | string | CoercibleRational): Arith {
-      if (!this.isExpr(a)) {
-        a = this.Real.val(a);
+    function Cbrt(a: Arith | number | bigint | string | CoercibleRational): Arith {
+      if (!isExpr(a)) {
+        a = Real.val(a);
       }
       return a.pow('1/3');
     }
 
-    BV2Int(a: BitVec, isSigned: boolean): Arith {
-      this._assertContext(a);
-      return new ArithImpl(this, Z3.mk_bv2int(this.ptr, a.ast, isSigned));
+    function BV2Int(a: BitVec, isSigned: boolean): Arith {
+      _assertContext(a);
+      return new ArithImpl(Z3.mk_bv2int(contextPtr, a.ast, isSigned));
     }
 
-    Int2BV(a: Arith | bigint | number, bits: number): BitVec<any> {
-      if (this.isArith(a)) {
-        assert(this.isInt(a), 'parameter must be an integer');
+    function Int2BV(a: Arith | bigint | number, bits: number): BitVec<any> {
+      if (isArith(a)) {
+        assert(isInt(a), 'parameter must be an integer');
       } else {
         assert(typeof a !== 'number' || Number.isSafeInteger(a), 'parameter must not have decimal places');
-        a = this.Int.val(a);
+        a = Int.val(a);
       }
-      return new BitVecImpl(this, Z3.mk_int2bv(this.ptr, bits, a.ast));
+      return new BitVecImpl(Z3.mk_int2bv(contextPtr, bits, a.ast));
     }
 
-    Concat(...bitvecs: BitVec[]): BitVec {
-      this._assertContext(...bitvecs);
-      return bitvecs.reduce((prev, curr) => new BitVecImpl(this, Z3.mk_concat(this.ptr, prev.ast, curr.ast)));
+    function Concat(...bitvecs: BitVec[]): BitVec {
+      _assertContext(...bitvecs);
+      return bitvecs.reduce((prev, curr) => new BitVecImpl(Z3.mk_concat(contextPtr, prev.ast, curr.ast)));
     }
 
-    Cond(probe: Probe, onTrue: Tactic, onFalse: Tactic): Tactic {
-      this._assertContext(probe, onTrue, onFalse);
-      return new this.Tactic(Z3.tactic_cond(this.ptr, probe.ptr, onTrue.ptr, onFalse.ptr));
+    function Cond(probe: Probe, onTrue: Tactic, onFalse: Tactic): Tactic {
+      _assertContext(probe, onTrue, onFalse);
+      return new TacticImpl(Z3.tactic_cond(contextPtr, probe.ptr, onTrue.ptr, onFalse.ptr));
     }
 
-    /////////////
-    // Private //
-    /////////////
-    _assertContext(...ctxs: (Context | { ctx: Context })[]) {
-      ctxs.forEach(other => assert('ctx' in other ? this === other.ctx : this === other, 'Context mismatch'));
-    }
+    class AstImpl<Ptr> implements Ast {
+      declare readonly __typename: Ast['__typename'];
+      readonly ctx: Context;
 
-    _toSymbol(s: string | number) {
-      if (typeof s === 'number') {
-        return Z3.mk_int_symbol(this.ptr, s);
-      } else {
-        return Z3.mk_string_symbol(this.ptr, s);
+      constructor(readonly ptr: Ptr) {
+        this.ctx = ctx;
+        const myAst = this.ast;
+
+        Z3.inc_ref(contextPtr, myAst);
+        cleanup.register(this, () => Z3.dec_ref(contextPtr, myAst));
       }
-    }
 
-    _fromSymbol(sym: Z3_symbol) {
-      const kind = Z3.get_symbol_kind(this.ptr, sym);
-      switch (kind) {
-        case Z3_symbol_kind.Z3_INT_SYMBOL:
-          return Z3.get_symbol_int(this.ptr, sym);
-        case Z3_symbol_kind.Z3_STRING_SYMBOL:
-          return Z3.get_symbol_string(this.ptr, sym);
-        default:
-          assertExhaustive(kind);
+      get ast(): Z3_ast {
+        return this.ptr as any as Z3_ast;
       }
-    }
 
-    _toAst(ast: Z3_ast): AnyAst {
-      switch (Z3.get_ast_kind(this.ptr, ast)) {
-        case Z3_ast_kind.Z3_SORT_AST:
-          return this._toSort(ast as Z3_sort);
-        case Z3_ast_kind.Z3_FUNC_DECL_AST:
-          return new FuncDeclImpl(this, ast as Z3_func_decl);
-        default:
-          return this._toExpr(ast);
+      get id() {
+        return Z3.get_ast_id(contextPtr, this.ast);
       }
-    }
 
-    _toSort(ast: Z3_sort): AnySort {
-      switch (Z3.get_sort_kind(this.ptr, ast)) {
-        case Z3_sort_kind.Z3_BOOL_SORT:
-          return new BoolSortImpl(this, ast);
-        case Z3_sort_kind.Z3_INT_SORT:
-        case Z3_sort_kind.Z3_REAL_SORT:
-          return new ArithSortImpl(this, ast);
-        case Z3_sort_kind.Z3_BV_SORT:
-          return new BitVecSortImpl(this, ast);
-        default:
-          return new SortImpl(this, ast);
+      eqIdentity(other: Ast) {
+        _assertContext(other);
+        return Z3.is_eq_ast(contextPtr, this.ast, other.ast);
+      }
+
+      neqIdentity(other: Ast) {
+        _assertContext(other);
+        return !this.eqIdentity(other);
+      }
+
+      sexpr() {
+        return Z3.ast_to_string(contextPtr, this.ast);
+      }
+
+      hash() {
+        return Z3.get_ast_hash(contextPtr, this.ast);
       }
     }
 
-    _toExpr(ast: Z3_ast): Bool | IntNum | RatNum | Arith | Expr {
-      const kind = Z3.get_ast_kind(this.ptr, ast);
-      if (kind === Z3_ast_kind.Z3_QUANTIFIER_AST) {
-        assert(false);
-      }
-      const sortKind = Z3.get_sort_kind(this.ptr, Z3.get_sort(this.ptr, ast));
-      switch (sortKind) {
-        case Z3_sort_kind.Z3_BOOL_SORT:
-          return new BoolImpl(this, ast);
-        case Z3_sort_kind.Z3_INT_SORT:
-          if (kind === Z3_ast_kind.Z3_NUMERAL_AST) {
-            return new IntNumImpl(this, ast);
-          }
-          return new ArithImpl(this, ast);
-        case Z3_sort_kind.Z3_REAL_SORT:
-          if (kind === Z3_ast_kind.Z3_NUMERAL_AST) {
-            return new RatNumImpl(this, ast);
-          }
-          return new ArithImpl(this, ast);
-        case Z3_sort_kind.Z3_BV_SORT:
-          if (kind === Z3_ast_kind.Z3_NUMERAL_AST) {
-            return new BitVecNumImpl(this, ast);
-          }
-          return new BitVecImpl(this, ast);
-        default:
-          return new ExprImpl(this, ast);
-      }
-    }
+    class SolverImpl implements Solver {
+      declare readonly __typename: Solver['__typename'];
 
-    _flattenArgs<T extends AnyAst = AnyAst>(args: (T | AstVector<T>)[]): T[] {
-      const result: T[] = [];
-      for (const arg of args) {
-        if (this.isAstVector(arg)) {
-          result.push(...arg.values());
+      readonly ptr: Z3_solver;
+      readonly ctx: Context;
+      constructor(ptr: Z3_solver | string = Z3.mk_solver(contextPtr)) {
+        this.ctx = ctx;
+        let myPtr: Z3_solver;
+        if (typeof ptr === 'string') {
+          myPtr = Z3.mk_solver_for_logic(contextPtr, _toSymbol(ptr));
         } else {
-          result.push(arg);
+          myPtr = ptr;
+        }
+        this.ptr = myPtr;
+        Z3.solver_inc_ref(contextPtr, myPtr);
+        cleanup.register(this, () => Z3.solver_dec_ref(contextPtr, myPtr));
+      }
+
+      push() {
+        Z3.solver_push(contextPtr, this.ptr);
+      }
+      pop(num: number = 1) {
+        Z3.solver_pop(contextPtr, this.ptr, num);
+      }
+      numScopes() {
+        return Z3.solver_get_num_scopes(contextPtr, this.ptr);
+      }
+      reset() {
+        Z3.solver_reset(contextPtr, this.ptr);
+      }
+      add(...exprs: (Bool | AstVector<Bool>)[]) {
+        _flattenArgs(exprs).forEach(expr => {
+          _assertContext(expr);
+          Z3.solver_assert(contextPtr, this.ptr, expr.ast);
+        });
+      }
+      addAndTrack(expr: Bool, constant: Bool | string) {
+        if (typeof constant === 'string') {
+          constant = Bool.const(constant);
+        }
+        assert(isConst(constant), 'Provided expression that is not a constant to addAndTrack');
+        Z3.solver_assert_and_track(contextPtr, this.ptr, expr.ast, constant.ast);
+      }
+
+      assertions(): AstVector<Bool> {
+        return new AstVectorImpl(Z3.solver_get_assertions(contextPtr, this.ptr));
+      }
+
+      async check(...exprs: (Bool | AstVector<Bool>)[]): Promise<CheckSatResult> {
+        const assumptions = _flattenArgs(exprs).map(expr => {
+          _assertContext(expr);
+          return expr.ast;
+        });
+        const result = await asyncMutex.runExclusive(() =>
+          Z3.solver_check_assumptions(contextPtr, this.ptr, assumptions),
+        );
+        switch (result) {
+          case Z3_lbool.Z3_L_FALSE:
+            return unsat;
+          case Z3_lbool.Z3_L_TRUE:
+            return sat;
+          case Z3_lbool.Z3_L_UNDEF:
+            return unknown;
+          default:
+            assertExhaustive(result);
         }
       }
-      return result;
-    }
 
-    _toProbe(p: Probe | Z3_probe): Probe {
-      if (this.isProbe(p)) {
-        return p;
-      }
-      return new ProbeImpl(this, p);
-    }
-
-    _probeNary(
-      f: (ctx: Z3_context, left: Z3_probe, right: Z3_probe) => Z3_probe,
-      args: [Probe | Z3_probe, ...(Probe | Z3_probe)[]],
-    ) {
-      assert(args.length > 0, 'At least one argument expected');
-      let r = this._toProbe(args[0]);
-      for (let i = 1; i < args.length; i++) {
-        r = new ProbeImpl(this, f(this.ptr, r.ptr, this._toProbe(args[i]).ptr));
-      }
-      return r;
-    }
-  }
-
-  class AstImpl<Ptr> implements Ast {
-    declare readonly __typename: Ast['__typename'];
-
-    constructor(readonly ctx: ContextImpl, readonly ptr: Ptr) {
-      const myAst = this.ast;
-
-      Z3.inc_ref(ctx.ptr, myAst);
-      cleanup.register(this, () => Z3.dec_ref(ctx.ptr, myAst));
-    }
-
-    get ast(): Z3_ast {
-      return this.ptr as any as Z3_ast;
-    }
-
-    get id() {
-      return Z3.get_ast_id(this.ctx.ptr, this.ast);
-    }
-
-    eqIdentity(other: Ast) {
-      this.ctx._assertContext(other);
-      return Z3.is_eq_ast(this.ctx.ptr, this.ast, other.ast);
-    }
-
-    neqIdentity(other: Ast) {
-      this.ctx._assertContext(other);
-      return !this.eqIdentity(other);
-    }
-
-    sexpr() {
-      return Z3.ast_to_string(this.ctx.ptr, this.ast);
-    }
-
-    hash() {
-      return Z3.get_ast_hash(this.ctx.ptr, this.ast);
-    }
-  }
-
-  class SolverImpl implements Solver {
-    declare readonly __typename: Solver['__typename'];
-
-    readonly ptr: Z3_solver;
-
-    constructor(readonly ctx: ContextImpl, ptr: Z3_solver | string = Z3.mk_solver(ctx.ptr)) {
-      let myPtr: Z3_solver;
-      if (typeof ptr === 'string') {
-        myPtr = Z3.mk_solver_for_logic(ctx.ptr, ctx._toSymbol(ptr));
-      } else {
-        myPtr = ptr;
-      }
-      this.ptr = myPtr;
-      Z3.solver_inc_ref(ctx.ptr, myPtr);
-      cleanup.register(this, () => Z3.solver_dec_ref(ctx.ptr, myPtr));
-    }
-
-    push() {
-      Z3.solver_push(this.ctx.ptr, this.ptr);
-    }
-    pop(num: number = 1) {
-      Z3.solver_pop(this.ctx.ptr, this.ptr, num);
-    }
-    numScopes() {
-      return Z3.solver_get_num_scopes(this.ctx.ptr, this.ptr);
-    }
-    reset() {
-      Z3.solver_reset(this.ctx.ptr, this.ptr);
-    }
-    add(...exprs: (Bool | AstVector<Bool>)[]) {
-      this.ctx._flattenArgs(exprs).forEach(expr => {
-        this.ctx._assertContext(expr);
-        Z3.solver_assert(this.ctx.ptr, this.ptr, expr.ast);
-      });
-    }
-    addAndTrack(expr: Bool, constant: Bool | string) {
-      if (typeof constant === 'string') {
-        constant = this.ctx.Bool.const(constant);
-      }
-      assert(this.ctx.isConst(constant), 'Provided expression that is not a constant to addAndTrack');
-      Z3.solver_assert_and_track(this.ctx.ptr, this.ptr, expr.ast, constant.ast);
-    }
-
-    assertions(): AstVector<Bool> {
-      return new AstVectorImpl(this.ctx, Z3.solver_get_assertions(this.ctx.ptr, this.ptr));
-    }
-
-    async check(...exprs: (Bool | AstVector<Bool>)[]): Promise<CheckSatResult> {
-      const assumptions = this.ctx._flattenArgs(exprs).map(expr => {
-        this.ctx._assertContext(expr);
-        return expr.ast;
-      });
-      const result = await asyncMutex.runExclusive(() =>
-        Z3.solver_check_assumptions(this.ctx.ptr, this.ptr, assumptions),
-      );
-      switch (result) {
-        case Z3_lbool.Z3_L_FALSE:
-          return unsat;
-        case Z3_lbool.Z3_L_TRUE:
-          return sat;
-        case Z3_lbool.Z3_L_UNDEF:
-          return unknown;
-        default:
-          assertExhaustive(result);
+      model() {
+        return new ModelImpl(Z3.solver_get_model(contextPtr, this.ptr));
       }
     }
 
-    model() {
-      return new this.ctx.Model(Z3.solver_get_model(this.ctx.ptr, this.ptr));
-    }
-  }
+    class ModelImpl implements Model {
+      declare readonly __typename: Model['__typename'];
+      readonly ctx: Context;
 
-  class ModelImpl implements Model {
-    declare readonly __typename: Model['__typename'];
-
-    constructor(readonly ctx: ContextImpl, readonly ptr: Z3_model = Z3.mk_model(ctx.ptr)) {
-      Z3.model_inc_ref(ctx.ptr, ptr);
-      cleanup.register(this, () => Z3.model_dec_ref(ctx.ptr, ptr));
-    }
-
-    get length() {
-      return Z3.model_get_num_consts(this.ctx.ptr, this.ptr) + Z3.model_get_num_funcs(this.ctx.ptr, this.ptr);
-    }
-
-    [Symbol.iterator](): Iterator<FuncDecl> {
-      return this.values();
-    }
-
-    *entries(): IterableIterator<[number, FuncDecl]> {
-      const length = this.length;
-      for (let i = 0; i < length; i++) {
-        yield [i, this.get(i)];
+      constructor(readonly ptr: Z3_model = Z3.mk_model(contextPtr)) {
+        this.ctx = ctx;
+        Z3.model_inc_ref(contextPtr, ptr);
+        cleanup.register(this, () => Z3.model_dec_ref(contextPtr, ptr));
       }
-    }
 
-    *keys(): IterableIterator<number> {
-      for (const [key] of this.entries()) {
-        yield key;
+      get length() {
+        return Z3.model_get_num_consts(contextPtr, this.ptr) + Z3.model_get_num_funcs(contextPtr, this.ptr);
       }
-    }
 
-    *values(): IterableIterator<FuncDecl> {
-      for (const [, value] of this.entries()) {
-        yield value;
+      [Symbol.iterator](): Iterator<FuncDecl> {
+        return this.values();
       }
-    }
 
-    decls() {
-      return [...this.values()];
-    }
-
-    sexpr() {
-      return Z3.model_to_string(this.ctx.ptr, this.ptr);
-    }
-
-    eval(expr: Bool, modelCompletion?: boolean): Bool;
-    eval(expr: Arith, modelCompletion?: boolean): Arith;
-    eval(expr: Expr, modelCompletion: boolean = false) {
-      this.ctx._assertContext(expr);
-      const r = Z3.model_eval(this.ctx.ptr, this.ptr, expr.ast, modelCompletion);
-      if (r === null) {
-        throw new Z3Error('Failed to evaluatio expression in the model');
-      }
-      return this.ctx._toExpr(r);
-    }
-
-    get(i: number): FuncDecl;
-    get(from: number, to: number): FuncDecl[];
-    get(declaration: FuncDecl): FuncInterp | Expr;
-    get(constant: Expr): Expr;
-    get(sort: Sort): AstVector<AnyExpr>;
-    get(
-      i: number | FuncDecl | Expr | Sort,
-      to?: number,
-    ): FuncDecl | FuncInterp | Expr | AstVector<AnyAst> | FuncDecl[] {
-      assert(to === undefined || typeof i === 'number');
-      if (typeof i === 'number') {
+      *entries(): IterableIterator<[number, FuncDecl]> {
         const length = this.length;
+        for (let i = 0; i < length; i++) {
+          yield [i, this.get(i)];
+        }
+      }
 
-        if (i >= length) {
+      *keys(): IterableIterator<number> {
+        for (const [key] of this.entries()) {
+          yield key;
+        }
+      }
+
+      *values(): IterableIterator<FuncDecl> {
+        for (const [, value] of this.entries()) {
+          yield value;
+        }
+      }
+
+      decls() {
+        return [...this.values()];
+      }
+
+      sexpr() {
+        return Z3.model_to_string(contextPtr, this.ptr);
+      }
+
+      eval(expr: Bool, modelCompletion?: boolean): Bool;
+      eval(expr: Arith, modelCompletion?: boolean): Arith;
+      eval(expr: Expr, modelCompletion: boolean = false) {
+        _assertContext(expr);
+        const r = Z3.model_eval(contextPtr, this.ptr, expr.ast, modelCompletion);
+        if (r === null) {
+          throw new Z3Error('Failed to evaluatio expression in the model');
+        }
+        return _toExpr(r);
+      }
+
+      get(i: number): FuncDecl;
+      get(from: number, to: number): FuncDecl[];
+      get(declaration: FuncDecl): FuncInterp | Expr;
+      get(constant: Expr): Expr;
+      get(sort: Sort): AstVector<AnyExpr>;
+      get(
+        i: number | FuncDecl | Expr | Sort,
+        to?: number,
+      ): FuncDecl | FuncInterp | Expr | AstVector<AnyAst> | FuncDecl[] {
+        assert(to === undefined || typeof i === 'number');
+        if (typeof i === 'number') {
+          const length = this.length;
+
+          if (i >= length) {
+            throw new RangeError();
+          }
+
+          if (to === undefined) {
+            const numConsts = Z3.model_get_num_consts(contextPtr, this.ptr);
+            if (i < numConsts) {
+              return new FuncDeclImpl(Z3.model_get_const_decl(contextPtr, this.ptr, i));
+            } else {
+              return new FuncDeclImpl(Z3.model_get_func_decl(contextPtr, this.ptr, i - numConsts));
+            }
+          }
+
+          if (to < 0) {
+            to += length;
+          }
+          if (to >= length) {
+            throw new RangeError();
+          }
+          const result = [];
+          for (let j = i; j < to; j++) {
+            result.push(this.get(j));
+          }
+          return result;
+        } else if (isFuncDecl(i) || (isExpr(i) && isConst(i))) {
+          const result = this.getInterp(i);
+          assert(result !== null);
+          return result;
+        } else if (isSort(i)) {
+          return this.getUniverse(i);
+        }
+        assert(false, 'Number, declaration or constant expected');
+      }
+
+      private getInterp(expr: FuncDecl | Expr): Expr | FuncInterp | null {
+        assert(isFuncDecl(expr) || isConst(expr), 'Declaration expected');
+        if (isConst(expr)) {
+          assert(isExpr(expr));
+          expr = expr.decl();
+        }
+        assert(isFuncDecl(expr));
+        if (expr.arity() === 0) {
+          const result = Z3.model_get_const_interp(contextPtr, this.ptr, expr.ptr);
+          if (result === null) {
+            return null;
+          }
+          return _toExpr(result);
+        } else {
+          const interp = Z3.model_get_func_interp(contextPtr, this.ptr, expr.ptr);
+          if (interp === null) {
+            return null;
+          }
+          return new FuncInterpImpl(interp);
+        }
+      }
+
+      private getUniverse(sort: Sort): AstVector<AnyAst> {
+        _assertContext(sort);
+        return new AstVectorImpl(Z3.model_get_sort_universe(contextPtr, this.ptr, sort.ptr));
+      }
+    }
+
+    class FuncInterpImpl implements FuncInterp {
+      declare readonly __typename: FuncInterp['__typename'];
+      readonly ctx: Context;
+
+      constructor(readonly ptr: Z3_func_interp) {
+        this.ctx = ctx;
+        Z3.func_interp_inc_ref(contextPtr, ptr);
+        cleanup.register(this, () => Z3.func_interp_dec_ref(contextPtr, ptr));
+      }
+    }
+
+    class SortImpl extends AstImpl<Z3_sort> implements Sort {
+      declare readonly __typename: Sort['__typename'];
+
+      get ast(): Z3_ast {
+        return Z3.sort_to_ast(contextPtr, this.ptr);
+      }
+
+      kind() {
+        return Z3.get_sort_kind(contextPtr, this.ptr);
+      }
+
+      subsort(other: Sort) {
+        _assertContext(other);
+        return false;
+      }
+
+      cast(expr: Expr): Expr {
+        _assertContext(expr);
+        assert(expr.sort.eqIdentity(expr.sort), 'Sort mismatch');
+        return expr;
+      }
+
+      name() {
+        return _fromSymbol(Z3.get_sort_name(contextPtr, this.ptr));
+      }
+
+      eqIdentity(other: Sort) {
+        _assertContext(other);
+        return Z3.is_eq_sort(contextPtr, this.ptr, other.ptr);
+      }
+
+      neqIdentity(other: Sort) {
+        return !this.eqIdentity(other);
+      }
+    }
+
+    class FuncDeclImpl extends AstImpl<Z3_func_decl> implements FuncDecl {
+      declare readonly __typename: FuncDecl['__typename'];
+
+      get ast() {
+        return Z3.func_decl_to_ast(contextPtr, this.ptr);
+      }
+
+      name() {
+        return _fromSymbol(Z3.get_decl_name(contextPtr, this.ptr));
+      }
+
+      arity() {
+        return Z3.get_arity(contextPtr, this.ptr);
+      }
+
+      domain(i: number) {
+        assert(i < this.arity(), 'Index out of bounds');
+        return _toSort(Z3.get_domain(contextPtr, this.ptr, i));
+      }
+
+      range() {
+        return _toSort(Z3.get_range(contextPtr, this.ptr));
+      }
+
+      kind() {
+        return Z3.get_decl_kind(contextPtr, this.ptr);
+      }
+
+      params(): (number | string | Z3_symbol | Sort | Expr | FuncDecl)[] {
+        const n = Z3.get_decl_num_parameters(contextPtr, this.ptr);
+        const result = [];
+        for (let i = 0; i < n; i++) {
+          const kind = Z3.get_decl_parameter_kind(contextPtr, this.ptr, i);
+          switch (kind) {
+            case Z3_parameter_kind.Z3_PARAMETER_INT:
+              result.push(Z3.get_decl_int_parameter(contextPtr, this.ptr, i));
+              break;
+            case Z3_parameter_kind.Z3_PARAMETER_DOUBLE:
+              result.push(Z3.get_decl_double_parameter(contextPtr, this.ptr, i));
+              break;
+            case Z3_parameter_kind.Z3_PARAMETER_RATIONAL:
+              result.push(Z3.get_decl_rational_parameter(contextPtr, this.ptr, i));
+              break;
+            case Z3_parameter_kind.Z3_PARAMETER_SYMBOL:
+              result.push(Z3.get_decl_symbol_parameter(contextPtr, this.ptr, i));
+              break;
+            case Z3_parameter_kind.Z3_PARAMETER_SORT:
+              result.push(new SortImpl(Z3.get_decl_sort_parameter(contextPtr, this.ptr, i)));
+              break;
+            case Z3_parameter_kind.Z3_PARAMETER_AST:
+              result.push(new ExprImpl(Z3.get_decl_ast_parameter(contextPtr, this.ptr, i)));
+              break;
+            case Z3_parameter_kind.Z3_PARAMETER_FUNC_DECL:
+              result.push(new FuncDeclImpl(Z3.get_decl_func_decl_parameter(contextPtr, this.ptr, i)));
+              break;
+            default:
+              assertExhaustive(kind);
+          }
+        }
+        return result;
+      }
+
+      call(...args: CoercibleToExpr[]) {
+        assert(args.length === this.arity(), `Incorrect number of arguments to ${this}`);
+        return _toExpr(
+          Z3.mk_app(
+            contextPtr,
+            this.ptr,
+            args.map((arg, i) => {
+              return this.domain(i).cast(arg).ast;
+            }),
+          ),
+        );
+      }
+    }
+
+    class ExprImpl<Ptr, S extends Sort = AnySort> extends AstImpl<Ptr> implements Expr {
+      declare readonly __typename: Expr['__typename'];
+
+      get sort(): S {
+        return _toSort(Z3.get_sort(contextPtr, this.ast)) as S;
+      }
+
+      eq(other: CoercibleToExpr): Bool {
+        return new BoolImpl(Z3.mk_eq(contextPtr, this.ast, from(other).ast));
+      }
+
+      neq(other: CoercibleToExpr): Bool {
+        return new BoolImpl(
+          Z3.mk_distinct(
+            contextPtr,
+            [this, other].map(expr => from(expr).ast),
+          ),
+        );
+      }
+
+      params() {
+        return this.decl().params();
+      }
+
+      decl(): FuncDecl {
+        assert(isApp(this), 'Z3 application expected');
+        return new FuncDeclImpl(Z3.get_app_decl(contextPtr, Z3.to_app(contextPtr, this.ast)));
+      }
+
+      numArgs(): number {
+        assert(isApp(this), 'Z3 applicaiton expected');
+        return Z3.get_app_num_args(contextPtr, Z3.to_app(contextPtr, this.ast));
+      }
+
+      arg(i: number): ReturnType<typeof _toExpr> {
+        assert(isApp(this), 'Z3 applicaiton expected');
+        assert(i < this.numArgs(), 'Invalid argument index');
+        return _toExpr(Z3.get_app_arg(contextPtr, Z3.to_app(contextPtr, this.ast), i));
+      }
+
+      children(): ReturnType<typeof _toExpr>[] {
+        const num_args = this.numArgs();
+        if (isApp(this)) {
+          const result = [];
+          for (let i = 0; i < num_args; i++) {
+            result.push(this.arg(i));
+          }
+          return result;
+        }
+        return [];
+      }
+    }
+
+    class BoolSortImpl extends SortImpl implements BoolSort {
+      declare readonly __typename: BoolSort['__typename'];
+
+      cast(other: Bool | boolean): Bool;
+      cast(other: CoercibleToExpr): never;
+      cast(other: CoercibleToExpr | Bool) {
+        if (typeof other === 'boolean') {
+          other = Bool.val(other);
+        }
+        assert(isExpr(other), 'true, false or Z3 Boolean expression expected.');
+        assert(this.eqIdentity(other.sort), 'Value cannot be converted into a Z3 Boolean value');
+        return other;
+      }
+
+      subsort(other: Sort) {
+        _assertContext(other.ctx);
+        return other instanceof ArithSortImpl;
+      }
+    }
+
+    class BoolImpl extends ExprImpl<Z3_ast, BoolSort> implements Bool {
+      declare readonly __typename: Bool['__typename'];
+
+      not(): Bool {
+        return Not(this);
+      }
+      and(other: Bool | boolean): Bool {
+        return And(this, other);
+      }
+      or(other: Bool | boolean): Bool {
+        return Or(this, other);
+      }
+      xor(other: Bool | boolean): Bool {
+        return Xor(this, other);
+      }
+    }
+
+    class ProbeImpl implements Probe {
+      declare readonly __typename: Probe['__typename'];
+      readonly ctx: Context;
+
+      constructor(readonly ptr: Z3_probe) {
+        this.ctx = ctx;
+      }
+    }
+
+    class TacticImpl implements Tactic {
+      declare readonly __typename: Tactic['__typename'];
+
+      readonly ptr: Z3_tactic;
+      readonly ctx: Context;
+
+      constructor(tactic: string | Z3_tactic) {
+        this.ctx = ctx;
+        let myPtr: Z3_tactic;
+        if (typeof tactic === 'string') {
+          myPtr = Z3.mk_tactic(contextPtr, tactic);
+        } else {
+          myPtr = tactic;
+        }
+
+        this.ptr = myPtr;
+
+        Z3.tactic_inc_ref(contextPtr, myPtr);
+        cleanup.register(this, () => Z3.tactic_dec_ref(contextPtr, myPtr));
+      }
+    }
+
+    class ArithSortImpl extends SortImpl implements ArithSort {
+      declare readonly __typename: ArithSort['__typename'];
+
+      cast(other: bigint | number): IntNum | RatNum;
+      cast(other: CoercibleRational | RatNum): RatNum;
+      cast(other: IntNum): IntNum;
+      cast(other: Bool | Arith): Arith;
+      cast(other: CoercibleToExpr): never;
+      cast(other: CoercibleToExpr): Arith | RatNum | IntNum {
+        const sortTypeStr = isIntSort(this) ? 'IntSort' : 'RealSort';
+        if (isExpr(other)) {
+          const otherS = other.sort;
+          if (isArith(other)) {
+            if (this.eqIdentity(otherS)) {
+              return other;
+            } else if (isIntSort(otherS) && isRealSort(this)) {
+              return ToReal(other);
+            }
+            assert(false, "Can't cast Real to IntSort without loss");
+          } else if (isBool(other)) {
+            if (isIntSort(this)) {
+              return If(other, 1, 0);
+            } else {
+              return ToReal(If(other, 1, 0));
+            }
+          }
+          assert(false, `Can't cast expression to ${sortTypeStr}`);
+        } else {
+          if (typeof other !== 'boolean') {
+            if (isIntSort(this)) {
+              assert(!isCoercibleRational(other), "Can't cast fraction to IntSort");
+              return Int.val(other);
+            }
+            return Real.val(other);
+          }
+          assert(false, `Can't cast primitive to ${sortTypeStr}`);
+        }
+      }
+    }
+
+    class ArithImpl extends ExprImpl<Z3_ast, ArithSort> implements Arith {
+      declare readonly __typename: Arith['__typename'];
+
+      add(other: Arith | number | bigint | string | CoercibleRational) {
+        return new ArithImpl(Z3.mk_add(contextPtr, [this.ast, this.sort.cast(other).ast]));
+      }
+
+      mul(other: Arith | number | bigint | string | CoercibleRational) {
+        return new ArithImpl(Z3.mk_mul(contextPtr, [this.ast, this.sort.cast(other).ast]));
+      }
+
+      sub(other: Arith | number | bigint | string | CoercibleRational) {
+        return new ArithImpl(Z3.mk_sub(contextPtr, [this.ast, this.sort.cast(other).ast]));
+      }
+
+      pow(exponent: Arith | number | bigint | string | CoercibleRational) {
+        return new ArithImpl(Z3.mk_power(contextPtr, this.ast, this.sort.cast(exponent).ast));
+      }
+
+      div(other: Arith | number | bigint | string | CoercibleRational) {
+        return new ArithImpl(Z3.mk_div(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+
+      mod(other: Arith | number | bigint | string | CoercibleRational) {
+        return new ArithImpl(Z3.mk_mod(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+
+      neg() {
+        return new ArithImpl(Z3.mk_unary_minus(contextPtr, this.ast));
+      }
+
+      le(other: Arith | number | bigint | string | CoercibleRational) {
+        return new BoolImpl(Z3.mk_le(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+
+      lt(other: Arith | number | bigint | string | CoercibleRational) {
+        return new BoolImpl(Z3.mk_lt(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+
+      gt(other: Arith | number | bigint | string | CoercibleRational) {
+        return new BoolImpl(Z3.mk_gt(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+
+      ge(other: Arith | number | bigint | string | CoercibleRational) {
+        return new BoolImpl(Z3.mk_ge(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+    }
+
+    class IntNumImpl extends ArithImpl implements IntNum {
+      declare readonly __typename: IntNum['__typename'];
+
+      get value() {
+        return BigInt(this.asString());
+      }
+
+      asString() {
+        return Z3.get_numeral_string(contextPtr, this.ast);
+      }
+
+      asBinary() {
+        return Z3.get_numeral_binary_string(contextPtr, this.ast);
+      }
+    }
+
+    class RatNumImpl extends ArithImpl implements RatNum {
+      declare readonly __typename: RatNum['__typename'];
+
+      get value() {
+        return { numerator: this.numerator().value, denominator: this.denominator().value };
+      }
+
+      numerator() {
+        return new IntNumImpl(Z3.get_numerator(contextPtr, this.ast));
+      }
+
+      denominator() {
+        return new IntNumImpl(Z3.get_denominator(contextPtr, this.ast));
+      }
+
+      asNumber() {
+        const { numerator, denominator } = this.value;
+        const div = numerator / denominator;
+        return Number(div) + Number(numerator - div * denominator) / Number(denominator);
+      }
+
+      asDecimal(prec: number = Number.parseInt(getParam('precision') ?? FALLBACK_PRECISION.toString())) {
+        return Z3.get_numeral_decimal_string(contextPtr, this.ast, prec);
+      }
+
+      asString() {
+        return Z3.get_numeral_string(contextPtr, this.ast);
+      }
+    }
+
+    class BitVecSortImpl extends SortImpl implements BitVecSort {
+      declare readonly __typename: BitVecSort['__typename'];
+
+      get size() {
+        return Z3.get_bv_sort_size(contextPtr, this.ptr);
+      }
+
+      subsort(other: Sort<any>): boolean {
+        return isBitVecSort(other) && this.size < other.size;
+      }
+
+      cast(other: CoercibleToBitVec): BitVec;
+      cast(other: CoercibleToExpr): Expr;
+      cast(other: CoercibleToExpr): Expr {
+        if (isExpr(other)) {
+          _assertContext(other);
+          return other;
+        }
+        assert(!isCoercibleRational(other), "Can't convert rational to BitVec");
+        return BitVec.val(other, this.size);
+      }
+    }
+
+    class BitVecImpl extends ExprImpl<Z3_ast, BitVecSortImpl> implements BitVec {
+      declare readonly __typename: BitVec['__typename'];
+
+      get size() {
+        return this.sort.size;
+      }
+
+      add(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvadd(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      mul(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvmul(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      sub(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvsub(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      sdiv(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvsdiv(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      udiv(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvudiv(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      smod(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvsmod(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      urem(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvurem(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      srem(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvsrem(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      neg(): BitVec {
+        return new BitVecImpl(Z3.mk_bvneg(contextPtr, this.ast));
+      }
+
+      or(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvor(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      and(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvand(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      nand(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvnand(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      xor(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvxor(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      xnor(other: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvxnor(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      shr(count: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvashr(contextPtr, this.ast, this.sort.cast(count).ast));
+      }
+      lshr(count: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvlshr(contextPtr, this.ast, this.sort.cast(count).ast));
+      }
+      shl(count: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_bvshl(contextPtr, this.ast, this.sort.cast(count).ast));
+      }
+      rotateRight(count: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_ext_rotate_right(contextPtr, this.ast, this.sort.cast(count).ast));
+      }
+      rotateLeft(count: CoercibleToBitVec): BitVec {
+        return new BitVecImpl(Z3.mk_ext_rotate_left(contextPtr, this.ast, this.sort.cast(count).ast));
+      }
+      not(): BitVec {
+        return new BitVecImpl(Z3.mk_bvnot(contextPtr, this.ast));
+      }
+
+      extract(high: number, low: number): BitVec {
+        return new BitVecImpl(Z3.mk_extract(contextPtr, high, low, this.ast));
+      }
+      signExt(count: number): BitVec {
+        return new BitVecImpl(Z3.mk_sign_ext(contextPtr, count, this.ast));
+      }
+      zeroExt(count: number): BitVec {
+        return new BitVecImpl(Z3.mk_zero_ext(contextPtr, count, this.ast));
+      }
+      repeat(count: number): BitVec {
+        return new BitVecImpl(Z3.mk_repeat(contextPtr, count, this.ast));
+      }
+
+      sle(other: CoercibleToBitVec): Bool {
+        return new BoolImpl(Z3.mk_bvsle(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      ule(other: CoercibleToBitVec): Bool {
+        return new BoolImpl(Z3.mk_bvule(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      slt(other: CoercibleToBitVec): Bool {
+        return new BoolImpl(Z3.mk_bvslt(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      ult(other: CoercibleToBitVec): Bool {
+        return new BoolImpl(Z3.mk_bvult(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      sge(other: CoercibleToBitVec): Bool {
+        return new BoolImpl(Z3.mk_bvsge(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      uge(other: CoercibleToBitVec): Bool {
+        return new BoolImpl(Z3.mk_bvuge(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      sgt(other: CoercibleToBitVec): Bool {
+        return new BoolImpl(Z3.mk_bvsgt(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      ugt(other: CoercibleToBitVec): Bool {
+        return new BoolImpl(Z3.mk_bvugt(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+
+      redAnd(): BitVec {
+        return new BitVecImpl(Z3.mk_bvredand(contextPtr, this.ast));
+      }
+      redOr(): BitVec {
+        return new BitVecImpl(Z3.mk_bvredor(contextPtr, this.ast));
+      }
+
+      addNoOverflow(other: CoercibleToBitVec, isSigned: boolean): Bool {
+        return new BoolImpl(Z3.mk_bvadd_no_overflow(contextPtr, this.ast, this.sort.cast(other).ast, isSigned));
+      }
+      addNoUnderflow(other: CoercibleToBitVec): Bool {
+        return new BoolImpl(Z3.mk_bvadd_no_underflow(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      subNoOverflow(other: CoercibleToBitVec): Bool {
+        return new BoolImpl(Z3.mk_bvsub_no_overflow(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      subNoUndeflow(other: CoercibleToBitVec, isSigned: boolean): Bool {
+        return new BoolImpl(Z3.mk_bvsub_no_underflow(contextPtr, this.ast, this.sort.cast(other).ast, isSigned));
+      }
+      sdivNoOverflow(other: CoercibleToBitVec): Bool {
+        return new BoolImpl(Z3.mk_bvsdiv_no_overflow(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      mulNoOverflow(other: CoercibleToBitVec, isSigned: boolean): Bool {
+        return new BoolImpl(Z3.mk_bvmul_no_overflow(contextPtr, this.ast, this.sort.cast(other).ast, isSigned));
+      }
+      mulNoUndeflow(other: CoercibleToBitVec): Bool {
+        return new BoolImpl(Z3.mk_bvmul_no_underflow(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      negNoOverflow(): Bool {
+        return new BoolImpl(Z3.mk_bvneg_no_overflow(contextPtr, this.ast));
+      }
+    }
+
+    class BitVecNumImpl extends BitVecImpl implements BitVecNum {
+      declare readonly __typename: BitVecNum['__typename'];
+      get value() {
+        return BigInt(this.asString());
+      }
+
+      asSignedValue() {
+        let val = this.value;
+        const size = BigInt(this.size);
+        if (val >= 2n ** (size - 1n)) {
+          val = val - 2n ** size;
+        }
+        if (val < (-2n) ** (size - 1n)) {
+          val = val + 2n ** size;
+        }
+        return val;
+      }
+      asString() {
+        return Z3.get_numeral_string(contextPtr, this.ast);
+      }
+      asBinaryString() {
+        return Z3.get_numeral_binary_string(contextPtr, this.ast);
+      }
+    }
+
+    class AstVectorImpl<Item extends AnyAst<Name>> {
+      declare readonly __typename: AstVector['__typename'];
+      readonly ctx: Context;
+
+      constructor(readonly ptr: Z3_ast_vector = Z3.mk_ast_vector(contextPtr)) {
+        this.ctx = ctx;
+        Z3.ast_vector_inc_ref(contextPtr, ptr);
+        cleanup.register(this, () => Z3.ast_vector_dec_ref(contextPtr, ptr));
+      }
+
+      get length(): number {
+        return Z3.ast_vector_size(contextPtr, this.ptr);
+      }
+
+      [Symbol.iterator](): IterableIterator<Item> {
+        return this.values();
+      }
+
+      *entries(): IterableIterator<[number, Item]> {
+        const length = this.length;
+        for (let i = 0; i < length; i++) {
+          yield [i, this.get(i)];
+        }
+      }
+
+      *keys(): IterableIterator<number> {
+        for (let [key] of this.entries()) {
+          yield key;
+        }
+      }
+
+      *values(): IterableIterator<Item> {
+        for (let [, value] of this.entries()) {
+          yield value;
+        }
+      }
+
+      get(i: number): Item;
+      get(from: number, to: number): Item[];
+      get(from: number, to?: number): Item | Item[] {
+        const length = this.length;
+        if (from < 0) {
+          from += length;
+        }
+        if (from >= length) {
           throw new RangeError();
         }
 
         if (to === undefined) {
-          const numConsts = Z3.model_get_num_consts(this.ctx.ptr, this.ptr);
-          if (i < numConsts) {
-            return new FuncDeclImpl(this.ctx, Z3.model_get_const_decl(this.ctx.ptr, this.ptr, i));
-          } else {
-            return new FuncDeclImpl(this.ctx, Z3.model_get_func_decl(this.ctx.ptr, this.ptr, i - numConsts));
-          }
+          return _toAst(Z3.ast_vector_get(contextPtr, this.ptr, from)) as Item;
         }
 
         if (to < 0) {
@@ -1105,769 +1715,196 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         if (to >= length) {
           throw new RangeError();
         }
-        const result = [];
-        for (let j = i; j < to; j++) {
-          result.push(this.get(j));
-        }
-        return result;
-      } else if (this.ctx.isFuncDecl(i) || (this.ctx.isExpr(i) && this.ctx.isConst(i))) {
-        const result = this.getInterp(i);
-        assert(result !== null);
-        return result;
-      } else if (this.ctx.isSort(i)) {
-        return this.getUniverse(i);
-      }
-      assert(false, 'Number, declaration or constant expected');
-    }
 
-    private getInterp(expr: FuncDecl | Expr): Expr | FuncInterp | null {
-      assert(this.ctx.isFuncDecl(expr) || this.ctx.isConst(expr), 'Declaration expected');
-      if (this.ctx.isConst(expr)) {
-        assert(this.ctx.isExpr(expr));
-        expr = expr.decl();
-      }
-      assert(this.ctx.isFuncDecl(expr));
-      if (expr.arity() === 0) {
-        const result = Z3.model_get_const_interp(this.ctx.ptr, this.ptr, expr.ptr);
-        if (result === null) {
-          return null;
-        }
-        return this.ctx._toExpr(result);
-      } else {
-        const interp = Z3.model_get_func_interp(this.ctx.ptr, this.ptr, expr.ptr);
-        if (interp === null) {
-          return null;
-        }
-        return new FuncInterpImpl(this.ctx, interp);
-      }
-    }
-
-    private getUniverse(sort: Sort): AstVector<AnyAst> {
-      this.ctx._assertContext(sort);
-      return new AstVectorImpl(this.ctx, Z3.model_get_sort_universe(this.ctx.ptr, this.ptr, sort.ptr));
-    }
-  }
-
-  class FuncInterpImpl implements FuncInterp {
-    declare readonly __typename: FuncInterp['__typename'];
-
-    constructor(readonly ctx: Context, readonly ptr: Z3_func_interp) {
-      Z3.func_interp_inc_ref(ctx.ptr, ptr);
-      cleanup.register(this, () => Z3.func_interp_dec_ref(ctx.ptr, ptr));
-    }
-  }
-
-  class SortImpl extends AstImpl<Z3_sort> implements Sort {
-    declare readonly __typename: Sort['__typename'];
-
-    get ast(): Z3_ast {
-      return Z3.sort_to_ast(this.ctx.ptr, this.ptr);
-    }
-
-    kind() {
-      return Z3.get_sort_kind(this.ctx.ptr, this.ptr);
-    }
-
-    subsort(other: Sort) {
-      this.ctx._assertContext(other);
-      return false;
-    }
-
-    cast(expr: Expr): Expr {
-      this.ctx._assertContext(expr);
-      assert(expr.sort.eqIdentity(expr.sort), 'Sort mismatch');
-      return expr;
-    }
-
-    name() {
-      return this.ctx._fromSymbol(Z3.get_sort_name(this.ctx.ptr, this.ptr));
-    }
-
-    eqIdentity(other: Sort) {
-      this.ctx._assertContext(other);
-      return Z3.is_eq_sort(this.ctx.ptr, this.ptr, other.ptr);
-    }
-
-    neqIdentity(other: Sort) {
-      return !this.eqIdentity(other);
-    }
-  }
-
-  class FuncDeclImpl extends AstImpl<Z3_func_decl> implements FuncDecl {
-    declare readonly __typename: FuncDecl['__typename'];
-
-    get ast() {
-      return Z3.func_decl_to_ast(this.ctx.ptr, this.ptr);
-    }
-
-    name() {
-      return this.ctx._fromSymbol(Z3.get_decl_name(this.ctx.ptr, this.ptr));
-    }
-
-    arity() {
-      return Z3.get_arity(this.ctx.ptr, this.ptr);
-    }
-
-    domain(i: number) {
-      assert(i < this.arity(), 'Index out of bounds');
-      return this.ctx._toSort(Z3.get_domain(this.ctx.ptr, this.ptr, i));
-    }
-
-    range() {
-      return this.ctx._toSort(Z3.get_range(this.ctx.ptr, this.ptr));
-    }
-
-    kind() {
-      return Z3.get_decl_kind(this.ctx.ptr, this.ptr);
-    }
-
-    params(): (number | string | Z3_symbol | Sort | Expr | FuncDecl)[] {
-      const n = Z3.get_decl_num_parameters(this.ctx.ptr, this.ptr);
-      const result = [];
-      for (let i = 0; i < n; i++) {
-        const kind = Z3.get_decl_parameter_kind(this.ctx.ptr, this.ptr, i);
-        switch (kind) {
-          case Z3_parameter_kind.Z3_PARAMETER_INT:
-            result.push(Z3.get_decl_int_parameter(this.ctx.ptr, this.ptr, i));
-            break;
-          case Z3_parameter_kind.Z3_PARAMETER_DOUBLE:
-            result.push(Z3.get_decl_double_parameter(this.ctx.ptr, this.ptr, i));
-            break;
-          case Z3_parameter_kind.Z3_PARAMETER_RATIONAL:
-            result.push(Z3.get_decl_rational_parameter(this.ctx.ptr, this.ptr, i));
-            break;
-          case Z3_parameter_kind.Z3_PARAMETER_SYMBOL:
-            result.push(Z3.get_decl_symbol_parameter(this.ctx.ptr, this.ptr, i));
-            break;
-          case Z3_parameter_kind.Z3_PARAMETER_SORT:
-            result.push(new SortImpl(this.ctx, Z3.get_decl_sort_parameter(this.ctx.ptr, this.ptr, i)));
-            break;
-          case Z3_parameter_kind.Z3_PARAMETER_AST:
-            result.push(new ExprImpl(this.ctx, Z3.get_decl_ast_parameter(this.ctx.ptr, this.ptr, i)));
-            break;
-          case Z3_parameter_kind.Z3_PARAMETER_FUNC_DECL:
-            result.push(new FuncDeclImpl(this.ctx, Z3.get_decl_func_decl_parameter(this.ctx.ptr, this.ptr, i)));
-            break;
-          default:
-            assertExhaustive(kind);
-        }
-      }
-      return result;
-    }
-
-    call(...args: CoercibleToExpr[]) {
-      assert(args.length === this.arity(), `Incorrect number of arguments to ${this}`);
-      return this.ctx._toExpr(
-        Z3.mk_app(
-          this.ctx.ptr,
-          this.ptr,
-          args.map((arg, i) => {
-            return this.domain(i).cast(arg).ast;
-          }),
-        ),
-      );
-    }
-  }
-
-  class ExprImpl<Ptr, S extends Sort = AnySort> extends AstImpl<Ptr> implements Expr {
-    declare readonly __typename: Expr['__typename'];
-
-    get sort(): S {
-      return this.ctx._toSort(Z3.get_sort(this.ctx.ptr, this.ast)) as S;
-    }
-
-    eq(other: CoercibleToExpr): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_eq(this.ctx.ptr, this.ast, this.ctx.from(other).ast));
-    }
-
-    neq(other: CoercibleToExpr): Bool {
-      return new BoolImpl(
-        this.ctx,
-        Z3.mk_distinct(
-          this.ctx.ptr,
-          [this, other].map(expr => this.ctx.from(expr).ast),
-        ),
-      );
-    }
-
-    params() {
-      return this.decl().params();
-    }
-
-    decl(): FuncDecl {
-      assert(this.ctx.isApp(this), 'Z3 application expected');
-      return new FuncDeclImpl(this.ctx, Z3.get_app_decl(this.ctx.ptr, Z3.to_app(this.ctx.ptr, this.ast)));
-    }
-
-    numArgs(): number {
-      assert(this.ctx.isApp(this), 'Z3 applicaiton expected');
-      return Z3.get_app_num_args(this.ctx.ptr, Z3.to_app(this.ctx.ptr, this.ast));
-    }
-
-    arg(i: number): ReturnType<typeof this.ctx._toExpr> {
-      assert(this.ctx.isApp(this), 'Z3 applicaiton expected');
-      assert(i < this.numArgs(), 'Invalid argument index');
-      return this.ctx._toExpr(Z3.get_app_arg(this.ctx.ptr, Z3.to_app(this.ctx.ptr, this.ast), i));
-    }
-
-    children(): ReturnType<typeof this.ctx._toExpr>[] {
-      const num_args = this.numArgs();
-      if (this.ctx.isApp(this)) {
-        const result = [];
-        for (let i = 0; i < num_args; i++) {
-          result.push(this.arg(i));
+        const result: Item[] = [];
+        for (let i = from; i < to; i++) {
+          result.push(_toAst(Z3.ast_vector_get(contextPtr, this.ptr, i)) as Item);
         }
         return result;
       }
-      return [];
-    }
-  }
 
-  class BoolSortImpl extends SortImpl implements BoolSort {
-    declare readonly __typename: BoolSort['__typename'];
-
-    cast(other: Bool | boolean): Bool;
-    cast(other: CoercibleToExpr): never;
-    cast(other: CoercibleToExpr | Bool) {
-      if (typeof other === 'boolean') {
-        other = this.ctx.Bool.val(other);
-      }
-      assert(this.ctx.isExpr(other), 'true, false or Z3 Boolean expression expected.');
-      assert(this.eqIdentity(other.sort), 'Value cannot be converted into a Z3 Boolean value');
-      return other;
-    }
-
-    subsort(other: Sort) {
-      this.ctx._assertContext(other.ctx);
-      return other instanceof ArithSortImpl;
-    }
-  }
-
-  class BoolImpl extends ExprImpl<Z3_ast, BoolSort> implements Bool {
-    declare readonly __typename: Bool['__typename'];
-
-    not(): Bool {
-      return this.ctx.Not(this);
-    }
-    and(other: Bool | boolean): Bool {
-      return this.ctx.And(this, other);
-    }
-    or(other: Bool | boolean): Bool {
-      return this.ctx.Or(this, other);
-    }
-    xor(other: Bool | boolean): Bool {
-      return this.ctx.Xor(this, other);
-    }
-  }
-
-  class ProbeImpl implements Probe {
-    declare readonly __typename: Probe['__typename'];
-
-    constructor(readonly ctx: ContextImpl, readonly ptr: Z3_probe) {}
-  }
-
-  class TacticImpl implements Tactic {
-    declare readonly __typename: Tactic['__typename'];
-
-    readonly ptr: Z3_tactic;
-
-    constructor(readonly ctx: ContextImpl, tactic: string | Z3_tactic) {
-      let myPtr: Z3_tactic;
-      if (typeof tactic === 'string') {
-        myPtr = Z3.mk_tactic(ctx.ptr, tactic);
-      } else {
-        myPtr = tactic;
+      set(i: number, v: Item): void {
+        _assertContext(v);
+        if (i >= this.length) {
+          throw new RangeError();
+        }
+        Z3.ast_vector_set(contextPtr, this.ptr, i, v.ast);
       }
 
-      this.ptr = myPtr;
+      push(v: Item): void {
+        _assertContext(v);
+        Z3.ast_vector_push(contextPtr, this.ptr, v.ast);
+      }
 
-      Z3.tactic_inc_ref(ctx.ptr, myPtr);
-      cleanup.register(this, () => Z3.tactic_dec_ref(ctx.ptr, myPtr));
-    }
-  }
+      resize(size: number): void {
+        Z3.ast_vector_resize(contextPtr, this.ptr, size);
+      }
 
-  class ArithSortImpl extends SortImpl implements ArithSort {
-    declare readonly __typename: ArithSort['__typename'];
-
-    cast(other: bigint | number): IntNum | RatNum;
-    cast(other: CoercibleRational | RatNum): RatNum;
-    cast(other: IntNum): IntNum;
-    cast(other: Bool | Arith): Arith;
-    cast(other: CoercibleToExpr): never;
-    cast(other: CoercibleToExpr): Arith | RatNum | IntNum {
-      const { If, isExpr, isArith, isBool, isIntSort, isRealSort, ToReal, Int, Real } = this.ctx;
-      const sortTypeStr = isIntSort(this) ? 'IntSort' : 'RealSort';
-      if (isExpr(other)) {
-        const otherS = other.sort;
-        if (isArith(other)) {
-          if (this.eqIdentity(otherS)) {
-            return other;
-          } else if (isIntSort(otherS) && isRealSort(this)) {
-            return this.ctx.ToReal(other);
-          }
-          assert(false, "Can't cast Real to IntSort without loss");
-        } else if (isBool(other)) {
-          if (isIntSort(this)) {
-            return If(other, 1, 0);
-          } else {
-            return ToReal(If(other, 1, 0));
+      has(v: Item): boolean {
+        _assertContext(v);
+        for (const item of this.values()) {
+          if (item.eqIdentity(v)) {
+            return true;
           }
         }
-        assert(false, `Can't cast expression to ${sortTypeStr}`);
-      } else {
-        if (typeof other !== 'boolean') {
-          if (isIntSort(this)) {
-            assert(!isCoercibleRational(other), "Can't cast fraction to IntSort");
-            return Int.val(other);
-          }
-          return Real.val(other);
-        }
-        assert(false, `Can't cast primitive to ${sortTypeStr}`);
+        return false;
       }
-    }
-  }
 
-  class ArithImpl extends ExprImpl<Z3_ast, ArithSort> implements Arith {
-    declare readonly __typename: Arith['__typename'];
-
-    add(other: Arith | number | bigint | string | CoercibleRational) {
-      return new ArithImpl(this.ctx, Z3.mk_add(this.ctx.ptr, [this.ast, this.sort.cast(other).ast]));
-    }
-
-    mul(other: Arith | number | bigint | string | CoercibleRational) {
-      return new ArithImpl(this.ctx, Z3.mk_mul(this.ctx.ptr, [this.ast, this.sort.cast(other).ast]));
-    }
-
-    sub(other: Arith | number | bigint | string | CoercibleRational) {
-      return new ArithImpl(this.ctx, Z3.mk_sub(this.ctx.ptr, [this.ast, this.sort.cast(other).ast]));
-    }
-
-    pow(exponent: Arith | number | bigint | string | CoercibleRational) {
-      return new ArithImpl(this.ctx, Z3.mk_power(this.ctx.ptr, this.ast, this.sort.cast(exponent).ast));
-    }
-
-    div(other: Arith | number | bigint | string | CoercibleRational) {
-      return new ArithImpl(this.ctx, Z3.mk_div(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-
-    mod(other: Arith | number | bigint | string | CoercibleRational) {
-      return new ArithImpl(this.ctx, Z3.mk_mod(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-
-    neg() {
-      return new ArithImpl(this.ctx, Z3.mk_unary_minus(this.ctx.ptr, this.ast));
-    }
-
-    le(other: Arith | number | bigint | string | CoercibleRational) {
-      return new BoolImpl(this.ctx, Z3.mk_le(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-
-    lt(other: Arith | number | bigint | string | CoercibleRational) {
-      return new BoolImpl(this.ctx, Z3.mk_lt(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-
-    gt(other: Arith | number | bigint | string | CoercibleRational) {
-      return new BoolImpl(this.ctx, Z3.mk_gt(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-
-    ge(other: Arith | number | bigint | string | CoercibleRational) {
-      return new BoolImpl(this.ctx, Z3.mk_ge(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-  }
-
-  class IntNumImpl extends ArithImpl implements IntNum {
-    declare readonly __typename: IntNum['__typename'];
-
-    get value() {
-      return BigInt(this.asString());
-    }
-
-    asString() {
-      return Z3.get_numeral_string(this.ctx.ptr, this.ast);
-    }
-
-    asBinary() {
-      return Z3.get_numeral_binary_string(this.ctx.ptr, this.ast);
-    }
-  }
-
-  class RatNumImpl extends ArithImpl implements RatNum {
-    declare readonly __typename: RatNum['__typename'];
-
-    get value() {
-      return { numerator: this.numerator().value, denominator: this.denominator().value };
-    }
-
-    numerator() {
-      return new IntNumImpl(this.ctx, Z3.get_numerator(this.ctx.ptr, this.ast));
-    }
-
-    denominator() {
-      return new IntNumImpl(this.ctx, Z3.get_denominator(this.ctx.ptr, this.ast));
-    }
-
-    asNumber() {
-      const { numerator, denominator } = this.value;
-      const div = numerator / denominator;
-      return Number(div) + Number(numerator - div * denominator) / Number(denominator);
-    }
-
-    asDecimal(prec: number = Number.parseInt(getParam('precision') ?? FALLBACK_PRECISION.toString())) {
-      return Z3.get_numeral_decimal_string(this.ctx.ptr, this.ast, prec);
-    }
-
-    asString() {
-      return Z3.get_numeral_string(this.ctx.ptr, this.ast);
-    }
-  }
-
-  class BitVecSortImpl extends SortImpl implements BitVecSort {
-    declare readonly __typename: BitVecSort['__typename'];
-
-    get size() {
-      return Z3.get_bv_sort_size(this.ctx.ptr, this.ptr);
-    }
-
-    subsort(other: Sort<any>): boolean {
-      return this.ctx.isBitVecSort(other) && this.size < other.size;
-    }
-
-    cast(other: CoercibleToBitVec): BitVec;
-    cast(other: CoercibleToExpr): Expr;
-    cast(other: CoercibleToExpr): Expr {
-      if (this.ctx.isExpr(other)) {
-        this.ctx._assertContext(other);
-        return other;
-      }
-      assert(!isCoercibleRational(other), "Can't convert rational to BitVec");
-      return this.ctx.BitVec.val(other, this.size);
-    }
-  }
-
-  class BitVecImpl extends ExprImpl<Z3_ast, BitVecSortImpl> implements BitVec {
-    declare readonly __typename: BitVec['__typename'];
-
-    get size() {
-      return this.sort.size;
-    }
-
-    add(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvadd(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    mul(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvmul(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    sub(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvsub(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    sdiv(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvsdiv(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    udiv(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvudiv(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    smod(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvsmod(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    urem(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvurem(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    srem(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvsrem(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    neg(): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvneg(this.ctx.ptr, this.ast));
-    }
-
-    or(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvor(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    and(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvand(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    nand(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvnand(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    xor(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvxor(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    xnor(other: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvxnor(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    shr(count: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvashr(this.ctx.ptr, this.ast, this.sort.cast(count).ast));
-    }
-    lshr(count: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvlshr(this.ctx.ptr, this.ast, this.sort.cast(count).ast));
-    }
-    shl(count: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvshl(this.ctx.ptr, this.ast, this.sort.cast(count).ast));
-    }
-    rotateRight(count: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_ext_rotate_right(this.ctx.ptr, this.ast, this.sort.cast(count).ast));
-    }
-    rotateLeft(count: CoercibleToBitVec): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_ext_rotate_left(this.ctx.ptr, this.ast, this.sort.cast(count).ast));
-    }
-    not(): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvnot(this.ctx.ptr, this.ast));
-    }
-
-    extract(high: number, low: number): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_extract(this.ctx.ptr, high, low, this.ast));
-    }
-    signExt(count: number): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_sign_ext(this.ctx.ptr, count, this.ast));
-    }
-    zeroExt(count: number): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_zero_ext(this.ctx.ptr, count, this.ast));
-    }
-    repeat(count: number): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_repeat(this.ctx.ptr, count, this.ast));
-    }
-
-    sle(other: CoercibleToBitVec): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvsle(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    ule(other: CoercibleToBitVec): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvule(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    slt(other: CoercibleToBitVec): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvslt(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    ult(other: CoercibleToBitVec): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvult(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    sge(other: CoercibleToBitVec): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvsge(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    uge(other: CoercibleToBitVec): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvuge(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    sgt(other: CoercibleToBitVec): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvsgt(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    ugt(other: CoercibleToBitVec): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvugt(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-
-    redAnd(): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvredand(this.ctx.ptr, this.ast));
-    }
-    redOr(): BitVec {
-      return new BitVecImpl(this.ctx, Z3.mk_bvredor(this.ctx.ptr, this.ast));
-    }
-
-    addNoOverflow(other: CoercibleToBitVec, isSigned: boolean): Bool {
-      return new BoolImpl(
-        this.ctx,
-        Z3.mk_bvadd_no_overflow(this.ctx.ptr, this.ast, this.sort.cast(other).ast, isSigned),
-      );
-    }
-    addNoUnderflow(other: CoercibleToBitVec): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvadd_no_underflow(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    subNoOverflow(other: CoercibleToBitVec): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvsub_no_overflow(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    subNoUndeflow(other: CoercibleToBitVec, isSigned: boolean): Bool {
-      return new BoolImpl(
-        this.ctx,
-        Z3.mk_bvsub_no_underflow(this.ctx.ptr, this.ast, this.sort.cast(other).ast, isSigned),
-      );
-    }
-    sdivNoOverflow(other: CoercibleToBitVec): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvsdiv_no_overflow(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    mulNoOverflow(other: CoercibleToBitVec, isSigned: boolean): Bool {
-      return new BoolImpl(
-        this.ctx,
-        Z3.mk_bvmul_no_overflow(this.ctx.ptr, this.ast, this.sort.cast(other).ast, isSigned),
-      );
-    }
-    mulNoUndeflow(other: CoercibleToBitVec): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvmul_no_underflow(this.ctx.ptr, this.ast, this.sort.cast(other).ast));
-    }
-    negNoOverflow(): Bool {
-      return new BoolImpl(this.ctx, Z3.mk_bvneg_no_overflow(this.ctx.ptr, this.ast));
-    }
-  }
-
-  class BitVecNumImpl extends BitVecImpl implements BitVecNum {
-    declare readonly __typename: BitVecNum['__typename'];
-    get value() {
-      return BigInt(this.asString());
-    }
-
-    asSignedValue() {
-      let val = this.value;
-      const size = BigInt(this.size);
-      if (val >= 2n ** (size - 1n)) {
-        val = val - 2n ** size;
-      }
-      if (val < (-2n) ** (size - 1n)) {
-        val = val + 2n ** size;
-      }
-      return val;
-    }
-    asString() {
-      return Z3.get_numeral_string(this.ctx.ptr, this.ast);
-    }
-    asBinaryString() {
-      return Z3.get_numeral_binary_string(this.ctx.ptr, this.ast);
-    }
-  }
-
-  class AstVectorImpl<Item extends AnyAst = AnyAst> {
-    declare readonly __typename: AstVector['__typename'];
-
-    constructor(readonly ctx: ContextImpl, readonly ptr: Z3_ast_vector = Z3.mk_ast_vector(ctx.ptr)) {
-      Z3.ast_vector_inc_ref(ctx.ptr, ptr);
-      cleanup.register(this, () => Z3.ast_vector_dec_ref(ctx.ptr, ptr));
-    }
-
-    get length(): number {
-      return Z3.ast_vector_size(this.ctx.ptr, this.ptr);
-    }
-
-    [Symbol.iterator](): IterableIterator<Item> {
-      return this.values();
-    }
-
-    *entries(): IterableIterator<[number, Item]> {
-      const length = this.length;
-      for (let i = 0; i < length; i++) {
-        yield [i, this.get(i)];
+      sexpr(): string {
+        return Z3.ast_vector_to_string(contextPtr, this.ptr);
       }
     }
 
-    *keys(): IterableIterator<number> {
-      for (let [key] of this.entries()) {
-        yield key;
-      }
-    }
+    class AstMapImpl<Key extends AnyAst<Name>, Value extends AnyAst<Name>> implements AstMap<Key, Value> {
+      declare readonly __typename: AstMap['__typename'];
+      readonly ctx: Context;
 
-    *values(): IterableIterator<Item> {
-      for (let [, value] of this.entries()) {
-        yield value;
-      }
-    }
-
-    get(i: number): Item;
-    get(from: number, to: number): Item[];
-    get(from: number, to?: number): Item | Item[] {
-      const length = this.length;
-      if (from < 0) {
-        from += length;
-      }
-      if (from >= length) {
-        throw new RangeError();
+      constructor(readonly ptr: Z3_ast_map = Z3.mk_ast_map(contextPtr)) {
+        this.ctx = ctx;
+        Z3.ast_map_inc_ref(contextPtr, ptr);
+        cleanup.register(this, () => Z3.ast_map_dec_ref(contextPtr, ptr));
       }
 
-      if (to === undefined) {
-        return this.ctx._toAst(Z3.ast_vector_get(this.ctx.ptr, this.ptr, from)) as Item;
+      [Symbol.iterator](): Iterator<[Key, Value]> {
+        return this.entries();
       }
 
-      if (to < 0) {
-        to += length;
-      }
-      if (to >= length) {
-        throw new RangeError();
+      get size(): number {
+        return Z3.ast_map_size(contextPtr, this.ptr);
       }
 
-      const result: Item[] = [];
-      for (let i = from; i < to; i++) {
-        result.push(this.ctx._toAst(Z3.ast_vector_get(this.ctx.ptr, this.ptr, i)) as Item);
-      }
-      return result;
-    }
-
-    set(i: number, v: Item): void {
-      this.ctx._assertContext(v);
-      if (i >= this.length) {
-        throw new RangeError();
-      }
-      Z3.ast_vector_set(this.ctx.ptr, this.ptr, i, v.ast);
-    }
-
-    push(v: Item): void {
-      this.ctx._assertContext(v);
-      Z3.ast_vector_push(this.ctx.ptr, this.ptr, v.ast);
-    }
-
-    resize(size: number): void {
-      Z3.ast_vector_resize(this.ctx.ptr, this.ptr, size);
-    }
-
-    has(v: Item): boolean {
-      this.ctx._assertContext(v);
-      for (const item of this.values()) {
-        if (item.eqIdentity(v)) {
-          return true;
+      *entries(): IterableIterator<[Key, Value]> {
+        for (const key of this.keys()) {
+          yield [key, this.get(key)];
         }
       }
-      return false;
-    }
 
-    sexpr(): string {
-      return Z3.ast_vector_to_string(this.ctx.ptr, this.ptr);
-    }
-  }
+      keys(): AstVector<Key> {
+        return new AstVectorImpl(Z3.ast_map_keys(contextPtr, this.ptr));
+      }
 
-  class AstMapImpl<Key extends AnyAst = AnyAst, Value extends AnyAst = AnyAst> implements AstMap<Key, Value> {
-    declare readonly __typename: AstMap['__typename'];
+      *values(): IterableIterator<Value> {
+        for (const [_, value] of this.entries()) {
+          yield value;
+        }
+      }
+      get(key: Key): Value {
+        return _toAst(Z3.ast_map_find(contextPtr, this.ptr, key.ast)) as Value;
+      }
 
-    constructor(readonly ctx: ContextImpl, readonly ptr: Z3_ast_map = Z3.mk_ast_map(ctx.ptr)) {
-      Z3.ast_map_inc_ref(ctx.ptr, ptr);
-      cleanup.register(this, () => Z3.ast_map_dec_ref(ctx.ptr, ptr));
-    }
+      set(key: Key, value: Value): void {
+        Z3.ast_map_insert(contextPtr, this.ptr, key.ast, value.ast);
+      }
 
-    [Symbol.iterator](): Iterator<[Key, Value]> {
-      return this.entries();
-    }
+      delete(key: Key): void {
+        Z3.ast_map_erase(contextPtr, this.ptr, key.ast);
+      }
 
-    get size(): number {
-      return Z3.ast_map_size(this.ctx.ptr, this.ptr);
-    }
+      clear(): void {
+        Z3.ast_map_reset(contextPtr, this.ptr);
+      }
 
-    *entries(): IterableIterator<[Key, Value]> {
-      for (const key of this.keys()) {
-        yield [key, this.get(key)];
+      has(key: Key): boolean {
+        return Z3.ast_map_contains(contextPtr, this.ptr, key.ast);
+      }
+
+      sexpr(): string {
+        return Z3.ast_map_to_string(contextPtr, this.ptr);
       }
     }
 
-    keys(): AstVector<Key> {
-      return new AstVectorImpl(this.ctx, Z3.ast_map_keys(this.ctx.ptr, this.ptr));
-    }
+    const ctx: Context<Name> = {
+      ptr: contextPtr,
+      name,
 
-    *values(): IterableIterator<Value> {
-      for (const [_, value] of this.entries()) {
-        yield value;
-      }
-    }
-    get(key: Key): Value {
-      return this.ctx._toAst(Z3.ast_map_find(this.ctx.ptr, this.ptr, key.ast)) as Value;
-    }
+      /////////////
+      // Classes //
+      /////////////
+      Solver: SolverImpl,
+      Model: ModelImpl,
+      Tactic: TacticImpl,
+      AstVector: AstVectorImpl as AstVectorCtor<Name>,
+      AstMap: AstMapImpl as AstMapCtor<Name>,
 
-    set(key: Key, value: Value): void {
-      Z3.ast_map_insert(this.ctx.ptr, this.ptr, key.ast, value.ast);
-    }
+      ///////////////
+      // Functions //
+      ///////////////
+      interrupt,
+      isModel,
+      isAst,
+      isSort,
+      isFuncDecl,
+      isApp,
+      isConst,
+      isExpr,
+      isVar,
+      isAppOf,
+      isBool,
+      isTrue,
+      isFalse,
+      isAnd,
+      isOr,
+      isImplies,
+      isNot,
+      isEq,
+      isDistinct,
+      isArith,
+      isArithSort,
+      isInt,
+      isIntVal,
+      isIntSort,
+      isReal,
+      isRealVal,
+      isRealSort,
+      isBitVecSort,
+      isBitVec,
+      isBitVecVal, // TODO fix ordering
+      isProbe,
+      isTactic,
+      isAstVector,
+      eqIdentity,
+      getVarIndex,
+      from,
+      solve,
 
-    delete(key: Key): void {
-      Z3.ast_map_erase(this.ctx.ptr, this.ptr, key.ast);
-    }
+      /////////////
+      // Objects //
+      /////////////
+      Sort,
+      Function,
+      RecFunc,
+      Bool,
+      Int,
+      Real,
+      BitVec,
 
-    clear(): void {
-      Z3.ast_map_reset(this.ctx.ptr, this.ptr);
-    }
-
-    has(key: Key): boolean {
-      return Z3.ast_map_contains(this.ctx.ptr, this.ptr, key.ast);
-    }
-
-    sexpr(): string {
-      return Z3.ast_map_to_string(this.ctx.ptr, this.ptr);
-    }
+      ////////////////
+      // Operations //
+      ////////////////
+      If,
+      Distinct,
+      Const,
+      Consts,
+      FreshConst,
+      Var,
+      Implies,
+      Eq,
+      Xor,
+      Not,
+      And,
+      Or,
+      ToReal,
+      ToInt,
+      IsInt,
+      Sqrt,
+      Cbrt,
+      BV2Int,
+      Int2BV,
+      Concat,
+      // Cond, // TODO
+    };
+    cleanup.register(ctx, () => Z3.del_context(contextPtr));
+    return ctx;
   }
 
   return {
@@ -1881,8 +1918,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
     getParam,
     setParam,
     resetParams,
-    isContext,
 
-    Context: ContextImpl as ContextCtor,
+    Context: createContext,
   };
 }

--- a/src/api/js/src/high-level/high-level.ts
+++ b/src/api/js/src/high-level/high-level.ts
@@ -159,7 +159,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
     Z3.set_ast_print_mode(contextPtr, Z3_ast_print_mode.Z3_PRINT_SMTLIB2_COMPLIANT);
     Z3.del_config(cfg);
 
-    function _assertContext(...ctxs: (Context | { ctx: Context })[]) {
+    function _assertContext(...ctxs: (Context<Name> | { ctx: Context<Name> })[]) {
       ctxs.forEach(other => assert('ctx' in other ? ctx === other.ctx : ctx === other, 'Context mismatch'));
     }
 
@@ -186,7 +186,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    function _toAst(ast: Z3_ast): AnyAst {
+    function _toAst(ast: Z3_ast): AnyAst<Name> {
       switch (Z3.get_ast_kind(contextPtr, ast)) {
         case Z3_ast_kind.Z3_SORT_AST:
           return _toSort(ast as Z3_sort);
@@ -197,7 +197,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    function _toSort(ast: Z3_sort): AnySort {
+    function _toSort(ast: Z3_sort): AnySort<Name> {
       switch (Z3.get_sort_kind(contextPtr, ast)) {
         case Z3_sort_kind.Z3_BOOL_SORT:
           return new BoolSortImpl(ast);
@@ -211,7 +211,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    function _toExpr(ast: Z3_ast): Bool | IntNum | RatNum | Arith | Expr {
+    function _toExpr(ast: Z3_ast): Bool<Name> | IntNum<Name> | RatNum<Name> | Arith<Name> | Expr<Name> {
       const kind = Z3.get_ast_kind(contextPtr, ast);
       if (kind === Z3_ast_kind.Z3_QUANTIFIER_AST) {
         assert(false);
@@ -240,7 +240,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    function _flattenArgs<T extends AnyAst = AnyAst>(args: (T | AstVector<T>)[]): T[] {
+    function _flattenArgs<T extends AnyAst<Name> = AnyAst<Name>>(args: (T | AstVector<Name, T>)[]): T[] {
       const result: T[] = [];
       for (const arg of args) {
         if (isAstVector(arg)) {
@@ -252,7 +252,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       return result;
     }
 
-    function _toProbe(p: Probe | Z3_probe): Probe {
+    function _toProbe(p: Probe<Name> | Z3_probe): Probe<Name> {
       if (isProbe(p)) {
         return p;
       }
@@ -261,7 +261,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
 
     function _probeNary(
       f: (ctx: Z3_context, left: Z3_probe, right: Z3_probe) => Z3_probe,
-      args: [Probe | Z3_probe, ...(Probe | Z3_probe)[]],
+      args: [Probe<Name> | Z3_probe, ...(Probe<Name> | Z3_probe)[]],
     ) {
       assert(args.length > 0, 'At least one argument expected');
       let r = _toProbe(args[0]);
@@ -278,25 +278,25 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       Z3.interrupt(contextPtr);
     }
 
-    function isModel(obj: unknown): obj is Model {
+    function isModel(obj: unknown): obj is Model<Name> {
       const r = obj instanceof ModelImpl;
       r && _assertContext(obj);
       return r;
     }
 
-    function isAst(obj: unknown): obj is Ast {
+    function isAst(obj: unknown): obj is Ast<Name> {
       const r = obj instanceof AstImpl;
       r && _assertContext(obj);
       return r;
     }
 
-    function isSort(obj: unknown): obj is Sort {
+    function isSort(obj: unknown): obj is Sort<Name> {
       const r = obj instanceof SortImpl;
       r && _assertContext(obj);
       return r;
     }
 
-    function isFuncDecl(obj: unknown): obj is FuncDecl {
+    function isFuncDecl(obj: unknown): obj is FuncDecl<Name> {
       const r = obj instanceof FuncDeclImpl;
       r && _assertContext(obj);
       return r;
@@ -314,7 +314,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       return isExpr(obj) && isApp(obj) && obj.numArgs() === 0;
     }
 
-    function isExpr(obj: unknown): obj is Expr {
+    function isExpr(obj: unknown): obj is Expr<Name> {
       const r = obj instanceof ExprImpl;
       r && _assertContext(obj);
       return r;
@@ -328,7 +328,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       return isExpr(obj) && isApp(obj) && obj.decl().kind() === kind;
     }
 
-    function isBool(obj: unknown): obj is Bool {
+    function isBool(obj: unknown): obj is Bool<Name> {
       const r = obj instanceof BoolImpl;
       r && _assertContext(obj);
       return r;
@@ -366,13 +366,13 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       return isAppOf(obj, Z3_decl_kind.Z3_OP_DISTINCT);
     }
 
-    function isArith(obj: unknown): obj is Arith {
+    function isArith(obj: unknown): obj is Arith<Name> {
       const r = obj instanceof ArithImpl;
       r && _assertContext(obj);
       return r;
     }
 
-    function isArithSort(obj: unknown): obj is ArithSort {
+    function isArithSort(obj: unknown): obj is ArithSort<Name> {
       const r = obj instanceof ArithSortImpl;
       r && _assertContext(obj);
       return r;
@@ -382,7 +382,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       return isArith(obj) && isIntSort(obj.sort);
     }
 
-    function isIntVal(obj: unknown): obj is IntNum {
+    function isIntVal(obj: unknown): obj is IntNum<Name> {
       const r = obj instanceof IntNumImpl;
       r && _assertContext(obj);
       return r;
@@ -396,7 +396,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       return isArith(obj) && isRealSort(obj.sort);
     }
 
-    function isRealVal(obj: unknown): obj is RatNum {
+    function isRealVal(obj: unknown): obj is RatNum<Name> {
       const r = obj instanceof RatNumImpl;
       r && _assertContext(obj);
       return r;
@@ -406,57 +406,57 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       return isSort(obj) && obj.kind() === Z3_sort_kind.Z3_REAL_SORT;
     }
 
-    function isBitVecSort(obj: unknown): obj is BitVecSort {
+    function isBitVecSort(obj: unknown): obj is BitVecSort<number, Name> {
       const r = obj instanceof BitVecSortImpl;
       r && _assertContext(obj);
       return r;
     }
 
-    function isBitVec(obj: unknown): obj is BitVec {
+    function isBitVec(obj: unknown): obj is BitVec<number, Name> {
       const r = obj instanceof BitVecImpl;
       r && _assertContext(obj);
       return r;
     }
 
-    function isBitVecVal(obj: unknown): obj is BitVecNum {
+    function isBitVecVal(obj: unknown): obj is BitVecNum<number, Name> {
       const r = obj instanceof BitVecNumImpl;
       r && _assertContext(obj);
       return r;
     }
 
-    function isProbe(obj: unknown): obj is Probe {
+    function isProbe(obj: unknown): obj is Probe<Name> {
       const r = obj instanceof ProbeImpl;
       r && _assertContext(obj);
       return r;
     }
 
-    function isTactic(obj: unknown): obj is Tactic {
+    function isTactic(obj: unknown): obj is Tactic<Name> {
       const r = obj instanceof TacticImpl;
       r && _assertContext(obj);
       return r;
     }
 
-    function isAstVector(obj: unknown): obj is AstVector {
+    function isAstVector(obj: unknown): obj is AstVector<Name> {
       const r = obj instanceof AstVectorImpl;
       r && _assertContext(obj);
       return r;
     }
 
-    function eqIdentity(a: Ast, b: Ast): boolean {
+    function eqIdentity(a: Ast<Name>, b: Ast<Name>): boolean {
       return a.eqIdentity(b);
     }
 
-    function getVarIndex(obj: Expr): number {
+    function getVarIndex(obj: Expr<Name>): number {
       assert(isVar(obj), 'Z3 bound variable expected');
       return Z3.get_index_value(contextPtr, obj.ast);
     }
 
-    function from(primitive: boolean): Bool;
-    function from(primitive: number | CoercibleRational): RatNum;
-    function from(primitive: bigint): IntNum;
-    function from<T extends Expr>(expr: T): T;
-    function from(expr: CoercibleToExpr): AnyExpr;
-    function from(value: CoercibleToExpr): AnyExpr {
+    function from(primitive: boolean): Bool<Name>;
+    function from(primitive: number | CoercibleRational): RatNum<Name>;
+    function from(primitive: bigint): IntNum<Name>;
+    function from<T extends Expr<Name>>(expr: T): T;
+    function from(expr: CoercibleToExpr<Name>): AnyExpr<Name>;
+    function from(value: CoercibleToExpr<Name>): AnyExpr<Name> {
       if (typeof value === 'boolean') {
         return Bool.val(value);
       } else if (typeof value === 'number' || isCoercibleRational(value)) {
@@ -469,7 +469,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       assert(false);
     }
 
-    async function solve(...assertions: Bool[]): Promise<Model | typeof unsat | typeof unknown> {
+    async function solve(...assertions: Bool<Name>[]): Promise<Model<Name> | typeof unsat | typeof unknown> {
       const solver = new ctx.Solver();
       solver.add(...assertions);
       const result = await solver.check();
@@ -486,7 +486,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       declare: (name: string) => new SortImpl(Z3.mk_uninterpreted_sort(contextPtr, _toSymbol(name))),
     };
     const Function = {
-      declare: (name: string, ...signature: FuncDeclSignature<any>) => {
+      declare: (name: string, ...signature: FuncDeclSignature<Name>) => {
         const arity = signature.length - 1;
         const rng = signature[arity];
         _assertContext(rng);
@@ -497,7 +497,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         }
         return new FuncDeclImpl(Z3.mk_func_decl(contextPtr, _toSymbol(name), dom, rng.ptr));
       },
-      fresh: (...signature: FuncDeclSignature<any>) => {
+      fresh: (...signature: FuncDeclSignature<Name>) => {
         const arity = signature.length - 1;
         const rng = signature[arity];
         _assertContext(rng);
@@ -510,7 +510,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       },
     };
     const RecFunc = {
-      declare: (name: string, ...signature: FuncDeclSignature<any>) => {
+      declare: (name: string, ...signature: FuncDeclSignature<Name>) => {
         const arity = signature.length - 1;
         const rng = signature[arity];
         _assertContext(rng);
@@ -522,7 +522,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         return new FuncDeclImpl(Z3.mk_rec_func_decl(contextPtr, _toSymbol(name), dom, rng.ptr));
       },
 
-      addDefinition: (f: FuncDecl, args: Expr[], body: Expr) => {
+      addDefinition: (f: FuncDecl<Name>, args: Expr<Name>[], body: Expr<Name>) => {
         _assertContext(f, ...args, body);
         Z3.add_rec_def(
           contextPtr,
@@ -609,28 +609,34 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       },
     };
     const BitVec = {
-      sort: (bits: number): BitVecSort<any> => {
+      sort<Bits extends number>(bits: Bits): BitVecSort<Bits, Name> {
         assert(Number.isSafeInteger(bits), 'number of bits must be an integer');
         return new BitVecSortImpl(Z3.mk_bv_sort(contextPtr, bits));
       },
 
-      const: (name: string, bits: number | BitVecSort): BitVec<any> =>
-        new BitVecImpl(Z3.mk_const(contextPtr, _toSymbol(name), isBitVecSort(bits) ? bits.ptr : BitVec.sort(bits).ptr)),
+      const<Bits extends number>(name: string, bits: Bits | BitVecSort<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(
+          Z3.mk_const(contextPtr, _toSymbol(name), isBitVecSort(bits) ? bits.ptr : BitVec.sort(bits).ptr),
+        );
+      },
 
-      consts: (names: string | string[], bits: number | BitVecSort): BitVec<any>[] => {
+      consts<Bits extends number>(names: string | string[], bits: Bits | BitVecSort<Bits, Name>): BitVec<Bits, Name>[] {
         if (typeof names === 'string') {
           names = names.split(' ');
         }
         return names.map(name => BitVec.const(name, bits));
       },
 
-      val: (value: bigint | number | boolean, bits: number | BitVecSort): BitVecNum<any> => {
+      val<Bits extends number>(
+        value: bigint | number | boolean,
+        bits: Bits | BitVecSort<Bits, Name>,
+      ): BitVecNum<Bits, Name> {
         if (value === true) {
           return BitVec.val(1, bits);
         } else if (value === false) {
           return BitVec.val(0, bits);
         }
-        return new BitVecNumImpl(
+        return new BitVecNumImpl<Bits>(
           Z3.mk_numeral(contextPtr, value.toString(), isBitVecSort(bits) ? bits.ptr : BitVec.sort(bits).ptr),
         );
       },
@@ -639,17 +645,17 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
     ////////////////
     // Operations //
     ////////////////
-    function If(condition: Probe, onTrue: Tactic, onFalse: Tactic): Tactic;
-    function If<OnTrueRef extends CoercibleToExpr, OnFalseRef extends CoercibleToExpr>(
-      condition: Bool | boolean,
+    function If(condition: Probe<Name>, onTrue: Tactic<Name>, onFalse: Tactic<Name>): Tactic<Name>;
+    function If<OnTrueRef extends CoercibleToExpr<Name>, OnFalseRef extends CoercibleToExpr<Name>>(
+      condition: Bool<Name> | boolean,
       onTrue: OnTrueRef,
       onFalse: OnFalseRef,
-    ): CoercibleToExprMap<OnTrueRef | OnFalseRef>;
+    ): CoercibleToExprMap<OnTrueRef | OnFalseRef, Name>;
     function If(
-      condition: Bool | Probe | boolean,
-      onTrue: CoercibleToExpr | Tactic,
-      onFalse: CoercibleToExpr | Tactic,
-    ): Expr | Tactic {
+      condition: Bool<Name> | Probe<Name> | boolean,
+      onTrue: CoercibleToExpr<Name> | Tactic<Name>,
+      onFalse: CoercibleToExpr<Name> | Tactic<Name>,
+    ): Expr<Name> | Tactic<Name> {
       if (isProbe(condition) && isTactic(onTrue) && isTactic(onFalse)) {
         return Cond(condition, onTrue, onFalse);
       }
@@ -662,7 +668,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       return _toExpr(Z3.mk_ite(contextPtr, condition.ptr, onTrue.ast, onFalse.ast));
     }
 
-    function Distinct(...exprs: CoercibleToExpr[]): Bool {
+    function Distinct(...exprs: CoercibleToExpr<Name>[]): Bool<Name> {
       assert(exprs.length > 0, "Can't make Distinct ouf of nothing");
 
       return new BoolImpl(
@@ -677,12 +683,12 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       );
     }
 
-    function Const<S extends Sort>(name: string, sort: S): SortToExprMap<S> {
+    function Const<S extends Sort<Name>>(name: string, sort: S): SortToExprMap<S, Name> {
       _assertContext(sort);
-      return _toExpr(Z3.mk_const(contextPtr, _toSymbol(name), sort.ptr)) as SortToExprMap<S>;
+      return _toExpr(Z3.mk_const(contextPtr, _toSymbol(name), sort.ptr)) as SortToExprMap<S, Name>;
     }
 
-    function Consts<S extends Sort>(names: string | string[], sort: S): SortToExprMap<S>[] {
+    function Consts<S extends Sort<Name>>(names: string | string[], sort: S): SortToExprMap<S, Name>[] {
       _assertContext(sort);
       if (typeof names === 'string') {
         names = names.split(' ');
@@ -690,40 +696,40 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       return names.map(name => Const(name, sort));
     }
 
-    function FreshConst<S extends Sort>(sort: S, prefix: string = 'c'): SortToExprMap<S> {
+    function FreshConst<S extends Sort<Name>>(sort: S, prefix: string = 'c'): SortToExprMap<S, Name> {
       _assertContext(sort);
-      return _toExpr(Z3.mk_fresh_const(sort.ctx.ptr, prefix, sort.ptr)) as SortToExprMap<S>;
+      return _toExpr(Z3.mk_fresh_const(sort.ctx.ptr, prefix, sort.ptr)) as SortToExprMap<S, Name>;
     }
 
-    function Var<S extends Sort>(idx: number, sort: S): SortToExprMap<S> {
+    function Var<S extends Sort<Name>>(idx: number, sort: S): SortToExprMap<S, Name> {
       _assertContext(sort);
-      return _toExpr(Z3.mk_bound(sort.ctx.ptr, idx, sort.ptr)) as SortToExprMap<S>;
+      return _toExpr(Z3.mk_bound(sort.ctx.ptr, idx, sort.ptr)) as SortToExprMap<S, Name>;
     }
 
-    function Implies(a: Bool | boolean, b: Bool | boolean): Bool {
-      a = from(a) as Bool;
-      b = from(b) as Bool;
+    function Implies(a: Bool<Name> | boolean, b: Bool<Name> | boolean): Bool<Name> {
+      a = from(a) as Bool<Name>;
+      b = from(b) as Bool<Name>;
       _assertContext(a, b);
       return new BoolImpl(Z3.mk_implies(contextPtr, a.ptr, b.ptr));
     }
 
-    function Eq(a: CoercibleToExpr, b: CoercibleToExpr): Bool {
+    function Eq(a: CoercibleToExpr<Name>, b: CoercibleToExpr<Name>): Bool<Name> {
       a = from(a);
       b = from(b);
       _assertContext(a, b);
       return a.eq(b);
     }
 
-    function Xor(a: Bool | boolean, b: Bool | boolean): Bool {
-      a = from(a) as Bool;
-      b = from(b) as Bool;
+    function Xor(a: Bool<Name> | boolean, b: Bool<Name> | boolean): Bool<Name> {
+      a = from(a) as Bool<Name>;
+      b = from(b) as Bool<Name>;
       _assertContext(a, b);
       return new BoolImpl(Z3.mk_xor(contextPtr, a.ptr, b.ptr));
     }
 
-    function Not(a: Probe): Probe;
-    function Not(a: Bool | boolean): Bool;
-    function Not(a: Bool | boolean | Probe): Bool | Probe {
+    function Not(a: Probe<Name>): Probe<Name>;
+    function Not(a: Bool<Name> | boolean): Bool<Name>;
+    function Not(a: Bool<Name> | boolean | Probe<Name>): Bool<Name> | Probe<Name> {
       if (typeof a === 'boolean') {
         a = from(a);
       }
@@ -734,11 +740,13 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       return new BoolImpl(Z3.mk_not(contextPtr, a.ptr));
     }
 
-    function And(): Bool;
-    function And(vector: AstVector<Bool>): Bool;
-    function And(...args: (Bool | boolean)[]): Bool;
-    function And(...args: Probe[]): Probe;
-    function And(...args: (AstVector<Bool> | Probe | Bool | boolean)[]): Bool | Probe {
+    function And(): Bool<Name>;
+    function And(vector: AstVector<Name, Bool<Name>>): Bool<Name>;
+    function And(...args: (Bool<Name> | boolean)[]): Bool<Name>;
+    function And(...args: Probe<Name>[]): Probe<Name>;
+    function And(
+      ...args: (AstVector<Name, Bool<Name>> | Probe<Name> | Bool<Name> | boolean)[]
+    ): Bool<Name> | Probe<Name> {
       if (args.length == 1 && args[0] instanceof ctx.AstVector) {
         args = [...args[0].values()];
         assert(allSatisfy(args, isBool) ?? true, 'AstVector containing not bools');
@@ -746,24 +754,26 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
 
       const allProbes = allSatisfy(args, isProbe) ?? false;
       if (allProbes) {
-        return _probeNary(Z3.probe_and, args as [Probe, ...Probe[]]);
+        return _probeNary(Z3.probe_and, args as [Probe<Name>, ...Probe<Name>[]]);
       } else {
-        args = args.map(from) as Bool[];
-        _assertContext(...(args as Bool[]));
+        args = args.map(from) as Bool<Name>[];
+        _assertContext(...(args as Bool<Name>[]));
         return new BoolImpl(
           Z3.mk_and(
             contextPtr,
-            args.map(arg => (arg as Bool).ptr),
+            args.map(arg => (arg as Bool<Name>).ptr),
           ),
         );
       }
     }
 
-    function Or(): Bool;
-    function Or(vector: AstVector<Bool>): Bool;
-    function Or(...args: (Bool | boolean)[]): Bool;
-    function Or(...args: Probe[]): Probe;
-    function Or(...args: (AstVector<Bool> | Probe | Bool | boolean)[]): Bool | Probe {
+    function Or(): Bool<Name>;
+    function Or(vector: AstVector<Name, Bool<Name>>): Bool<Name>;
+    function Or(...args: (Bool<Name> | boolean)[]): Bool<Name>;
+    function Or(...args: Probe<Name>[]): Probe<Name>;
+    function Or(
+      ...args: (AstVector<Name, Bool<Name>> | Probe<Name> | Bool<Name> | boolean)[]
+    ): Bool<Name> | Probe<Name> {
       if (args.length == 1 && args[0] instanceof ctx.AstVector) {
         args = [...args[0].values()];
         assert(allSatisfy(args, isBool) ?? true, 'AstVector containing not bools');
@@ -771,27 +781,27 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
 
       const allProbes = allSatisfy(args, isProbe) ?? false;
       if (allProbes) {
-        return _probeNary(Z3.probe_or, args as [Probe, ...Probe[]]);
+        return _probeNary(Z3.probe_or, args as [Probe<Name>, ...Probe<Name>[]]);
       } else {
-        args = args.map(from) as Bool[];
-        _assertContext(...(args as Bool[]));
+        args = args.map(from) as Bool<Name>[];
+        _assertContext(...(args as Bool<Name>[]));
         return new BoolImpl(
           Z3.mk_or(
             contextPtr,
-            args.map(arg => (arg as Bool).ptr),
+            args.map(arg => (arg as Bool<Name>).ptr),
           ),
         );
       }
     }
 
-    function ToReal(expr: Arith | bigint): Arith {
-      expr = from(expr) as Arith;
+    function ToReal(expr: Arith<Name> | bigint): Arith<Name> {
+      expr = from(expr) as Arith<Name>;
       _assertContext(expr);
       assert(isInt(expr), 'Int expression expected');
       return new ArithImpl(Z3.mk_int2real(contextPtr, expr.ast));
     }
 
-    function ToInt(expr: Arith | number | CoercibleRational | string): Arith {
+    function ToInt(expr: Arith<Name> | number | CoercibleRational | string): Arith<Name> {
       if (!isExpr(expr)) {
         expr = Real.val(expr);
       }
@@ -800,7 +810,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       return new ArithImpl(Z3.mk_real2int(contextPtr, expr.ast));
     }
 
-    function IsInt(expr: Arith | number | CoercibleRational | string): Bool {
+    function IsInt(expr: Arith<Name> | number | CoercibleRational | string): Bool<Name> {
       if (!isExpr(expr)) {
         expr = Real.val(expr);
       }
@@ -809,48 +819,48 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       return new BoolImpl(Z3.mk_is_int(contextPtr, expr.ast));
     }
 
-    function Sqrt(a: Arith | number | bigint | string | CoercibleRational): Arith {
+    function Sqrt(a: Arith<Name> | number | bigint | string | CoercibleRational): Arith<Name> {
       if (!isExpr(a)) {
         a = Real.val(a);
       }
       return a.pow('1/2');
     }
 
-    function Cbrt(a: Arith | number | bigint | string | CoercibleRational): Arith {
+    function Cbrt(a: Arith<Name> | number | bigint | string | CoercibleRational): Arith<Name> {
       if (!isExpr(a)) {
         a = Real.val(a);
       }
       return a.pow('1/3');
     }
 
-    function BV2Int(a: BitVec, isSigned: boolean): Arith {
+    function BV2Int<Bits extends number>(a: BitVec<Bits, Name>, isSigned: boolean): Arith<Name> {
       _assertContext(a);
       return new ArithImpl(Z3.mk_bv2int(contextPtr, a.ast, isSigned));
     }
 
-    function Int2BV(a: Arith | bigint | number, bits: number): BitVec<any> {
+    function Int2BV<Bits extends number>(a: Arith<Name> | bigint | number, bits: Bits): BitVec<Bits, Name> {
       if (isArith(a)) {
         assert(isInt(a), 'parameter must be an integer');
       } else {
         assert(typeof a !== 'number' || Number.isSafeInteger(a), 'parameter must not have decimal places');
         a = Int.val(a);
       }
-      return new BitVecImpl(Z3.mk_int2bv(contextPtr, bits, a.ast));
+      return new BitVecImpl<Bits>(Z3.mk_int2bv(contextPtr, bits, a.ast));
     }
 
-    function Concat(...bitvecs: BitVec[]): BitVec {
+    function Concat<Bits extends number>(...bitvecs: BitVec<Bits, Name>[]): BitVec<Bits, Name> {
       _assertContext(...bitvecs);
-      return bitvecs.reduce((prev, curr) => new BitVecImpl(Z3.mk_concat(contextPtr, prev.ast, curr.ast)));
+      return bitvecs.reduce((prev, curr) => new BitVecImpl<Bits>(Z3.mk_concat(contextPtr, prev.ast, curr.ast)));
     }
 
-    function Cond(probe: Probe, onTrue: Tactic, onFalse: Tactic): Tactic {
+    function Cond(probe: Probe<Name>, onTrue: Tactic<Name>, onFalse: Tactic<Name>): Tactic<Name> {
       _assertContext(probe, onTrue, onFalse);
       return new TacticImpl(Z3.tactic_cond(contextPtr, probe.ptr, onTrue.ptr, onFalse.ptr));
     }
 
-    class AstImpl<Ptr> implements Ast {
+    class AstImpl<Ptr> implements Ast<Name> {
       declare readonly __typename: Ast['__typename'];
-      readonly ctx: Context;
+      readonly ctx: Context<Name>;
 
       constructor(readonly ptr: Ptr) {
         this.ctx = ctx;
@@ -861,19 +871,19 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
 
       get ast(): Z3_ast {
-        return this.ptr as any as Z3_ast;
+        return this.ptr as unknown as Z3_ast;
       }
 
       get id() {
         return Z3.get_ast_id(contextPtr, this.ast);
       }
 
-      eqIdentity(other: Ast) {
+      eqIdentity(other: Ast<Name>) {
         _assertContext(other);
         return Z3.is_eq_ast(contextPtr, this.ast, other.ast);
       }
 
-      neqIdentity(other: Ast) {
+      neqIdentity(other: Ast<Name>) {
         _assertContext(other);
         return !this.eqIdentity(other);
       }
@@ -887,11 +897,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    class SolverImpl implements Solver {
+    class SolverImpl implements Solver<Name> {
       declare readonly __typename: Solver['__typename'];
 
       readonly ptr: Z3_solver;
-      readonly ctx: Context;
+      readonly ctx: Context<Name>;
       constructor(ptr: Z3_solver | string = Z3.mk_solver(contextPtr)) {
         this.ctx = ctx;
         let myPtr: Z3_solver;
@@ -917,13 +927,13 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       reset() {
         Z3.solver_reset(contextPtr, this.ptr);
       }
-      add(...exprs: (Bool | AstVector<Bool>)[]) {
+      add(...exprs: (Bool<Name> | AstVector<Name, Bool<Name>>)[]) {
         _flattenArgs(exprs).forEach(expr => {
           _assertContext(expr);
           Z3.solver_assert(contextPtr, this.ptr, expr.ast);
         });
       }
-      addAndTrack(expr: Bool, constant: Bool | string) {
+      addAndTrack(expr: Bool<Name>, constant: Bool<Name> | string) {
         if (typeof constant === 'string') {
           constant = Bool.const(constant);
         }
@@ -931,11 +941,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         Z3.solver_assert_and_track(contextPtr, this.ptr, expr.ast, constant.ast);
       }
 
-      assertions(): AstVector<Bool> {
+      assertions(): AstVector<Name, Bool<Name>> {
         return new AstVectorImpl(Z3.solver_get_assertions(contextPtr, this.ptr));
       }
 
-      async check(...exprs: (Bool | AstVector<Bool>)[]): Promise<CheckSatResult> {
+      async check(...exprs: (Bool<Name> | AstVector<Name, Bool<Name>>)[]): Promise<CheckSatResult> {
         const assumptions = _flattenArgs(exprs).map(expr => {
           _assertContext(expr);
           return expr.ast;
@@ -960,9 +970,9 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    class ModelImpl implements Model {
+    class ModelImpl implements Model<Name> {
       declare readonly __typename: Model['__typename'];
-      readonly ctx: Context;
+      readonly ctx: Context<Name>;
 
       constructor(readonly ptr: Z3_model = Z3.mk_model(contextPtr)) {
         this.ctx = ctx;
@@ -974,11 +984,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         return Z3.model_get_num_consts(contextPtr, this.ptr) + Z3.model_get_num_funcs(contextPtr, this.ptr);
       }
 
-      [Symbol.iterator](): Iterator<FuncDecl> {
+      [Symbol.iterator](): Iterator<FuncDecl<Name>> {
         return this.values();
       }
 
-      *entries(): IterableIterator<[number, FuncDecl]> {
+      *entries(): IterableIterator<[number, FuncDecl<Name>]> {
         const length = this.length;
         for (let i = 0; i < length; i++) {
           yield [i, this.get(i)];
@@ -991,7 +1001,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         }
       }
 
-      *values(): IterableIterator<FuncDecl> {
+      *values(): IterableIterator<FuncDecl<Name>> {
         for (const [, value] of this.entries()) {
           yield value;
         }
@@ -1005,9 +1015,9 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         return Z3.model_to_string(contextPtr, this.ptr);
       }
 
-      eval(expr: Bool, modelCompletion?: boolean): Bool;
-      eval(expr: Arith, modelCompletion?: boolean): Arith;
-      eval(expr: Expr, modelCompletion: boolean = false) {
+      eval(expr: Bool<Name>, modelCompletion?: boolean): Bool<Name>;
+      eval(expr: Arith<Name>, modelCompletion?: boolean): Arith<Name>;
+      eval(expr: Expr<Name>, modelCompletion: boolean = false) {
         _assertContext(expr);
         const r = Z3.model_eval(contextPtr, this.ptr, expr.ast, modelCompletion);
         if (r === null) {
@@ -1016,15 +1026,15 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         return _toExpr(r);
       }
 
-      get(i: number): FuncDecl;
-      get(from: number, to: number): FuncDecl[];
-      get(declaration: FuncDecl): FuncInterp | Expr;
-      get(constant: Expr): Expr;
-      get(sort: Sort): AstVector<AnyExpr>;
+      get(i: number): FuncDecl<Name>;
+      get(from: number, to: number): FuncDecl<Name>[];
+      get(declaration: FuncDecl<Name>): FuncInterp<Name> | Expr<Name>;
+      get(constant: Expr<Name>): Expr<Name>;
+      get(sort: Sort<Name>): AstVector<Name, AnyExpr<Name>>;
       get(
-        i: number | FuncDecl | Expr | Sort,
+        i: number | FuncDecl<Name> | Expr<Name> | Sort<Name>,
         to?: number,
-      ): FuncDecl | FuncInterp | Expr | AstVector<AnyAst> | FuncDecl[] {
+      ): FuncDecl<Name> | FuncInterp<Name> | Expr<Name> | AstVector<Name, AnyAst<Name>> | FuncDecl<Name>[] {
         assert(to === undefined || typeof i === 'number');
         if (typeof i === 'number') {
           const length = this.length;
@@ -1063,7 +1073,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         assert(false, 'Number, declaration or constant expected');
       }
 
-      private getInterp(expr: FuncDecl | Expr): Expr | FuncInterp | null {
+      private getInterp(expr: FuncDecl<Name> | Expr<Name>): Expr<Name> | FuncInterp<Name> | null {
         assert(isFuncDecl(expr) || isConst(expr), 'Declaration expected');
         if (isConst(expr)) {
           assert(isExpr(expr));
@@ -1085,15 +1095,15 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         }
       }
 
-      private getUniverse(sort: Sort): AstVector<AnyAst> {
+      private getUniverse(sort: Sort<Name>): AstVector<Name, AnyAst<Name>> {
         _assertContext(sort);
         return new AstVectorImpl(Z3.model_get_sort_universe(contextPtr, this.ptr, sort.ptr));
       }
     }
 
-    class FuncInterpImpl implements FuncInterp {
+    class FuncInterpImpl implements FuncInterp<Name> {
       declare readonly __typename: FuncInterp['__typename'];
-      readonly ctx: Context;
+      readonly ctx: Context<Name>;
 
       constructor(readonly ptr: Z3_func_interp) {
         this.ctx = ctx;
@@ -1102,7 +1112,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    class SortImpl extends AstImpl<Z3_sort> implements Sort {
+    class SortImpl extends AstImpl<Z3_sort> implements Sort<Name> {
       declare readonly __typename: Sort['__typename'];
 
       get ast(): Z3_ast {
@@ -1113,12 +1123,12 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         return Z3.get_sort_kind(contextPtr, this.ptr);
       }
 
-      subsort(other: Sort) {
+      subsort(other: Sort<Name>) {
         _assertContext(other);
         return false;
       }
 
-      cast(expr: Expr): Expr {
+      cast(expr: Expr<Name>): Expr<Name> {
         _assertContext(expr);
         assert(expr.sort.eqIdentity(expr.sort), 'Sort mismatch');
         return expr;
@@ -1128,17 +1138,17 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         return _fromSymbol(Z3.get_sort_name(contextPtr, this.ptr));
       }
 
-      eqIdentity(other: Sort) {
+      eqIdentity(other: Sort<Name>) {
         _assertContext(other);
         return Z3.is_eq_sort(contextPtr, this.ptr, other.ptr);
       }
 
-      neqIdentity(other: Sort) {
+      neqIdentity(other: Sort<Name>) {
         return !this.eqIdentity(other);
       }
     }
 
-    class FuncDeclImpl extends AstImpl<Z3_func_decl> implements FuncDecl {
+    class FuncDeclImpl extends AstImpl<Z3_func_decl> implements FuncDecl<Name> {
       declare readonly __typename: FuncDecl['__typename'];
 
       get ast() {
@@ -1166,7 +1176,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         return Z3.get_decl_kind(contextPtr, this.ptr);
       }
 
-      params(): (number | string | Z3_symbol | Sort | Expr | FuncDecl)[] {
+      params(): (number | string | Z3_symbol | Sort<Name> | Expr<Name> | FuncDecl<Name>)[] {
         const n = Z3.get_decl_num_parameters(contextPtr, this.ptr);
         const result = [];
         for (let i = 0; i < n; i++) {
@@ -1200,7 +1210,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         return result;
       }
 
-      call(...args: CoercibleToExpr[]) {
+      call(...args: CoercibleToExpr<Name>[]) {
         assert(args.length === this.arity(), `Incorrect number of arguments to ${this}`);
         return _toExpr(
           Z3.mk_app(
@@ -1214,18 +1224,18 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    class ExprImpl<Ptr, S extends Sort = AnySort> extends AstImpl<Ptr> implements Expr {
+    class ExprImpl<Ptr, S extends Sort<Name> = AnySort<Name>> extends AstImpl<Ptr> implements Expr<Name> {
       declare readonly __typename: Expr['__typename'];
 
       get sort(): S {
         return _toSort(Z3.get_sort(contextPtr, this.ast)) as S;
       }
 
-      eq(other: CoercibleToExpr): Bool {
+      eq(other: CoercibleToExpr<Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_eq(contextPtr, this.ast, from(other).ast));
       }
 
-      neq(other: CoercibleToExpr): Bool {
+      neq(other: CoercibleToExpr<Name>): Bool<Name> {
         return new BoolImpl(
           Z3.mk_distinct(
             contextPtr,
@@ -1238,7 +1248,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         return this.decl().params();
       }
 
-      decl(): FuncDecl {
+      decl(): FuncDecl<Name> {
         assert(isApp(this), 'Z3 application expected');
         return new FuncDeclImpl(Z3.get_app_decl(contextPtr, Z3.to_app(contextPtr, this.ast)));
       }
@@ -1267,12 +1277,12 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    class BoolSortImpl extends SortImpl implements BoolSort {
+    class BoolSortImpl extends SortImpl implements BoolSort<Name> {
       declare readonly __typename: BoolSort['__typename'];
 
-      cast(other: Bool | boolean): Bool;
-      cast(other: CoercibleToExpr): never;
-      cast(other: CoercibleToExpr | Bool) {
+      cast(other: Bool<Name> | boolean): Bool<Name>;
+      cast(other: CoercibleToExpr<Name>): never;
+      cast(other: CoercibleToExpr<Name> | Bool<Name>) {
         if (typeof other === 'boolean') {
           other = Bool.val(other);
         }
@@ -1281,43 +1291,43 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         return other;
       }
 
-      subsort(other: Sort) {
+      subsort(other: Sort<Name>) {
         _assertContext(other.ctx);
         return other instanceof ArithSortImpl;
       }
     }
 
-    class BoolImpl extends ExprImpl<Z3_ast, BoolSort> implements Bool {
+    class BoolImpl extends ExprImpl<Z3_ast, BoolSort<Name>> implements Bool<Name> {
       declare readonly __typename: Bool['__typename'];
 
-      not(): Bool {
+      not(): Bool<Name> {
         return Not(this);
       }
-      and(other: Bool | boolean): Bool {
+      and(other: Bool<Name> | boolean): Bool<Name> {
         return And(this, other);
       }
-      or(other: Bool | boolean): Bool {
+      or(other: Bool<Name> | boolean): Bool<Name> {
         return Or(this, other);
       }
-      xor(other: Bool | boolean): Bool {
+      xor(other: Bool<Name> | boolean): Bool<Name> {
         return Xor(this, other);
       }
     }
 
-    class ProbeImpl implements Probe {
+    class ProbeImpl implements Probe<Name> {
       declare readonly __typename: Probe['__typename'];
-      readonly ctx: Context;
+      readonly ctx: Context<Name>;
 
       constructor(readonly ptr: Z3_probe) {
         this.ctx = ctx;
       }
     }
 
-    class TacticImpl implements Tactic {
+    class TacticImpl implements Tactic<Name> {
       declare readonly __typename: Tactic['__typename'];
 
       readonly ptr: Z3_tactic;
-      readonly ctx: Context;
+      readonly ctx: Context<Name>;
 
       constructor(tactic: string | Z3_tactic) {
         this.ctx = ctx;
@@ -1335,15 +1345,15 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    class ArithSortImpl extends SortImpl implements ArithSort {
+    class ArithSortImpl extends SortImpl implements ArithSort<Name> {
       declare readonly __typename: ArithSort['__typename'];
 
-      cast(other: bigint | number): IntNum | RatNum;
-      cast(other: CoercibleRational | RatNum): RatNum;
-      cast(other: IntNum): IntNum;
-      cast(other: Bool | Arith): Arith;
-      cast(other: CoercibleToExpr): never;
-      cast(other: CoercibleToExpr): Arith | RatNum | IntNum {
+      cast(other: bigint | number): IntNum<Name> | RatNum<Name>;
+      cast(other: CoercibleRational | RatNum<Name>): RatNum<Name>;
+      cast(other: IntNum<Name>): IntNum<Name>;
+      cast(other: Bool<Name> | Arith<Name>): Arith<Name>;
+      cast(other: CoercibleToExpr<Name>): never;
+      cast(other: CoercibleToExpr<Name>): Arith<Name> | RatNum<Name> | IntNum<Name> {
         const sortTypeStr = isIntSort(this) ? 'IntSort' : 'RealSort';
         if (isExpr(other)) {
           const otherS = other.sort;
@@ -1375,30 +1385,30 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    class ArithImpl extends ExprImpl<Z3_ast, ArithSort> implements Arith {
+    class ArithImpl extends ExprImpl<Z3_ast, ArithSort<Name>> implements Arith<Name> {
       declare readonly __typename: Arith['__typename'];
 
-      add(other: Arith | number | bigint | string | CoercibleRational) {
+      add(other: Arith<Name> | number | bigint | string | CoercibleRational) {
         return new ArithImpl(Z3.mk_add(contextPtr, [this.ast, this.sort.cast(other).ast]));
       }
 
-      mul(other: Arith | number | bigint | string | CoercibleRational) {
+      mul(other: Arith<Name> | number | bigint | string | CoercibleRational) {
         return new ArithImpl(Z3.mk_mul(contextPtr, [this.ast, this.sort.cast(other).ast]));
       }
 
-      sub(other: Arith | number | bigint | string | CoercibleRational) {
+      sub(other: Arith<Name> | number | bigint | string | CoercibleRational) {
         return new ArithImpl(Z3.mk_sub(contextPtr, [this.ast, this.sort.cast(other).ast]));
       }
 
-      pow(exponent: Arith | number | bigint | string | CoercibleRational) {
+      pow(exponent: Arith<Name> | number | bigint | string | CoercibleRational) {
         return new ArithImpl(Z3.mk_power(contextPtr, this.ast, this.sort.cast(exponent).ast));
       }
 
-      div(other: Arith | number | bigint | string | CoercibleRational) {
+      div(other: Arith<Name> | number | bigint | string | CoercibleRational) {
         return new ArithImpl(Z3.mk_div(contextPtr, this.ast, this.sort.cast(other).ast));
       }
 
-      mod(other: Arith | number | bigint | string | CoercibleRational) {
+      mod(other: Arith<Name> | number | bigint | string | CoercibleRational) {
         return new ArithImpl(Z3.mk_mod(contextPtr, this.ast, this.sort.cast(other).ast));
       }
 
@@ -1406,24 +1416,24 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         return new ArithImpl(Z3.mk_unary_minus(contextPtr, this.ast));
       }
 
-      le(other: Arith | number | bigint | string | CoercibleRational) {
+      le(other: Arith<Name> | number | bigint | string | CoercibleRational) {
         return new BoolImpl(Z3.mk_le(contextPtr, this.ast, this.sort.cast(other).ast));
       }
 
-      lt(other: Arith | number | bigint | string | CoercibleRational) {
+      lt(other: Arith<Name> | number | bigint | string | CoercibleRational) {
         return new BoolImpl(Z3.mk_lt(contextPtr, this.ast, this.sort.cast(other).ast));
       }
 
-      gt(other: Arith | number | bigint | string | CoercibleRational) {
+      gt(other: Arith<Name> | number | bigint | string | CoercibleRational) {
         return new BoolImpl(Z3.mk_gt(contextPtr, this.ast, this.sort.cast(other).ast));
       }
 
-      ge(other: Arith | number | bigint | string | CoercibleRational) {
+      ge(other: Arith<Name> | number | bigint | string | CoercibleRational) {
         return new BoolImpl(Z3.mk_ge(contextPtr, this.ast, this.sort.cast(other).ast));
       }
     }
 
-    class IntNumImpl extends ArithImpl implements IntNum {
+    class IntNumImpl extends ArithImpl implements IntNum<Name> {
       declare readonly __typename: IntNum['__typename'];
 
       get value() {
@@ -1439,7 +1449,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    class RatNumImpl extends ArithImpl implements RatNum {
+    class RatNumImpl extends ArithImpl implements RatNum<Name> {
       declare readonly __typename: RatNum['__typename'];
 
       get value() {
@@ -1469,20 +1479,20 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    class BitVecSortImpl extends SortImpl implements BitVecSort {
+    class BitVecSortImpl<Bits extends number> extends SortImpl implements BitVecSort<Bits, Name> {
       declare readonly __typename: BitVecSort['__typename'];
 
       get size() {
-        return Z3.get_bv_sort_size(contextPtr, this.ptr);
+        return Z3.get_bv_sort_size(contextPtr, this.ptr) as Bits;
       }
 
-      subsort(other: Sort<any>): boolean {
+      subsort(other: Sort<Name>): boolean {
         return isBitVecSort(other) && this.size < other.size;
       }
 
-      cast(other: CoercibleToBitVec): BitVec;
-      cast(other: CoercibleToExpr): Expr;
-      cast(other: CoercibleToExpr): Expr {
+      cast(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name>;
+      cast(other: CoercibleToExpr<Name>): Expr<Name>;
+      cast(other: CoercibleToExpr<Name>): Expr<Name> {
         if (isExpr(other)) {
           _assertContext(other);
           return other;
@@ -1492,147 +1502,147 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    class BitVecImpl extends ExprImpl<Z3_ast, BitVecSortImpl> implements BitVec {
+    class BitVecImpl<Bits extends number> extends ExprImpl<Z3_ast, BitVecSortImpl<Bits>> implements BitVec<Bits, Name> {
       declare readonly __typename: BitVec['__typename'];
 
       get size() {
         return this.sort.size;
       }
 
-      add(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvadd(contextPtr, this.ast, this.sort.cast(other).ast));
+      add(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvadd(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      mul(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvmul(contextPtr, this.ast, this.sort.cast(other).ast));
+      mul(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvmul(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      sub(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvsub(contextPtr, this.ast, this.sort.cast(other).ast));
+      sub(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvsub(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      sdiv(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvsdiv(contextPtr, this.ast, this.sort.cast(other).ast));
+      sdiv(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvsdiv(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      udiv(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvudiv(contextPtr, this.ast, this.sort.cast(other).ast));
+      udiv(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvudiv(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      smod(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvsmod(contextPtr, this.ast, this.sort.cast(other).ast));
+      smod(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvsmod(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      urem(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvurem(contextPtr, this.ast, this.sort.cast(other).ast));
+      urem(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvurem(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      srem(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvsrem(contextPtr, this.ast, this.sort.cast(other).ast));
+      srem(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvsrem(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      neg(): BitVec {
-        return new BitVecImpl(Z3.mk_bvneg(contextPtr, this.ast));
-      }
-
-      or(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvor(contextPtr, this.ast, this.sort.cast(other).ast));
-      }
-      and(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvand(contextPtr, this.ast, this.sort.cast(other).ast));
-      }
-      nand(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvnand(contextPtr, this.ast, this.sort.cast(other).ast));
-      }
-      xor(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvxor(contextPtr, this.ast, this.sort.cast(other).ast));
-      }
-      xnor(other: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvxnor(contextPtr, this.ast, this.sort.cast(other).ast));
-      }
-      shr(count: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvashr(contextPtr, this.ast, this.sort.cast(count).ast));
-      }
-      lshr(count: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvlshr(contextPtr, this.ast, this.sort.cast(count).ast));
-      }
-      shl(count: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_bvshl(contextPtr, this.ast, this.sort.cast(count).ast));
-      }
-      rotateRight(count: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_ext_rotate_right(contextPtr, this.ast, this.sort.cast(count).ast));
-      }
-      rotateLeft(count: CoercibleToBitVec): BitVec {
-        return new BitVecImpl(Z3.mk_ext_rotate_left(contextPtr, this.ast, this.sort.cast(count).ast));
-      }
-      not(): BitVec {
-        return new BitVecImpl(Z3.mk_bvnot(contextPtr, this.ast));
+      neg(): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvneg(contextPtr, this.ast));
       }
 
-      extract(high: number, low: number): BitVec {
-        return new BitVecImpl(Z3.mk_extract(contextPtr, high, low, this.ast));
+      or(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvor(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      signExt(count: number): BitVec {
-        return new BitVecImpl(Z3.mk_sign_ext(contextPtr, count, this.ast));
+      and(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvand(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      zeroExt(count: number): BitVec {
-        return new BitVecImpl(Z3.mk_zero_ext(contextPtr, count, this.ast));
+      nand(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvnand(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      repeat(count: number): BitVec {
-        return new BitVecImpl(Z3.mk_repeat(contextPtr, count, this.ast));
+      xor(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvxor(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      xnor(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvxnor(contextPtr, this.ast, this.sort.cast(other).ast));
+      }
+      shr(count: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvashr(contextPtr, this.ast, this.sort.cast(count).ast));
+      }
+      lshr(count: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvlshr(contextPtr, this.ast, this.sort.cast(count).ast));
+      }
+      shl(count: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvshl(contextPtr, this.ast, this.sort.cast(count).ast));
+      }
+      rotateRight(count: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_ext_rotate_right(contextPtr, this.ast, this.sort.cast(count).ast));
+      }
+      rotateLeft(count: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_ext_rotate_left(contextPtr, this.ast, this.sort.cast(count).ast));
+      }
+      not(): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvnot(contextPtr, this.ast));
       }
 
-      sle(other: CoercibleToBitVec): Bool {
+      extract(high: number, low: number): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_extract(contextPtr, high, low, this.ast));
+      }
+      signExt(count: number): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_sign_ext(contextPtr, count, this.ast));
+      }
+      zeroExt(count: number): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_zero_ext(contextPtr, count, this.ast));
+      }
+      repeat(count: number): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_repeat(contextPtr, count, this.ast));
+      }
+
+      sle(other: CoercibleToBitVec<Bits, Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_bvsle(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      ule(other: CoercibleToBitVec): Bool {
+      ule(other: CoercibleToBitVec<Bits, Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_bvule(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      slt(other: CoercibleToBitVec): Bool {
+      slt(other: CoercibleToBitVec<Bits, Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_bvslt(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      ult(other: CoercibleToBitVec): Bool {
+      ult(other: CoercibleToBitVec<Bits, Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_bvult(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      sge(other: CoercibleToBitVec): Bool {
+      sge(other: CoercibleToBitVec<Bits, Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_bvsge(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      uge(other: CoercibleToBitVec): Bool {
+      uge(other: CoercibleToBitVec<Bits, Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_bvuge(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      sgt(other: CoercibleToBitVec): Bool {
+      sgt(other: CoercibleToBitVec<Bits, Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_bvsgt(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      ugt(other: CoercibleToBitVec): Bool {
+      ugt(other: CoercibleToBitVec<Bits, Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_bvugt(contextPtr, this.ast, this.sort.cast(other).ast));
       }
 
-      redAnd(): BitVec {
-        return new BitVecImpl(Z3.mk_bvredand(contextPtr, this.ast));
+      redAnd(): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvredand(contextPtr, this.ast));
       }
-      redOr(): BitVec {
-        return new BitVecImpl(Z3.mk_bvredor(contextPtr, this.ast));
+      redOr(): BitVec<Bits, Name> {
+        return new BitVecImpl<Bits>(Z3.mk_bvredor(contextPtr, this.ast));
       }
 
-      addNoOverflow(other: CoercibleToBitVec, isSigned: boolean): Bool {
+      addNoOverflow(other: CoercibleToBitVec<Bits, Name>, isSigned: boolean): Bool<Name> {
         return new BoolImpl(Z3.mk_bvadd_no_overflow(contextPtr, this.ast, this.sort.cast(other).ast, isSigned));
       }
-      addNoUnderflow(other: CoercibleToBitVec): Bool {
+      addNoUnderflow(other: CoercibleToBitVec<Bits, Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_bvadd_no_underflow(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      subNoOverflow(other: CoercibleToBitVec): Bool {
+      subNoOverflow(other: CoercibleToBitVec<Bits, Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_bvsub_no_overflow(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      subNoUndeflow(other: CoercibleToBitVec, isSigned: boolean): Bool {
+      subNoUndeflow(other: CoercibleToBitVec<Bits, Name>, isSigned: boolean): Bool<Name> {
         return new BoolImpl(Z3.mk_bvsub_no_underflow(contextPtr, this.ast, this.sort.cast(other).ast, isSigned));
       }
-      sdivNoOverflow(other: CoercibleToBitVec): Bool {
+      sdivNoOverflow(other: CoercibleToBitVec<Bits, Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_bvsdiv_no_overflow(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      mulNoOverflow(other: CoercibleToBitVec, isSigned: boolean): Bool {
+      mulNoOverflow(other: CoercibleToBitVec<Bits, Name>, isSigned: boolean): Bool<Name> {
         return new BoolImpl(Z3.mk_bvmul_no_overflow(contextPtr, this.ast, this.sort.cast(other).ast, isSigned));
       }
-      mulNoUndeflow(other: CoercibleToBitVec): Bool {
+      mulNoUndeflow(other: CoercibleToBitVec<Bits, Name>): Bool<Name> {
         return new BoolImpl(Z3.mk_bvmul_no_underflow(contextPtr, this.ast, this.sort.cast(other).ast));
       }
-      negNoOverflow(): Bool {
+      negNoOverflow(): Bool<Name> {
         return new BoolImpl(Z3.mk_bvneg_no_overflow(contextPtr, this.ast));
       }
     }
 
-    class BitVecNumImpl extends BitVecImpl implements BitVecNum {
+    class BitVecNumImpl<Bits extends number> extends BitVecImpl<Bits> implements BitVecNum<Bits, Name> {
       declare readonly __typename: BitVecNum['__typename'];
       get value() {
         return BigInt(this.asString());
@@ -1659,7 +1669,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
 
     class AstVectorImpl<Item extends AnyAst<Name>> {
       declare readonly __typename: AstVector['__typename'];
-      readonly ctx: Context;
+      readonly ctx: Context<Name>;
 
       constructor(readonly ptr: Z3_ast_vector = Z3.mk_ast_vector(contextPtr)) {
         this.ctx = ctx;
@@ -1755,9 +1765,9 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       }
     }
 
-    class AstMapImpl<Key extends AnyAst<Name>, Value extends AnyAst<Name>> implements AstMap<Key, Value> {
+    class AstMapImpl<Key extends AnyAst<Name>, Value extends AnyAst<Name>> implements AstMap<Name, Key, Value> {
       declare readonly __typename: AstMap['__typename'];
-      readonly ctx: Context;
+      readonly ctx: Context<Name>;
 
       constructor(readonly ptr: Z3_ast_map = Z3.mk_ast_map(contextPtr)) {
         this.ctx = ctx;
@@ -1779,7 +1789,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         }
       }
 
-      keys(): AstVector<Key> {
+      keys(): AstVector<Name, Key> {
         return new AstVectorImpl(Z3.ast_map_keys(contextPtr, this.ptr));
       }
 

--- a/src/api/js/src/high-level/high-level.ts
+++ b/src/api/js/src/high-level/high-level.ts
@@ -1945,7 +1945,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       BV2Int,
       Int2BV,
       Concat,
-      // Cond, // TODO
+      Cond,
     };
     cleanup.register(ctx, () => Z3.del_context(contextPtr));
     return ctx;

--- a/src/api/js/src/high-level/types.ts
+++ b/src/api/js/src/high-level/types.ts
@@ -81,23 +81,8 @@ export type CoercibleToExpr<Name extends string = 'main'> = number | bigint | bo
 export class Z3Error extends Error {}
 export class Z3AssertionError extends Z3Error {}
 
-/**
- * Returned by {@link Solver.check} when Z3 could find a solution
- * @category Global
- */
-export const sat = Symbol('Solver found a solution');
-/**
- * Returned by {@link Solver.check} when Z3 couldn't find a solution
- * @category Global
- */
-export const unsat = Symbol("Solver didn't find a solution");
-/**
- * Returned by {@link Solver.check} when Z3 couldn't reason about the assumptions
- * @category Global
- */
-export const unknown = Symbol("Solver couldn't reason about the assumptions");
 /** @category Global */
-export type CheckSatResult = typeof sat | typeof unsat | typeof unknown;
+export type CheckSatResult = 'sat' | 'unsat' | 'unknown';
 
 /** @hidden */
 export interface ContextCtor {
@@ -229,7 +214,7 @@ export interface Context<Name extends string = 'main'> {
    *
    * @see {@link Solver}
    * @category Functions */
-  solve(...assertions: Bool<Name>[]): Promise<Model<Name> | typeof unsat | typeof unknown>;
+  solve(...assertions: Bool<Name>[]): Promise<Model<Name> | 'unsat' | 'unknown'>;
 
   /////////////
   // Classes //

--- a/src/api/js/src/high-level/types.ts
+++ b/src/api/js/src/high-level/types.ts
@@ -350,6 +350,8 @@ export interface Context<Name extends string = 'main'> {
   Int2BV<Bits extends number>(a: Arith<Name> | bigint | number, bits: Bits): BitVec<Bits, Name>;
   /** @category Operations */
   Concat(...bitvecs: BitVec<number, Name>[]): BitVec<number, Name>;
+  /** @category Operations */
+  Cond(probe: Probe<Name>, onTrue: Tactic<Name>, onFalse: Tactic<Name>): Tactic<Name>
 }
 
 export interface Ast<Name extends string = 'main', Ptr = unknown> {

--- a/src/api/js/src/high-level/types.ts
+++ b/src/api/js/src/high-level/types.ts
@@ -16,13 +16,13 @@ import {
 } from '../low-level';
 
 /** @hidden */
-export type AnySort<Name extends string = any> =
+export type AnySort<Name extends string = 'main'> =
   | Sort<Name>
   | BoolSort<Name>
   | ArithSort<Name>
   | BitVecSort<number, Name>;
 /** @hidden */
-export type AnyExpr<Name extends string = any> =
+export type AnyExpr<Name extends string = 'main'> =
   | Expr<Name>
   | Bool<Name>
   | Arith<Name>
@@ -31,10 +31,10 @@ export type AnyExpr<Name extends string = any> =
   | BitVec<number, Name>
   | BitVecNum<number, Name>;
 /** @hidden */
-export type AnyAst<Name extends string = any> = AnyExpr<Name> | AnySort<Name> | FuncDecl<Name>;
+export type AnyAst<Name extends string = 'main'> = AnyExpr<Name> | AnySort<Name> | FuncDecl<Name>;
 
 /** @hidden */
-export type SortToExprMap<S extends AnySort<Name>, Name extends string = any> = S extends BoolSort
+export type SortToExprMap<S extends AnySort<Name>, Name extends string = 'main'> = S extends BoolSort
   ? Bool<Name>
   : S extends ArithSort<Name>
   ? Arith<Name>
@@ -45,7 +45,7 @@ export type SortToExprMap<S extends AnySort<Name>, Name extends string = any> = 
   : never;
 
 /** @hidden */
-export type CoercibleToExprMap<S extends CoercibleToExpr<Name>, Name extends string = any> = S extends bigint
+export type CoercibleToExprMap<S extends CoercibleToExpr<Name>, Name extends string = 'main'> = S extends bigint
   ? IntNum<Name>
   : S extends number | CoercibleRational
   ? RatNum<Name>
@@ -76,7 +76,7 @@ export type CoercibleToExprMap<S extends CoercibleToExpr<Name>, Name extends str
 export type CoercibleRational = { numerator: bigint | number; denominator: bigint | number };
 
 /** @hidden */
-export type CoercibleToExpr<Name extends string = any> = number | bigint | boolean | CoercibleRational | Expr<Name>;
+export type CoercibleToExpr<Name extends string = 'main'> = number | bigint | boolean | CoercibleRational | Expr<Name>;
 
 export class Z3Error extends Error {}
 export class Z3AssertionError extends Z3Error {}
@@ -104,7 +104,7 @@ export interface ContextCtor {
   <Name extends string>(name: Name, options?: Record<string, any>): Context<Name>;
 }
 
-export interface Context<Name extends string = any> {
+export interface Context<Name extends string = 'main'> {
   /** @hidden */
   readonly ptr: Z3_context;
   /**
@@ -187,7 +187,7 @@ export interface Context<Name extends string = any> {
   /** @category Functions */
   isTactic(obj: unknown): obj is Tactic<Name>;
   /** @category Functions */
-  isAstVector(obj: unknown): obj is AstVector<AnyAst<Name>, Name>;
+  isAstVector(obj: unknown): obj is AstVector<Name, AnyAst<Name>>;
   /**
    * Returns whether two Asts are the same thing
    * @category Functions */
@@ -229,7 +229,7 @@ export interface Context<Name extends string = any> {
    *
    * @see {@link Solver}
    * @category Functions */
-  solve(...assertions: Bool[]): Promise<Model | typeof unsat | typeof unknown>;
+  solve(...assertions: Bool<Name>[]): Promise<Model<Name> | typeof unsat | typeof unknown>;
 
   /////////////
   // Classes //
@@ -247,9 +247,9 @@ export interface Context<Name extends string = any> {
    */
   readonly Model: new () => Model<Name>;
   /** @category Classes */
-  readonly AstVector: new <Item extends Ast<Name> = AnyAst<Name>>() => AstVector<Item, Name>;
+  readonly AstVector: new <Item extends Ast<Name> = AnyAst<Name>>() => AstVector<Name, Item>;
   /** @category Classes */
-  readonly AstMap: new <Key extends Ast = AnyAst, Value extends Ast = AnyAst>() => AstMap<Key, Value, Name>;
+  readonly AstMap: new <Key extends Ast<Name> = AnyAst<Name>, Value extends Ast<Name> = AnyAst<Name>>() => AstMap<Name, Key, Value>;
   /** @category Classes */
   readonly Tactic: new (name: string) => Tactic<Name>;
 
@@ -306,7 +306,7 @@ export interface Context<Name extends string = any> {
   /** @category Operations */
   And(): Bool<Name>;
   /** @category Operations */
-  And(vector: AstVector<Bool<Name>, Name>): Bool<Name>;
+  And(vector: AstVector<Name, Bool<Name>>): Bool<Name>;
   /** @category Operations */
   And(...args: (Bool<Name> | boolean)[]): Bool<Name>;
   /** @category Operations */
@@ -314,7 +314,7 @@ export interface Context<Name extends string = any> {
   /** @category Operations */
   Or(): Bool<Name>;
   /** @category Operations */
-  Or(vector: AstVector<Bool<Name>, Name>): Bool<Name>;
+  Or(vector: AstVector<Name, Bool<Name>>): Bool<Name>;
   /** @category Operations */
   Or(...args: (Bool<Name> | boolean)[]): Bool<Name>;
   /** @category Operations */
@@ -367,7 +367,7 @@ export interface Context<Name extends string = any> {
   Concat(...bitvecs: BitVec<number, Name>[]): BitVec<number, Name>;
 }
 
-export interface Ast<Name extends string = any, Ptr = unknown> {
+export interface Ast<Name extends string = 'main', Ptr = unknown> {
   /** @hidden */
   readonly __typename: 'Ast' | Sort['__typename'] | FuncDecl['__typename'] | Expr['__typename'];
 
@@ -389,7 +389,7 @@ export interface Ast<Name extends string = any, Ptr = unknown> {
 export interface SolverCtor<Name extends string> {
   new (): Solver<Name>;
 }
-export interface Solver<Name extends string = any> {
+export interface Solver<Name extends string = 'main'> {
   /** @hidden */
   readonly __typename: 'Solver';
 
@@ -404,10 +404,10 @@ export interface Solver<Name extends string = any> {
   pop(num?: number): void;
   numScopes(): number;
   reset(): void;
-  add(...exprs: (Bool<Name> | AstVector<Bool<Name>, Name>)[]): void;
+  add(...exprs: (Bool<Name> | AstVector<Name, Bool<Name>>)[]): void;
   addAndTrack(expr: Bool<Name>, constant: Bool<Name> | string): void;
-  assertions(): AstVector<Bool<Name>, Name>;
-  check(...exprs: (Bool<Name> | AstVector<Bool<Name>, Name>)[]): Promise<CheckSatResult>;
+  assertions(): AstVector<Name, Bool<Name>>;
+  check(...exprs: (Bool<Name> | AstVector<Name, Bool<Name>>)[]): Promise<CheckSatResult>;
   model(): Model<Name>;
 }
 
@@ -415,7 +415,7 @@ export interface Solver<Name extends string = any> {
 export interface ModelCtor<Name extends string> {
   new (): Model<Name>;
 }
-export interface Model<Name extends string = any> extends Iterable<FuncDecl<Name>> {
+export interface Model<Name extends string = 'main'> extends Iterable<FuncDecl<Name>> {
   /** @hidden */
   readonly __typename: 'Model';
 
@@ -433,10 +433,10 @@ export interface Model<Name extends string = any> extends Iterable<FuncDecl<Name
   eval(expr: Arith<Name>, modelCompletion?: boolean): Arith<Name>;
   eval(expr: Expr<Name>, modelCompletion?: boolean): Expr<Name>;
   get(i: number): FuncDecl<Name>;
-  get(from: number, to: number): FuncDecl[];
+  get(from: number, to: number): FuncDecl<Name>[];
   get(declaration: FuncDecl<Name>): FuncInterp<Name> | Expr<Name>;
   get(constant: Expr<Name>): Expr<Name>;
-  get(sort: Sort<Name>): AstVector<AnyExpr<Name>, Name>;
+  get(sort: Sort<Name>): AstVector<Name, AnyExpr<Name>>;
 }
 
 /**
@@ -458,7 +458,7 @@ export interface Model<Name extends string = any> extends Iterable<FuncDecl<Name
 export interface SortCreation<Name extends string> {
   declare(name: string): Sort<Name>;
 }
-export interface Sort<Name extends string = any> extends Ast<Name, Z3_sort> {
+export interface Sort<Name extends string = 'main'> extends Ast<Name, Z3_sort> {
   /** @hidden */
   readonly __typename: 'Sort' | BoolSort['__typename'] | ArithSort['__typename'] | BitVecSort['__typename'];
 
@@ -473,7 +473,7 @@ export interface Sort<Name extends string = any> extends Ast<Name, Z3_sort> {
 /**
  * @category Functions
  */
-export interface FuncInterp<Name extends string = any> {
+export interface FuncInterp<Name extends string = 'main'> {
   /** @hidden */
   readonly __typename: 'FuncInterp';
 
@@ -513,7 +513,7 @@ export interface RecFuncCreation<Name extends string> {
 /**
  * @category Functions
  */
-export interface FuncDecl<Name extends string = any> extends Ast<Name, Z3_func_decl> {
+export interface FuncDecl<Name extends string = 'main'> extends Ast<Name, Z3_func_decl> {
   /** @hidden */
   readonly __typename: 'FuncDecl';
 
@@ -526,7 +526,7 @@ export interface FuncDecl<Name extends string = any> extends Ast<Name, Z3_func_d
   call(...args: CoercibleToExpr<Name>[]): AnyExpr<Name>;
 }
 
-export interface Expr<Name extends string = any, S extends Sort<Name> = AnySort<Name>, Ptr = unknown>
+export interface Expr<Name extends string = 'main', S extends Sort<Name> = AnySort<Name>, Ptr = unknown>
   extends Ast<Name, Ptr> {
   /** @hidden */
   readonly __typename: 'Expr' | Bool['__typename'] | Arith['__typename'] | BitVec['__typename'];
@@ -543,7 +543,7 @@ export interface Expr<Name extends string = any, S extends Sort<Name> = AnySort<
 }
 
 /** @category Booleans */
-export interface BoolSort<Name extends string = any> extends Sort<Name> {
+export interface BoolSort<Name extends string = 'main'> extends Sort<Name> {
   /** @hidden */
   readonly __typename: 'BoolSort';
 
@@ -551,7 +551,7 @@ export interface BoolSort<Name extends string = any> extends Sort<Name> {
   cast(expr: CoercibleToExpr<Name>): never;
 }
 /** @category Booleans */
-export interface BoolCreation<Name extends string = any> {
+export interface BoolCreation<Name extends string = 'main'> {
   sort(): BoolSort<Name>;
 
   const(name: string): Bool<Name>;
@@ -562,7 +562,7 @@ export interface BoolCreation<Name extends string = any> {
   val(value: boolean): Bool<Name>;
 }
 /** @category Booleans */
-export interface Bool<Name extends string = any> extends Expr<Name, BoolSort<Name>, Z3_ast> {
+export interface Bool<Name extends string = 'main'> extends Expr<Name, BoolSort<Name>, Z3_ast> {
   /** @hidden */
   readonly __typename: 'Bool';
 
@@ -576,7 +576,7 @@ export interface Bool<Name extends string = any> extends Expr<Name, BoolSort<Nam
  * A Sort that represents Integers or Real numbers
  * @category Arithmetic
  */
-export interface ArithSort<Name extends string = any> extends Sort<Name> {
+export interface ArithSort<Name extends string = 'main'> extends Sort<Name> {
   /** @hidden */
   readonly __typename: 'ArithSort';
 
@@ -612,7 +612,7 @@ export interface RealCreation<Name extends string> {
  * Represents Integer or Real number expression
  * @category Arithmetic
  */
-export interface Arith<Name extends string = any> extends Expr<Name, ArithSort<Name>, Z3_ast> {
+export interface Arith<Name extends string = 'main'> extends Expr<Name, ArithSort<Name>, Z3_ast> {
   /** @hidden */
   readonly __typename: 'Arith' | IntNum['__typename'] | RatNum['__typename'];
 
@@ -680,7 +680,7 @@ export interface Arith<Name extends string = any> extends Expr<Name, ArithSort<N
  * A constant Integer value expression
  * @category Arithmetic
  */
-export interface IntNum<Name extends string = any> extends Arith<Name> {
+export interface IntNum<Name extends string = 'main'> extends Arith<Name> {
   /** @hidden */
   readonly __typename: 'IntNum';
 
@@ -704,7 +704,7 @@ export interface IntNum<Name extends string = any> extends Arith<Name> {
  * ```
  * @category Arithmetic
  */
-export interface RatNum<Name extends string = any> extends Arith<Name> {
+export interface RatNum<Name extends string = 'main'> extends Arith<Name> {
   /** @hidden */
   readonly __typename: 'RatNum';
 
@@ -722,7 +722,7 @@ export interface RatNum<Name extends string = any> extends Arith<Name> {
  * @typeParam Bits - A number representing amount of bits for this sort
  * @category Bit Vectors
  */
-export interface BitVecSort<Bits extends number = number, Name extends string = any> extends Sort<Name> {
+export interface BitVecSort<Bits extends number = number, Name extends string = 'main'> extends Sort<Name> {
   /** @hidden */
   readonly __typename: 'BitVecSort';
 
@@ -743,7 +743,7 @@ export interface BitVecSort<Bits extends number = number, Name extends string = 
 }
 
 /** @hidden */
-export type CoercibleToBitVec<Bits extends number = number, Name extends string = any> =
+export type CoercibleToBitVec<Bits extends number = number, Name extends string = 'main'> =
   | bigint
   | number
   | BitVec<Bits, Name>;
@@ -766,7 +766,7 @@ export interface BitVecCreation<Name extends string> {
  * Represents Bit Vector expression
  * @category Bit Vectors
  */
-export interface BitVec<Bits extends number = number, Name extends string = any>
+export interface BitVec<Bits extends number = number, Name extends string = 'main'>
   extends Expr<Name, BitVecSort<Bits, Name>, Z3_ast> {
   /** @hidden */
   readonly __typename: 'BitVec' | BitVecNum['__typename'];
@@ -956,7 +956,7 @@ export interface BitVec<Bits extends number = number, Name extends string = any>
  * Represents Bit Vector constant value
  * @category Bit Vectors
  */
-export interface BitVecNum<Bits extends number = number, Name extends string = any> extends BitVec<Bits, Name> {
+export interface BitVecNum<Bits extends number = number, Name extends string = 'main'> extends BitVec<Bits, Name> {
   /** @hidden */
   readonly __typename: 'BitVecNum';
 
@@ -966,7 +966,7 @@ export interface BitVecNum<Bits extends number = number, Name extends string = a
   asBinaryString(): string;
 }
 
-export interface Probe<Name extends string = any> {
+export interface Probe<Name extends string = 'main'> {
   /** @hidden */
   readonly __typename: 'Probe';
 
@@ -978,7 +978,7 @@ export interface Probe<Name extends string = any> {
 export interface TacticCtor<Name extends string> {
   new (name: string): Tactic<Name>;
 }
-export interface Tactic<Name extends string = any> {
+export interface Tactic<Name extends string = 'main'> {
   /** @hidden */
   readonly __typename: 'Tactic';
 
@@ -988,7 +988,7 @@ export interface Tactic<Name extends string = any> {
 
 /** @hidden */
 export interface AstVectorCtor<Name extends string> {
-  new <Item extends Ast<Name> = AnyAst<Name>>(): AstVector<Item, Name>;
+  new <Item extends Ast<Name> = AnyAst<Name>>(): AstVector<Name, Item>;
 }
 /**
  * Stores multiple {@link Ast} objects
@@ -1006,7 +1006,7 @@ export interface AstVectorCtor<Name extends string> {
  * // [2, x]
  * ```
  */
-export interface AstVector<Item extends Ast<Name> = AnyAst, Name extends string = any> extends Iterable<Item> {
+export interface AstVector<Name extends string = 'main', Item extends Ast<Name> = AnyAst<Name>> extends Iterable<Item> {
   /** @hidden */
   readonly __typename: 'AstVector';
 
@@ -1028,7 +1028,7 @@ export interface AstVector<Item extends Ast<Name> = AnyAst, Name extends string 
 
 /** @hidden */
 export interface AstMapCtor<Name extends string> {
-  new <Key extends Ast = AnyAst, Value extends Ast = AnyAst>(): AstMap<Key, Value, Name>;
+  new <Key extends Ast<Name> = AnyAst<Name>, Value extends Ast<Name> = AnyAst<Name>>(): AstMap<Name, Key, Value>;
 }
 /**
  * Stores a mapping between different {@link Ast} objects
@@ -1051,7 +1051,7 @@ export interface AstMapCtor<Name extends string> {
  * // 0
  * ```
  */
-export interface AstMap<Key extends Ast<Name> = AnyAst, Value extends Ast = AnyAst, Name extends string = any>
+export interface AstMap<Name extends string = 'main', Key extends Ast<Name> = AnyAst<Name>, Value extends Ast<Name> = AnyAst<Name>>
   extends Iterable<[Key, Value]> {
   /** @hidden */
   readonly __typename: 'AstMap';
@@ -1061,7 +1061,7 @@ export interface AstMap<Key extends Ast<Name> = AnyAst, Value extends Ast = AnyA
   get size(): number;
 
   entries(): IterableIterator<[Key, Value]>;
-  keys(): AstVector<Key, Name>;
+  keys(): AstVector<Name, Key>;
   values(): IterableIterator<Value>;
   get(key: Key): Value | undefined;
   set(key: Key, value: Value): void;

--- a/src/api/js/src/high-level/types.ts
+++ b/src/api/js/src/high-level/types.ts
@@ -101,13 +101,10 @@ export type CheckSatResult = typeof sat | typeof unsat | typeof unknown;
 
 /** @hidden */
 export interface ContextCtor {
-  new <Name extends string>(name: Name, options?: Record<string, any>): Context<Name>;
+  <Name extends string>(name: Name, options?: Record<string, any>): Context<Name>;
 }
 
 export interface Context<Name extends string = any> {
-  /** @hidden */
-  readonly __typename: 'Context';
-
   /** @hidden */
   readonly ptr: Z3_context;
   /**
@@ -1118,11 +1115,6 @@ export interface Z3HighLevel {
    * Returns a global Z3 parameter
    */
   getParam(name: string): string | null;
-
-  /**
-   * Returns whether the given object is a {@link Context}
-   */
-  isContext(obj: unknown): obj is Context;
 
   /**
    * Use this to create new contexts

--- a/src/api/js/src/high-level/types.ts
+++ b/src/api/js/src/high-level/types.ts
@@ -364,7 +364,7 @@ export interface Ast<Name extends string = 'main', Ptr = unknown> {
   /** @virtual */
   get ast(): Z3_ast;
   /** @virtual */
-  get id(): number;
+  id(): number;
 
   eqIdentity(other: Ast<Name>): boolean;
   neqIdentity(other: Ast<Name>): boolean;
@@ -409,7 +409,7 @@ export interface Model<Name extends string = 'main'> extends Iterable<FuncDecl<N
   readonly ctx: Context<Name>;
   readonly ptr: Z3_model;
 
-  get length(): number;
+  length(): number;
 
   entries(): IterableIterator<[number, FuncDecl<Name>]>;
   keys(): IterableIterator<number>;
@@ -671,7 +671,7 @@ export interface IntNum<Name extends string = 'main'> extends Arith<Name> {
   /** @hidden */
   readonly __typename: 'IntNum';
 
-  get value(): bigint;
+  value(): bigint;
   asString(): string;
   asBinary(): string;
 }
@@ -695,7 +695,7 @@ export interface RatNum<Name extends string = 'main'> extends Arith<Name> {
   /** @hidden */
   readonly __typename: 'RatNum';
 
-  get value(): { numerator: bigint; denominator: bigint };
+  value(): { numerator: bigint; denominator: bigint };
   numerator(): IntNum<Name>;
   denominator(): IntNum<Name>;
   asNumber(): number;
@@ -723,7 +723,7 @@ export interface BitVecSort<Bits extends number = number, Name extends string = 
    * // 32
    * ```
    */
-  get size(): Bits;
+  size(): Bits;
 
   cast(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name>;
   cast(other: CoercibleToExpr<Name>): Expr<Name>;
@@ -774,7 +774,7 @@ export interface BitVec<Bits extends number = number, Name extends string = 'mai
    * // 8
    * ```
    */
-  get size(): Bits;
+  size(): Bits;
 
   /** @category Arithmetic */
   add(other: CoercibleToBitVec<Bits, Name>): BitVec<Bits, Name>;
@@ -947,7 +947,7 @@ export interface BitVecNum<Bits extends number = number, Name extends string = '
   /** @hidden */
   readonly __typename: 'BitVecNum';
 
-  get value(): bigint;
+  value(): bigint;
   asSignedValue(): bigint;
   asString(): string;
   asBinaryString(): string;
@@ -999,7 +999,7 @@ export interface AstVector<Name extends string = 'main', Item extends Ast<Name> 
 
   readonly ctx: Context<Name>;
   readonly ptr: Z3_ast_vector;
-  get length(): number;
+  length(): number;
 
   entries(): IterableIterator<[number, Item]>;
   keys(): IterableIterator<number>;

--- a/src/api/js/src/high-level/utils.test.ts
+++ b/src/api/js/src/high-level/utils.test.ts
@@ -1,5 +1,5 @@
 import { Z3AssertionError } from './types';
-import { allSatisfy, assert, assertExhaustive, autoBind } from './utils';
+import { allSatisfy, assert, assertExhaustive } from './utils';
 
 describe('allSatisfy', () => {
   it('returns null on empty array', () => {
@@ -53,28 +53,6 @@ describe('assertExhaustive', () => {
       default:
         expect(() => assertExhaustive(result)).toThrowError();
     }
-  });
-});
-
-describe('autoBind', () => {
-  class Binded {
-    readonly name = 'Richard';
-    constructor(shouldBind: boolean) {
-      if (shouldBind === true) {
-        autoBind(this);
-      }
-    }
-
-    test(): string {
-      return `Hello ${this.name}`;
-    }
-  }
-
-  it('binds this', () => {
-    const { test: withoutBind } = new Binded(false);
-    const { test: withBind } = new Binded(true);
-    expect(() => withoutBind()).toThrowError(TypeError);
-    expect(withBind()).toStrictEqual('Hello Richard');
   });
 });
 

--- a/src/api/js/src/high-level/utils.ts
+++ b/src/api/js/src/high-level/utils.ts
@@ -10,32 +10,6 @@ function getAllProperties(obj: Record<string, any>) {
   return properties;
 }
 
-// https://github.com/sindresorhus/auto-bind
-// We modify it to use CommonJS instead of ESM
-/*
-MIT License
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
-export function autoBind<Self extends Record<string | symbol, any>>(self: Self): Self {
-  for (const [obj, key] of getAllProperties(self.constructor.prototype)) {
-    if (key === 'constructor') {
-      continue;
-    }
-    const descriptor = Reflect.getOwnPropertyDescriptor(obj, key);
-    if (descriptor && typeof descriptor.value === 'function') {
-      (self[key] as any) = self[key].bind(self);
-    }
-  }
-  return self;
-}
-
 /**
  * Use to ensure that switches are checked to be exhaustive at compile time
  *


### PR DESCRIPTION
This is a followup to @ritave's #6048. This makes the implementation and API a little more idiomatic, makes the typechecking stricter, adds a more complete example, and adds error checking. Specifically:

- the first commit makes the implementation more idiomatic JavaScript (mainly by not using classes and `bind` when a single object literal and closures will work)
- in the second commit makes the type checker able to distinguish between contexts by default (previously it used `any`, which is a special non-type sigil which tells the type checker not to check types, basically)
- the third commit changes the return types for `solve` from `Symbol` to `string` - symbols are annoying in this case because they have to be imported every time they're used (also the description for `unsat` was wrong; it said "Z3 couldn't find a solution", whereas it actually means "determined there was not a solution")
- the fourth commit adds a couple of `toString` methods useful for printing results
- the fifth commit adds the example
- the sixth commit makes `from` on integral values create an Int rather than a Real, which makes the example run ~25x faster on my machine (26 seconds, instead of 11 minutes)
- the seventh commit adds `Z3_get_error_code !== Z3_OK` checks after every nontrivial call to the low-level API
- the eighth commit adds an operator which was apparently left out of the types
- the ninth commit replaces various getters with methods, since getters should not be expensive (as calling out to wasm arguably is)