### PR TITLE
fix (get-proof) command to respect option pp.simplify_implies

### DIFF
--- a/src/ast/ast_smt_pp.cpp
+++ b/src/ast/ast_smt_pp.cpp
@@ -986,7 +986,7 @@ void ast_smt_pp::display_smt2(std::ostream& strm, expr* n) {
     ast_mark sort_mark;
     for (sort* s : decls.get_sorts()) {
         if (!(*m_is_declared)(s)) {
-            smt_printer p(strm, m, ql, rn, m_logic, true, true, m_simplify_implies, 0);
+            smt_printer p(strm, m, ql, rn, m_logic, true, m_simplify_implies, 0);
             p.pp_sort_decl(sort_mark, s);
         }
     }
@@ -994,7 +994,7 @@ void ast_smt_pp::display_smt2(std::ostream& strm, expr* n) {
     for (unsigned i = 0; i < decls.get_num_decls(); ++i) {
         func_decl* d = decls.get_func_decls()[i];
         if (!(*m_is_declared)(d)) {
-            smt_printer p(strm, m, ql, rn, m_logic, true, true, m_simplify_implies, 0);
+            smt_printer p(strm, m, ql, rn, m_logic, true, m_simplify_implies, 0);
             p(d);
             strm << "\n";
         }
@@ -1003,20 +1003,20 @@ void ast_smt_pp::display_smt2(std::ostream& strm, expr* n) {
 #endif
 
     for (expr* a : m_assumptions) {
-        smt_printer p(strm, m, ql, rn, m_logic, false, true, m_simplify_implies, 1);
+        smt_printer p(strm, m, ql, rn, m_logic, false, m_simplify_implies, 1);
         strm << "(assert\n ";
         p(a);
         strm << ")\n";
     }
 
     for (expr* a : m_assumptions_star) {
-        smt_printer p(strm, m, ql, rn, m_logic, false, true, m_simplify_implies, 1);
+        smt_printer p(strm, m, ql, rn, m_logic, false, m_simplify_implies, 1);
         strm << "(assert\n ";
         p(a);
         strm << ")\n";
     }
 
-    smt_printer p(strm, m, ql, rn, m_logic, false, true, m_simplify_implies, 0);
+    smt_printer p(strm, m, ql, rn, m_logic, false, m_simplify_implies, 0);
     if (m.is_bool(n)) {
         if (!m.is_true(n)) {
             strm << "(assert\n ";

--- a/src/cmd_context/basic_cmds.cpp
+++ b/src/cmd_context/basic_cmds.cpp
@@ -202,6 +202,7 @@ ATOMIC_CMD(get_proof_cmd, "get-proof", "retrieve proof", {
         cmd_is_declared isd(ctx);
         pp.set_is_declared(&isd);
         pp.set_logic(ctx.get_logic());
+        pp.set_simplify_implies(params.simplify_implies());
         pp.display_smt2(ctx.regular_stream(), pr);
         ctx.regular_stream() << std::endl;
     }


### PR DESCRIPTION
This PR contains two parts:

1. Change to `src/cmd_context/basic_cmds.cpp`:

This change makes the `pp.simplify_implies` parameter work when using the `(get-proof)` command.

It is important that the `pp.simplify_implies` feature can be disabled by the user, because otherwise the pretty-printer will mangle the `(asserted ...)` proof rules in the proof output, which means that the terms in these rules will not match the actual terms that were asserted in the input file, therefore making reconstructing the Z3 proof significantly more difficult in some cases.

As a historical note, this issue has been breaking proof reconstruction in HOL4's HolSmt implementation (for some inputs) for at least 13 years, if not more.

2. Changes to `src/ast/ast_smt_pp.cpp`:

This fixes some bugs introduced around 6 years ago which are now preventing the `simplify_implies` parameter from being passed down from `ast_smt_pp` objects to `smt_printer` objects.

Specifically, commit b8e5fc9f435f6c67de4c9ea78298ac567dd40502 removed the `bool is_smt2` parameter from the constructor of the `smt_printer` class. Some places which constructed instances of this class were fixed to remove this parameter.

However, in other places, this parameter was not removed, thus all subsequent parameters were shifted one place to the right.

This means that in some places where `ast_smt_pp` objects were initializing the `smt_printer` class by passing the `m_simplify_implies` variable to the `simplify_implies` parameter, the variable was actually being passed to the `indent` parameter instead, while the `simplify_implies` parameter was always being initialized to `true` (which was meant to initialize the `is_smt2` parameter that the commit removed).
