### PR TITLE
Naxaes/clang build fix

### DIFF
--- a/src/muz/spacer/spacer_iuc_solver.h
+++ b/src/muz/spacer/spacer_iuc_solver.h
@@ -68,7 +68,7 @@ private:
     app* fresh_proxy();
     void elim_proxies(expr_ref_vector &v);
 public:
-    iuc_solver(solver &, unsigned iuc, unsigned iuc_arith,
+    iuc_solver(solver &s, unsigned iuc, unsigned iuc_arith,
                bool print_farkas_stats, bool old_hyp_reducer,
                bool split_literals = false) :
         solver(m),

--- a/src/sat/smt/euf_proof_checker.cpp
+++ b/src/sat/smt/euf_proof_checker.cpp
@@ -243,7 +243,10 @@ namespace euf {
 
         expr_ref_vector clause(app* jst) override {
             expr_ref_vector result(m);
-            auto [pivot, proof1, proof2] = jst->args3();
+            auto x = jst->args3();
+            auto pivot  = std::get<0>(x);
+            auto proof1 = std::get<1>(x);
+            auto proof2 = std::get<2>(x);
             expr* narg;
             auto is_pivot = [&](expr* arg) {
                 if (arg == pivot)


### PR DESCRIPTION
 Fixed compilation bugs. 

Added a missing parameter in `iuc_solver` constructor and fixed the error `error: reference to local binding 'pivot' declared in enclosing function 'euf::res_proof_checker::clause'` which was due to an error with structured bindings.