### PR TITLE
Clear up Z3_LIBRARY_PATH error message

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1887,10 +1887,10 @@ if _lib is None:
   print("  - to the custom Z3_LIB_DIRS Python-builtin before importing the z3 module, e.g. via")
   if sys.version < '3':
     print("    import __builtin__")
-    print("    __builtin__.Z3_LIB_DIRS = [ '/path/to/libz3.%s' ] " % _ext)
+    print("    __builtin__.Z3_LIB_DIRS = [ '/path/to/z3/lib/dir' ] \# directory containing libz3.%s" % _ext)
   else:
     print("    import builtins")
-    print("    builtins.Z3_LIB_DIRS = [ '/path/to/libz3.%s' ] " % _ext)
+    print("    builtins.Z3_LIB_DIRS = [ '/path/to/z3/lib/dir' ] \# directory containing libz3.%s" % _ext)
   print(_failures)
   raise Z3Exception("libz3.%s not found." % _ext)
 


### PR DESCRIPTION
The following error message:
```
to the custom Z3_LIB_DIRS Python-builtin before importing the z3 module, e.g. via
   import __builtin__
   __builtin__.Z3_LIB_DIRS = [ '/path/to/libz3.dll' ]
```
can be misread, making people enter the path to the `libz3.dll` in `Z3_LIB_DIRS`, instead of the parent folder. Maybe we can help by changing the example slightly?