### PR TITLE
Fix a compilation error with clang-cl (VS2022)

### DIFF
--- a/src/math/polynomial/upolynomial_factorization.cpp
+++ b/src/math/polynomial/upolynomial_factorization.cpp
@@ -27,7 +27,7 @@ Notes:
 #include "math/polynomial/upolynomial_factorization_int.h"
 #include "util/prime_generator.h"
 
-using namespace std;
+using std::endl;
 
 namespace upolynomial {
 


### PR DESCRIPTION
```
D:\CodeBlocks\cxx-common-cmake\build\z3-prefix\src\z3\src\util/vector.h(741,35): error: reference to 'vector' is ambiguous
    svector(SZ s, T const & elem):vector<T, false, SZ>(s, elem) {}
                                  ^
D:\CodeBlocks\cxx-common-cmake\build\z3-prefix\src\z3\src\util/vector.h(163,7): note: candidate found by name lookup is 'vector'
class vector {
      ^
c:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\vector(494,7): note: candidate found by name lookup is 'std::vector'
class vector { // varying size array of values
      ^
In file included from D:\CodeBlocks\cxx-common-cmake\build\z3-prefix\src\z3\src\math\polynomial\upolynomial_factorization.cpp:27:
In file included from D:\CodeBlocks\cxx-common-cmake\build\z3-prefix\src\z3\src\math/polynomial/upolynomial_factorization_int.h:28:
In file included from D:\CodeBlocks\cxx-common-cmake\build\z3-prefix\src\z3\src\math/polynomial/upolynomial_factorization.h:27:
In file included from D:\CodeBlocks\cxx-common-cmake\build\z3-prefix\src\z3\src\math/polynomial/upolynomial.h:26:
In file included from D:\CodeBlocks\cxx-common-cmake\build\z3-prefix\src\z3\src\util/mpzzp.h:28:
In file included from D:\CodeBlocks\cxx-common-cmake\build\z3-prefix\src\z3\src\util/mpz.h:27:
```

I'm not exactly sure why this is erroring (the `using` is after the headers after all), but `using namespace std;` is bad practice regardless and this seems to be almost the only place that has it.