### PR TITLE
Fix regular expression strings with escapes

### DIFF
--- a/scripts/mk_genfile_common.py
+++ b/scripts/mk_genfile_common.py
@@ -139,7 +139,7 @@ def mk_z3consts_py_internal(api_files, output_dir):
                     assert False, "Invalid %s, line: %s" % (api_file, linenum)
             else:
                 assert mode == IN_ENUM
-                words = re.split('[^\-a-zA-Z0-9_]+', line)
+                words = re.split('[^-a-zA-Z0-9_]+', line)
                 m = closebrace_pat.match(line)
                 if m:
                     name = words[1]
@@ -227,7 +227,7 @@ def mk_z3consts_dotnet_internal(api_files, output_dir):
                     assert False, "Invalid %s, line: %s" % (api_file, linenum)
             else:
                 assert mode == IN_ENUM
-                words = re.split('[^\-a-zA-Z0-9_]+', line)
+                words = re.split('[^-a-zA-Z0-9_]+', line)
                 m = closebrace_pat.match(line)
                 if m:
                     name = words[1]
@@ -315,7 +315,7 @@ def mk_z3consts_java_internal(api_files, package_name, output_dir):
                     assert False, "Invalid %s, line: %s" % (api_file, linenum)
             else:
                 assert mode == IN_ENUM
-                words = re.split('[^\-a-zA-Z0-9_]+', line)
+                words = re.split('[^-a-zA-Z0-9_]+', line)
                 m = closebrace_pat.match(line)
                 if m:
                     name = words[1]
@@ -441,7 +441,7 @@ def mk_z3consts_ml_internal(api_files, output_dir):
                     assert False, "Invalid %s, line: %s" % (api_file, linenum)
             else:
                 assert mode == IN_ENUM
-                words = re.split('[^\-a-zA-Z0-9_]+', line)
+                words = re.split('[^-a-zA-Z0-9_]+', line)
                 m = closebrace_pat.match(line)
                 if m:
                     name = words[1]
@@ -574,7 +574,7 @@ def mk_def_file_internal(defname, dll_name, export_header_files):
         for line in api:
             m = pat1.match(line)
             if m:
-                words = re.split('\W+', line)
+                words = re.split(r'\W+', line)
                 i = 0
                 for w in words:
                     if w == 'Z3_API':
@@ -618,9 +618,9 @@ def mk_gparams_register_modules_internal(h_files_full_path, path):
     fout  = open(fullname, 'w')
     fout.write('// Automatically generated file.\n')
     fout.write('#include "util/gparams.h"\n')
-    reg_pat = re.compile('[ \t]*REG_PARAMS\(\'([^\']*)\'\)')
-    reg_mod_pat = re.compile('[ \t]*REG_MODULE_PARAMS\(\'([^\']*)\', *\'([^\']*)\'\)')
-    reg_mod_descr_pat = re.compile('[ \t]*REG_MODULE_DESCRIPTION\(\'([^\']*)\', *\'([^\']*)\'\)')
+    reg_pat = re.compile(r'[ \t]*REG_PARAMS\(\'([^\']*)\'\)')
+    reg_mod_pat = re.compile(r'[ \t]*REG_MODULE_PARAMS\(\'([^\']*)\', *\'([^\']*)\'\)')
+    reg_mod_descr_pat = re.compile(r'[ \t]*REG_MODULE_DESCRIPTION\(\'([^\']*)\', *\'([^\']*)\'\)')
     for h_file in sorted_headers_by_component(h_files_full_path):
         added_include = False
         with io.open(h_file, encoding='utf-8', mode='r') as fin:
@@ -698,9 +698,9 @@ def mk_install_tactic_cpp_internal(h_files_full_path, path):
     fout.write('#include "cmd_context/tactic_cmds.h"\n')
     fout.write('#include "cmd_context/simplifier_cmds.h"\n')
     fout.write('#include "cmd_context/cmd_context.h"\n')
-    tactic_pat   = re.compile('[ \t]*ADD_TACTIC\(.*\)')
-    probe_pat    = re.compile('[ \t]*ADD_PROBE\(.*\)')
-    simplifier_pat = re.compile('[ \t]*ADD_SIMPLIFIER\(.*\)')
+    tactic_pat   = re.compile(r'[ \t]*ADD_TACTIC\(.*\)')
+    probe_pat    = re.compile(r'[ \t]*ADD_PROBE\(.*\)')
+    simplifier_pat = re.compile(r'[ \t]*ADD_SIMPLIFIER\(.*\)')
     for h_file in sorted_headers_by_component(h_files_full_path):
         added_include = False
         try:
@@ -780,10 +780,10 @@ def mk_mem_initializer_cpp_internal(h_files_full_path, path):
     fullname = os.path.join(path, 'mem_initializer.cpp')
     fout  = open(fullname, 'w')
     fout.write('// Automatically generated file.\n')
