### PR TITLE
ADT-constructor generation crashed

### DIFF
--- a/src/api/dotnet/Context.cs
+++ b/src/api/dotnet/Context.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Z3
         /// </summary>
         internal Symbol[] MkSymbols(string[] names)
         {
-            if (names == null) return null;
+            if (names == null) return new Symbol[0];
             Symbol[] result = new Symbol[names.Length];
             for (int i = 0; i < names.Length; ++i) result[i] = MkSymbol(names[i]);
             return result;

--- a/src/api/java/Context.java
+++ b/src/api/java/Context.java
@@ -110,7 +110,7 @@ public class Context implements AutoCloseable {
     Symbol[] mkSymbols(String[] names)
     {
         if (names == null)
-            return null;
+            return new Symbol[0];
         Symbol[] result = new Symbol[names.length];
         for (int i = 0; i < names.length; ++i)
             result[i] = mkSymbol(names[i]);


### PR DESCRIPTION
... in .NET/Java when no (= default) fields are given