### PR TITLE
Update script to use importlib_resources

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1827,17 +1827,25 @@ def write_core_py_preamble(core_py):
   core_py.write(
 """
 # Automatically generated file
+import atexit
 import sys, os
+import contextlib
 import ctypes
-import pkg_resources
+import importlib_resources
 from .z3types import *
 from .z3consts import *
 
+_file_manager = contextlib.ExitStack()
+atexit.register(_file_manager.close)
 _ext = 'dll' if sys.platform in ('win32', 'cygwin') else 'dylib' if sys.platform == 'darwin' else 'so'
 _lib = None
+_z3_lib_resource = importlib_resources.files('z3', 'lib')
+_z3_lib_resource_path = _file_manager.enter_context(
+    importlib_resources.as_file(_z3_lib_resource)
+)
 _default_dirs = ['.',
                  os.path.dirname(os.path.abspath(__file__)),
-                 pkg_resources.resource_filename('z3', 'lib'),
+                 _z3_lib_resource_path,
                  os.path.join(sys.prefix, 'lib'),
                  None]
 _all_dirs = []


### PR DESCRIPTION
To avoid a deprecation warning, this change updates scripts/update_api.py to use 'importlib_resources' instead of 'pkg_resources'.

See https://setuptools.pypa.io/en/latest/pkg_resources.html and https://importlib-resources.readthedocs.io/en/latest/migration.html for more information.