### PR TITLE
DotNet Api: Ensure native Z3 context is freed on disposing dotnet context

### DIFF
--- a/src/api/dotnet/Context.cs
+++ b/src/api/dotnet/Context.cs
@@ -4778,7 +4778,8 @@ namespace Microsoft.Z3
         #endregion
 
         #region Internal
-        internal readonly IntPtr m_ctx;
+        internal IntPtr m_ctx;
+        private readonly object m_ctxLock = new object();
         internal Native.Z3_error_handler m_n_err_handler = null;
         internal static Object creation_lock = new Object();
         internal IntPtr nCtx { get { return m_ctx; } }
@@ -5012,7 +5013,13 @@ namespace Microsoft.Z3
             m_n_err_handler = null;
             IntPtr ctx = m_ctx;
             if (!is_external)
-                Native.Z3_del_context(ctx);
+            {   
+                lock (m_ctxLock)
+                {
+                    Native.Z3_del_context(ctx);
+                    m_ctx = IntPtr.Zero;
+                }                                                                                                }
+            }
             GC.SuppressFinalize(this);
         }
 

--- a/src/api/dotnet/Context.cs
+++ b/src/api/dotnet/Context.cs
@@ -4778,7 +4778,7 @@ namespace Microsoft.Z3
         #endregion
 
         #region Internal
-        internal IntPtr m_ctx = IntPtr.Zero;
+        internal readonly IntPtr m_ctx;
         internal Native.Z3_error_handler m_n_err_handler = null;
         internal static Object creation_lock = new Object();
         internal IntPtr nCtx { get { return m_ctx; } }
@@ -4966,9 +4966,7 @@ namespace Microsoft.Z3
         /// Optimize DRQ
         /// </summary>
         public IDecRefQueue Optimize_DRQ { get { return m_Fixedpoint_DRQ; } }
-
-        internal long refCount = 0;
-
+        
         /// <summary>
         /// Finalizer.
         /// </summary>
@@ -5011,16 +5009,11 @@ namespace Microsoft.Z3
             m_realSort = null;
             m_stringSort = null;
             m_charSort = null;
-            if (refCount == 0 && m_ctx != IntPtr.Zero)
-            {
-                m_n_err_handler = null;
-                IntPtr ctx = m_ctx;
-                m_ctx = IntPtr.Zero;
-                if (!is_external) 
-                   Native.Z3_del_context(ctx);
-            }
-            else
-                GC.ReRegisterForFinalize(this);
+            m_n_err_handler = null;
+            IntPtr ctx = m_ctx;
+            if (!is_external)
+                Native.Z3_del_context(ctx);
+            GC.SuppressFinalize(this);
         }
 
 

--- a/src/api/dotnet/Context.cs
+++ b/src/api/dotnet/Context.cs
@@ -5013,12 +5013,12 @@ namespace Microsoft.Z3
             m_n_err_handler = null;
             IntPtr ctx = m_ctx;
             if (!is_external)
-            {   
+            {
                 lock (m_ctxLock)
                 {
                     Native.Z3_del_context(ctx);
                     m_ctx = IntPtr.Zero;
-                }                                                                                                }
+                }
             }
             GC.SuppressFinalize(this);
         }

--- a/src/api/dotnet/Z3Object.cs
+++ b/src/api/dotnet/Z3Object.cs
@@ -50,13 +50,6 @@ namespace Microsoft.Z3
                 m_n_obj = IntPtr.Zero;                
             }
 
-            if (m_ctx != null)
-            {
-                if (Interlocked.Decrement(ref m_ctx.refCount) == 0)
-                    GC.ReRegisterForFinalize(m_ctx);
-                m_ctx = null;
-            }
-
             GC.SuppressFinalize(this);
         }
 
@@ -64,29 +57,25 @@ namespace Microsoft.Z3
         
         private void ObjectInvariant()
         {
-            Debug.Assert(this.m_ctx != null);
+            Debug.Assert(this.Context != null);
         }
 
         #endregion
 
         #region Internal
-        private Context m_ctx = null;
-        private IntPtr m_n_obj = IntPtr.Zero;
+
+        private IntPtr m_n_obj;
 
         internal Z3Object(Context ctx)
