### PR TITLE
Change to 4 digit assembly version

### DIFF
--- a/scripts/mk_project.py
+++ b/scripts/mk_project.py
@@ -8,7 +8,7 @@
 from mk_util import *
 
 def init_version():
-    set_version(4, 11, 1, 0)
+    set_version(4, 11, 1, 0) # express a default build version or pick up ci build version
     
 # Z3 Project definition
 def init_project_def():

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -91,6 +91,7 @@ TRACE = False
 PYTHON_ENABLED=False
 DOTNET_CORE_ENABLED=False
 DOTNET_KEY_FILE=getenv("Z3_DOTNET_KEY_FILE", None)
+ASSEMBLY_VERSION=getenv("Z2_ASSEMBLY_VERSION", None)
 JAVA_ENABLED=False
 ML_ENABLED=False
 PYTHON_INSTALL_ENABLED=False
@@ -540,15 +541,30 @@ def find_c_compiler():
     raise MKException('C compiler was not found. Try to set the environment variable CC with the C compiler available in your system.')
 
 def set_version(major, minor, build, revision):
-    global VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK, GIT_DESCRIBE
+    global ASSEMBLY_VERSION,VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK, GIT_DESCRIBE
+
+    # We need to give the assembly a build specific version
+    # global version overrides local default expression
+    if not ASSEMBLY_VERSION is None:
+        versionSplits = ASSEMBLY_VERSION.split('.')
+        if len(versionSplits) > 3:
+            VER_MAJOR = versionSplits[0]
+            VER_MINOR = versionSplits[1]
+            VER_BUILD = versionSplits[2]
+            VER_TWEAK = versionSplits[3]
+            return
+
+    # use parameters to set up version if not provided by script args            
     VER_MAJOR = major
     VER_MINOR = minor
     VER_BUILD = build
     VER_TWEAK = revision
+
+    # update VER_TWEAK base on github     
     if GIT_DESCRIBE:
         branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
         VER_TWEAK = int(check_output(['git', 'rev-list', '--count', 'HEAD']))
-
+    
 def get_version():
     return (VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK)
 
@@ -666,6 +682,7 @@ def display_help(exit_code):
         print("  --optimize                    generate optimized code during linking.")
     print("  --dotnet                      generate .NET platform bindings.")
     print("  --dotnet-key=<file>           sign the .NET assembly using the private key in <file>.")
+    print("  --assembly-version=<x.x.x.x>  provide version number for build")
     print("  --java                        generate Java bindings.")
     print("  --ml                          generate OCaml bindings.")
     print("  --js                          generate JScript bindings.")
@@ -700,14 +717,14 @@ def display_help(exit_code):
 # Parse configuration option for mk_make script
 def parse_options():
     global VERBOSE, DEBUG_MODE, IS_WINDOWS, VS_X64, ONLY_MAKEFILES, SHOW_CPPS, VS_PROJ, TRACE, VS_PAR, VS_PAR_NUM
-    global DOTNET_CORE_ENABLED, DOTNET_KEY_FILE, JAVA_ENABLED, ML_ENABLED, STATIC_LIB, STATIC_BIN, PREFIX, GMP, PYTHON_PACKAGE_DIR, GPROF, GIT_HASH, GIT_DESCRIBE, PYTHON_INSTALL_ENABLED, PYTHON_ENABLED
+    global DOTNET_CORE_ENABLED, DOTNET_KEY_FILE, ASSEMBLY_VERSION, JAVA_ENABLED, ML_ENABLED, STATIC_LIB, STATIC_BIN, PREFIX, GMP, PYTHON_PACKAGE_DIR, GPROF, GIT_HASH, GIT_DESCRIBE, PYTHON_INSTALL_ENABLED, PYTHON_ENABLED
     global LINUX_X64, SLOW_OPTIMIZE, LOG_SYNC, SINGLE_THREADED
     global GUARD_CF, ALWAYS_DYNAMIC_BASE, IS_ARCH_ARM64
     try:
         options, remainder = getopt.gnu_getopt(sys.argv[1:],
                                                'b:df:sxa:hmcvtnp:gj',
                                                ['build=', 'debug', 'silent', 'x64', 'arm64=', 'help', 'makefiles', 'showcpp', 'vsproj', 'guardcf',
-                                                'trace', 'dotnet', 'dotnet-key=', 'staticlib', 'prefix=', 'gmp', 'java', 'parallel=', 'gprof', 'js',
+                                                'trace', 'dotnet', 'dotnet-key=', 'assembly-version=', 'staticlib', 'prefix=', 'gmp', 'java', 'parallel=', 'gprof', 'js',
                                                 'githash=', 'git-describe', 'x86', 'ml', 'optimize', 'pypkgdir=', 'python', 'staticbin', 'log-sync', 'single-threaded'])
     except:
         print("ERROR: Invalid command line option")
