### PR TITLE
Remove remainder workaround for pre-MSVC2013.

### DIFF
--- a/src/util/hwf.cpp
+++ b/src/util/hwf.cpp
@@ -312,13 +312,7 @@ void hwf_manager::round_to_integral(mpf_rounding_mode rm, hwf const & x, hwf & o
 }
 
 void hwf_manager::rem(hwf const & x, hwf const & y, hwf & o) {
-#if defined(_WINDOWS) && _MSC_VER <= 1700
-    o.value = fmod(x.value, y.value);
-    if (o.value >= (y.value/2.0))
-        o.value -= y.value;
-#else
     o.value = remainder(x.value, y.value);
-#endif
 }
 
 void hwf_manager::maximum(hwf const & x, hwf const & y, hwf & o) {


### PR DESCRIPTION
This workaround was built for _MSC_VER <= 1700. 1700 was
Visual Studio 2012, which is no longer supported for
building Z3.