### PR TITLE
Pass size to deallocation functions

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -757,7 +757,7 @@ public:
     }
 
     ~tmp_app() {
-        dealloc_svect(m_data);
+        dealloc_svect(m_data, app::get_obj_size(m_num_args));
     }
 
     app * get_app() {

--- a/src/ast/euf/euf_egraph.cpp
+++ b/src/ast/euf/euf_egraph.cpp
@@ -43,7 +43,7 @@ namespace euf {
 
     enode* egraph::find(expr* e, unsigned n, enode* const* args) {
         if (m_tmp_node && m_tmp_node_capacity < n) {
-            memory::deallocate(m_tmp_node);
+            enode::del_tmp(m_tmp_node, m_tmp_node_capacity);
             m_tmp_node = nullptr;
         }
         if (!m_tmp_node) {
@@ -139,7 +139,7 @@ namespace euf {
         for (enode* n : m_nodes) 
             n->m_parents.finalize();
         if (m_tmp_node)
-            memory::deallocate(m_tmp_node);
+            enode::del_tmp(m_tmp_node, m_tmp_node_capacity);
     }
 
     void egraph::add_th_eq(theory_id id, theory_var v1, theory_var v2, enode* c, enode* r) {

--- a/src/ast/euf/euf_enode.h
+++ b/src/ast/euf/euf_enode.h
@@ -127,6 +127,10 @@ namespace euf {
             return n;
         }    
        
+        static void del_tmp(enode * e, unsigned num_args) {
+            memory::deallocate(e, get_enode_size(num_args));
+        }
+
         friend class add_th_var_trail;
         friend class replace_th_var_trail;
         void add_th_var(theory_var v, theory_id id, region & r) { m_th_vars.add_var(v, id, r); }

--- a/src/math/polynomial/polynomial.cpp
+++ b/src/math/polynomial/polynomial.cpp
@@ -515,7 +515,7 @@ namespace polynomial {
         }
 
         void deallocate(monomial * ptr, unsigned capacity) {
-            memory::deallocate(ptr);
+            memory::deallocate(ptr, monomial::get_obj_size(capacity));
         }
 
         void increase_capacity(unsigned new_capacity) {

--- a/src/muz/rel/dl_base.h
+++ b/src/muz/rel/dl_base.h
@@ -432,7 +432,8 @@ namespace datalog {
             */
             void destroy() {
                 this->~base_ancestor();
-                memory::deallocate(this);
+                // TODO: revise the size below; can sub-classes hit this?
+                memory::deallocate(this, sizeof(*this));
             }
         public:
             /**

--- a/src/sat/sat_allocator.h
+++ b/src/sat/sat_allocator.h
@@ -82,7 +82,7 @@ public:
     void deallocate(size_t size, void * p) {
         m_alloc_size -= size;
         if (size >= SMALL_OBJ_SIZE) {
-            memory::deallocate(p);
+            memory::deallocate(p, size);
         }
         else {
             m_free[free_slot_id(size)].push_back(p);

--- a/src/sat/sat_clause.cpp
+++ b/src/sat/sat_clause.cpp
@@ -137,7 +137,7 @@ namespace sat {
 
     void tmp_clause::set(unsigned num_lits, literal const * lits, bool learned) {
         if (m_clause && m_clause->m_capacity < num_lits) {
-            dealloc_svect(m_clause);
+            dealloc_svect(m_clause, m_clause->get_size());
             m_clause = nullptr;
         }
         if (!m_clause) {

--- a/src/sat/sat_clause.h
+++ b/src/sat/sat_clause.h
@@ -56,9 +56,9 @@ namespace sat {
         literal            m_lits[0];
 
         static size_t get_obj_size(unsigned num_lits) { return sizeof(clause) + num_lits * sizeof(literal); }
-        size_t get_size() const { return get_obj_size(m_capacity); }
         clause(unsigned id, unsigned sz, literal const * lits, bool learned);
     public:
+        size_t get_size() const { return get_obj_size(m_capacity); }
         unsigned id() const { return m_id; }
         unsigned size() const { return m_size; }
         unsigned capacity() const { return m_capacity; }
@@ -125,7 +125,7 @@ namespace sat {
         clause * m_clause;
     public:
         tmp_clause():m_clause(nullptr) {}
-        ~tmp_clause() { if (m_clause) dealloc_svect(m_clause); }
+        ~tmp_clause() { if (m_clause) dealloc_svect(m_clause, m_clause->get_size()); }
         clause * get() const { return m_clause; }
         void set(unsigned num_lits, literal const * lits, bool learned);
         void set(literal l1, literal l2, bool learned) { literal ls[2] = { l1, l2 }; set(2, ls, learned); }

--- a/src/smt/smt_enode.cpp
+++ b/src/smt/smt_enode.cpp
@@ -333,13 +333,13 @@ namespace smt {
     }
 
     tmp_enode::~tmp_enode() {
-        dealloc_svect(m_enode_data);
+        dealloc_svect(m_enode_data, sizeof(enode) + m_capacity * sizeof(enode*));
     }
 
     void tmp_enode::set_capacity(unsigned new_capacity) {
         SASSERT(new_capacity > m_capacity);
         if (m_enode_data)
-            dealloc_svect(m_enode_data);
+            dealloc_svect(m_enode_data, sizeof(enode) + m_capacity * sizeof(enode*));
         m_capacity   = new_capacity;
         unsigned sz  = sizeof(enode) + m_capacity * sizeof(enode*);
         m_enode_data = alloc_svect(char, sz);

--- a/src/smt/smt_enode.h
+++ b/src/smt/smt_enode.h
@@ -146,7 +146,7 @@ namespace smt {
 
         static enode * mk_dummy(ast_manager & m, app2enode_t const & app2enode, app * owner);
         
-        static void del_dummy(enode * n) { dealloc_svect(reinterpret_cast<char*>(n)); }
+        static void del_dummy(enode * n) { dealloc_svect(reinterpret_cast<char*>(n), get_enode_size(n->m_owner->get_num_args())); }
 
         unsigned get_func_decl_id() const {
             return m_func_decl_id;

--- a/src/smt/smt_justification.cpp
+++ b/src/smt/smt_justification.cpp
@@ -69,7 +69,7 @@ namespace smt {
 
     unit_resolution_justification::~unit_resolution_justification() {
         if (!in_region()) {
-            dealloc_svect(m_literals); // I don't need to invoke destructor...
+            dealloc_svect(m_literals, m_num_literals); // I don't need to invoke destructor...
             dealloc(m_antecedent);
         }
     }
@@ -413,7 +413,7 @@ namespace smt {
 
     theory_lemma_justification::~theory_lemma_justification() {
         SASSERT(!in_region());
-        dealloc_svect(m_literals); 
+        dealloc_svect(m_literals, m_num_literals);
     }
     
     void theory_lemma_justification::del_eh(ast_manager & m) {

--- a/src/smt/watch_list.cpp
+++ b/src/smt/watch_list.cpp
@@ -30,7 +30,8 @@ namespace smt {
 
     void watch_list::destroy() {
         if (m_data) {
-            dealloc_svect(reinterpret_cast<char*>(m_data) - HEADER_SIZE);
+            unsigned size = reinterpret_cast<unsigned *>(m_data)[-1] + HEADER_SIZE;
+            dealloc_svect(reinterpret_cast<char*>(m_data) - HEADER_SIZE, size);
         }
     }
     

--- a/src/util/bit_vector.h
+++ b/src/util/bit_vector.h
@@ -89,7 +89,7 @@ public:
     }
 
     ~bit_vector() {
-        dealloc_svect(m_data);
+        dealloc_svect(m_data, m_capacity);
     }
     
     void reset() {
@@ -193,7 +193,7 @@ public:
             return *this;
 
         if (m_capacity < source.m_capacity) {
-            dealloc_svect(m_data);
+            dealloc_svect(m_data, m_capacity);
             m_data     = alloc_svect(unsigned, source.m_capacity);
             m_capacity = source.m_capacity;
         }

--- a/src/util/buffer.h
+++ b/src/util/buffer.h
@@ -34,14 +34,14 @@ protected:
 
     void free_memory() {
         if (m_buffer != reinterpret_cast<T*>(m_initial_buffer)) {
-            dealloc_svect(m_buffer);
+            dealloc_svect(m_buffer, m_capacity);
         }
     }
 
     void expand() {
         static_assert(std::is_nothrow_move_constructible<T>::value);
         unsigned new_capacity = m_capacity << 1;
-        T * new_buffer        = reinterpret_cast<T*>(memory::allocate(sizeof(T) * new_capacity));
+        T * new_buffer        = reinterpret_cast<T*>(alloc_svect(T, new_capacity));
         for (unsigned i = 0; i < m_pos; ++i) {
             new (&new_buffer[i]) T(std::move(m_buffer[i]));
             if (CallDestructors) {

--- a/src/util/memory_manager.cpp
+++ b/src/util/memory_manager.cpp
@@ -266,7 +266,7 @@ void memory::deallocate(void * p, unsigned given_size) {
     if (g_memory_thread_alloc_size < -SYNCH_THRESHOLD) {
         synchronize_counters(false);
     }
-    SASSERT(sz - sizeof(size_t) == given_size);
+    SASSERT(given_size == 0 || sz - sizeof(size_t) == given_size);
 }
 
 void * memory::allocate(size_t s) {
@@ -324,7 +324,7 @@ void memory::deallocate(void * p, unsigned given_size) {
         g_memory_alloc_size -= sz;
     }
     free(real_p);
-    SASSERT(sz - sizeof(size_t) == given_size);
+    SASSERT(given_size == 0 || sz - sizeof(size_t) == given_size);
 }
 
 void * memory::allocate(size_t s) {

--- a/src/util/memory_manager.h
+++ b/src/util/memory_manager.h
@@ -80,10 +80,10 @@ public:
 #define dealloc(_ptr_) deallocf(__FILE__,__LINE__,_ptr_)
 
 template<typename T>
-void deallocf(char const* file, int line, T * ptr, unsigned size) {
+void deallocf(char const* file, int line, T * ptr) {
     if (ptr == 0) return;
     ptr->~T();
-    memory::deallocate(file, line, ptr, size);
+    memory::deallocate(file, line, ptr, sizeof(T));
 }
 
 #else 

--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -212,7 +212,7 @@ void mpz_manager<SYNCH>::deallocate(bool is_heap, mpz_cell * ptr) {
         m_allocator.deallocate(cell_size(ptr->m_capacity), ptr); 
 #else
         if (SYNCH) {
-            memory::deallocate(ptr);
+            memory::deallocate(ptr, cell_size(ptr->m_capacity));
         }
         else {
             m_allocator.deallocate(cell_size(ptr->m_capacity), ptr);        

--- a/src/util/page.h
+++ b/src/util/page.h
@@ -20,7 +20,7 @@ Revision History:
 
 #include "util/memory_manager.h"
 
-#define PAGE_HEADER_SZ sizeof(size_t)
+#define PAGE_HEADER_SZ 2 * sizeof(size_t)
 #define DEFAULT_PAGE_SIZE (8192 - PAGE_HEADER_SZ)
 #define PAGE_HEADER_MASK (static_cast<size_t>(-1) - 1)
 

--- a/src/util/region.cpp
+++ b/src/util/region.cpp
@@ -32,7 +32,7 @@ void * region::allocate(size_t size) {
 
 void region::reset() {
     for (auto* c : m_chunks)
-        dealloc_svect(c);
+        dealloc_svect(c, /* FIXME */ 0);
     m_chunks.reset();
     m_scopes.reset();
 }
@@ -43,7 +43,7 @@ void region::pop_scope() {
     ptr_vector<char>::iterator it  = m_chunks.begin() + old_size;
     ptr_vector<char>::iterator end = m_chunks.end();
     for (; it != end; ++it) 
-        dealloc_svect(*it);    
+        dealloc_svect(*it, /* FIXME */ 0);    
     m_chunks.shrink(old_size);
 }
 

--- a/src/util/small_object_allocator.cpp
+++ b/src/util/small_object_allocator.cpp
@@ -84,7 +84,7 @@ void small_object_allocator::deallocate(size_t size, void * p) {
     SASSERT(p);
     m_alloc_size -= size;
     if (size >= SMALL_OBJ_SIZE - (1 << PTR_ALIGNMENT)) {
-        memory::deallocate(p);
+        memory::deallocate(p, size);
         return;
     }
     unsigned slot_id = static_cast<unsigned>(size >> PTR_ALIGNMENT);

--- a/src/util/small_object_allocator.cpp
+++ b/src/util/small_object_allocator.cpp
@@ -77,7 +77,7 @@ void small_object_allocator::deallocate(size_t size, void * p) {
 
 #if defined(Z3DEBUG) && !defined(_WINDOWS)
     // Valgrind friendly
-    memory::deallocate(p);
+    memory::deallocate(p, size);
     return;
 #endif
     SASSERT(m_alloc_size >= size);

--- a/src/util/stack.cpp
+++ b/src/util/stack.cpp
@@ -140,7 +140,7 @@ void stack::deallocate() {
         SASSERT(m_curr_ptr < m_curr_end_ptr);
     }
     if (external_ptr(m)) {
-        dealloc_svect(reinterpret_cast<char**>(m_curr_ptr)[0]);
+        dealloc_svect(reinterpret_cast<char**>(m_curr_ptr)[0], 0 /* FIXME */);
     }
     SASSERT(m_curr_ptr > m_curr_page);
 }

--- a/src/util/string_buffer.h
+++ b/src/util/string_buffer.h
@@ -37,7 +37,7 @@ class string_buffer {
         char * new_buffer   = alloc_svect(char, new_capacity);
         memcpy(new_buffer, m_buffer, m_pos);
         if (m_capacity > INITIAL_SIZE) {
-            dealloc_svect(m_buffer);
+            dealloc_svect(m_buffer, m_capacity);
         }
         m_capacity = new_capacity;
         m_buffer   = new_buffer;
@@ -52,7 +52,7 @@ public:
 
     ~string_buffer() {
         if (m_capacity > INITIAL_SIZE) {
-            dealloc_svect(m_buffer);
+            dealloc_svect(m_buffer, m_capacity);
         }
     }
 

--- a/src/util/vector.h
+++ b/src/util/vector.h
@@ -170,7 +170,9 @@ class vector {
     }
 
     void free_memory() { 
-        memory::deallocate(reinterpret_cast<char*>(reinterpret_cast<SZ*>(m_data) - 2));
+        SZ capacity = reinterpret_cast<SZ *>(m_data)[CAPACITY_IDX];
+        memory::deallocate(reinterpret_cast<char*>(reinterpret_cast<SZ*>(m_data) - 2),
+                           sizeof(T) * capacity + sizeof(SZ) * 2);
     }
 
     void expand_vector() {


### PR DESCRIPTION
WARNING: This is a proof of concept that needs a lot of testing and some fixes.

The goal of this PR is to remove the size data we store alongside every allocation. Most of the times we can get the alloc size automatically through compiler magic.
With vectors we cannot, and thus users need to pass in the number of elements.

This PR builds at least! I didn't remove the size data, but use it to assert that the passed data is equal.
Only when we are sure all is good we can move on with removing the data & reaping the perf benefits 🥳