### PR TITLE
cmake: Require cmake 3.16 or later.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Enforce some CMake policies
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.16)
 
 set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cxx_compiler_flags_overrides.cmake")
 project(Z3 VERSION 4.12.3.0 LANGUAGES CXX)


### PR DESCRIPTION
Support for requiring cmake < 3.4 may go away soon (according to a deprecation notice when building).

Ubuntu 20.04 provides cmake 3.16 and current is 3.27, so that seems like a reasonable version to require.