### PR TITLE
Handle cross compile within manylinux

### DIFF
--- a/scripts/nightly.yaml
+++ b/scripts/nightly.yaml
@@ -203,6 +203,12 @@ stages:
       vmImage: "ubuntu-latest"
     container: "quay.io/pypa/manylinux2014_x86_64:latest"
     steps:
+    - script: yum install wget
+    - script: wget -q -O /tmp/arm-toolchain.tar.xz 'https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-aarch64-none-linux-gnu.tar.xz?rev=22c39fc25e5541818967b4ff5a09ef3e&hash=E7676169CE35FC2AAECF4C121E426083871CA6E5'
+    - script: tar xf /tmp/arm-toolchain.tar.xz -C /arm-toolchain/ --strip-components=1
+    - script: echo '##vso[task.prependpath]/arm-toolchain/bin'
+    - script: echo $PATH
+    - script: stat /arm-toolchain/bin/aarch64-none-linux-gnu-gcc
     - task: PythonScript@0
       displayName: Build
       inputs:


### PR DESCRIPTION
I reproduce the issue in python build process that manylinux does not understand cross compiling.

Current manylinux build method is on Centos 7, so we need to download ARM GNU toolchain. Once the toolchain is installed, we can point CC and CXX to the cross compiling toolchain for cross-compiling.

I am not familiar with Azure Devops pipeline, i try my best to install wget, download ARM GNU toolchain, and then update the path for subsequent task to have updated path to point to toolchain. 

Note: I don't have any good idea how to run the cross-compiled binary to handle the test. since it's already insider docker (running docker within docker is a headache. the centos 7 distro doesn't really have a corresponding qemu-user-static. building that from source will balloon the build time)