### PR TITLE
Tiny fix to qprofdiff

### DIFF
--- a/contrib/qprofdiff/main.cpp
+++ b/contrib/qprofdiff/main.cpp
@@ -65,7 +65,7 @@ int parse(string const & filename, map<string, map_entry> & data) {
                 inx != string::npos;
                 inx = line.find(" : ", from)) {
                 tokens[ti] = trim(line.substr(from, inx-from));
-                from = inx+1;
+                from = inx+3; //3 is the length of " : "
                 ti++;
             }
             if (from != line.length() && ti < 4)


### PR DESCRIPTION
I use qprofdiff for differential profiling for F* SMT qi profiles.
But, the most recent version fails to parse the qi profile entries correctly because of a small bug.
It is searching for a delimiter token " : " of length 3, but when it finds it, it only advances the position by 1. I've fixed that.

@wintersteiger does it makes sense? Thanks!