### PR TITLE
Prevent data race

### DIFF
--- a/src/solver/parallel_tactical.cpp
+++ b/src/solver/parallel_tactical.cpp
@@ -460,6 +460,7 @@ private:
             conquer->get_model(mdl);
         }
         else {
+            std::lock_guard<std::mutex> lock(m_mutex);
             s.get_solver().get_model(mdl);
         }
         if (mdl) {


### PR DESCRIPTION
I maintain the z3 package for the Fedora Linux distribution.  Recently a user [reported a segfault](https://bugzilla.redhat.com/show_bug.cgi?id=2157972).  A build with `-fsanitize=thread` revealed a data race.  Two threads are executing `parallel_tactic::report_sat`.  One thread holds `m_mutex` and is incrementing the reference count of an AST.  The other thread does _not_ hold `m_mutex` and is decrementing the reference count of the same AST.  In some cases, this leads to a segfault down the road when a bad array access is attempted.  See the linked bug report for details.  This commit forces the thread that decrements the reference count to hold `m_mutex` so that the reference count manipulations are properly synchronized.  With this change, the segfault is no longer reproducible.
