### PR TITLE
switch mpz to using 64-bit integers for the small case

### DIFF
--- a/src/util/mpq.h
+++ b/src/util/mpq.h
@@ -161,9 +161,9 @@ public:
 
     void abs(mpq & a) { mpz_manager<SYNCH>::abs(a.m_num); }
 
-    static int sign(mpz const & a) { return mpz_manager<SYNCH>::sign(a); }
+    static int64_t sign(mpz const & a) { return mpz_manager<SYNCH>::sign(a); }
 
-    static int sign(mpq const & a) { return mpz_manager<SYNCH>::sign(a.m_num); }
+    static int64_t sign(mpq const & a) { return mpz_manager<SYNCH>::sign(a.m_num); }
 
     static bool is_pos(mpz const & a) { return mpz_manager<SYNCH>::is_pos(a); }
 

--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -1993,6 +1993,17 @@ void mpz_manager<SYNCH>::normalize(mpz & a) {
         a.set(mpz_small);
         return;
     }
+
+    if (i == 2) {
+        static_assert(sizeof(digit_t) == sizeof(unsigned));
+        auto val = ((static_cast<uint64_t>(ds[1]) << 32) | static_cast<uint64_t>(ds[0]));
+        if (val <= INT64_MAX) {
+            a.m_val = a.m_val < 0 ? -static_cast<int64_t>(val) : static_cast<int64_t>(val);
+            a.set(mpz_small);
+            return;
+        }
+    }
+
     // adjust size
     c->m_size = i;
 }

