### PR TITLE
ci: Update `microsoft/setup-msbuild` to `v2` from `v1.3`.

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@v2
       - run: |
           md build
           cd build


### PR DESCRIPTION
This changes from using Node 16 to Node 20 internally, eliminating some deprecation warnings from within GitHub Actions.