### PR TITLE
mk_unix_dist.py: Fix --nopython

### DIFF
--- a/scripts/mk_unix_dist.py
+++ b/scripts/mk_unix_dist.py
@@ -66,7 +66,7 @@ def display_help():
 
 # Parse configuration option for mk_make script
 def parse_options():
-    global FORCE_MK, JAVA_ENABLED, GIT_HASH, DOTNET_CORE_ENABLED, DOTNET_KEY_FILE, OS_NAME
+    global FORCE_MK, JAVA_ENABLED, GIT_HASH, DOTNET_CORE_ENABLED, DOTNET_KEY_FILE, PYTHON_ENABLED, OS_NAME
     path = BUILD_DIR
     options, remainder = getopt.gnu_getopt(sys.argv[1:], 'b:hsf', ['build=',
                                                                    'help',


### PR DESCRIPTION
Writing to the global PYTHON_ENABLED requires that it be flagged
as a global.