### PR TITLE
Declare param to seq_util::rex::is_epsilon() as pointer to const

### DIFF
--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -1250,7 +1250,7 @@ bool seq_util::rex::is_loop(expr const* n, expr*& body, expr*& lo) const {
 /**
    Returns true iff e is the epsilon regex.
  */
-bool seq_util::rex::is_epsilon(expr* r) const {
+bool seq_util::rex::is_epsilon(expr const* r) const {
     expr* s;
     return is_to_re(r, s) && u.str.is_empty(s);
 }
@@ -1856,5 +1856,3 @@ seq_util::rex::info& seq_util::rex::info::operator=(info const& other) {
     min_length = other.min_length;
     return *this;
 }
-
-

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -588,7 +588,7 @@ public:
         bool is_loop(expr const* n, expr*& body, expr*& lo) const;
         unsigned min_length(expr* r) const;
         unsigned max_length(expr* r) const;
-        bool is_epsilon(expr* r) const;
+        bool is_epsilon(expr const* r) const;
         app* mk_epsilon(sort* seq_sort);
         info get_info(expr* r) const;
         std::string to_str(expr* r) const;
@@ -639,4 +639,3 @@ public:
 inline std::ostream& operator<<(std::ostream& out, seq_util::rex::pp const & p) { return p.display(out); }
 
 inline std::ostream& operator<<(std::ostream& out, seq_util::rex::info const& p) { return p.display(out); }
-


### PR DESCRIPTION
This PR declares the parameter of `seq_util::rex::is_epsilon()` as a pointer to const `app` instead of the (assumed incorrect) pointer to `app`.
      
This modified declaration replicates the other `seq_util::rex::is_<something>()` declarations in `seq_util::rex` class (which all have parameters for `app` declared as pointers to const `app`) and allows for the `seq_util::rex::is_epsilon()` to be used in the same context as the other functions in a consistent manner. As far as I am aware, there should be no reason for the check for epsilon to be handled differently from the other `seq_util::rex::is_<something>` member functions. 

The PR also removes some superfluous trailing newlines at the end of modified files.