### PR TITLE
Add check for libatomic requirement to Python build system

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -314,6 +314,23 @@ def test_fpmath(cc):
         FPMATH_FLAGS=""
         return "UNKNOWN"
 
+def test_atomic_required(cc):
+    t = TempFile('tstatomic.cpp')
+    t.add("""
+    #include <atomic>
+    std::atomic<int> x;
+    std::atomic<short> y;
+    std::atomic<char> z;
+    std::atomic<long long> w;
+    int main() {
+        ++z;
+        ++y;
+        ++w;
+        return ++x;
+    }")
+    """)
+    t.commit()
+    return exec_compiler_cmd([cc, CPPFLAGS, '', 'tstatomic.cpp', LDFLAGS, '']) != 0
 
 def find_jni_h(path):
     for root, dirs, files in os.walk(path):
@@ -555,19 +572,19 @@ def set_version(major, minor, build, revision):
             print("Set Assembly Version (BUILD):", VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK)
             return
 
-    # use parameters to set up version if not provided by script args            
+    # use parameters to set up version if not provided by script args
     VER_MAJOR = major
     VER_MINOR = minor
     VER_BUILD = build
     VER_TWEAK = revision
 
-    # update VER_TWEAK base on github     
+    # update VER_TWEAK base on github
     if GIT_DESCRIBE:
         branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
         VER_TWEAK = int(check_output(['git', 'rev-list', '--count', 'HEAD']))
-    
+
     print("Set Assembly Version (DEFAULT):", VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK)
-    
+
 def get_version():
     return (VER_MAJOR, VER_MINOR, VER_BUILD, VER_TWEAK)
 
@@ -1858,7 +1875,7 @@ class JavaDLLComponent(Component):
                           os.path.join('api', 'java', 'Native'))
             elif IS_OSX and IS_ARCH_ARM64:
                 out.write('\t$(SLINK) $(SLINK_OUT_FLAG)libz3java$(SO_EXT) $(SLINK_FLAGS) -arch arm64 %s$(OBJ_EXT) libz3$(SO_EXT)\n' %
-                          os.path.join('api', 'java', 'Native'))                
+                          os.path.join('api', 'java', 'Native'))
             else:
                 out.write('\t$(SLINK) $(SLINK_OUT_FLAG)libz3java$(SO_EXT) $(SLINK_FLAGS) %s$(OBJ_EXT) libz3$(SO_EXT)\n' %
                           os.path.join('api', 'java', 'Native'))
@@ -2600,6 +2617,9 @@ def mk_config():
         CXXFLAGS = '%s -fvisibility=hidden -fvisibility-inlines-hidden -c' % CXXFLAGS
         FPMATH = test_fpmath(CXX)
         CXXFLAGS = '%s %s' % (CXXFLAGS, FPMATH_FLAGS)
+        atomic_required = test_atomic_required(CXX)
+        if atomic_required:
+            LDFLAGS  = '%s -latomic' % LDFLAGS
         if LOG_SYNC:
             CXXFLAGS = '%s -DZ3_LOG_SYNC' % CXXFLAGS
         if SINGLE_THREADED:
@@ -2710,6 +2730,7 @@ def mk_config():
             print('Prefix:         %s' % PREFIX)
             print('64-bit:         %s' % is64())
             print('FP math:        %s' % FPMATH)
+            print('libatomic:      %s' % ('required' if atomic_required else 'not required'))
             print("Python pkg dir: %s" % PYTHON_PACKAGE_DIR)
             if GPROF:
                 print('gprof:          enabled')
@@ -2854,7 +2875,7 @@ def update_version():
     revision = VER_TWEAK
 
     print("UpdateVersion:", get_full_version_string(major, minor, build, revision))
-    
+
     if major is None or minor is None or build is None or revision is None:
         raise MKException("set_version(major, minor, build, revision) must be used before invoking update_version()")
     if not ONLY_MAKEFILES:
@@ -3068,7 +3089,7 @@ def mk_bindings(api_files):
           z3py_output_dir=get_z3py_dir(),
           dotnet_output_dir=dotnet_output_dir,
           java_input_dir=java_input_dir,
-          java_output_dir=java_output_dir,                                  
+          java_output_dir=java_output_dir,
           java_package_name=java_package_name,
           ml_output_dir=ml_output_dir,
           ml_src_dir=ml_output_dir

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -327,7 +327,7 @@ def test_atomic_required(cc):
         ++y;
         ++w;
         return ++x;
-    }")
+    }
     """)
     t.commit()
     fails_without = exec_compiler_cmd([cc, CPPFLAGS, '', 'tstatomic.cpp', LDFLAGS, '']) != 0

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -330,7 +330,10 @@ def test_atomic_required(cc):
     }")
     """)
     t.commit()
-    return exec_compiler_cmd([cc, CPPFLAGS, '', 'tstatomic.cpp', LDFLAGS, '']) != 0
+    fails_without = exec_compiler_cmd([cc, CPPFLAGS, '', 'tstatomic.cpp', LDFLAGS, '']) != 0
+    ok_with = exec_compiler_cmd([cc, CPPFLAGS, '', 'tstatomic.cpp', LDFLAGS + ' -latomic', '']) == 0
+    return fails_without and ok_with
+
 
 def find_jni_h(path):
     for root, dirs, files in os.walk(path):


### PR DESCRIPTION
Same check as in cmake, to determine whether we need -latomic. This fixes the Opam build on RISC V and other toolchains that use GCC.

Fixes #7181