@@ -745,6 +762,8 @@ def parse_options():
             DOTNET_CORE_ENABLED = True
         elif opt in ('--dotnet-key'):
             DOTNET_KEY_FILE = arg
+        elif opt in ('--assembly-version'):
+            ASSEMBLY_VERSION = arg
         elif opt in ('--staticlib'):
             STATIC_LIB = True
         elif opt in ('--staticbin'):
@@ -1694,7 +1713,7 @@ class DotNetDLLComponent(Component):
             key = "<AssemblyOriginatorKeyFile>%s</AssemblyOriginatorKeyFile>" % self.key_file
             key += "\n<SignAssembly>true</SignAssembly>"
 
-        version = get_version_string(3)
+        version = get_version_string(4)
 
         core_csproj_str = """<Project Sdk="Microsoft.NET.Sdk">
 

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -1720,8 +1720,7 @@ class DotNetDLLComponent(Component):
 
         print(f'Version output to csproj: {version}')
 
-        core_csproj_str = f'""<Project Sdk="Microsoft.NET.Sdk">'
-
+        core_csproj_str = f"""<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
     <LangVersion>8.0</LangVersion>

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -552,6 +552,7 @@ def set_version(major, minor, build, revision):
             VER_MINOR = versionSplits[1]
             VER_BUILD = versionSplits[2]
             VER_TWEAK = versionSplits[3]
+            print("Set Assembly Version (BUILD):", VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK)
             return
 
     # use parameters to set up version if not provided by script args            
@@ -564,6 +565,8 @@ def set_version(major, minor, build, revision):
     if GIT_DESCRIBE:
         branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
         VER_TWEAK = int(check_output(['git', 'rev-list', '--count', 'HEAD']))
+    
+    print("Set Assembly Version (DEFAULT):", VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK)
     
 def get_version():
     return (VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK)
@@ -1715,7 +1718,9 @@ class DotNetDLLComponent(Component):
 
         version = get_version_string(4)
 
-        core_csproj_str = """<Project Sdk="Microsoft.NET.Sdk">
+        print(f"Version output to csproj: {version}");
+
+        core_csproj_str = f"""<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
@@ -1727,7 +1732,7 @@ class DotNetDLLComponent(Component):
     <PackageId>Microsoft.Z3</PackageId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
-    <Version>%s</Version>
+    <Version>{version}</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
@@ -1735,14 +1740,14 @@ class DotNetDLLComponent(Component):
     <Description>Z3 is a satisfiability modulo theories solver from Microsoft Research.</Description>
     <Copyright>Copyright Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>smt constraint solver theorem prover</PackageTags>
-    %s
+    {key}
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\%s\*.cs;*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
+    <Compile Include="..\{self.to_src_dir}\*.cs;*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
 
-</Project>""" % (version, key, self.to_src_dir)
+</Project>"""
 
         mk_dir(os.path.join(BUILD_DIR, 'dotnet'))
         csproj = os.path.join('dotnet', 'z3.csproj')
@@ -2845,6 +2850,9 @@ def update_version():
     minor = VER_MINOR
     build = VER_BUILD
     revision = VER_TWEAK
