### PR TITLE
z3.h: Don't include `stdio.h`

### DIFF
--- a/src/api/z3.h
+++ b/src/api/z3.h
@@ -20,7 +20,6 @@ Notes:
 
 #pragma once
 
-#include <stdio.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include "z3_macros.h"


### PR DESCRIPTION
This doesn't seem to actually be used or needed here.