### PR TITLE
Revert "Disable Python compilation cache during build"

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2994,16 +2994,9 @@ def cp_z3py_to_build():
         for f in files:
             if f.endswith('.pyc'):
                 rmf(os.path.join(root, f))
-    # We do not want a second copy of the compiled files in the system-wide cache,
-    # so we disable it temporarily. This is an issue with recent versions of MacOS
-    # where XCode's Python has a cache, but the build scripts don't have access to
-    # it (e.g. during OPAM package installation).
-    pycache_prefix_before = sys.pycache_prefix
-    sys.pycache_prefix = None
     # Compile Z3Py files
     if compileall.compile_dir(z3py_src, force=1) != 1:
         raise MKException("failed to compile Z3Py sources")
-    sys.pycache_prefix = pycache_prefix_before
     if is_verbose:
         print("Generated python bytecode")
     # Copy sources to build


### PR DESCRIPTION
Reverts Z3Prover/z3#7052

Nightly: manylinux build:

Traceback (most recent call last):
  File "scripts/mk_make.py", line 18, in <module>
    mk_bindings(API_files)
  File "/__w/1/s/scripts/mk_util.py", line 3073, in mk_bindings
    cp_z3py_to_build()
  File "/__w/1/s/scripts/mk_util.py", line 3001, in cp_z3py_to_build
    pycache_prefix_before = sys.pycache_prefix
AttributeError: module 'sys' has no attribute 'pycache_prefix'