+
+    print(f"UpdateVersion: {major}.{minor}.{build}.{revision}");
+    
     if major is None or minor is None or build is None or revision is None:
         raise MKException("set_version(major, minor, build, revision) must be used before invoking update_version()")
     if not ONLY_MAKEFILES:

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -541,11 +541,11 @@ def find_c_compiler():
     raise MKException('C compiler was not found. Try to set the environment variable CC with the C compiler available in your system.')
 
 def set_version(major, minor, build, revision):
-    global ASSEMBLY_VERSION,VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK, GIT_DESCRIBE
+    global ASSEMBLY_VERSION, VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK, GIT_DESCRIBE
 
     # We need to give the assembly a build specific version
     # global version overrides local default expression
-    if not ASSEMBLY_VERSION is None:
+    if ASSEMBLY_VERSION is not None:
         versionSplits = ASSEMBLY_VERSION.split('.')
         if len(versionSplits) > 3:
             VER_MAJOR = versionSplits[0]
@@ -1718,7 +1718,7 @@ class DotNetDLLComponent(Component):
 
         version = get_version_string(4)
 
-        print(f'Version output to csproj: {version}')
+        print(f"Version output to csproj: {version}")
 
         core_csproj_str = f"""<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -1718,9 +1718,9 @@ class DotNetDLLComponent(Component):
 
         version = get_version_string(4)
 
-        print(f"Version output to csproj: {version}");
+        print(f'Version output to csproj: {version}')
 
-        core_csproj_str = f"""<Project Sdk="Microsoft.NET.Sdk">
+        core_csproj_str = f'""<Project Sdk="Microsoft.NET.Sdk">'
 
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -1718,9 +1718,10 @@ class DotNetDLLComponent(Component):
 
         version = get_version_string(4)
 
-        print(f"Version output to csproj: {version}")
+        print("Version output to csproj:", version)
 
-        core_csproj_str = f"""<Project Sdk="Microsoft.NET.Sdk">
+        core_csproj_str = """<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
     <LangVersion>8.0</LangVersion>
@@ -1731,7 +1732,7 @@ class DotNetDLLComponent(Component):
     <PackageId>Microsoft.Z3</PackageId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
-    <Version>{version}</Version>
+    <Version>%s</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
@@ -1739,14 +1740,14 @@ class DotNetDLLComponent(Component):
     <Description>Z3 is a satisfiability modulo theories solver from Microsoft Research.</Description>
     <Copyright>Copyright Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>smt constraint solver theorem prover</PackageTags>
-    {key}
+    %s
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\{self.to_src_dir}\*.cs;*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
+    <Compile Include="..\%s\*.cs;*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
 
-</Project>"""
+</Project>""" % (version, key, self.to_src_dir)
 
         mk_dir(os.path.join(BUILD_DIR, 'dotnet'))
         csproj = os.path.join('dotnet', 'z3.csproj')
@@ -2850,7 +2851,7 @@ def update_version():
     build = VER_BUILD
     revision = VER_TWEAK
 
-    print(f"UpdateVersion: {major}.{minor}.{build}.{revision}");
+    print("UpdateVersion:", get_full_version_string(major, minor, build, revision))
     
     if major is None or minor is None or build is None or revision is None:
         raise MKException("set_version(major, minor, build, revision) must be used before invoking update_version()")

--- a/scripts/mk_win_dist.py
+++ b/scripts/mk_win_dist.py
@@ -24,6 +24,7 @@ BUILD_X86_DIR=os.path.join('build-dist', 'x86')
 VERBOSE=True
 DIST_DIR='dist'
 FORCE_MK=False
+ASSEMBLY_VERSION=None
 DOTNET_CORE_ENABLED=True
 DOTNET_KEY_FILE=None
 JAVA_ENABLED=True
@@ -62,6 +63,7 @@ def display_help():
     print("  -s, --silent                  do not print verbose messages.")
     print("  -b <sudir>, --build=<subdir>  subdirectory where x86 and x64 Z3 versions will be built (default: build-dist).")
     print("  -f, --force                   force script to regenerate Makefiles.")
