### PR TITLE
increase wasm stack size

### DIFF
--- a/src/api/js/scripts/build-wasm.ts
+++ b/src/api/js/scripts/build-wasm.ts
@@ -69,7 +69,7 @@ const fns = JSON.stringify(exportedFuncs());
 const methods = '["ccall","FS","allocate","UTF8ToString","intArrayFromString","ALLOC_NORMAL"]';
 const libz3a = path.normalize('../../../build/libz3.a');
 spawnSync(
-  `emcc build/async-fns.cc ${libz3a} --std=c++20 --pre-js src/low-level/async-wrapper.js -g2 -pthread -fexceptions -s WASM_BIGINT -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=0 -s PTHREAD_POOL_SIZE_STRICT=0 -s MODULARIZE=1 -s 'EXPORT_NAME="initZ3"' -s EXPORTED_RUNTIME_METHODS=${methods} -s EXPORTED_FUNCTIONS=${fns} -s DISABLE_EXCEPTION_CATCHING=0 -s SAFE_HEAP=0 -s DEMANGLE_SUPPORT=1 -s TOTAL_MEMORY=1GB -I z3/src/api/ -o build/z3-built.js`,
+  `emcc build/async-fns.cc ${libz3a} --std=c++20 --pre-js src/low-level/async-wrapper.js -g2 -pthread -fexceptions -s WASM_BIGINT -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=0 -s PTHREAD_POOL_SIZE_STRICT=0 -s MODULARIZE=1 -s 'EXPORT_NAME="initZ3"' -s EXPORTED_RUNTIME_METHODS=${methods} -s EXPORTED_FUNCTIONS=${fns} -s DISABLE_EXCEPTION_CATCHING=0 -s SAFE_HEAP=0 -s DEMANGLE_SUPPORT=1 -s TOTAL_MEMORY=1GB -s TOTAL_STACK=20MB -I z3/src/api/ -o build/z3-built.js`,
 );
 
 fs.rmSync(ccWrapperPath);


### PR DESCRIPTION
I have been using the z3-solver npm package and have come across an issue with very big benchmarks.

Specifically, the one that I've had issues with is ~10MB. Using either `solver.fromString` or `Z3.solver_from_string` results in the following error:

```
RuntimeError: memory access out of bounds
    at z3-built.wasm.strlen (wasm://wasm/z3-built.wasm-0779380e:wasm-function[31680]:0x18c955c)
    at z3-built.wasm.Z3_solver_from_string (wasm://wasm/z3-built.wasm-0779380e:wasm-function[889]:0x57f80)
    at apply (/home/lufy/VUT/IP1/z3-git/src/api/js/build/z3-built.js:1555:18)
    at Object.ccall (/home/lufy/VUT/IP1/z3-git/src/api/js/build/z3-built.js:6124:22)
    at Object.solver_from_string (/home/lufy/VUT/IP1/z3-git/src/api/js/build/low-level/wrapper.__GENERATED__.js:1455:28)
    at SolverImpl.fromString (/home/lufy/VUT/IP1/z3-git/src/api/js/build/high-level/high-level.js:945:20)
    at runZ3Worker (file:///home/lufy/VUT/IP1/src/run/z3.ts:81:10)
```

Indicating insufficient stack size.

I have tried working around this by using `Z3.solver_from_file`, but have been unable to make it work. The call fails with `file access error` for both absolute and relative paths. The only filenames that didn't cause this issue were `/`, `../`, `../..` and the like.