### PR TITLE
fixes issue #6119

### DIFF
--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -1842,7 +1842,7 @@ std::string mpz_manager<SYNCH>::to_string(mpz const & a) const {
 template<bool SYNCH>
 unsigned mpz_manager<SYNCH>::hash(mpz const & a) {
     if (is_small(a))
-        return a.m_val;
+        return ::abs(a.m_val);
 #ifndef _MP_GMP
     unsigned sz = size(a);
     if (sz == 1)


### PR DESCRIPTION
Makes sure that two equal integers always have the same hash value, even in corner cases where they are represented differently.
The issue observed was that the integer `-2147483647` was hashed to different values depending on being represented as small or large integer. 
In the small case it used to be hashed to `unsigned(-2147483647)` which is `2147483649`, and in the large case it was hashed to `2147483647`, as the digits are all represented as `unsigned`s anyways.