+    print("  --assembly-version             assembly version for dll")
     print("  --nodotnet                    do not include .NET bindings in the binary distribution files.")
     print("  --dotnet-key=<file>           strongname sign the .NET assembly with the private key in <file>.")
     print("  --nojava                      do not include Java bindings in the binary distribution files.")
@@ -102,6 +104,8 @@ def parse_options():
             FORCE_MK = True
         elif opt == '--nodotnet':
             DOTNET_CORE_ENABLED = False
+        elif opt == '--assemblyVersion':
+            ASSEMBLY_VERSION = arg
         elif opt == '--nopython':
             PYTHON_ENABLED = False
         elif opt == '--dotnet-key':
@@ -133,6 +137,8 @@ def mk_build_dir(path, x64):
             opts.append('--dotnet')
             if not DOTNET_KEY_FILE is None:
                 opts.append('--dotnet-key=' + DOTNET_KEY_FILE)
+        if not ASSEMBLY_VERSION is None:
+            opts.append('--assembly-version='+ASSEMBLY_VERSION)
         if JAVA_ENABLED:
             opts.append('--java')
         if x64:
@@ -299,9 +305,10 @@ def cp_licenses():
     cp_license(False)
 
 def init_flags():
-    global DOTNET_KEY_FILE, JAVA_ENABLED, PYTHON_ENABLED
+    global DOTNET_KEY_FILE, JAVA_ENABLED, PYTHON_ENABLED, ASSEMBLY_VERSION
     mk_util.DOTNET_CORE_ENABLED = True
     mk_util.DOTNET_KEY_FILE = DOTNET_KEY_FILE
+    mk_util.ASSEMBLY_VERSION = ASSEMBLY_VERSION
     mk_util.JAVA_ENABLED = JAVA_ENABLED
     mk_util.PYTHON_ENABLED = PYTHON_ENABLED
     mk_util.ALWAYS_DYNAMIC_BASE = True

--- a/scripts/mk_win_dist.py
+++ b/scripts/mk_win_dist.py
@@ -63,7 +63,7 @@ def display_help():
     print("  -s, --silent                  do not print verbose messages.")
     print("  -b <sudir>, --build=<subdir>  subdirectory where x86 and x64 Z3 versions will be built (default: build-dist).")
     print("  -f, --force                   force script to regenerate Makefiles.")
-    print("  --assembly-version             assembly version for dll")
+    print("  --assembly-version            assembly version for dll")
     print("  --nodotnet                    do not include .NET bindings in the binary distribution files.")
     print("  --dotnet-key=<file>           strongname sign the .NET assembly with the private key in <file>.")
     print("  --nojava                      do not include Java bindings in the binary distribution files.")
@@ -136,9 +136,9 @@ def mk_build_dir(path, x64):
         opts = ["python", os.path.join('scripts', 'mk_make.py'), parallel, "-b", path]
         if DOTNET_CORE_ENABLED:
             opts.append('--dotnet')
-            if not DOTNET_KEY_FILE is None:
+            if DOTNET_KEY_FILE is not None:
                 opts.append('--dotnet-key=' + DOTNET_KEY_FILE)
-        if not ASSEMBLY_VERSION is None:
+        if ASSEMBLY_VERSION is not None:
             opts.append('--assembly-version='+ASSEMBLY_VERSION)
         if JAVA_ENABLED:
             opts.append('--java')

--- a/scripts/mk_win_dist.py
+++ b/scripts/mk_win_dist.py
@@ -76,7 +76,7 @@ def display_help():
 
 # Parse configuration option for mk_make script
 def parse_options():
