### PR TITLE
Remove remnants of _MP_MSBIGNUM checks.

### DIFF
--- a/src/util/mpz.h
+++ b/src/util/mpz.h
@@ -44,7 +44,7 @@ typedef unsigned digit_t;
 template<bool SYNCH> class mpz_manager;
 template<bool SYNCH> class mpq_manager;
 
-#if !defined(_MP_GMP) && !defined(_MP_MSBIGNUM) && !defined(_MP_INTERNAL)
+#if !defined(_MP_GMP) && !defined(_MP_INTERNAL)
 #ifdef _WINDOWS
 #define _MP_INTERNAL
 #else
@@ -52,13 +52,8 @@ template<bool SYNCH> class mpq_manager;
 #endif
 #endif
 
-#if defined(_MP_MSBIGNUM)
-typedef size_t digit_t;
-#elif defined(_MP_INTERNAL)
-typedef unsigned int digit_t;
-#endif
-
 #ifndef _MP_GMP
+typedef unsigned int digit_t;
 class mpz_cell {
     unsigned  m_size;
     unsigned  m_capacity;


### PR DESCRIPTION
It looks like `_MP_MSBIGNUM` support was dropped in 2012.

I'm not sure if/how we should update this comment:

```
src/util/mpz.cpp:// LEHMER assumes 32-bit digits, so it cannot be used with MSBIGNUM library + 64-bit binary
```
