### PR TITLE
bump emscripten version used to build wasm artifact

### DIFF
--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -10,7 +10,7 @@ defaults:
     working-directory: src/api/js
 
 env:
-  EM_VERSION: 3.1.0
+  EM_VERSION: 3.1.15
 
 jobs:
   publish:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -10,7 +10,7 @@ defaults:
     working-directory: src/api/js
 
 env:
-  EM_VERSION: 3.1.0
+  EM_VERSION: 3.1.15
 
 jobs:
   check:


### PR DESCRIPTION
This should make it possible to use the published package on node 18, by using a version of emscripten which includes https://github.com/emscripten-core/emscripten/pull/16917.

Fixes https://github.com/Z3Prover/z3/issues/6045.