-    initializer_pat      = re.compile('[ \t]*ADD_INITIALIZER\(\'([^\']*)\'\)')
+    initializer_pat      = re.compile(r'[ \t]*ADD_INITIALIZER\(\'([^\']*)\'\)')
     # ADD_INITIALIZER with priority
-    initializer_prio_pat = re.compile('[ \t]*ADD_INITIALIZER\(\'([^\']*)\',[ \t]*(-?[0-9]*)\)')
-    finalizer_pat        = re.compile('[ \t]*ADD_FINALIZER\(\'([^\']*)\'\)')
+    initializer_prio_pat = re.compile(r'[ \t]*ADD_INITIALIZER\(\'([^\']*)\',[ \t]*(-?[0-9]*)\)')
+    finalizer_pat        = re.compile(r'[ \t]*ADD_FINALIZER\(\'([^\']*)\'\)')
     for h_file in sorted_headers_by_component(h_files_full_path):
         added_include = False
         with io.open(h_file, encoding='utf-8', mode='r') as fin:

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -395,7 +395,7 @@ def check_java():
     else:
         # Search for jni.h in the library directories...
         t = open('errout', 'r')
-        open_pat = re.compile("\[search path for class files: (.*)\]")
+        open_pat = re.compile(r"\[search path for class files: (.*)\]")
         cdirs = []
         for line in t:
             m = open_pat.match(line)
@@ -812,8 +812,8 @@ def parse_options():
 def extract_c_includes(fname):
     result = {}
     # We look for well behaved #include directives
-    std_inc_pat     = re.compile("[ \t]*#include[ \t]*\"(.*)\"[ \t]*")
-    system_inc_pat  = re.compile("[ \t]*#include[ \t]*\<.*\>[ \t]*")
+    std_inc_pat     = re.compile(r"[ \t]*#include[ \t]*\"(.*)\"[ \t]*")
+    system_inc_pat  = re.compile(r"[ \t]*#include[ \t]*\<.*\>[ \t]*")
     # We should generate and error for any occurrence of #include that does not match the previous pattern.
     non_std_inc_pat = re.compile(".*#include.*")
 
@@ -1720,7 +1720,7 @@ class DotNetDLLComponent(Component):
 
         print("Version output to csproj:", version)
 
-        core_csproj_str = """<Project Sdk="Microsoft.NET.Sdk">
+        core_csproj_str = r"""<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
@@ -2246,7 +2246,7 @@ class DotNetExampleComponent(ExampleComponent):
             else:
                 platform = 'x86'
 
-            dotnet_proj_str = """<Project Sdk="Microsoft.NET.Sdk">
+            dotnet_proj_str = r"""<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -3162,7 +3162,7 @@ def mk_vs_proj_property_groups(f, name, target_ext, type):
     f.write('    <Keyword>Win32Proj</Keyword>\n')
     f.write('    <PlatformToolset>%s</PlatformToolset>\n' % get_platform_toolset_str())
     f.write('  </PropertyGroup>\n')
-    f.write('  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />\n')
+    f.write('  <Import Project="$(VCTargetsPath)\\Microsoft.Cpp.Default.props" />\n')
     f.write('  <PropertyGroup Condition="\'$(Configuration)|$(Platform)\'==\'Debug|Win32\'" Label="Configuration">\n')
     f.write('    <ConfigurationType>%s</ConfigurationType>\n' % type)
     f.write('    <CharacterSet>Unicode</CharacterSet>\n')
@@ -3173,24 +3173,24 @@ def mk_vs_proj_property_groups(f, name, target_ext, type):
     f.write('    <CharacterSet>Unicode</CharacterSet>\n')
     f.write('    <UseOfMfc>false</UseOfMfc>\n')
     f.write('  </PropertyGroup>\n')
-    f.write('  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />\n')
+    f.write('  <Import Project="$(VCTargetsPath)\\Microsoft.Cpp.props" />\n')
     f.write('  <ImportGroup Label="ExtensionSettings" />\n')
     f.write('   <ImportGroup Label="PropertySheets">\n')
-    f.write('    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists(\'$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props\')" Label="LocalAppDataPlatform" />  </ImportGroup>\n')
+    f.write('    <Import Project="$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props" Condition="exists(\'$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props\')" Label="LocalAppDataPlatform" />  </ImportGroup>\n')
     f.write('  <PropertyGroup Label="UserMacros" />\n')
     f.write('  <PropertyGroup>\n')
