### PR TITLE
Fix SIGINT handler to use sigaction with SA_ONSTACK flag

### DIFF
--- a/src/util/scoped_ctrl_c.h
+++ b/src/util/scoped_ctrl_c.h
@@ -20,13 +20,14 @@ Revision History:
 
 #include "util/event_handler.h"
 #include "util/util.h"
+#include <signal.h>
 
 struct scoped_ctrl_c {
     event_handler & m_cancel_eh;
     bool m_first;
     bool m_once;
     bool m_enabled;
-    void  (STD_CALL *m_old_handler)(int);
+    struct sigaction m_old_action;
     scoped_ctrl_c * m_old_scoped_ctrl_c;
 public:
     // If once == true, then the cancel_eh is invoked only at the first Ctrl-C.
@@ -36,4 +37,3 @@ public:
     ~scoped_ctrl_c();
     void reset() { m_first = true; }
 };
-


### PR DESCRIPTION
Related to #7305

Update SIGINT signal handler to use `sigaction` with `SA_ONSTACK` flag.

* Replace `signal` function with `sigaction` function in `src/util/scoped_ctrl_c.cpp` to register the SIGINT handler.
* Set the `SA_ONSTACK` flag for the SIGINT signal handler in `src/util/scoped_ctrl_c.cpp`.
* Update `on_ctrl_c` function to use `sigaction` in `src/util/scoped_ctrl_c.cpp`.
* Modify `scoped_ctrl_c` struct in `src/util/scoped_ctrl_c.h` to include `struct sigaction m_old_action` instead of `void (STD_CALL *m_old_handler)(int)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Z3Prover/z3/issues/7305?shareId=e00543fa-583e-4b92-affa-e8a73d553547).