-    global FORCE_MK, JAVA_ENABLED, ZIP_BUILD_OUTPUTS, GIT_HASH, DOTNET_CORE_ENABLED, DOTNET_KEY_FILE, PYTHON_ENABLED, X86ONLY, X64ONLY
+    global FORCE_MK, JAVA_ENABLED, ZIP_BUILD_OUTPUTS, GIT_HASH, DOTNET_CORE_ENABLED, DOTNET_KEY_FILE, ASSEMBLY_VERSION, PYTHON_ENABLED, X86ONLY, X64ONLY
     path = BUILD_DIR
     options, remainder = getopt.gnu_getopt(sys.argv[1:], 'b:hsf', ['build=',
                                                                    'help',
@@ -85,6 +85,7 @@ def parse_options():
                                                                    'nojava',
                                                                    'nodotnet',
                                                                    'dotnet-key=',
+                                                                   'assembly-version=',
                                                                    'zip',
                                                                    'githash',
                                                                    'nopython',
@@ -104,7 +105,7 @@ def parse_options():
             FORCE_MK = True
         elif opt == '--nodotnet':
             DOTNET_CORE_ENABLED = False
-        elif opt == '--assemblyVersion':
+        elif opt == '--assembly-version':
             ASSEMBLY_VERSION = arg
         elif opt == '--nopython':
             PYTHON_ENABLED = False

--- a/scripts/mk_win_dist.py
+++ b/scripts/mk_win_dist.py
@@ -203,6 +203,7 @@ def mk_z3s():
 
 def get_z3_name(x64):
     major, minor, build, revision = get_version()
+    print("Assembly version:", major, minor, build, revision)
     if x64:
         platform = "x64"
     else:

--- a/scripts/mk_win_dist.py
+++ b/scripts/mk_win_dist.py
@@ -139,7 +139,7 @@ def mk_build_dir(path, x64):
             if DOTNET_KEY_FILE is not None:
                 opts.append('--dotnet-key=' + DOTNET_KEY_FILE)
         if ASSEMBLY_VERSION is not None:
-            opts.append('--assembly-version='+ASSEMBLY_VERSION)
+            opts.append('--assembly-version=' + ASSEMBLY_VERSION)
         if JAVA_ENABLED:
             opts.append('--java')
         if x64:

--- a/scripts/nightly.yaml
+++ b/scripts/nightly.yaml
@@ -1,14 +1,14 @@
 variables:
-
   Major: '4'
   Minor: '11'
   Patch: '1'
-  NightlyVersion: $(Major).$(Minor).$(Patch).$(Build.BuildId)-$(Build.DefinitionName)
+  AssemblyVersion: $(Major).$(Minor).$(Patch).$(Build.BuildId)
+  NightlyVersion: $(AssemblyVersion)-$(Build.DefinitionName)
 
 stages:
 - stage: Build
   jobs:
-
+  
   - job: Mac
     displayName: "Mac Build"
     pool:
@@ -135,6 +135,7 @@ stages:
         script:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86 &
           python scripts\mk_win_dist.py
+            --assembly-version=$(AssemblyVersion)
             --x86-only
             --dotnet-key=$(Build.SourcesDirectory)/resources/z3.snk
             --zip
@@ -174,6 +175,7 @@ stages:
         script:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 &
           python scripts\mk_win_dist.py
+            --assembly-version=$(AssemblyVersion)
             --x64-only
             --dotnet-key=$(Build.SourcesDirectory)/resources/z3.snk
             --zip

--- a/scripts/nightly.yaml
+++ b/scripts/nightly.yaml
@@ -8,7 +8,6 @@ variables:
 stages:
 - stage: Build
   jobs:
-  
   - job: Mac
     displayName: "Mac Build"
     pool:
@@ -23,7 +22,6 @@ stages:
         artifactName: 'Mac'
         targetPath: $(Build.ArtifactStagingDirectory)
 
-
   - job: MacArm64
     displayName: "Mac ARM64 Build"
     pool:
@@ -36,7 +34,6 @@ stages:
       inputs:
         artifactName: 'MacArm64'
         targetPath: $(Build.ArtifactStagingDirectory)
-
 
   - job: Ubuntu
     displayName: "Ubuntu build"
@@ -123,7 +120,6 @@ stages:
 #      inputs:
 #        artifactName: '$(name)Build'
 #        targetPath: $(Build.ArtifactStagingDirectory)
-
 
   - job: Windows32
     displayName: "Windows 32-bit build"


### PR DESCRIPTION
This change allows symbols to be archived for each new build rather than overwriting the archived symbols for the 3 digit build number that is manually updated. 

For example: version will go from 4.11.1.0 to 4.11.1.4515