### PR TITLE
remove double assignment

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -1597,7 +1597,6 @@ br_status seq_rewriter::mk_seq_at(expr* a, expr* b, expr_ref& result) {
     for (expr* rhs : lens) {
         pos = m_autil.mk_add(pos, str().mk_length(rhs));
     }
-    result = str().mk_concat(m_lhs.size() - i , m_lhs.data() + i, sort_a);
     result = str().mk_at(result, pos);
     return BR_REWRITE2;   
 }


### PR DESCRIPTION
I think this assignment was useless, because I don't think any of its components is side-effecting.

Stumbled upon it while trying to understand the behaviour of out-of-bounds sequence indexing. Feel free to close and ignore if this is intended of course