### PR TITLE
Add solver::interrupt to Python's API.

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -7136,6 +7136,13 @@ class Solver(Z3PPObject):
         """Import model converter from other into the current solver"""
         Z3_solver_import_model_converter(self.ctx.ref(), other.solver, self.solver)
 
+    def interrupt(self):
+        """Interrupt the execution of the solver object.
+        Remarks: This ensures that the interrupt applies only
+        to the given solver object and it applies only if it is running.
+        """
+        Z3_solver_interrupt(self.ctx.ref(), self.solver)
+
     def unsat_core(self):
         """Return a subset (as an AST vector) of the assumptions provided to the last check().
 


### PR DESCRIPTION
Hi,

I just wanted to contribute this small change which extends the Solver's API for Python. This is similar to https://github.com/Z3Prover/z3/commit/0f5cc2ec703427e6b7530537a7fa9b490590dfe9. I borrowed the comment from it.

Best regards,
Manuel