### PR TITLE
fix missing <cstdint> include

### DIFF
--- a/src/util/tptr.h
+++ b/src/util/tptr.h
@@ -19,6 +19,7 @@ Revision History:
 
 #pragma once
 
+#include <cstdint>
 #include "util/machine.h"
 
 #define TAG_SHIFT        PTR_ALIGNMENT


### PR DESCRIPTION
Fix missing <cstdint> include in src/util/tptr.h that causes build failure with GCC 13:

```
In file included from /tmp/z3/src/util/region.cpp:53:
/tmp/z3/src/util/region.cpp: In member function ‘void* region::allocate(size_t)’:
/tmp/z3/src/util/tptr.h:29:62: error: ‘uintptr_t’ does not name a type
   29 | #define ALIGN(T, PTR) reinterpret_cast<T>(((reinterpret_cast<uintptr_t>(PTR) >> PTR_ALIGNMENT) + \
      |                                                              ^~~~~~~~~
/tmp/z3/src/util/region.cpp:82:22: note: in expansion of macro ‘ALIGN’
   82 |         m_curr_ptr = ALIGN(char *, new_curr_ptr);
      |                      ^~~~~
/tmp/z3/src/util/region.cpp:57:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   56 | #include "util/page.h"
  +++ |+#include <cstdint>
   57 |
```