### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ python scripts/mk_make.py
 or instead, for a 64-bit build:
 
 ```bash
-python scripts/mk_make.py -x
+python scripts/mk_make.py opt=-x
 ```
 
 then:


### PR DESCRIPTION
Minor change suggestion.
It seems that it is needed to add opt=-x for running the make script in a x64 machine.