### PR TITLE
Fix Android CI CMake Java JNI error

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -27,7 +27,7 @@ jobs:
       run:  |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=21 -DCMAKE_ANDROID_ARCH_ABI=${{ matrix.android-abi }} "-DCMAKE_ANDROID_NDK=$ANDROID_NDK_LATEST_HOME" -DZ3_BUILD_JAVA_BINDINGS=TRUE -G "Unix Makefiles" -DJAVA_AWT_LIBRARY=NotNeeded -DJAVA_JVM_LIBRARY=NotNeeded -DJAVA_INCLUDE_PATH2=NotNeeded -DJAVA_AWT_INCLUDE_PATH=NotNeeded ../
+        cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_SYSTEM_NAME=Android -DCMAKE_ANDROID_API=21 -DCMAKE_ANDROID_ARCH_ABI=${{ matrix.android-abi }} "-DCMAKE_ANDROID_NDK=$ANDROID_NDK_LATEST_HOME" -DZ3_BUILD_JAVA_BINDINGS=TRUE -G "Unix Makefiles" ../
         make -j $(nproc)
         tar -cvf z3-build-${{ matrix.android-abi }}.tar *.jar *.so
 


### PR DESCRIPTION
Specifying `CMAKE_ANDROID_API` is apparently more correct than specifying `CMAKE_SYSTEM_VERSION` on CMake 3.24 (and earlier versions). Reference is here https://cmake.org/cmake/help/v3.24/manual/cmake-toolchains.7.html#cross-compiling-for-android-with-the-ndk where it describes the `CMAKE_SYSTEM_VERSION` variable:
> If not specified, the value is determined as follows: If the CMAKE_ANDROID_API variable is set, its value is used as the API level."

Passing CI is here for a commit that enabled CI on my branch for these changes https://github.com/ekilmer/z3/actions/runs/2890880110