### PR TITLE
Fix Ocaml bindings FuncEntry to_string

### DIFF
--- a/src/api/ml/z3.ml
+++ b/src/api/ml/z3.ml
@@ -1542,7 +1542,7 @@ struct
 
       let to_string (x:func_entry) =
         let a = get_args x in
-        let f c p = (p ^ (Expr.to_string c) ^ ", ") in
+        let f c p = ((Expr.to_string c) ^ ", " ^ p) in
         "[" ^ List.fold_right f a ((Expr.to_string (get_value x)) ^ "]")
     end
 


### PR DESCRIPTION
Hello, I was looking at the different api string conversions for FuncEntry and I believe that the ml version is incorrect? Clearly we want the argument(`c`) to be comma separated from the accumulated string `p`. The current implementation just so happens to have most of the arguments comma separated, but the order is flipped and one of the commas is misplaced.