### PR TITLE
ci: Stop using deprecated `::set-output`.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,6 +90,7 @@ jobs:
     - name: Get date
       id: date
       run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This has been deprecated and the replacement functionality is described here:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/