### PR TITLE
Fix memory_high_watermark parameter according to the documentation

### DIFF
--- a/src/util/env_params.cpp
+++ b/src/util/env_params.cpp
@@ -28,7 +28,7 @@ void env_params::updt_params() {
     enable_warning_messages(p.get_bool("warning", true));
     memory::set_max_size(megabytes_to_bytes(p.get_uint("memory_max_size", 0)));
     memory::set_max_alloc_count(p.get_uint("memory_max_alloc_count", 0));
-    memory::set_high_watermark(p.get_uint("memory_high_watermark", 0));
+    memory::set_high_watermark(megabytes_to_bytes(p.get_uint("memory_high_watermark", 0)));
 }
 
 void env_params::collect_param_descrs(param_descrs & d) {


### PR DESCRIPTION
Convert `memory_high_watermark` parameter from megabytes to bytes since `set_high_watermark` accepts value in bytes but [parameter description](https://github.com/Z3Prover/z3/blob/d8c99480c67efba789b39717ae04db07524b3bd4/src/util/env_params.cpp#L39) says that the value is in megabytes.
