### PR TITLE
Fix syntax warning when using Python 3.12.

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1895,10 +1895,10 @@ if _lib is None:
   print("  - to the custom Z3_LIB_DIRS Python-builtin before importing the z3 module, e.g. via")
   if sys.version < '3':
     print("    import __builtin__")
-    print("    __builtin__.Z3_LIB_DIRS = [ '/path/to/z3/lib/dir' ] \# directory containing libz3.%s" % _ext)
+    print("    __builtin__.Z3_LIB_DIRS = [ '/path/to/z3/lib/dir' ] # directory containing libz3.%s" % _ext)
   else:
     print("    import builtins")
-    print("    builtins.Z3_LIB_DIRS = [ '/path/to/z3/lib/dir' ] \# directory containing libz3.%s" % _ext)
+    print("    builtins.Z3_LIB_DIRS = [ '/path/to/z3/lib/dir' ] # directory containing libz3.%s" % _ext)
   print(_failures)
   raise Z3Exception("libz3.%s not found." % _ext)
 


### PR DESCRIPTION
This happens when generating the Python API and you are using Python 3.12 in the build environment:

```
.../z3/scripts/update_api.py:1828: SyntaxWarning: invalid escape sequence '\#'
```

This was a `DeprecationWarning` previously, but Python 3.12 changed it to a `SyntaxWarning` to make it more visible. The release notes indicate that this will be a syntax error in the future.