### PR TITLE
fix z3str3 re.is_range symbolic argument bug

### DIFF
--- a/src/smt/theory_str_regex.cpp
+++ b/src/smt/theory_str_regex.cpp
@@ -725,7 +725,11 @@ namespace smt {
             return _qadd(lo, cx);
         } else if (u.re.is_range(re, sub1, sub2)) {
             SASSERT(u.str.is_string(sub1));
+            if (!u.str.is_string(sub1))
+                throw default_exception("regular expressions must be built from string literals");
             SASSERT(u.str.is_string(sub2));
+            if (!u.str.is_string(sub2))
+                throw default_exception("regular expressions must be built from string literals");
             zstring str1, str2;
             u.str.is_string(sub1, str1);
             u.str.is_string(sub2, str2);
@@ -768,7 +772,11 @@ namespace smt {
             return _qmul(2, cx);
         } else if (u.re.is_range(re, sub1, sub2)) {
             SASSERT(u.str.is_string(sub1));
+            if (!u.str.is_string(sub1))
+                throw default_exception("regular expressions must be built from string literals");
             SASSERT(u.str.is_string(sub2));
+            if (!u.str.is_string(sub2))
+                throw default_exception("regular expressions must be built from string literals");
             zstring str1, str2;
             u.str.is_string(sub1, str1);
             u.str.is_string(sub2, str2);
@@ -875,7 +883,11 @@ namespace smt {
             lens.reset();
         } else if (u.re.is_range(re, sub1, sub2)) {
             SASSERT(u.str.is_string(sub1));
+            if (!u.str.is_string(sub1))
+                throw default_exception("regular expressions must be built from string literals");
             SASSERT(u.str.is_string(sub2));
+            if (!u.str.is_string(sub2))
+                throw default_exception("regular expressions must be built from string literals");
             zstring str1, str2;
             u.str.is_string(sub1, str1);
             u.str.is_string(sub2, str2);
@@ -1007,7 +1019,11 @@ namespace smt {
             return retval;
         } else if (u.re.is_range(re, sub1, sub2)) {
             SASSERT(u.str.is_string(sub1));
+            if (!u.str.is_string(sub1))
+                throw default_exception("regular expressions must be built from string literals");
             SASSERT(u.str.is_string(sub2));
+            if (!u.str.is_string(sub2))
+                throw default_exception("regular expressions must be built from string literals");
             zstring str1, str2;
             u.str.is_string(sub1, str1);
             u.str.is_string(sub2, str2);


### PR DESCRIPTION
Currently Z3str3 doesn't support re.is_range symbolic arguments.