### PR TITLE
cmake: Remove telling the Intel compiler to link OpenMP.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,15 +276,7 @@ endif()
 # FIXME: Support ARM "-mfpu=vfp -mfloat-abi=hard"
 if ((TARGET_ARCHITECTURE STREQUAL "x86_64") OR (TARGET_ARCHITECTURE STREQUAL "i686"))
   if ((CMAKE_CXX_COMPILER_ID MATCHES "GNU") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "Intel"))
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-      # Intel's compiler requires linking with libiomp5
-      list(APPEND Z3_DEPENDENT_LIBS "iomp5")
-    endif()
     set(SSE_FLAGS "-mfpmath=sse" "-msse" "-msse2")
-  elseif (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-    set(SSE_FLAGS "-mfpmath=sse" "-msse" "-msse2")
-    # Intel's compiler requires linking with libiomp5
-    list(APPEND Z3_DEPENDENT_LIBS "iomp5")
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(SSE_FLAGS "/arch:SSE2")
   else()


### PR DESCRIPTION
This also removes a duplicated branch since the Intel compiler
is already handled at the same time as GCC and Clang, so it
doesn't need its own block as well.