### PR TITLE
[draft] Use half SipHash-1-3 for AST hashing

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -192,7 +192,7 @@ public:
     bool operator==(parameter const & p) const;
     bool operator!=(parameter const & p) const { return !operator==(p); }
 
-    unsigned hash() const;
+    void addHash(GenHash &hash) const;
 
     std::ostream& display(std::ostream& out) const;
 };
@@ -287,7 +287,7 @@ public:
     };
     iterator parameters() const { return iterator(*this); }
 
-    unsigned hash() const;
+    void addHash(GenHash &hash) const;
     bool operator==(decl_info const & info) const;
 };
 
@@ -602,8 +602,7 @@ public:
         parameter const* end() const { return begin() + d.get_num_parameters(); }
     };
     iterator parameters() const { return iterator(*this); }
-
-
+    void addHash(GenHash &hash) const;
 };
 
 // -----------------------------------
@@ -666,7 +665,7 @@ public:
     unsigned get_size() const { return get_obj_size(m_arity); }
     sort * const * begin() const { return get_domain(); }
     sort * const * end() const { return get_domain() + get_arity(); }
-
+    void addHash(GenHash &hash) const;
 };
 
 // -----------------------------------
@@ -688,7 +687,7 @@ public:
     sort* get_sort() const;
 
     unsigned get_small_id() const { return get_id(); }
-    
+
 };
 
 // -----------------------------------
@@ -748,6 +747,7 @@ public:
     bool is_ground() const { return flags()->m_ground; }
     bool has_quantifiers() const { return flags()->m_has_quantifiers; }
     bool has_labels() const { return flags()->m_has_labels; }
+    void addHash(GenHash &hash) const;
 };
 
 // -----------------------------------
@@ -833,6 +833,7 @@ public:
     unsigned get_idx() const { return m_idx; }
     sort * _get_sort() const { return m_sort; }
     unsigned get_size() const { return get_obj_size(); }
+    void addHash(GenHash &hash) const;
 };
 
 // -----------------------------------
@@ -919,6 +920,7 @@ public:
         else
             return get_no_pattern(idx - get_num_patterns() - 1);
     }
+    void addHash(GenHash &hash) const;
 };
 
 // -----------------------------------

--- a/src/util/hash.h
+++ b/src/util/hash.h
@@ -18,8 +18,138 @@ Revision History:
 --*/
 #pragma once
 
-#include<algorithm>
+#include <algorithm>
+#include <cstring>
 #include "util/util.h"
+
+// halfsip(1,3) hash
+// Inspired from https://github.com/veorq/SipHash/blob/master/halfsiphash.c
+// In public domain
+
+#define ROTL(x, b) (uint32_t)(((x) << (b)) | ((x) >> (32 - (b))))
+
+#define U32TO8_LE(p, v)                                                        \
+    (p)[0] = (uint8_t)((v));                                                   \
+    (p)[1] = (uint8_t)((v) >> 8);                                              \
+    (p)[2] = (uint8_t)((v) >> 16);                                             \
+    (p)[3] = (uint8_t)((v) >> 24);
+
+#define U8TO32_LE(p)                                                           \
+    (((uint32_t)((p)[0])) | ((uint32_t)((p)[1]) << 8) |                        \
+     ((uint32_t)((p)[2]) << 16) | ((uint32_t)((p)[3]) << 24))
+
+class GenHash {
+    uint32_t v0 = 0;
+    uint32_t v1 = 0;
+    uint32_t v2 = UINT32_C(0x6c796765);
+    uint32_t v3 = UINT32_C(0x74656462);
+    uint32_t total_length = 0;
+
+    void sipround() {
+        v0 += v1;
+        v1 = ROTL(v1, 5);
+        v1 ^= v0;
+        v0 = ROTL(v0, 16);
+        v2 += v3;
+        v3 = ROTL(v3, 8);
+        v3 ^= v2;
+        v0 += v3;
+        v3 = ROTL(v3, 7);
+        v3 ^= v0;
+        v2 += v1;
+        v1 = ROTL(v1, 13);
+        v1 ^= v2;
+        v2 = ROTL(v2, 16);
+    }
+
+    void c_rounds() {
+        sipround();
+    }
+
+    void d_rounds() {
+        sipround();
+        sipround();
+        sipround();
+    }
+
+
+    void hash(const void *in, size_t inlen) {
+        unsigned char *ni = (unsigned char *)in;
+        const unsigned char *end = ni + inlen - (inlen % sizeof(uint32_t));
+
+        total_length += inlen;
+
+        for (; ni != end; ni += 4) {
+            uint32_t m = U8TO32_LE(ni);
+            v3 ^= m;
+            c_rounds();
+            v0 ^= m;
+        }
+
+        if (int left = inlen & 3) {
+            uint32_t b = ((uint32_t)inlen) << 24;
+            switch (left) {
+            case 3:
+                b |= ((uint32_t)ni[2]) << 16;
+                Z3_fallthrough;
+            case 2:
+                b |= ((uint32_t)ni[1]) << 8;
+                Z3_fallthrough;
+            case 1:
+                b |= ((uint32_t)ni[0]);
+                break;
+            }
+            v3 ^= b;
+            c_rounds();
+            v0 ^= b;
+        }
+    }
+
+public:
+    void add(int v) {
+        hash(&v, sizeof(v));
+    }
+
+    void add(unsigned v) {
+        hash(&v, sizeof(v));
+    }
+
+    void add(uint64_t v) {
+        hash(&v, sizeof(v));
+    }
+
+    void add(double v) {
+        hash(&v, sizeof(v));
+    }
+
+    void add(const std::string &str) {
+        hash(str.c_str(), str.size());
+    }
+
+    void add(const void *ptr, size_t sz) {
+        hash(ptr, sz);
+    }
+
+    unsigned operator()() {
+        uint32_t b = total_length << 24;
+        v3 ^= b;
+        c_rounds();
+        v0 ^= b;
+
+        v2 ^= 0xff;
+        d_rounds();
+        b = v1 ^ v3;
+
+        uint8_t array[4];
+        U32TO8_LE(array, b);
+        unsigned out;
+        std::memcpy(&out, array, sizeof(out));
+        return out;
+    }
+};
+
+
+
 
 #define mix(a,b,c)              \
 {                               \

--- a/src/util/hash.h
+++ b/src/util/hash.h
@@ -72,12 +72,11 @@ class GenHash {
         sipround();
     }
 
-
     void hash(const void *in, size_t inlen) {
         unsigned char *ni = (unsigned char *)in;
         const unsigned char *end = ni + inlen - (inlen % sizeof(uint32_t));
 
-        total_length += inlen;
+        total_length += (uint32_t)inlen;
 
         for (; ni != end; ni += 4) {
             uint32_t m = U8TO32_LE(ni);
@@ -147,7 +146,6 @@ public:
         return out;
     }
 };
-
 
 
 

--- a/src/util/mpq.h
+++ b/src/util/mpq.h
@@ -558,6 +558,11 @@ public:
         mod(a.m_num, b.m_num, c);
     }
 
