### PR TITLE
cmake: Remove ExternalProject BUILD_ALWAYS workaround.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,11 +1,4 @@
 include(ExternalProject)
-# Unfortunately `BUILD_ALWAYS` only seems to be supported with the version of ExternalProject
-# that shipped with CMake >= 3.1.
-if (("${CMAKE_VERSION}" VERSION_EQUAL "3.1") OR ("${CMAKE_VERSION}" VERSION_GREATER "3.1"))
-  set(EXTERNAL_PROJECT_BUILD_ALWAYS_ARG BUILD_ALWAYS 1)
-else()
-  set(EXTERNAL_PROJECT_BUILD_ALWAYS_ARG "")
-endif()
 
 option(Z3_C_EXAMPLES_FORCE_CXX_LINKER
   "Force C++ linker when building C example projects" OFF)
@@ -43,7 +36,7 @@ ExternalProject_Add(c_example
     "${EXTERNAL_C_PROJ_USE_CXX_LINKER_ARG}"
     "${EXTERNAL_PROJECT_CMAKE_BUILD_TYPE_ARG}"
   # Build step
-  ${EXTERNAL_PROJECT_BUILD_ALWAYS_ARG}
+  BUILD_ALWAYS ON
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/c_example_build_dir"
   # Install Step
   INSTALL_COMMAND "${CMAKE_COMMAND}" -E echo "" # Dummy command
@@ -62,7 +55,7 @@ ExternalProject_Add(c_maxsat_example
     "${EXTERNAL_C_PROJ_USE_CXX_LINKER_ARG}"
     "${EXTERNAL_PROJECT_CMAKE_BUILD_TYPE_ARG}"
   # Build step
-  ${EXTERNAL_PROJECT_BUILD_ALWAYS_ARG}
+  BUILD_ALWAYS ON
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/c_maxsat_example_build_dir"
   # Install Step
   INSTALL_COMMAND "${CMAKE_COMMAND}" -E echo "" # Dummy command
@@ -81,7 +74,7 @@ ExternalProject_Add(cpp_example
     "-DZ3_DIR=${PROJECT_BINARY_DIR}"
     "${EXTERNAL_PROJECT_CMAKE_BUILD_TYPE_ARG}"
   # Build step
-  ${EXTERNAL_PROJECT_BUILD_ALWAYS_ARG}
+  BUILD_ALWAYS ON
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/cpp_example_build_dir"
   # Install Step
   INSTALL_COMMAND "${CMAKE_COMMAND}" -E echo "" # Dummy command
@@ -99,7 +92,7 @@ ExternalProject_Add(z3_tptp5
     "-DZ3_DIR=${PROJECT_BINARY_DIR}"
     "${EXTERNAL_PROJECT_CMAKE_BUILD_TYPE_ARG}"
   # Build step
-  ${EXTERNAL_PROJECT_BUILD_ALWAYS_ARG}
+  BUILD_ALWAYS ON
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/tptp_build_dir"
   # Install Step
   INSTALL_COMMAND "${CMAKE_COMMAND}" -E echo "" # Dummy command
@@ -117,7 +110,7 @@ ExternalProject_Add(userPropagator
         "-DZ3_DIR=${PROJECT_BINARY_DIR}"
         "${EXTERNAL_PROJECT_CMAKE_BUILD_TYPE_ARG}"
         # Build step
-        ${EXTERNAL_PROJECT_BUILD_ALWAYS_ARG}
+        BUILD_ALWAYS ON
         BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/userPropagator_build_dir"
         # Install Step
         INSTALL_COMMAND "${CMAKE_COMMAND}" -E echo "" # Dummy command


### PR DESCRIPTION
This was only needed for cmake < 3.1, but we require later
than that.