### PR TITLE
z3++.h: No longer include unused sstream.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@ Version 4.next
 Version 4.11.0
 ==============
 - remove `Z3_bool`, `Z3_TRUE`, `Z3_FALSE` from the API. Use `bool`, `true`, `false` instead.
+- z3++.h no longer includes `<sstream>` as it did not use it.
 
 Version 4.10.2
 ==============

--- a/examples/c++/example.cpp
+++ b/examples/c++/example.cpp
@@ -5,6 +5,7 @@ Copyright (c) 2015 Microsoft Corporation
 --*/
 
 #include <iostream>
+#include <sstream>
 #include<vector>
 #include"z3++.h"
 

--- a/examples/tptp/tptp5.cpp
+++ b/examples/tptp/tptp5.cpp
@@ -15,6 +15,7 @@ Copyright (c) 2015 Microsoft Corporation
 #include <iostream>
 #include <fstream>
 #include <limits>
+#include <sstream>
 #include <string.h>
 #include <cstdlib>
 #include "z3++.h"

--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -23,7 +23,6 @@ Notes:
 #include<cassert>
 #include<ostream>
 #include<string>
-#include<sstream>
 #include<memory>
 #include<vector>
 #include<z3.h>

--- a/src/api/julia/z3jl.cpp
+++ b/src/api/julia/z3jl.cpp
@@ -1,4 +1,5 @@
 #include "jlcxx/jlcxx.hpp"
+#include <sstream>
 #include "z3++.h"
 
 using namespace z3;


### PR DESCRIPTION
This makes some code using the C++ API have to include `<sstream>`
if they used the functionality but didn't include it themselves.