### PR TITLE
fix tpl instantiation issue for mingw

### DIFF
--- a/src/ast/rewriter/rewriter.h
+++ b/src/ast/rewriter/rewriter.h
@@ -347,7 +347,7 @@ public:
     Config & cfg() { return m_cfg; }
     Config const & cfg() const { return m_cfg; }
 
-    ~rewriter_tpl() override;
+    ~rewriter_tpl() override {};
     
     void reset();
     void cleanup();

--- a/src/ast/rewriter/rewriter_def.h
+++ b/src/ast/rewriter/rewriter_def.h
@@ -641,10 +641,6 @@ rewriter_tpl<Config>::rewriter_tpl(ast_manager & m, bool proof_gen, Config & cfg
 }
 
 template<typename Config>
-rewriter_tpl<Config>::~rewriter_tpl() {
-}
-
-template<typename Config>
 void rewriter_tpl<Config>::reset() {
     m_cfg.reset();
     rewriter_core::reset();


### PR DESCRIPTION
```c
/usr/bin/i686-w64-mingw32-ld: CMakeFiles/shell.dir/objects.a(q_solver.cpp.obj):q_solver.cpp:(.text$_ZN20pattern_inference_rwD4Ev+0x149): undefined reference to `rewriter_tpl<pattern_inference_cfg>::~rewriter_tpl()'
collect2: error: ld returned 1 exit status
```