### PR TITLE
Faster param symbol management

### DIFF
--- a/src/api/api_solver.cpp
+++ b/src/api/api_solver.cpp
@@ -391,9 +391,11 @@ extern "C" {
             bool new_model = params.get_bool("model", true);
             if (old_model != new_model)
                 to_solver_ref(s)->set_produce_models(new_model);
-            param_descrs r;
-            to_solver_ref(s)->collect_param_descrs(r);
-            context_params::collect_solver_param_descrs(r);
+            param_descrs& r = to_solver(s)->m_param_descrs;
+            if(r.size () == 0) {
+              to_solver_ref(s)->collect_param_descrs(r);
+              context_params::collect_solver_param_descrs(r);
+            }
             params.validate(r);
             to_solver_ref(s)->updt_params(params);
         }

--- a/src/api/api_solver.h
+++ b/src/api/api_solver.h
@@ -42,6 +42,7 @@ struct Z3_solver_ref : public api::object {
     scoped_ptr<solver_factory> m_solver_factory;
     ref<solver>                m_solver;
     params_ref                 m_params;
+    param_descrs               m_param_descrs;
     symbol                     m_logic;
     scoped_ptr<solver2smt2_pp> m_pp;
     scoped_ptr<cmd_context>    m_cmd_context;


### PR DESCRIPTION
`*::get_param_descrs` is called many times during the a run of z3 (in my case, a cegis loop), which causes `string_hash` to be approximately 5% of the runtime of the program, according to callgrind.
The issues are constant strings that are getting converted to symbols on every call, which requires hashing of the string so that we can check the global symbol table.

I have a proof of concept patch here, which turns a lot of the symbols into static entries in the symbol table.

It's only meant for discussion, not for merging, since afaict, it currently only works in debug mode (since the initialization at startup requires some resources that aren't created yet), and requires the library to eagerly initialize the symbol table. However, it does remove the 5% hashing overhead.