### PR TITLE
fixed possible undefined variable assigment

### DIFF
--- a/src/math/polynomial/polynomial.cpp
+++ b/src/math/polynomial/polynomial.cpp
@@ -5648,7 +5648,7 @@ namespace polynomial {
             unsigned d0 = 0;
             unsigned d1 = n1 - n2;
             unsigned i  = 1;
-            unsigned n3;
+            unsigned n3 = 0;
             S.reset();
             while (true) {
                 // Compute Gh_{i+2}


### PR DESCRIPTION
On line 5690
 ```
n2 = n3
```
n3 gets a value on line 5657 only if is_zero is false.
On occurences where is_zero is true, n3 keeps its undefined value, potentially effecting n2 and the the rest of the calculations.
Simple fix of defining n3 = 0 - not effecting other calculations if value stays on 0 as it is only used in a '-' operation as the subtrahend.