### PR TITLE
Set the SA_ONSTACK flag for SIGINT handlers

### DIFF
--- a/src/util/scoped_ctrl_c.cpp
+++ b/src/util/scoped_ctrl_c.cpp
@@ -21,37 +21,48 @@ Revision History:
 
 static scoped_ctrl_c * g_obj = nullptr;
 
+static void (*signal_sigint(void (*eh)(int)))(int) {
+    void (*old_eh)(int);
+    struct sigaction action;
+    sigaction(SIGINT, NULL, &action);
+    old_eh = action.sa_handler;
+    action.sa_handler = eh;
+    action.sa_flags |= SA_ONSTACK;
+    sigaction(SIGINT, &action, NULL);
+    return old_eh;
+}
+
 static void on_ctrl_c(int) {
     if (g_obj->m_first) {
         g_obj->m_cancel_eh(CTRL_C_EH_CALLER);
         if (g_obj->m_once) {
             g_obj->m_first = false;
-            signal(SIGINT, on_ctrl_c); // re-install the handler
+            signal_sigint(on_ctrl_c); // re-install the handler
         }
     }
     else {
-        signal(SIGINT, g_obj->m_old_handler); 
+        signal_sigint(g_obj->m_old_handler);
         raise(SIGINT);
     }
 }
 
 scoped_ctrl_c::scoped_ctrl_c(event_handler & eh, bool once, bool enabled):
-    m_cancel_eh(eh), 
+    m_cancel_eh(eh),
     m_first(true),
     m_once(once),
     m_enabled(enabled),
     m_old_scoped_ctrl_c(g_obj) {
     if (m_enabled) {
         g_obj = this;
-        m_old_handler = signal(SIGINT, on_ctrl_c); 
+        m_old_handler = signal_sigint(on_ctrl_c);
     }
 }
 
-scoped_ctrl_c::~scoped_ctrl_c() { 
+scoped_ctrl_c::~scoped_ctrl_c() {
     if (m_enabled) {
         g_obj = m_old_scoped_ctrl_c;
         if (m_old_handler != SIG_ERR) {
-            signal(SIGINT, m_old_handler);
+            signal_sigint(m_old_handler);
         }
     }
 }


### PR DESCRIPTION
Golang requires the `SA_ONSTACK` flag to be set on all signal handlers (https://pkg.go.dev/os/signal#hdr-Go_programs_that_use_cgo_or_SWIG). This commit adds the `SA_ONSTACK` flag to `SIGINT` handlers in `src/util/scoped_ctrl_c.cpp`. Although signals are registered in other parts of the code base, they are not exposed through the C api (i.e., in `/src/test`, `/src/shell`, and `/src/api`).

Issue reported in #7305