### PR TITLE
New python packaging and tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,8 +43,20 @@ jobs:
     - ${{if eq(variables['runRegressions'], 'True')}}:
       - template: scripts/test-regressions.yml
 
-- job: LinuxBuildsArm64
-  displayName: "ManyLinux ARM64 build"
+- job: "ManylinuxPythonBuildAmd64"
+  displayName: "Python bindings (manylinux Centos AMD64) build"
+  pool:
+    vmImage: "ubuntu-latest"
+  container: "quay.io/pypa/manylinux2014_x86_64:latest"
+  steps:
+  - script: "/opt/python/cp38-cp38/bin/python -m venv $PWD/env"
+  - script: 'echo "##vso[task.prependpath]$PWD/env/bin"'
+  - script: "pip install build git+https://github.com/rhelmot/auditwheel"  # @TODO remove when patches make it upstream
+  - script: "cd src/api/python && python -m build && AUDITWHEEL_PLAT= auditwheel repair --best-plat dist/*.whl && cd ../../.."
+  - script: "pip install ./src/api/python/wheelhouse/*.whl && python - <src/api/python/z3test.py z3 && python - <src/api/python/z3test.py z3num"
+
+- job: ManyLinuxPythonBuildArm64
+  displayName: "Python bindings (manylinux Centos ARM64 cross) build"
   variables:
     name: ManyLinux
     python: "/opt/python/cp37-cp37m/bin/python"
@@ -55,17 +67,14 @@ jobs:
   - script: curl -L -o /tmp/arm-toolchain.tar.xz 'https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel/gcc-arm-11.2-2022.02-x86_64-aarch64-none-linux-gnu.tar.xz?rev=33c6e30e5ac64e6dba8f0431f2c35f1b&hash=9918A05BF47621B632C7A5C8D2BB438FB80A4480'
   - script: mkdir -p /tmp/arm-toolchain/
   - script: tar xf /tmp/arm-toolchain.tar.xz -C /tmp/arm-toolchain/ --strip-components=1
+  - script: "/opt/python/cp38-cp38/bin/python -m venv $PWD/env"
+  - script: 'echo "##vso[task.prependpath]$PWD/env/bin"'
   - script: echo '##vso[task.prependpath]/tmp/arm-toolchain/bin'
   - script: echo '##vso[task.prependpath]/tmp/arm-toolchain/aarch64-none-linux-gnu/libc/usr/bin'
   - script: echo $PATH
-  - script: stat /tmp/arm-toolchain/bin/aarch64-none-linux-gnu-gcc
-  - task: PythonScript@0
-    displayName: Build
-    inputs:
-      scriptSource: 'filepath'
-      scriptPath: scripts/mk_unix_dist.py
-      arguments: --nodotnet --nojava --arch=arm64
-      pythonInterpreter: $(python)
+  - script: "stat `which aarch64-none-linux-gnu-gcc`"
+  - script: "pip install build git+https://github.com/rhelmot/auditwheel"  # @TODO remove when patches make it upstream
+  - script: "cd src/api/python && CC=aarch64-none-linux-gnu-gcc CXX=aarch64-none-linux-gnu-g++ AR=aarch64-none-linux-gnu-ar LD=aarch64-none-linux-gnu-ld python -m build && AUDITWHEEL_PLAT= auditwheel repair --best-plat dist/*.whl && cd ../../.."
 
 - job: "Ubuntu20OCaml"
   displayName: "Ubuntu 20 with OCaml"

--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=46.4.0", "wheel", "cmake"]
+requires = ["setuptools>=59", "wheel", "cmake"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The new best-practices way of building a python package looks like this:

- use `python -m build` to generate wheels
- use `auditwheel repair` to verify that those wheels are conformant to symbol versioning standards and are tagged correctly

To this end, I was able to simplify the python bindings build substantially. This involved making some upstream changes to auditwheel, which is generally not very happy about auditing cross builds, but it was done and my PR is pending. The "most best-practices" way of doing cross builds is to use a full container image for the target architecture and using binfmt_misc + qemu-user to perform the build and audit, but I don't think this is possible on azure.