### PR TITLE
pattern_inference.h: include rewriter_def.h

### DIFF
--- a/src/ast/pattern/pattern_inference.h
+++ b/src/ast/pattern/pattern_inference.h
@@ -20,6 +20,7 @@ Revision History:
 
 #include "ast/ast.h"
 #include "ast/rewriter/rewriter.h"
+#include "ast/rewriter/rewriter_def.h"
 #include "params/pattern_inference_params.h"
 #include "util/vector.h"
 #include "util/uint_set.h"


### PR DESCRIPTION
Needed to use the `rewriter_tpl` constructor.

Fixes #6764