+    static void addHash(GenHash &hash, const mpq &a) {
+        mpz_manager<SYNCH>::addHash(hash, a.m_num);
+        mpz_manager<SYNCH>::addHash(hash, a.m_den);
+    }
+
     static unsigned hash(mpz const & a) { return mpz_manager<SYNCH>::hash(a); }
 
     static unsigned hash(mpq const & a) { return hash(a.m_num) + 3*hash(a.m_den); }

--- a/src/util/mpz.cpp
+++ b/src/util/mpz.cpp
@@ -1848,6 +1848,19 @@ std::string mpz_manager<SYNCH>::to_string(mpz const & a) const {
 }
 
 template<bool SYNCH>
+void mpz_manager<SYNCH>::addHash(GenHash &hash, const mpz &a) {
+    if (is_small(a)) {
+        hash.add(a.m_val);
+    } else {
+#ifndef _MP_GMP
+        hash.add(digits(a), size(a) * sizeof(digit_t));
+#else
+        hash.add(mpz_get_si(*a.m_ptr));
+#endif
+    }
+}
+
+template<bool SYNCH>
 unsigned mpz_manager<SYNCH>::hash(mpz const & a) {
     if (is_small(a))
         return ::abs(a.m_val);

--- a/src/util/mpz.h
+++ b/src/util/mpz.h
@@ -619,6 +619,7 @@ public:
     */
     void display_bin(std::ostream & out, mpz const & a, unsigned num_bits) const;
 
+    static void addHash(GenHash &hash, const mpz &a);
 
     static unsigned hash(mpz const & a);
 

--- a/src/util/rational.h
+++ b/src/util/rational.h
@@ -80,6 +80,10 @@ public:
 
     bool is_big() const { return !is_small(); }
     
+    void addHash(GenHash &hash) const {
+        m().addHash(hash, m_val);
+    }
+
     unsigned hash() const { return m().hash(m_val); }
 
     struct hash_proc {  unsigned operator()(rational const& r) const { return r.hash(); }  };

--- a/src/util/symbol.cpp
+++ b/src/util/symbol.cpp
@@ -204,3 +204,12 @@ bool lt(symbol const & s1, symbol const & s2) {
     return cmp < 0;
 }
 
+void symbol::addHash(GenHash &hash) const {
+    if (is_numerical()) {
+        hash.add(get_num());
+    } else if (bare_str() == nullptr) {
+        hash.add(0);
+    } else {
+        hash.add(bare_str(), strlen(bare_str()));
+    }
+}

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -21,6 +21,7 @@ Revision History:
 #include <string>
 #include <ostream>
 
+#include "util/hash.h"
 #include "util/util.h"
 #include "util/tptr.h"
 #include "util/string_buffer.h"
@@ -126,6 +127,7 @@ public:
         }
         return target;
     }
+    void addHash(GenHash &hash) const;
 };
 
 struct symbol_hash_proc {

--- a/src/util/zstring.cpp
+++ b/src/util/zstring.cpp
@@ -238,8 +238,8 @@ zstring zstring::extract(unsigned offset, unsigned len) const {
     return result;
 }
 
-unsigned zstring::hash() const {
-    return unsigned_ptr_hash(m_buffer.data(), m_buffer.size(), 23);
+void zstring::addHash(GenHash &hash) const {
+    hash.add(m_buffer.data(), m_buffer.size());
 }
 
 zstring zstring::operator+(zstring const& other) const {

--- a/src/util/zstring.h
+++ b/src/util/zstring.h
@@ -83,7 +83,7 @@ public:
     zstring operator+(zstring const& other) const;
     bool operator==(const zstring& other) const;
     bool operator!=(const zstring& other) const;
-    unsigned hash() const;
+    void addHash(GenHash &hash) const;
 
     friend std::ostream& operator<<(std::ostream &os, const zstring &str);
     friend bool operator<(const zstring& lhs, const zstring& rhs);


### PR DESCRIPTION
I've been hitting a bunch of cases where I see billions of AST hash collisions and then the run time goes through the roof.
We've partially offset this by increasing the initial AST hash table size, but I still many bad collisions.

This patch changes the code a bit to use a more modern API, where we have a hasher collecting data, and then there's a final mixing step.
I've used the half SipHash-1-3 (https://en.wikipedia.org/wiki/SipHash) to get started.

I'll benchmarks multiple algorithms. This one works well (in terms of number of collisions), but it's a bit slow.