### PR TITLE
unit propagate more intensively in nl

### DIFF
--- a/src/math/lp/emonics.cpp
+++ b/src/math/lp/emonics.cpp
@@ -596,19 +596,5 @@ bool emonics::invariant() const {
 }
 
 
-void emonics::set_propagated(monic const& m) {
-    struct set_unpropagated : public trail {
-        emonics& em;
-        unsigned var;
-    public:
-        set_unpropagated(emonics& em, unsigned var): em(em), var(var) {}
-        void undo() override {
-            em[var].set_propagated(false);
-        }
-    };
-    SASSERT(!m.is_propagated());
-    (*this)[m.var()].set_propagated(true);
-    m_u_f_stack.push(set_unpropagated(*this, m.var()));
-}
 
 }

--- a/src/math/lp/emonics.h
+++ b/src/math/lp/emonics.h
@@ -141,9 +141,6 @@ public:
     
     void merge_eh(unsigned r2, unsigned r1, unsigned v2, unsigned v1) {}
     void after_merge_eh(unsigned r2, unsigned r1, unsigned v2, unsigned v1) {}
-
-    void set_propagated(monic const& m);
-
     // this method is required by union_find
     trail_stack & get_trail_stack() { return m_u_f_stack; }
 

--- a/src/math/lp/monic.h
+++ b/src/math/lp/monic.h
@@ -58,7 +58,6 @@ class monic: public mon_eq {
     svector<lpvar>   m_rvars;
     bool             m_rsign;
     mutable unsigned m_visited;
-    bool             m_propagated = false;
 public:
     // constructors
     monic(lpvar v, unsigned sz, lpvar const* vs, unsigned idx):  
@@ -75,8 +74,6 @@ public:
     void reset_rfields() { m_rsign = false; m_rvars.reset(); SASSERT(m_rvars.size() == 0); }
     void push_rvar(signed_var sv) { m_rsign ^= sv.sign(); m_rvars.push_back(sv.var()); }
     void sort_rvars() { std::sort(m_rvars.begin(), m_rvars.end()); }
-    void set_propagated(bool p) { m_propagated = p; }
-    bool is_propagated() const { return m_propagated; }
     
     svector<lpvar>::const_iterator begin() const { return vars().begin(); }
     svector<lpvar>::const_iterator end() const { return vars().end(); }

--- a/src/math/lp/monomial_bounds.cpp
+++ b/src/math/lp/monomial_bounds.cpp
@@ -303,8 +303,6 @@ namespace nla {
     }
 
     void monomial_bounds::unit_propagate(monic & m) {
-        if (m.is_propagated())
-            return;
         lpvar w, fixed_to_zero;
         if (!is_linear(m, w, fixed_to_zero)) {
 #if UNIT_PROPAGATE_BOUNDS
@@ -312,8 +310,6 @@ namespace nla {
 #endif            
             return;
         }
-
-        c().emons().set_propagated(m);
 
         if (fixed_to_zero != null_lpvar) {
             propagate_fixed_to_zero(m, fixed_to_zero);
@@ -338,6 +334,8 @@ namespace nla {
     }
     
     void monomial_bounds::propagate_fixed_to_zero(monic const& m, lpvar fixed_to_zero) {
+        if (c().var_is_fixed_to_zero(m.var())) return;
+        
         auto* dep = c().lra.get_bound_constraint_witnesses_for_column(fixed_to_zero);
         TRACE("nla_solver", tout << "propagate fixed " << m << " =  0, fixed_to_zero = " << fixed_to_zero << "\n";);
         c().lra.update_column_type_and_bound(m.var(), lp::lconstraint_kind::EQ, rational(0), dep);
@@ -348,6 +346,8 @@ namespace nla {
     }
 
     void monomial_bounds::propagate_fixed(monic const& m, rational const& k) {
+        if (c().var_is_fixed_to_val(m.var(), k)) return;
+        
         auto* dep = explain_fixed(m, k);
         TRACE("nla_solver", tout << "propagate fixed " << m << " = " << k << "\n";);
         c().lra.update_column_type_and_bound(m.var(), lp::lconstraint_kind::EQ, k, dep);


### PR DESCRIPTION
The unit propagation on monomials runs more intensively, based on the columns with changed bounds.
This change solves 1 more benchmark comparing with how many master solves on z3-solver-comparison: 21 against 20. 
It slightly improves centora benchmarks: three percent faster, gives less timeouts too.
The performance is 3.8 percent worser on QF_NIA, more timeouts as well. 
??