### PR TITLE
Migrate string_buffer to use C++ smart pointer.

### DIFF
--- a/src/tactic/aig/aig_tactic.cpp
+++ b/src/tactic/aig/aig_tactic.cpp
@@ -27,24 +27,21 @@ class aig_manager;
 class aig_tactic : public tactic {
     unsigned long long m_max_memory;
     bool               m_aig_gate_encoding;
-    aig_manager *      m_aig_manager;
+    std::unique_ptr<aig_manager> m_aig_manager;
 
     struct mk_aig_manager {
         aig_tactic & m_owner;
 
         mk_aig_manager(aig_tactic & o, ast_manager & m):m_owner(o) {
             aig_manager * mng = alloc(aig_manager, m, o.m_max_memory, o.m_aig_gate_encoding);
-            m_owner.m_aig_manager = mng;            
+            m_owner.m_aig_manager.reset(mng);  
         }
         
-        ~mk_aig_manager() {
-            dealloc(m_owner.m_aig_manager);
-            m_owner.m_aig_manager = nullptr;
-        }
+        ~mk_aig_manager() {}
     };
 
 public:
-    aig_tactic(params_ref const & p = params_ref()):m_aig_manager(nullptr) {
+    aig_tactic(params_ref const & p = params_ref()) {
         updt_params(p); 
     }
 

--- a/src/test/string_buffer.cpp
+++ b/src/test/string_buffer.cpp
@@ -45,8 +45,18 @@ static void tst3() {
   ENSURE(strcmp(b.c_str(), "Hello World") == 0);
 }
 
+static void tst_small_buffer_expand(){
+  string_buffer<4> b;
+  b << "Hello";
+  ENSURE(strcmp(b.c_str(), "Hello") == 0);
+
+  b << " World";
+  ENSURE(strcmp(b.c_str(), "Hello World") == 0);
+}
+
 void tst_string_buffer() {
   tst1();
   tst2();
   tst3();
+  tst_small_buffer_expand();
 }


### PR DESCRIPTION
1. `string_buffer` class is now migrated to use smart pointers instead of manually allocated and deallocated memory.
The `buffer` function decides and returns if the buffer is currently using initial buffer or the allocated buffer.
2. Added `tst_small_buffer_expand` to test memory expansion of the small buffer, i.e., the test forces the buffer to go from `m_initial_buffer` to dynamically allocated `m_buffer`. 