### PR TITLE
Fix warning about \ref when building website.dox

### DIFF
--- a/doc/website.dox.in
+++ b/doc/website.dox.in
@@ -8,5 +8,5 @@
 
    This website hosts the automatically generated documentation for the Z3 APIs.
 
-   - \ref @C_API@ @CPP_API@ @DOTNET_API@ @JAVA_API@ @PYTHON_API@ @OCAML_API@ @JS_API@
+   @C_API@ @CPP_API@ @DOTNET_API@ @JAVA_API@ @PYTHON_API@ @OCAML_API@ @JS_API@
 */


### PR DESCRIPTION
This isn't actually doing a ref to anything. The generated file has new bullet list entries for each of the available APIs, so nothing else goes on that `- \ref` line, resulting in the warning.