### PR TITLE
fix js distributable

### DIFF
--- a/src/api/js/package-lock.json
+++ b/src/api/js/package-lock.json
@@ -27,7 +27,7 @@
         "typescript": "^4.5.4"
       },
       "engines": {
-        "node": ">=16 <18"
+        "node": ">=16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/api/js/package.json
+++ b/src/api/js/package.json
@@ -12,13 +12,13 @@
   "homepage": "https://github.com/Z3Prover/z3/tree/master/src/api/js",
   "repository": "github:Z3Prover/z3",
   "engines": {
-    "node": ">=16 <18"
+    "node": ">=16"
   },
   "browser": "build/browser.js",
   "main": "build/node.js",
   "types": "build/node.d.ts",
   "files": [
-    "build/*.{js,d.ts,wasm}"
+    "build/**/*.{js,d.ts,wasm}"
   ],
   "scripts": {
     "build:ts": "run-s -l build:ts:generate build:ts:tsc",


### PR DESCRIPTION
https://github.com/Z3Prover/z3/pull/6048 reorganized the files in the JS api which made the published artifact not work (so the just-published 4.9.0 doesn't work at all; attempting to import it throws). This fixes that. It also marks the package as usable on node 18, due to the inclusion of https://github.com/Z3Prover/z3/pull/6136.