+            : this(ctx, IntPtr.Zero)
         {
-            Debug.Assert(ctx != null);
-
-            Interlocked.Increment(ref ctx.refCount);
-            m_ctx = ctx;
         }
 
         internal Z3Object(Context ctx, IntPtr obj)
         {
             Debug.Assert(ctx != null);
 
-            Interlocked.Increment(ref ctx.refCount);
-            m_ctx = ctx;
+            Context = ctx;
             IncRef(obj);
             m_n_obj = obj;
         }
@@ -116,13 +105,7 @@ namespace Microsoft.Z3
         /// <summary>
         /// Access Context object 
         /// </summary>
-	    public Context Context
-        {
-            get 
-            {
-                return m_ctx; 
-            }            
-        }
+	    public Context Context { get; }
 
         internal static IntPtr[] ArrayToNative(Z3Object[] a)
         {


### PR DESCRIPTION
fixes #5043

When using the Dotnet API there is still a big amount of memory being lost over time when using the Z3 solver. I am using Z3 in a web application, where a lot of Contexts are created and solved over time. Lastly, the memory increases in a way that the application gets killed.

In my opinion, the cause for the memory loss is the custom reference counting of Dotnet objects that impedes the native context from being freed. 
The mechanism of re-scheduling the GC (`GC.ReRegisterForFinalize`) relies on the assumption that the GC will reliably clean up all Dotnet Z3Objects before the memory consumption kills the process. In my experience, it is unpredictable and too late, at which time the GC will decide to clean up these objects. 
I assume the amount of memory that is managed by the Dotnet GC is very small (most Z3 Dotnet objects contain only a pointer and some references to other objects). Whereas the memory on the native side of Z3 (that is not managed/seen by the Dotnet GC) increases with every native Z3 Context that is not being cleaned up.

I understand that reference counting is needed for the native Z3 objects. Therefore the `DecRefQueue` mechanism reliable maintains the calling of native reference-count methods for all Z3Objects that need to be reference-counted.
What I do not understand is, why there is a second reference counter for the Dotnet Z3Objects. In Dotnet, there is a garbage collector that is reliable and automatically takes care of cleaning up objects that are not referenced anymore.
When `Context.Dispose()` is called, all `DecRefQueue` are cleared -> consequently all objects that are reference-counted on the native side of Z3 got reliable dec-referenced at this point of time (except the native Z3 Context)!
So why wait on the Dotnet GC for cleaning up all these little Dotnet Z3Objects now before calling `Z3_del_context`?

I made several tests with this approach. In order to enforce the memory cleanup (by using memory pressure), I ran these tests inside a docker container where I can easily apply a memory limit (5Gb) and a memory reservation (3Gb) and disallow the container to swap the memory.
Inside the docker container, a process creates around 250 contexts and does some solving, always with an equivalent model that has around 100 mostly boolean variables and 100 constraints.
The process runs in a loop, after each cycle, the context is disposed. The loop runs in parallel, but each loop has its own context.
Without these changes, the container gets killed sometimes after 50 sometimes after 500 cycles because of hitting the 5Gb limit. The cycles after which the container gets killed are very fluctuating, maybe this shows the unpredictability of the Dotnet GC, sometime it cleans something up, sometimes not.
With these changes, the docker container does not get killed anymore. I stop the container regularly after 5000-10000 cycles (because the test takes hours). The memory reaches 3 Gb after 2-3 cycles and then nearly continuously stays around 3Gb - 3.1Gb (around the specified ram reservation for the container).
So I can see at least a significant improvement in the memory-consuming behavior and suggest discussing/integrating these changes.

Sorry for the long explanation in this pull request, due to the difficulty in reproducing/understanding this memory-related problem I felt that it is important for others to understand/follow/question which thoughts led to this change.

Here are some measurements visualized in Grafana, we can see the memory consumption (process working set) over time.
Without the changes the process gets killed after  20min (250  cycles) due to hitting the 5Gb memory limit:
![Screenshot 2022-09-06 165918](https://user-images.githubusercontent.com/582627/188669211-fcb9e7cc-737d-4b89-9022-a8f8c2d06882.png)

With the given changes process runs 4 hours (5000 cycles) without hitting the 5Gb memory limit:

![Screenshot 2022-09-06 163719](https://user-images.githubusercontent.com/582627/188666808-3370ef28-e424-4dfa-9351-cabb944f004c.png)
