### PR TITLE
cmake: Remove dep on mk_util.py for update_api.py calls.

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -26,8 +26,6 @@ add_custom_command(OUTPUT ${generated_files}
   DEPENDS "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
           ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
           ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
-          # FIXME: When update_api.py no longer uses ``mk_util`` drop this dependency
-          "${PROJECT_SOURCE_DIR}/scripts/mk_util.py"
   COMMENT "Generating ${generated_files}"
   USES_TERMINAL
   VERBATIM

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -29,8 +29,6 @@ add_custom_command(OUTPUT "${Z3_JAVA_NATIVE_JAVA}" "${Z3_JAVA_NATIVE_CPP}"
     ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
     "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
-    # FIXME: When update_api.py no longer uses ``mk_util`` drop this dependency
-    "${PROJECT_SOURCE_DIR}/scripts/mk_util.py"
   COMMENT "Generating \"${Z3_JAVA_NATIVE_JAVA}\" and \"${Z3_JAVA_NATIVE_CPP}\""
   USES_TERMINAL
 )


### PR DESCRIPTION
update_api.py doesn't depend on mk_util.py any longer, so these
dependencies can go away.