### PR TITLE
model_based_opt: fix enabling complete resolution

### DIFF
--- a/src/math/simplex/model_based_opt.cpp
+++ b/src/math/simplex/model_based_opt.cpp
@@ -981,7 +981,7 @@ namespace opt {
         lub_rows.reset();
         glb_rows.reset();
         mod_rows.reset();
-        bool lub_is_unit = false, glb_is_unit = false;
+        bool lub_is_unit = true, glb_is_unit = true;
         unsigned eq_row = UINT_MAX;
         // select the lub and glb.
         for (unsigned row_id : row_ids) {


### PR DESCRIPTION
@NikolajBjorner please review carefully. 

It appears that an optimization that does complete FM when the size is small has been disabled.
This might have adverse (or positive) effects on the clients. It might be useful to add a flag to make it optional.

a bug prevented an optimization to be enabled