### PR TITLE
(cmake): fix visibility on shell z3 binary

### DIFF
--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -34,6 +34,14 @@ add_executable(shell
 # we don't want (I think).
   ${shell_object_files}
 )
+
+set_target_properties(shell PROPERTIES
+    # Position independent code needed in shared libraries
+    POSITION_INDEPENDENT_CODE ON
+    # Symbol visibility
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON)
+
 z3_add_install_tactic_rule(${shell_deps})
 z3_add_memory_initializer_rule(${shell_deps})
 z3_add_gparams_register_modules_rule(${shell_deps})


### PR DESCRIPTION
Commit #b361226 changed symbol visibility from a global to a local option.
This creates inconsistency for shell that is compiled as an executable rather
than as z3 component.

This commit adds same local options to shell target in cmake.

Prior to the fix, clang on OSX complains with lots of warnings about symbol visibility
being different in different translation units that are linked together