### PR TITLE
simple equality propagation

### DIFF
--- a/src/math/lp/lar_core_solver.h
+++ b/src/math/lp/lar_core_solver.h
@@ -215,9 +215,9 @@ public:
     }
 
     bool column_is_fixed(unsigned j) const {
-        return m_column_types()[j] == column_type::fixed ||
-            ( m_column_types()[j] == column_type::boxed &&
+        lp_assert(m_column_types()[j] != column_type::fixed ||
               m_r_solver.m_lower_bounds[j] == m_r_solver.m_upper_bounds[j]);
+        return m_column_types()[j] == column_type::fixed;
     }
 
     bool column_is_free(unsigned j) const {

--- a/src/math/lp/lar_core_solver.h
+++ b/src/math/lp/lar_core_solver.h
@@ -216,7 +216,7 @@ public:
 
     bool column_is_fixed(unsigned j) const {
         lp_assert(m_column_types()[j] != column_type::fixed ||
-              m_r_solver.m_lower_bounds[j] == m_r_solver.m_upper_bounds[j]);
+              m_r_solver.m_lower_bounds[j] >= m_r_solver.m_upper_bounds[j]);
         return m_column_types()[j] == column_type::fixed;
     }
 

--- a/src/math/lp/lar_solver.cpp
+++ b/src/math/lp/lar_solver.cpp
@@ -623,6 +623,28 @@ namespace lp {
             m_touched_rows.insert(rid);
     }
 
+    void lar_solver::remove_fixed_vars_from_base() {
+        row_tracker_temp_disabler ch(*this);
+        unsigned num = A_r().column_count();
+        for (unsigned v = 0; v < num; v++) {
+            if (!is_base(v) || !is_fixed(v))
+                continue;
+
+            lp_assert(is_base(v) && is_fixed(v));    
+
+            auto const& r = basic2row(v);
+
+            for (auto const& c : r) {
+			    unsigned j = c.var();
+                if (j != v && !is_fixed(j)) {
+                    pivot(j, v);
+                    lp_assert(is_base(j));
+                    break;
+                }
+            }
+        }
+    }
+
     bool lar_solver::use_tableau_costs() const {
         return m_settings.simplex_strategy() == simplex_strategy_enum::tableau_costs;
     }

--- a/src/math/lp/lar_solver.cpp
+++ b/src/math/lp/lar_solver.cpp
@@ -646,7 +646,7 @@ namespace lp {
             auto const& r = basic2row(j);
             for (auto const& c : r) {
                 unsigned j_entering = c.var();
-                if (j_entering != j && !is_fixed(j_entering)) {
+                if (!is_fixed(j_entering)) {
                     pivot(j_entering, j);
                     to_remove.push_back(j);
                     lp_assert(is_base(j_entering));
@@ -1645,7 +1645,6 @@ namespace lp {
         m_incorrect_columns.increase_size_by_one();
         m_touched_rows.increase_size_by_one();
         add_new_var_to_core_fields_for_mpq(true);
-        
     }
 
     bool lar_solver::bound_is_integer_for_integer_column(unsigned j, const mpq& right_side) const {

--- a/src/math/lp/lar_solver.cpp
+++ b/src/math/lp/lar_solver.cpp
@@ -1394,6 +1394,9 @@ namespace lp {
     }
 
     bool lar_solver::column_is_fixed(unsigned j) const {
+        if (j == m_crossed_bounds_column) {
+            return false;
+        }
         return m_mpq_lar_core_solver.column_is_fixed(j);
     }
 

--- a/src/math/lp/lar_solver.cpp
+++ b/src/math/lp/lar_solver.cpp
@@ -478,9 +478,17 @@ namespace lp {
         }
         return false;
     }
-
-    bool lar_solver::remove_from_basis(unsigned j) {
-        return m_mpq_lar_core_solver.m_r_solver.remove_from_basis(j);
+// returns true iff the row of j has a non-fixed column different from j
+    bool lar_solver::remove_from_basis(unsigned j) {    
+        lp_assert(is_base(j));
+        unsigned i = row_of_basic_column(j);
+        for (const auto & c : A_r().m_rows[i]) {
+            if (j != c.var() && !is_fixed(c.var())) {
+                return m_mpq_lar_core_solver.m_r_solver.remove_from_basis_core(c.var(), j);
+            }
+            
+        }
+        return false;
     }
 
     lar_term lar_solver::get_term_to_maximize(unsigned j_or_term) const {
@@ -633,23 +641,42 @@ namespace lp {
                 continue;
             }
 
-            lp_assert(is_base(j) && is_fixed(j));    
+            lp_assert(is_base(j) && is_fixed(j));
             auto const& r = basic2row(j);
             for (auto const& c : r) {
-		unsigned j_entering = c.var();
+                unsigned j_entering = c.var();
                 if (j_entering != j && !is_fixed(j_entering)) {
                     pivot(j_entering, j);
-		    to_remove.push_back(j);	
+                    to_remove.push_back(j);
                     lp_assert(is_base(j_entering));
                     break;
                 }
-            }     
-
+            }
         }
         for (unsigned j : to_remove) {
             m_fixed_base_var_set.remove(j);
         }
+        lp_assert(fixed_base_removed_correctly());
     }
+#ifdef Z3DEBUG    
+    bool lar_solver::fixed_base_removed_correctly() const {
+        for (unsigned i = 0; i < A_r().row_count(); i++) {
+            unsigned j = get_base_column_in_row(i);
+            if (column_is_fixed(j)) {
+                for (const auto & c : A_r().m_rows[i] ) {
+                    if (!column_is_fixed(c.var())) {
+                        TRACE("lar_solver", print_row(A_r().m_rows[i], tout) << "\n";
+                        for(const auto & c : A_r().m_rows[i]) {
+                            print_column_info(c.var(), tout) << "\n";
+                        });
+                        return false;
+                    }
+                }                
+            }
+        }
+        return true;
+    }
+#endif
 
     bool lar_solver::use_tableau_costs() const {
         return m_settings.simplex_strategy() == simplex_strategy_enum::tableau_costs;
@@ -1394,10 +1421,7 @@ namespace lp {
         return m_var_register.local_is_int(j);
     }
 
-    bool lar_solver::column_is_fixed(unsigned j) const {
-        if (j == m_crossed_bounds_column) {
-            return false;
-        }
+    bool lar_solver::column_is_fixed(unsigned j) const {        
         return m_mpq_lar_core_solver.column_is_fixed(j);
     }
 

--- a/src/math/lp/lar_solver.cpp
+++ b/src/math/lp/lar_solver.cpp
@@ -4,7 +4,7 @@
 */
 #include "math/lp/lar_solver.h"
 #include "smt/params/smt_params_helper.hpp"
-
+#include  "util/util.h"
 
 namespace lp {
 
@@ -632,9 +632,10 @@ namespace lp {
     }
 
     void lar_solver::remove_fixed_vars_from_base() {
-        row_tracker_temp_disabler ch(*this);
+	   // this will allow to disable and restore the tracking of the touched rows
+        flet<u_set*> f(m_mpq_lar_core_solver.m_r_solver.m_touched_rows, nullptr);
         unsigned num = A_r().column_count();
-        vector<unsigned> to_remove;
+        unsigned_vector to_remove;
         for (unsigned j : m_fixed_base_var_set) {
             if (j >= num || !is_base(j) || !is_fixed(j)) {
                 to_remove.push_back(j);

--- a/src/math/lp/lar_solver.cpp
+++ b/src/math/lp/lar_solver.cpp
@@ -655,7 +655,7 @@ namespace lp {
             }
         }
         for (unsigned j : to_remove) {
-            m_fixed_base_var_set.remove(j);
+            m_fixed_base_var_set.erase(j);
         }
         lp_assert(fixed_base_removed_correctly());
     }

--- a/src/math/lp/lar_solver.cpp
+++ b/src/math/lp/lar_solver.cpp
@@ -636,9 +636,10 @@ namespace lp {
             lp_assert(is_base(j) && is_fixed(j));    
             auto const& r = basic2row(j);
             for (auto const& c : r) {
-			    unsigned j_entering = c.var();
+		unsigned j_entering = c.var();
                 if (j_entering != j && !is_fixed(j_entering)) {
                     pivot(j_entering, j);
+		    to_remove.push_back(j);	
                     lp_assert(is_base(j_entering));
                     break;
                 }

--- a/src/math/lp/lar_solver.h
+++ b/src/math/lp/lar_solver.h
@@ -108,7 +108,7 @@ class lar_solver : public column_namer {
     // maps values to non-integral fixed vars
     map<mpq, unsigned, obj_hash<mpq>, default_eq<mpq>> m_fixed_var_table_real;
     // the set of fixed variables which are also base variables
-    uint_set                                           m_fixed_base_var_set;
+    tracked_uint_set                                   m_fixed_base_var_set;
     // end of fields
 
     ////////////////// methods ////////////////////////////////

--- a/src/math/lp/lar_solver.h
+++ b/src/math/lp/lar_solver.h
@@ -107,6 +107,8 @@ class lar_solver : public column_namer {
     map<mpq, unsigned, obj_hash<mpq>, default_eq<mpq>> m_fixed_var_table_int;
     // maps values to non-integral fixed vars
     map<mpq, unsigned, obj_hash<mpq>, default_eq<mpq>> m_fixed_var_table_real;
+    // the set of fixed variables which are also base variables
+    uint_set                                           m_fixed_base_var_set;
     // end of fields
 
     ////////////////// methods ////////////////////////////////

--- a/src/math/lp/lar_solver.h
+++ b/src/math/lp/lar_solver.h
@@ -324,8 +324,9 @@ class lar_solver : public column_namer {
     inline unsigned get_base_column_in_row(unsigned row_index) const {
         return m_mpq_lar_core_solver.m_r_solver.get_base_column_in_row(row_index);
     }
-
-    // lp_assert(implied_bound_is_correctly_explained(ib, explanation)); }
+#ifdef Z3DEBUG
+    bool fixed_base_removed_correctly() const;
+#endif
     constraint_index mk_var_bound(var_index j, lconstraint_kind kind, const mpq& right_side);
     void activate_check_on_equal(constraint_index, var_index&);
     void activate(constraint_index);
@@ -431,9 +432,10 @@ class lar_solver : public column_namer {
     bool try_to_patch(lpvar j, const mpq& val,
                       const Blocker& is_blocked,
                       const ChangeReport& change_report) {
-        if (is_base(j)) {
+        if (is_base(j))  {
             TRACE("nla_solver", get_int_solver()->display_row_info(tout, row_of_basic_column(j)) << "\n";);
-            remove_from_basis(j);
+            if (!remove_from_basis(j))
+               return false;
         }
 
         impq ival(val);

--- a/src/math/lp/lar_solver.h
+++ b/src/math/lp/lar_solver.h
@@ -648,19 +648,5 @@ class lar_solver : public column_namer {
     friend int_solver;
     friend int_branch;
 };
-// this will allow to disable the tracking of the touched rows, 
-// and then restore its previous value
-struct row_tracker_temp_disabler {
-    lar_solver&      lra;
-    bool             m_track_touched_rows;
-    row_tracker_temp_disabler(lar_solver& ls) :
-        lra(ls),
-        m_track_touched_rows(lra.touched_rows_are_tracked()) {
-        lra.track_touched_rows(false);
-    }
-    ~row_tracker_temp_disabler() {
-        lra.track_touched_rows(m_track_touched_rows);
-    }
-};
 
 }  // namespace lp

--- a/src/math/lp/lar_solver.h
+++ b/src/math/lp/lar_solver.h
@@ -108,7 +108,7 @@ class lar_solver : public column_namer {
     // maps values to non-integral fixed vars
     map<mpq, unsigned, obj_hash<mpq>, default_eq<mpq>> m_fixed_var_table_real;
     // the set of fixed variables which are also base variables
-    tracked_uint_set                                   m_fixed_base_var_set;
+    u_set                                              m_fixed_base_var_set;
     // end of fields
 
     ////////////////// methods ////////////////////////////////

--- a/src/math/lp/lp_bound_propagator.h
+++ b/src/math/lp/lp_bound_propagator.h
@@ -193,6 +193,7 @@ class lp_bound_propagator {
 
     bool add_eq_on_columns(const explanation& exp, lpvar j, lpvar k, bool is_fixed) {
         lp_assert(j != k && is_int(j) == is_int(k));
+        lp_assert(ival(j) == ival(k));
 
         unsigned je = lp().column_to_reported_index(j);
         unsigned ke = lp().column_to_reported_index(k);
@@ -357,6 +358,11 @@ class lp_bound_propagator {
             try_add_equation_with_lp_fixed_tables(row_index, x);
             return;
         }
+        if (y_sign == 0) {
+            // the coefficient before y is not 1 or -1
+            return;
+        }
+        lp_assert(y_sign == -1 || y_sign == 1);
         lp_assert(lp().is_base(y) == false);
         auto& table = y_sign == 1 ? m_row2index_pos : m_row2index_neg;
         table.insert(val(x), row_index);        

--- a/src/math/lp/lp_bound_propagator.h
+++ b/src/math/lp/lp_bound_propagator.h
@@ -12,7 +12,7 @@
 namespace lp {
 template <typename T>
 class lp_bound_propagator {
-	hashtable<unsigned, u_hash, u_eq> m_visited_rows;
+	uint_set m_visited_rows;
     // these maps map a column index to the corresponding index in ibounds
     std::unordered_map<unsigned, unsigned> m_improved_lower_bounds;
     std::unordered_map<unsigned, unsigned> m_improved_upper_bounds;
@@ -60,6 +60,7 @@ class lp_bound_propagator {
         unsigned debv1, debv2;
         lp_assert(only_one_nfixed(r1, debv1) && only_one_nfixed(r2, debv2));
         lp_assert(debv1 == v1 && debv2 == v2);
+        lp_assert(ival(v1).y == ival(v2).y);
 #endif
         explanation ex;
         explain_fixed_in_row(r1, ex);

--- a/src/math/lp/lp_core_solver_base.cpp
+++ b/src/math/lp/lp_core_solver_base.cpp
@@ -65,6 +65,6 @@ template bool lp::lp_core_solver_base<lp::mpq, lp::mpq>::pivot_column_tableau(un
 template void lp::lp_core_solver_base<lp::mpq, lp::numeric_pair<lp::mpq> >::transpose_rows_tableau(unsigned int, unsigned int);
 template bool lp::lp_core_solver_base<lp::mpq, lp::numeric_pair<lp::mpq> >::inf_heap_is_correct() const;
 template bool lp::lp_core_solver_base<lp::mpq, lp::mpq>::inf_heap_is_correct() const;
-template bool lp::lp_core_solver_base<lp::mpq, lp::numeric_pair<lp::mpq> >::remove_from_basis(unsigned int);
+template bool lp::lp_core_solver_base<lp::mpq, lp::numeric_pair<lp::mpq> >::remove_from_basis_core(unsigned int, unsigned int);
 
 

--- a/src/math/lp/lp_core_solver_base.h
+++ b/src/math/lp/lp_core_solver_base.h
@@ -338,7 +338,7 @@ public:
         
     }
 
-    bool remove_from_basis(unsigned j);
+    bool remove_from_basis_core(unsigned entering, unsigned leaving);
     bool pivot_column_general(unsigned j, unsigned j_basic, indexed_vector<T> & w);
     void init_basic_part_of_basis_heading() {
         unsigned m = m_basis.size();
@@ -388,6 +388,8 @@ public:
     
     void change_basis(unsigned entering, unsigned leaving) {
         TRACE("lar_solver", tout << "entering = " << entering << ", leaving = " << leaving << "\n";);
+        CTRACE("lar_solver", column_is_fixed(entering),  tout << "entering is fixed\n";); 
+        
         lp_assert(m_basis_heading[entering] < 0);
 		lp_assert(m_basis_heading[leaving] >= 0);
         

--- a/src/math/lp/lp_core_solver_base_def.h
+++ b/src/math/lp/lp_core_solver_base_def.h
@@ -404,30 +404,24 @@ template <typename T, typename X>  void lp_core_solver_base<T, X>::transpose_row
     transpose_basis(i, j);
     m_A.transpose_rows(i, j);
 }
-// j is the new basic column, j_basic - the leaving column
-template <typename T, typename X> bool lp_core_solver_base<T, X>::pivot_column_general(unsigned j, unsigned j_basic, indexed_vector<T> & w) {
-	lp_assert(m_basis_heading[j] < 0);
-	lp_assert(m_basis_heading[j_basic] >= 0);
-	unsigned row_index = m_basis_heading[j_basic];
+// entering is the new base column, leaving - the column leaving the basis
+template <typename T, typename X> bool lp_core_solver_base<T, X>::pivot_column_general(unsigned entering, unsigned leaving, indexed_vector<T> & w) {
+	lp_assert(m_basis_heading[entering] < 0);
+	lp_assert(m_basis_heading[leaving] >= 0);
+	unsigned row_index = m_basis_heading[leaving];
 	  // the tableau case
-	if (pivot_column_tableau(j, row_index))
-		change_basis(j, j_basic);
-	else return false;
+	if (pivot_column_tableau(entering, row_index))
+		change_basis(entering, leaving);
+	else 
+        return false;
 	
 	return true;
 }
 
 
-template <typename T, typename X> bool lp_core_solver_base<T, X>::remove_from_basis(unsigned basic_j) {
+template <typename T, typename X> bool lp_core_solver_base<T, X>::remove_from_basis_core(unsigned entering, unsigned leaving) {
     indexed_vector<T> w(m_basis.size()); // the buffer
-    unsigned i = m_basis_heading[basic_j];
-    for (auto &c : m_A.m_rows[i]) {
-        if (c.var() == basic_j)
-            continue;
-        if (pivot_column_general(c.var(), basic_j, w))
-            return true;
-    }
-    return false;
+    return pivot_column_general(entering, leaving, w);
 }
 
 

--- a/src/math/lp/lp_settings.h
+++ b/src/math/lp/lp_settings.h
@@ -50,6 +50,7 @@ inline std::ostream& operator<<(std::ostream& out, column_type const& t) {
     case column_type::boxed: return out << "boxed";
     case column_type::fixed: return out << "fixed";
     }
+    return out<<"erroneous column type";
 }
 
 enum class simplex_strategy_enum {

--- a/src/math/lp/u_set.h
+++ b/src/math/lp/u_set.h
@@ -40,7 +40,9 @@ public:
         return m_data[j] >= 0;
     }
     void insert(unsigned j) {
-        lp_assert(j < m_data.size());
+        if (j >= m_data.size()) {
+            m_data.resize(j + 1, -1);
+        }
         if (contains(j)) return;
         m_data[j] = m_index.size();
         m_index.push_back(j);

--- a/src/smt/theory_lra.cpp
+++ b/src/smt/theory_lra.cpp
@@ -3675,7 +3675,7 @@ public:
 
 
     void validate_solution() {
-        verbose_stream() << "validate solution\n";
+        // verbose_stream() << "validate solution\n";
 
         unsigned nv = th.get_num_vars();
         for (unsigned v = 0; v < nv; ++v) {
@@ -3688,11 +3688,12 @@ public:
             auto* n = get_enode(v);
             expr* e = n->get_expr(), *e1, *e2;
             rational r, r1, r2;
-            if (use_nra_model())
-                m_nla->am().display(verbose_stream() << " = ", nl_value(v, *m_a1)) << "\n";
+            if (use_nra_model()) {
+               //   m_nla->am().display(verbose_stream() << " = ", nl_value(v, *m_a1)) << "\n";
+            }
             else {
                 r = lp().get_tv_value(get_tv(v));
-                verbose_stream() << r << "\n";
+               // verbose_stream() << r << "\n";
                 if (a.is_mod(e, e1, e2)) {
                     auto v1 = th.get_th_var(e1);
                     auto v2 = th.get_th_var(e2);
@@ -3706,12 +3707,12 @@ public:
                     auto v2 = th.get_th_var(e2);
                     r1 = lp().get_tv_value(get_tv(v1));
                     r2 = lp().get_tv_value(get_tv(v2));
-                    verbose_stream() << mk_pp(e, m) << " " << r << " == " << r1 << " div " << r2 << "\n";
+                 //   verbose_stream() << mk_pp(e, m) << " " << r << " == " << r1 << " div " << r2 << "\n";
                     if (r2 > 0)
                         VERIFY(r == div(r1, r2));
                 }
                 else if (a.is_add(e)) {
-                    verbose_stream() << "add v" << v << " " << r <<"\n";
+                   // verbose_stream() << "add v" << v << " " << r <<"\n";
                 }
                 else if (a.is_numeral(e, r2)) {
                     VERIFY(r == r2);
@@ -3720,7 +3721,7 @@ public:
 
                 }
                 else {
-                    verbose_stream() << "other " << enode_pp(n, ctx()) << "\n";
+                   // verbose_stream() << "other " << enode_pp(n, ctx()) << "\n";
                 }
             }
         }

--- a/src/smt/theory_lra.cpp
+++ b/src/smt/theory_lra.cpp
@@ -1714,6 +1714,9 @@ public:
         final_check_status result = final_check_core();
         if (result != FC_DONE)
             return result;
+        if (!m_changed_assignment) {
+            return FC_DONE;
+        }
         m_liberal_final_check = false;
         m_changed_assignment = false;
         result = final_check_core();

--- a/src/smt/theory_lra.cpp
+++ b/src/smt/theory_lra.cpp
@@ -1700,10 +1700,6 @@ public:
     bool m_changed_assignment = false;
 
     final_check_status final_check_eh() {
-        // verbose_stream() << "final " << ctx().get_scope_level() << " " << ctx().assigned_literals().size() << "\n";
-        //ctx().display(verbose_stream());
-        //exit(0);
-        
         TRACE("arith_eq_adapter_info", m_arith_eq_adapter.display_already_processed(tout););
         TRACE("arith", display(tout););
 
@@ -1718,21 +1714,10 @@ public:
         final_check_status result = final_check_core();
         if (result != FC_DONE)
             return result;
-#ifdef Z3DEBUG
-        if (!m_changed_assignment) {
-            validate_solution();
-            return FC_DONE;
-        }
-#endif        
         m_liberal_final_check = false;
         m_changed_assignment = false;
         result = final_check_core();
         TRACE("arith", tout << "result: " << result << "\n";);
-#ifdef Z3DEBUG
-        if (result == FC_DONE) {
-            validate_solution();
-        }
-#endif
         return result;
     }
     
@@ -3672,61 +3657,6 @@ public:
             nctx.assert_expr(m.mk_eq(eq.first->get_expr(), eq.second->get_expr()));
         }
     }        
-
-
-    void validate_solution() {
-        // verbose_stream() << "validate solution\n";
-
-        unsigned nv = th.get_num_vars();
-        for (unsigned v = 0; v < nv; ++v) {
-            auto t = get_tv(v);
-            auto vi = lp().external_to_column_index(v);
-
-            if (!is_registered_var(v))
-                continue;
-            
-            auto* n = get_enode(v);
-            expr* e = n->get_expr(), *e1, *e2;
-            rational r, r1, r2;
-            if (use_nra_model()) {
-               //   m_nla->am().display(verbose_stream() << " = ", nl_value(v, *m_a1)) << "\n";
-            }
-            else {
-                r = lp().get_tv_value(get_tv(v));
-               // verbose_stream() << r << "\n";
-                if (a.is_mod(e, e1, e2)) {
-                    auto v1 = th.get_th_var(e1);
-                    auto v2 = th.get_th_var(e2);
-                    r1 = lp().get_tv_value(get_tv(v1));
-                    r2 = lp().get_tv_value(get_tv(v2));
-                    if (r2 > 0)
-                        VERIFY(r == r1 % r2);
-                }
-                else if (a.is_idiv(e, e1, e2)) {
-                    auto v1 = th.get_th_var(e1);
-                    auto v2 = th.get_th_var(e2);
-                    r1 = lp().get_tv_value(get_tv(v1));
-                    r2 = lp().get_tv_value(get_tv(v2));
-                 //   verbose_stream() << mk_pp(e, m) << " " << r << " == " << r1 << " div " << r2 << "\n";
-                    if (r2 > 0)
-                        VERIFY(r == div(r1, r2));
-                }
-                else if (a.is_add(e)) {
-                   // verbose_stream() << "add v" << v << " " << r <<"\n";
-                }
-                else if (a.is_numeral(e, r2)) {
-                    VERIFY(r == r2);
-                }
-                else if (is_uninterp_const(e)) {
-
-                }
-                else {
-                   // verbose_stream() << "other " << enode_pp(n, ctx()) << "\n";
-                }
-            }
-        }
-
-    }
 
     theory_lra::inf_eps value(theory_var v) {
         lp::impq ival = get_ivalue(v);

--- a/src/smt/theory_lra.cpp
+++ b/src/smt/theory_lra.cpp
@@ -1072,13 +1072,11 @@ public:
     bool delayed_diseqs() {
         if (m_diseqs_qhead == m_diseqs.size())
             return false;
-        verbose_stream() << m_diseqs_qhead << " out of " << m_diseqs.size() << "\n";
         ctx().push_trail(value_trail(m_diseqs_qhead));
         bool has_eq = false;
         while (m_diseqs_qhead < m_diseqs.size()) {
             auto [v1,v2] = m_diseqs[m_diseqs_qhead];
             if (is_eq(v1, v2)) {
-                verbose_stream() << "bad diseq " << m_diseqs_qhead << "\n";
                 m_arith_eq_adapter.new_diseq_eh(v1, v2);
                 has_eq = true;
             }
@@ -1720,33 +1718,25 @@ public:
         final_check_status result = final_check_core();
         if (result != FC_DONE)
             return result;
+#ifdef Z3DEBUG
         if (!m_changed_assignment) {
             validate_solution();
             return FC_DONE;
         }
+#endif        
         m_liberal_final_check = false;
         m_changed_assignment = false;
         result = final_check_core();
         TRACE("arith", tout << "result: " << result << "\n";);
+#ifdef Z3DEBUG
         if (result == FC_DONE) {
             validate_solution();
         }
+#endif
         return result;
     }
     
     final_check_status final_check_core() {
-
-        if (false)
-        {
-            verbose_stream() << "final\n";
-            ::statistics stats;
-            collect_statistics(stats);
-            stats.display(verbose_stream());
-        }
-#if 0
-        if (!m_has_propagated_fixed && propagate_fixed())
-            return FC_CONTINUE;
-#endif
         if (propagate_core())
             return FC_CONTINUE;
         m_model_is_initialized = false;
@@ -1853,13 +1843,12 @@ public:
             }
             if (st == FC_DONE) {
                 if (assume_eqs()) {
-                    // verbose_stream() << "not done\n";
                     return FC_CONTINUE;
                 }
                 st = check_nla();
-                if (st != FC_DONE)
+                if (st != FC_DONE) {
                     return st;
-
+                }
             }
             return st;
         case l_false:
@@ -3686,7 +3675,6 @@ public:
 
 
     void validate_solution() {
-        return;
         verbose_stream() << "validate solution\n";
 
         unsigned nv = th.get_num_vars();

--- a/src/test/lp/lp.cpp
+++ b/src/test/lp/lp.cpp
@@ -1072,20 +1072,18 @@ void test_bound_propagation() {
 }
 
 void test_int_set() {
-    u_set s(4);
-    s.insert(2);
+    indexed_uint_set s;
     s.insert(1);
     s.insert(2);
     lp_assert(s.contains(2));
     lp_assert(s.size() == 2);
     s.erase(2);
     lp_assert(s.size() == 1);
-    s.erase(2);
-    lp_assert(s.size() == 1);
     s.insert(3);
     s.insert(2);
-    s.clear();
+    s.reset();
     lp_assert(s.size() == 0);
+    std::cout << "done test_int_set\n";
 }
 
 void test_rationals_no_numeric_pairs() {


### PR DESCRIPTION
Use the simple equality propagation by connecting the vertices with the same value on the non-basic column, instead of using a tree.
remove_fixed_vars_from_base() is fixed.
lar_solver::column_is_fixed()'s performance improved.
The branch gives about 11 percent speedup on Certora's benchmarks for lp6.
It behaves not worser than the previous lp6 on QF_LIA.
The pull request has the final_check_eh() in theory_lra.cpp ported from branch arith.