### PR TITLE
[document] Add vcpkg instruction step

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ Z3 has a build system using CMake. Read the [README-CMake.md](README-CMake.md)
 file for details. It is recommended for most build tasks, 
 except for building OCaml bindings.
 
+## Building Z3 using vcpkg
+
+vcpkg is a full platform package manager, you can easily install libzmq with vcpkg.
+ 
+Execute:
+
+```bash
+git clone https://github.com/microsoft/vcpkg.git
+./bootstrap-vcpkg.bat # For powershell
+./bootstrap-vcpkg.sh # For bash
+./vcpkg install z3
+```
+
 ## Dependencies
 Z3 itself has few dependencies. It uses C++ runtime libraries, including pthreads for multi-threading.
 It is optionally possible to use GMP for multi-precision integers, but Z3 contains its own self-contained 


### PR DESCRIPTION
`z3` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `z3` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `z3`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/z3/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)

