### PR TITLE
Initialize m_istamp_id in lookahead::init

### DIFF
--- a/src/sat/sat_lookahead.cpp
+++ b/src/sat/sat_lookahead.cpp
@@ -1001,6 +1001,7 @@ namespace sat {
         m_inconsistent = false;
         m_qhead = 0;
         m_bstamp_id = 0;
+        m_istamp_id = 0;
 
         for (unsigned i = 0; i < m_num_vars; ++i) {
             init_var(i);


### PR DESCRIPTION
A build with `-fsanitize=address` complains that the branch in `lookahead::inc_istamp` on line 128 of `src/sat/sat_lookahead.cpp` depends on an uninitialized value.  Valgrind makes the same complaint.  Code inspection shows that `m_istamp_id` is read and incremented, but never initialized.  Initialize it in `lookahead::init` at the same time that `m_bstamp_id` is initialized.
