### PR TITLE
new hashtable.h invariants

### DIFF
--- a/src/test/dlist.cpp
+++ b/src/test/dlist.cpp
@@ -1,3 +1,20 @@
+/*++
+Copyright (c) 2024 Microsoft Corporation
+
+Module Name:
+
+    tst_dlist.cpp
+
+Abstract:
+
+    Test dlist module
+
+Author:
+
+    Chuyue Sun 2024-07-18.
+
+--*/
+
 #include <cassert>
 #include <iostream>
 #include "util/dlist.h"

--- a/src/util/hashtable.h
+++ b/src/util/hashtable.h
@@ -12,6 +12,7 @@ Abstract:
 Author:
 
     Leonardo de Moura (leonardo) 2006-09-11.
+    Chuyue Sun (liviasun) 2024-07-18.
 
 Revision History:
 

--- a/src/util/hashtable.h
+++ b/src/util/hashtable.h
@@ -639,6 +639,19 @@ public:
 
 #ifdef Z3DEBUG
     bool check_invariant() {
+        // The capacity must always be a power of two.
+        if (!is_power_of_two(m_capacity))
+            return false;
+
+        // The number of deleted plus the size must not exceed the capacity.
+        if (m_num_deleted + m_size > m_capacity)
+            return false;
+
+        // Checking that m_num_deleted is less than or equal to m_size.
+        if (m_num_deleted > m_size) {
+            return false;
+        }
+
         entry * curr = m_table;
         entry * end  = m_table + m_capacity;
         unsigned num_deleted = 0;


### PR DESCRIPTION
-  new invariant 1:  The capacity must always be a power of two.
-  new invariant 2:  The number of deleted plus the size must not exceed the capacity.
-  new invariant 3:  Checking that m_num_deleted is less than or equal to m_size.
