### PR TITLE
Avoid broken stack at few places

### DIFF
--- a/src/nlsat/nlsat_solver.cpp
+++ b/src/nlsat/nlsat_solver.cpp
@@ -2835,7 +2835,7 @@ namespace nlsat {
         struct degree_lit_num_lt {
             unsigned_vector & m_degrees;
             unsigned_vector & m_lit_num;
-            degree_lit_num_lt(unsigned_vector & ds, unsigned_vector ln) :
+            degree_lit_num_lt(unsigned_vector & ds, unsigned_vector & ln) :
             m_degrees(ds),
             m_lit_num(ln) {
             }

--- a/src/tactic/arith/fix_dl_var_tactic.cpp
+++ b/src/tactic/arith/fix_dl_var_tactic.cpp
@@ -35,7 +35,7 @@ class fix_dl_var_tactic : public tactic {
         struct failed {};
         ast_manager &          m;
         arith_util &           m_util;
-        expr_fast_mark1 *      m_visited;
+        expr_fast_mark1 *      m_visited = nullptr;
         ptr_vector<expr>       m_todo;
         obj_map<app, unsigned> m_occs;
         obj_map<app, unsigned> m_non_nested_occs;
@@ -214,8 +214,10 @@ class fix_dl_var_tactic : public tactic {
 
         app * operator()(goal const & g) {
             try {
-                expr_fast_mark1 visited;
-                m_visited = &visited;
+                if (m_visited != nullptr) {
+                    dealloc(m_visited);
+                }
+                m_visited = alloc(expr_fast_mark1);
                 unsigned sz = g.size();
                 for (unsigned i = 0; i < sz; i++) {
                     process(g.form(i));


### PR DESCRIPTION
Here a similar fixes which I had discovered in the codebase. All of them follow the pattern: an object is allocated on the stack, but stored as pointer. As result an access to it may lead to crash, or write into it brokes the stack.