### PR TITLE
Flush the trace stream before displaying sat results

### DIFF
--- a/src/cmd_context/cmd_context.cpp
+++ b/src/cmd_context/cmd_context.cpp
@@ -1825,6 +1825,10 @@ void cmd_context::add_declared_functions(model& mdl) {
 }
 
 void cmd_context::display_sat_result(lbool r) {
+    if (has_manager() && m().has_trace_stream()) {
+        m().trace_stream().flush();
+    }
+
     switch (r) {
     case l_true:
         regular_stream() << "sat" << std::endl;


### PR DESCRIPTION
The trace stream can be set to log quantifier instantiations with `(set-option :trace true)`, `(set-option :trace-file-name <filename>)`.

[We](https://github.com/secure-foundations/verus) use the log to profile quantifier instantiations in our verification tool: we use z3's smtlib interface interactively, and we inspect the log after a `check-sat` returns. Because the trace stream writer is buffered, we witness a partial log of the instantiations if we read it after a sat result is returned but before terminating z3 (we run additional queries on the same z3 process).

This change flushes the trace stream just before reporting a sat result. This seems minimally invasive, but there may be other ways to achieve a similar result that you may prefer, such as adding a new command to flush the trace stream. We could also make this configurable with an additional :trace option.

/cc @parno @chris-hawblitzel