### PR TITLE
Disable Python compilation cache during build

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2998,7 +2998,7 @@ def cp_z3py_to_build():
     # so we disable it temporarily. This is an issue with recent versions of MacOS
     # where XCode's Python has a cache, but the build scripts don't have access to
     # it (e.g. during OPAM package installation).
-    have_cache = hasattr(sys, 'pycache_prefix') and sys.pycache_prefix != None
+    have_cache = hasattr(sys, 'pycache_prefix') and sys.pycache_prefix is not None
     if have_cache:
         pycache_prefix_before = sys.pycache_prefix
         sys.pycache_prefix = None

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2994,9 +2994,19 @@ def cp_z3py_to_build():
         for f in files:
             if f.endswith('.pyc'):
                 rmf(os.path.join(root, f))
+    # We do not want a second copy of the compiled files in the system-wide cache,
+    # so we disable it temporarily. This is an issue with recent versions of MacOS
+    # where XCode's Python has a cache, but the build scripts don't have access to
+    # it (e.g. during OPAM package installation).
+    have_cache = hasattr(sys, 'pycache_prefix') and sys.pycache_prefix != None
+    if have_cache:
+        pycache_prefix_before = sys.pycache_prefix
+        sys.pycache_prefix = None
     # Compile Z3Py files
     if compileall.compile_dir(z3py_src, force=1) != 1:
         raise MKException("failed to compile Z3Py sources")
+    if have_cache:
+        sys.pycache_prefix = pycache_prefix_before
     if is_verbose:
         print("Generated python bytecode")
     # Copy sources to build


### PR DESCRIPTION
Updated version that checks for the existence of the `pycache_prefix` attribute, to make it work with older Pythons that don't have it.