### PR TITLE
Remove Z3_bool, Z3_TRUE, Z3_FALSE from the API.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,7 +12,7 @@ Version 4.next
 
 Version 4.11.0
 ==============
-- remove Z3_bool from API
+- remove `Z3_bool`, `Z3_TRUE`, `Z3_FALSE` from the API. Use `bool`, `true`, `false` instead.
 
 Version 4.10.2
 ==============

--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -76,26 +76,11 @@ DEFINE_TYPE(Z3_rcf_num);
 */
 
 /**
-   \brief Z3 Boolean type. It is just an alias for \c bool.
-*/
-typedef bool Z3_bool;
-
-/**
    \brief Z3 string type. It is just an alias for \ccode{const char *}.
 */
 typedef const char * Z3_string;
 typedef char const*  Z3_char_ptr;
 typedef Z3_string * Z3_string_ptr;
-
-/**
-   \brief True value. It is just an alias for \c true.
-*/
-#define Z3_TRUE  true
-
-/**
-   \brief False value. It is just an alias for \c false.
-*/
-#define Z3_FALSE false
 
 /**
    \brief Lifted Boolean type: \c false, \c undefined, \c true.


### PR DESCRIPTION
These have just been aliases for the standard type `bool` and
values `true` and `false` for a long time now.