-    f.write('    <OutDir Condition="\'$(Configuration)|$(Platform)\'==\'Debug|Win32\'">$(SolutionDir)\$(ProjectName)\$(Configuration)\</OutDir>\n')
+    f.write('    <OutDir Condition="\'$(Configuration)|$(Platform)\'==\'Debug|Win32\'">$(SolutionDir)\\$(ProjectName)\\$(Configuration)\\</OutDir>\n')
     f.write('    <TargetName Condition="\'$(Configuration)|$(Platform)\'==\'Debug|Win32\'">%s</TargetName>\n' % name)
     f.write('    <TargetExt Condition="\'$(Configuration)|$(Platform)\'==\'Debug|Win32\'">.%s</TargetExt>\n' % target_ext)
-    f.write('    <OutDir Condition="\'$(Configuration)|$(Platform)\'==\'Release|Win32\'">$(SolutionDir)\$(ProjectName)\$(Configuration)\</OutDir>\n')
+    f.write('    <OutDir Condition="\'$(Configuration)|$(Platform)\'==\'Release|Win32\'">$(SolutionDir)\\$(ProjectName)\\$(Configuration)\\</OutDir>\n')
     f.write('    <TargetName Condition="\'$(Configuration)|$(Platform)\'==\'Release|Win32\'">%s</TargetName>\n' % name)
     f.write('    <TargetExt Condition="\'$(Configuration)|$(Platform)\'==\'Release|Win32\'">.%s</TargetExt>\n' % target_ext)
     f.write('  </PropertyGroup>\n')
     f.write('  <PropertyGroup Condition="\'$(Configuration)|$(Platform)\'==\'Debug|Win32\'">\n')
-    f.write('        <IntDir>$(ProjectName)\$(Configuration)\</IntDir>\n')
+    f.write('        <IntDir>$(ProjectName)\\$(Configuration)\\</IntDir>\n')
     f.write('  </PropertyGroup>\n')
     f.write('  <PropertyGroup Condition="\'$(Configuration)|$(Platform)\'==\'Release|Win32\'">\n')
-    f.write('    <IntDir>$(ProjectName)\$(Configuration)\</IntDir>\n')
+    f.write('    <IntDir>$(ProjectName)\\$(Configuration)\\</IntDir>\n')
     f.write('  </PropertyGroup>\n')
 
 
@@ -3267,7 +3267,7 @@ def mk_vs_proj(name, components):
     mk_vs_proj_link_exe(f, name, debug=False)
     f.write('  </ItemDefinitionGroup>\n')
     mk_vs_proj_dep_groups(f, name, components)
-    f.write('  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />\n')
+    f.write('  <Import Project="$(VCTargetsPath)\\Microsoft.Cpp.targets" />\n')
     f.write('  <ImportGroup Label="ExtensionTargets">\n')
     f.write('  </ImportGroup>\n')
     f.write('</Project>\n')
@@ -3308,7 +3308,7 @@ def mk_vs_proj_dll(name, components):
     mk_vs_proj_link_dll(f, name, debug=False)
     f.write('  </ItemDefinitionGroup>\n')
     mk_vs_proj_dep_groups(f, name, components)
-    f.write('  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />\n')
+    f.write('  <Import Project="$(VCTargetsPath)\\Microsoft.Cpp.targets" />\n')
     f.write('  <ImportGroup Label="ExtensionTargets">\n')
     f.write('  </ImportGroup>\n')
     f.write('</Project>\n')

--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -116,8 +116,8 @@ class APITypes:
         
     def def_Types(self, api_files):
         global Closures
-        pat1 = re.compile(" *def_Type\(\'(.*)\',[^\']*\'(.*)\',[^\']*\'(.*)\'\)[ \t]*")
-        pat2 = re.compile("Z3_DECLARE_CLOSURE\((.*),(.*), \((.*)\)\)")
+        pat1 = re.compile(r" *def_Type\(\'(.*)\',[^\']*\'(.*)\',[^\']*\'(.*)\'\)[ \t]*")
+        pat2 = re.compile(r"Z3_DECLARE_CLOSURE\((.*),(.*), \((.*)\)\)")
         for api_file in api_files:
             with open(api_file, 'r') as api:
                 for line in api:


### PR DESCRIPTION
The Fedora project is rebuilding all of its packages with the current python 3.12 beta.  While the z3 build succeeded, I saw a number of warnings in the build log of this form:
```
/builddir/build/BUILD/z3-z3-4.12.2/scripts/mk_genfile_common.py:142: SyntaxWarning: invalid escape sequence '\-'
  words = re.split('[^\-a-zA-Z0-9_]+', line)
/builddir/build/BUILD/z3-z3-4.12.2/scripts/mk_genfile_common.py:577: SyntaxWarning: invalid escape sequence '\W'
  words = re.split('\W+', line)
```

The first 4 changes in `scripts/mk_genfile_common.py` remove escapes from hyphens.  A hyphen must be escaped only if it could be interpreted as a range.  The rest either convert strings into raw strings, or double up escape characters to avoid messing up the nice alignment of bunch of strings.