### PR TITLE
Disable Python compilation cache during build

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -3003,7 +3003,7 @@ def cp_z3py_to_build():
     # Compile Z3Py files
     if compileall.compile_dir(z3py_src, force=1) != 1:
         raise MKException("failed to compile Z3Py sources")
-    sys.pycache_prefix = sys.pycache_prefix_before
+    sys.pycache_prefix = pycache_prefix_before
     if is_verbose:
         print("Generated python bytecode")
     # Copy sources to build

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2994,9 +2994,16 @@ def cp_z3py_to_build():
         for f in files:
             if f.endswith('.pyc'):
                 rmf(os.path.join(root, f))
+    # We do not want a second copy of the compiled files in the system-wide cache,
+    # so we disable it temporarily. This is an issue with recent versions of MacOS
+    # where XCode's Python has a cache, but the build scripts don't have access to
+    # it (e.g. during OPAM package installation).
+    pycache_prefix_before = sys.pycache_prefix
+    sys.pycache_prefix = None
     # Compile Z3Py files
     if compileall.compile_dir(z3py_src, force=1) != 1:
         raise MKException("failed to compile Z3Py sources")
+    sys.pycache_prefix = sys.pycache_prefix_before
     if is_verbose:
         print("Generated python bytecode")
     # Copy sources to build


### PR DESCRIPTION
As the comment says, there are some very special circumstances, in which the Python cache is set, but not accessible, so we disable it during build script execution.

(For the curious, see also https://github.com/ocaml/opam-repository/pull/24897)