### PR TITLE
Downgrade arm cross compile toolchain to glibc 2.34

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,10 +52,11 @@ jobs:
     vmImage: "ubuntu-latest"
   container: "quay.io/pypa/manylinux2014_x86_64:latest"
   steps:
-  - script: curl -L -o /tmp/arm-toolchain.tar.xz 'https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-aarch64-none-linux-gnu.tar.xz?rev=22c39fc25e5541818967b4ff5a09ef3e&hash=E7676169CE35FC2AAECF4C121E426083871CA6E5'
+  - script: curl -L -o /tmp/arm-toolchain.tar.xz 'https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-x86_64-aarch64-none-linux-gnu.tar.xz?rev=33c6e30e5ac64e6dba8f0431f2c35f1b&hash=9918A05BF47621B632C7A5C8D2BB438FB80A4480'
   - script: mkdir -p /tmp/arm-toolchain/
   - script: tar xf /tmp/arm-toolchain.tar.xz -C /tmp/arm-toolchain/ --strip-components=1
   - script: echo '##vso[task.prependpath]/tmp/arm-toolchain/bin'
+  - script: echo '##vso[task.prependpath]/tmp/arm-toolchain/aarch64-none-linux-gnu/libc/usr/bin'
   - script: echo $PATH
   - script: stat /tmp/arm-toolchain/bin/aarch64-none-linux-gnu-gcc
   - task: PythonScript@0
@@ -64,15 +65,6 @@ jobs:
       scriptSource: 'filepath'
       scriptPath: scripts/mk_unix_dist.py
       arguments: --nodotnet --nojava --arch=arm64
-      pythonInterpreter: $(python)
-  - script: git clone https://github.com/z3prover/z3test z3test
-    displayName: 'Clone z3test'
-  - task: PythonScript@0
-    displayName: Test
-    inputs:
-      scriptSource: 'filepath'
-      scriptPath: z3test/scripts/test_benchmarks.py
-      arguments: build-dist/z3 z3test/regressions/smt2
       pythonInterpreter: $(python)
   - task: CopyFiles@2
     inputs:

--- a/scripts/nightly.yaml
+++ b/scripts/nightly.yaml
@@ -203,10 +203,11 @@ stages:
       vmImage: "ubuntu-latest"
     container: "quay.io/pypa/manylinux2014_x86_64:latest"
     steps:
-    - script: curl -L -o /tmp/arm-toolchain.tar.xz 'https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-aarch64-none-linux-gnu.tar.xz?rev=22c39fc25e5541818967b4ff5a09ef3e&hash=E7676169CE35FC2AAECF4C121E426083871CA6E5'
+    - script: curl -L -o /tmp/arm-toolchain.tar.xz 'https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-x86_64-aarch64-none-linux-gnu.tar.xz?rev=33c6e30e5ac64e6dba8f0431f2c35f1b&hash=9918A05BF47621B632C7A5C8D2BB438FB80A4480'
     - script: mkdir -p /tmp/arm-toolchain/
     - script: tar xf /tmp/arm-toolchain.tar.xz -C /tmp/arm-toolchain/ --strip-components=1
     - script: echo '##vso[task.prependpath]/tmp/arm-toolchain/bin'
+    - script: echo '##vso[task.prependpath]/tmp/arm-toolchain/aarch64-none-linux-gnu/libc/usr/bin'
     - script: echo $PATH
     - script: stat /tmp/arm-toolchain/bin/aarch64-none-linux-gnu-gcc
     - task: PythonScript@0


### PR DESCRIPTION
I discover the most recent toolchain is built against glibc 2.36, this will defeat the purpose of manylinux.  (too new)

I find a lower version that is built against glibc 2.34. 

The original pypa-manylinux_2014 is built against glibc 2.17 but that is going to EOL by 2024-06-30.

The really old ARM toolchain has its own pain, so let's settle for glibc 2.34 for cross compiling.

I also plumb the correct glibc information during packaging so it reflect the version from the cross compile toolchain.

Bonus fix: native host aarch64 compiling, so those that need to build their own wheel can easily fire up the container on their own arch to build custom wheel in their own package repository.

