### PR TITLE
Use built-in `importlib.resources` on Python 3.9+

### DIFF
--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -1831,7 +1831,10 @@ import atexit
 import sys, os
 import contextlib
 import ctypes
-import importlib_resources
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 from .z3types import *
 from .z3consts import *
 


### PR DESCRIPTION
Use built-in `importlib.resources` module rather than the external `importlib_resources` package on Python 3.9 and newer.  The latter is only intended as a backport for old Python versions, and since modern Linux distributions may no longer support such old Python versions, they also no longer provide importlib_resources (this is the case on Gentoo).

CC @rsetaluri 