### PR TITLE
tptr.h: Include `<cstdint>` once rather than twice.

### DIFF
--- a/src/util/tptr.h
+++ b/src/util/tptr.h
@@ -21,7 +21,6 @@ Revision History:
 
 #include <cstdint>
 #include "util/machine.h"
-#include <cstdint>
 
 #define TAG_SHIFT        PTR_ALIGNMENT
 #define ALIGNMENT_VALUE  (1 << PTR_ALIGNMENT)


### PR DESCRIPTION
One of these lines was added in: c9d8e646ed505a9cd4c84b2cb31d846b8588109f
The other was added in:  520e692a43c41e8981eb091494bef0297ecbe3c6

But we only need it once.