### PR TITLE
move flushes in display_statistics

### DIFF
--- a/src/shell/smtlib_frontend.cpp
+++ b/src/shell/smtlib_frontend.cpp
@@ -44,12 +44,12 @@ static void display_statistics() {
     lock_guard lock(*display_stats_mux);
     clock_t end_time = clock();
     if (g_cmd_context && g_display_statistics) {
-        std::cout.flush();
-        std::cerr.flush();
         if (g_cmd_context) {
             g_cmd_context->set_regular_stream("stdout");
             g_cmd_context->display_statistics(true, ((static_cast<double>(end_time) - static_cast<double>(g_start_time)) / CLOCKS_PER_SEC));
         }
+        std::cout.flush();
+        std::cerr.flush();
     }
 }
 


### PR DESCRIPTION
We encountered issues with Z3 commandline stats display. Specifically in the case where the output is redirected to a file, the results are cutoff upon timeout. For example:  `z3 test.smt2 -T:3 -st > out_st`
Assuming the query timeout after 3 seconds, `out_st` would only contain the `timeout` error, but without the `rlimit-count`, `:total-time` etc. 

Such behavior does not happen when the output is just printed to `stdout`. The difference might be due to that `stdout` flushed on newline, but a redirected file doesn't. 

This change moves the force flush a bit later, so that the complete output will also get written to a file. 