### PR TITLE
mark_nonzero(expr* e) should call m_nonzero.mark(e)

### DIFF
--- a/src/ast/simplifiers/extract_eqs.cpp
+++ b/src/ast/simplifiers/extract_eqs.cpp
@@ -218,7 +218,7 @@ namespace euf {
 
         void mark_nonzero(expr* e) {
             m_trail.push_back(e);
-            m_nonzero(e);
+            m_nonzero.mark(e);
         }
 
         void add_pos(expr* f) {


### PR DESCRIPTION
`expr_sparse_mark` does not provide a call operator, which results in a compiler error when building Z3 from clean ([CI link](https://dev.azure.com/Z3Public/Z3/_build/results?buildId=4687&view=logs&j=25f03a8c-89e4-519e-4fe2-231b276a55e2&t=c28741a1-9c08-5aad-c435-dc9261ab7976&l=494)).

I believe the author intended to change this to `m_nonzero.mark(e)`