### PR TITLE
some code cleaning and complexity improvements

### DIFF
--- a/src/api/ml/z3.ml
+++ b/src/api/ml/z3.ml
@@ -2086,7 +2086,14 @@ struct
 
   let mk_roots (ctx:context) (a:rcf_num list) =
     let n, r = Z3native.rcf_mk_roots ctx (List.length a) a in
-    List.filteri (fun i _v -> i < n) r
+    let _i, l =
+      (* keep only the first `n` elements of the list `r` *)
+      List.fold_left (fun (i, acc) x ->
+        if i = 0 then i, acc
+        else (i - 1, x :: acc)
+      ) (n, []) r
+    in
+    List.rev l
 
   let add (ctx:context) (a:rcf_num) (b:rcf_num) = Z3native.rcf_add ctx a b
   let sub (ctx:context) (a:rcf_num) (b:rcf_num) = Z3native.rcf_sub ctx a b

--- a/src/api/ml/z3native.ml.pre
+++ b/src/api/ml/z3native.ml.pre
@@ -4,36 +4,36 @@ open Z3enums
 
 (**/**)
 type ptr
-and symbol = ptr
-and config = ptr
-and context = ptr
-and ast = ptr
-and app = ast
-and sort = ast
-and func_decl = ast
-and pattern = ast
-and model = ptr
-and literals = ptr
-and constructor = ptr
-and constructor_list = ptr
-and solver = ptr
-and solver_callback = ptr
-and goal = ptr
-and tactic = ptr
-and simplifier = ptr
-and params = ptr
-and parser_context = ptr
-and probe = ptr
-and stats = ptr
-and ast_vector = ptr
-and ast_map = ptr
-and apply_result = ptr
-and func_interp = ptr
-and func_entry = ptr
-and fixedpoint = ptr
-and optimize = ptr
-and param_descrs = ptr
-and rcf_num = ptr
+type symbol = ptr
+type config = ptr
+type context = ptr
+type ast = ptr
+type app = ast
+type sort = ast
+type func_decl = ast
+type pattern = ast
+type model = ptr
+type literals = ptr
+type constructor = ptr
+type constructor_list = ptr
+type solver = ptr
+type solver_callback = ptr
+type goal = ptr
+type tactic = ptr
+type simplifier = ptr
+type params = ptr
+type parser_context = ptr
+type probe = ptr
+type stats = ptr
+type ast_vector = ptr
+type ast_map = ptr
+type apply_result = ptr
+type func_interp = ptr
+type func_entry = ptr
+type fixedpoint = ptr
+type optimize = ptr
+type param_descrs = ptr
+type rcf_num = ptr
 
 external set_internal_error_handler : ptr -> unit
   = "n_set_internal_error_handler"


### PR DESCRIPTION
Hi,

I was reading the code and decided to do three things:

- clean code with things should not be controversial and are clear improvements (first commit and second commit)
- fix the complexity of a few operations (the `List.filteri` and `List.compare_length_with` changes), one of them was quadratic for no good reason (second commit)
- explicit some parameters, this allows to get less false positives warnings of the kind "this argument will not be used by the function" when one still wants to enable warnings in its editor without having propoer support through the dune build system, this may be more controversial and I'm fine with removing it (third commit)

Thanks!