### PR TITLE
conditionally depend on importlib_resources

### DIFF
--- a/src/api/python/setup.py
+++ b/src/api/python/setup.py
@@ -341,7 +341,7 @@ setup(
     license='MIT License',
     keywords=['z3', 'smt', 'sat', 'prover', 'theorem'],
     packages=['z3'],
-    install_requires = ['importlib-resources'],
+    install_requires = ["importlib-resources; python_version < '3.9'"],
     include_package_data=True,
     package_data={
         'z3': [os.path.join('lib', '*'), os.path.join('include', '*.h'), os.path.join('include', 'c++', '*.h')]


### PR DESCRIPTION
In Python >= 3.9, `importlib.resources` is available as part of the stdlib.

This change makes it so that the backport is only installed for Python versions where it is actually needed and used.

Relevant docs: https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers

Originally noticed here: https://github.com/cj81499/advent-of-code/pull/330#discussion_r1482498607