### PR TITLE
Add __enter__ and __exit__ methods to Solver class in Python API

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -6955,6 +6955,13 @@ class Solver(Z3PPObject):
         if self.solver is not None and self.ctx.ref() is not None and Z3_solver_dec_ref is not None:
             Z3_solver_dec_ref(self.ctx.ref(), self.solver)
 
+    def __enter__(self):
+        self.push()
+        return self
+
+    def __exit__(self, *exc_info):
+        self.pop()
+
     def set(self, *args, **keys):
         """Set a configuration option.
         The method `help()` return a string containing all available options.


### PR DESCRIPTION
This pull request adds the `__enter__()` and `__exit__()` methods to the `Solver` class in Python API for implicit scope management. This allows the usage of the `with` statement as a more concise and safer alternative to explicitly calling the push() and pop() methods when appropriate.

Example usage:

```
from z3 import *

p, q = Bools('p q')

with Solver() as s:
    s.add(Implies(p, q))    
    with s:
        s.add(p)
        print(s.check(Not(q))) # unsat
    print(s.check(Not(q)))     # sat

print(s.assertions())          # []
```