--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -847,7 +847,7 @@ void mpz_manager<SYNCH>::gcd(mpz const & a, mpz const & b, mpz & c) {
         int64_t _b = b.m_val;
         if (_a < 0) _a = -_a;
         if (_b < 0) _b = -_b;
-        unsigned r = u64_gcd(_a, _b);
+        auto r = u64_gcd(_a, _b);
         set(c, r);
     }
     else {
@@ -1018,7 +1018,7 @@ void mpz_manager<SYNCH>::gcd(mpz const & a, mpz const & b, mpz & c) {
             SASSERT(ge(a1, b1));
             if (is_small(b1)) {
                 if (is_small(a1)) {
-                    unsigned r = u64_gcd(a1.m_val, b1.m_val);
+                    auto r = u64_gcd(a1.m_val, b1.m_val);
                     set(c, r);
                     break;
                 }
@@ -2113,6 +2113,10 @@ unsigned mpz_manager<SYNCH>::power_of_two_multiple(mpz const & a) {
         unsigned r = 0;
         int64_t v  = a.m_val;
 #define COUNT_DIGIT_RIGHT_ZEROS()               \
+        if (v % (1ll << 32) == 0) {             \
+            r += 32;                            \
+            v /= (1ll << 32);                   \
+        }                                       \
         if (v % (1 << 16) == 0) {               \
             r += 16;                            \
             v /= (1 << 16);                     \

--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -1926,8 +1926,8 @@ bool mpz_manager<SYNCH>::is_power_of_two(mpz const & a, unsigned & shift) {
     if (is_nonpos(a))
         return false;
     if (is_small(a)) {
-        if (::is_power_of_two(a.m_val)) {
-            shift = ::log2((unsigned)a.m_val);
+        if (::is_power_of_two((uint64_t)a.m_val)) {
+            shift = ::uint64_log2((uint64_t)a.m_val);
             return true;
         }
         else {
@@ -2216,7 +2216,7 @@ unsigned mpz_manager<SYNCH>::log2(mpz const & a) {
     if (is_nonpos(a))
         return 0;
     if (is_small(a))
-        return ::log2((uint64_t)a.m_val);
+        return uint64_log2((uint64_t)a.m_val);
 #ifndef _MP_GMP
     static_assert(sizeof(digit_t) == 8 || sizeof(digit_t) == 4, "");
     const mpz_cell * c = a.ptr();

--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -2440,14 +2440,14 @@ template<bool SYNCH>
 bool mpz_manager<SYNCH>::decompose(mpz const & a, svector<digit_t> & digits) {
     digits.reset();
     if (is_small(a)) {
-        if (a.m_val < 0) {
-            digits.push_back(-a.m_val);
-            return true;
-        }
-        else {
-            digits.push_back(a.m_val);
-            return false;
-        }
+        auto v = (uint64_t)a.m_val;
+        if (a.m_val < 0)
+            v = -v;
+
+        static_assert(sizeof(digit_t) == sizeof(unsigned));
+        digits.push_back(static_cast<unsigned>(v));
+        digits.push_back(static_cast<unsigned>(v >> 32));
+        return a.m_val < 0;
     }
     else {
 #ifndef _MP_GMP

--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -692,7 +692,7 @@ void mpz_manager<SYNCH>::big_add_sub(mpz const & a0, mpz const & b0, mpz & c) {
     set_big_i64(a, a0.m_val);
     set_big_i64(b, b0.m_val);
     sign_cell ca(*this, a), cb(*this, b);
-    int sign_b = cb.sign();
+    auto sign_b = cb.sign();
     mpz_stack tmp;
     if (SUB)
         sign_b = -sign_b;

--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -1571,7 +1571,7 @@ bool mpz_manager<SYNCH>::is_uint64(mpz const & a) const {
 #ifndef _MP_GMP
     if (a.m_val < 0)
         return false;
-    if (is_small(a) && a.m_val <= UINT64_MAX)
+    if (is_small(a))
         return true;
     if (sizeof(digit_t) == sizeof(uint64_t)) {
         return size(a) <= 1;

--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -689,9 +689,12 @@ template<bool SYNCH>
 template<bool SUB>
 void mpz_manager<SYNCH>::big_add_sub(mpz const & a0, mpz const & b0, mpz & c) {
     mpz a, b;
-    set_big_i64(a, a0.m_val);
-    set_big_i64(b, b0.m_val);
-    sign_cell ca(*this, a), cb(*this, b);
+    if (is_small(a0))
+        set_big_i64(a, a0.m_val);
+    if (is_small(b0))
+        set_big_i64(b, b0.m_val);
+    sign_cell ca(*this, is_small(a0) ? a : a0);
+    sign_cell cb(*this, is_small(b0) ? b : b0);
     auto sign_b = cb.sign();
     mpz_stack tmp;
     if (SUB)

--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -1973,27 +1973,10 @@ void mpz_manager<SYNCH>::ensure_capacity(mpz & a, unsigned capacity) {
         capacity = m_init_cell_capacity;
     
     if (is_small(a)) {
-        int64_t val = a.m_val;
         allocate_if_needed(a, capacity);
         a.set(mpz_large);
         SASSERT(a.ptr()->m_capacity >= capacity);
-        if (val == INT64_MIN) {
-            unsigned intmin_sz = m_int_min.ptr()->m_size;
-            for (unsigned i = 0; i < intmin_sz; i++)
-                a.ptr()->m_digits[i] = m_int_min.ptr()->m_digits[i];
-            a.m_val = -1;
-            a.ptr()->m_size = m_int_min.ptr()->m_size;
-        }
-        else if (val < 0) {
-            a.ptr()->m_digits[0] = -val;
-            a.m_val = -1;
-            a.ptr()->m_size = 1;
-        }
-        else {
-            a.ptr()->m_digits[0] =  val;
-            a.m_val = 1;
-            a.ptr()->m_size = 1;
-        }
+        set_big_i64(a, a.m_val);
     }
     else if (a.ptr()->m_capacity < capacity) {
         mpz_cell * new_cell = allocate(capacity);

--- a/src/util/mpz.h
+++ b/src/util/mpz.h
@@ -320,26 +320,24 @@ class mpz_manager {
 
     void get_sign_cell(mpz const & a, int64_t & sign, mpz_cell * & cell, mpz_cell* reserve) {
         if (is_small(a)) {
-            if (a.m_val == INT64_MIN) {
+            cell = reserve;
+            uint64_t v;
+            if (a.m_val < 0) {
                 sign = -1;
-                cell = m_int_min.ptr();
-            }
-            else {
-                cell = reserve;
-                uint64_t v;
-                if (a.m_val < 0) {
-                    sign = -1;
+                if (a.m_val == INT64_MIN) {
+                    v = (uint64_t)INT64_MAX + 1;
+                } else {
                     v = -a.m_val;
                 }
-                else {
-                    sign = 1;
-                    v = a.m_val;
-                }
-                static_assert(sizeof(digit_t) == sizeof(unsigned));
-                cell->m_digits[0] = static_cast<unsigned>(v);
-                cell->m_digits[1] = static_cast<unsigned>(v >> 32);
-                cell->m_size = cell->m_digits[1] == 0 ? 1 : 2;
             }
+            else {
+                sign = 1;
+                v = a.m_val;
+            }
+            static_assert(sizeof(digit_t) == sizeof(unsigned));
+            cell->m_digits[0] = static_cast<unsigned>(v);
+            cell->m_digits[1] = static_cast<unsigned>(v >> 32);
+            cell->m_size = cell->m_digits[1] == 0 ? 1 : 2;
         }
         else {
             sign = a.m_val;

--- a/src/util/mpz.h
+++ b/src/util/mpz.h
@@ -458,7 +458,7 @@ public:
     
     static bool is_zero(mpz const & a) { return sign(a) == 0; }
 
-    static int sign(mpz const & a) {
+    static int64_t sign(mpz const & a) {
 #ifndef _MP_GMP
         return a.m_val;
 #else

--- a/src/util/mpz.h
+++ b/src/util/mpz.h
@@ -310,15 +310,15 @@ class mpz_manager {
         unsigned char m_bytes[sizeof(mpz_cell) + sizeof(digit_t) * capacity];
         mpz m_local;
         mpz const& m_a;
-        int m_sign;
+        int64_t m_sign;
         mpz_cell* m_cell;
     public:
         sign_cell(mpz_manager& m, mpz const& a);
-        int             sign() { return m_sign; }
+        int64_t         sign() { return m_sign; }
         mpz_cell const* cell() { return m_cell; }
     };
 
-    void get_sign_cell(mpz const & a, int & sign, mpz_cell * & cell, mpz_cell* reserve) {
+    void get_sign_cell(mpz const & a, int64_t & sign, mpz_cell * & cell, mpz_cell* reserve) {
         if (is_small(a)) {
             if (a.m_val == INT64_MIN) {
                 sign = -1;
@@ -326,15 +326,19 @@ class mpz_manager {
             }
             else {
                 cell = reserve;
-                cell->m_size = 1;
+                uint64_t v;
                 if (a.m_val < 0) {
                     sign = -1;
-                    cell->m_digits[0] = -a.m_val;
+                    v = -a.m_val;
                 }
                 else {
                     sign = 1;
-                    cell->m_digits[0] = a.m_val;
+                    v = a.m_val;
                 }
+                static_assert(sizeof(digit_t) == sizeof(unsigned));
+                cell->m_digits[0] = static_cast<unsigned>(v);
+                cell->m_digits[1] = static_cast<unsigned>(v >> 32);
+                cell->m_size = cell->m_digits[1] == 0 ? 1 : 2;
             }
         }
         else {

--- a/src/util/mpz.h
+++ b/src/util/mpz.h
@@ -99,7 +99,7 @@ class mpz {
     const mpz_type* ptr() const { return (mpz_type*)(m_ptr & ~3); }
     mpz_kind kind() const { return mpz_kind(m_ptr & 1); }
     mpz_owner owner() const { return mpz_owner(m_ptr & 2); }
-    void set(mpz_type* ptr) { m_ptr = (uintptr_t)ptr; SASSERT(ptr & ~3 == 0); }
+    void set(mpz_type* ptr) { m_ptr = (uintptr_t)ptr; SASSERT((m_ptr & 3) == 0); }
     void set(mpz_kind k)  { m_ptr = (m_ptr & ~1) | k; }
     void set(mpz_owner o) { m_ptr = (m_ptr & ~2) | (o << 1); }
 

--- a/src/util/mpz.h
+++ b/src/util/mpz.h
@@ -558,10 +558,8 @@ public:
     }
 
     void set(mpz & a, unsigned val) {
-        if (val <= INT_MAX)
-            set(a, static_cast<int>(val));
-        else
-            set(a, static_cast<int64_t>(static_cast<uint64_t>(val)));
+        a.m_val = val;
+        a.set(mpz_small);
     }
 
     void set(mpz & a, char const * val);

--- a/src/util/mpz.h
+++ b/src/util/mpz.h
@@ -181,12 +181,9 @@ class mpz_manager {
             deallocate(n);
             n.m_val = 1;
             n.set(allocate(c));
-            n.set(mpz_large);
             n.set(mpz_self);
         }
-        else {
-            n.set(mpz_large);
-        }
+        n.set(mpz_large);
     }
 
     void deallocate(bool is_heap, mpz_cell * ptr);

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -76,7 +76,7 @@ static_assert(sizeof(int64_t) == 8, "64 bits");
 # define Z3_fallthrough
 #endif
 
-inline bool is_power_of_two(unsigned v) { return !(v & (v - 1)) && v; }
+inline bool is_power_of_two(uint64_t v) { return !(v & (v - 1)) && v; }
 
 /**
    \brief Return the next power of two that is greater than or equal to v.


### PR DESCRIPTION
This doesn't increase the size of the mpz structure by reusing 2 bits from the pointer.
This will hopefully reduce memory consumption by keeping more cases as "small".

Don't merge yet. Need to test it more thoroughly & benchmark.

After this, we can switch all of mp* to 64-bit integers to get a 2x speedup on this stuff.