### PR TITLE
fix typo in comment defining macros

### DIFF
--- a/src/ast/macros/macro_manager.h
+++ b/src/ast/macros/macro_manager.h
@@ -29,7 +29,7 @@ Revision History:
    \brief Macros are universally quantified formulas of the form:
      (forall X  (= (f X) T[X]))
      (forall X  (iff (f X) T[X]))
-   where T[X] does not contain X.
+   where T[X] does not contain f.
 
    This class is responsible for storing macros and expanding them.
    It has support for backtracking and tagging declarations in an expression as forbidded for being macros.


### PR DESCRIPTION
The existing comment describes macros as "formulas of the form
`(forall X (= (f X) T[X]))` ... where `T[X]` does not contain `X`". This is
incorrect; of course the macros' definitions are allowed to be in terms of
the macros' arguments. The comment should say "...does not contain `f`" because
macros can't be recursive.