### PR TITLE
Add cmake option for malloc_usable_size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ list(APPEND Z3_COMPONENT_EXTRA_INCLUDE_DIRS
 option(Z3_USE_MALLOC_USABLE_SIZE "Use malloc_usable_size (or equivalents like malloc_size or _msize)" ON)
 if (Z3_USE_MALLOC_USABLE_SIZE)
   message(STATUS "Using malloc_usable_size")
-  list(APPEND Z3_COMPONENT_CXX_DEFINES "-DHAS_MALLOC_USABLE_SIZE")
+  list(APPEND Z3_COMPONENT_CXX_DEFINES "-DUSE_MALLOC_USABLE_SIZE")
 else()
   message(STATUS "Not using malloc_usable_size")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,17 @@ list(APPEND Z3_COMPONENT_EXTRA_INCLUDE_DIRS
 )
 
 ################################################################################
+# malloc_usable_size()
+################################################################################
+option(Z3_USE_MALLOC_USABLE_SIZE "Use malloc_usable_size (or equivalents like malloc_size or _msize)" ON)
+if (Z3_USE_MALLOC_USABLE_SIZE)
+  message(STATUS "Using malloc_usable_size")
+  list(APPEND Z3_COMPONENT_CXX_DEFINES "-DHAS_MALLOC_USABLE_SIZE")
+else()
+  message(STATUS "Not using malloc_usable_size")
+endif()
+
+################################################################################
 # GNU multiple precision library support
 ################################################################################
 option(Z3_USE_LIB_GMP "Use GNU Multiple Precision Library" OFF)

--- a/src/util/memory_manager.cpp
+++ b/src/util/memory_manager.cpp
@@ -13,19 +13,17 @@ Copyright (c) 2015 Microsoft Corporation
 #include "util/error_codes.h"
 #include "util/debug.h"
 #include "util/scoped_timer.h"
-#ifdef __GLIBC__
+#ifndef HAS_MALLOC_USABLE_SIZE
+// drop calls to malloc_usable_size
+#elif defined(__GLIBC__)
 # include <malloc.h>
-# define HAS_MALLOC_USABLE_SIZE
 #elif defined(__APPLE__)
 # include <malloc/malloc.h>
-# define HAS_MALLOC_USABLE_SIZE
 # define malloc_usable_size malloc_size
 #elif defined(__FreeBSD__)
 # include <malloc_np.h>
-# define HAS_MALLOC_USABLE_SIZE
 #elif defined(_WINDOWS)
 # include <malloc.h>
-# define HAS_MALLOC_USABLE_SIZE
 # define malloc_usable_size _msize
 #endif
 

--- a/src/util/memory_manager.cpp
+++ b/src/util/memory_manager.cpp
@@ -13,17 +13,21 @@ Copyright (c) 2015 Microsoft Corporation
 #include "util/error_codes.h"
 #include "util/debug.h"
 #include "util/scoped_timer.h"
-#ifndef HAS_MALLOC_USABLE_SIZE
+#ifndef USE_MALLOC_USABLE_SIZE
 // drop calls to malloc_usable_size
 #elif defined(__GLIBC__)
 # include <malloc.h>
+# define HAS_MALLOC_USABLE_SIZE
 #elif defined(__APPLE__)
 # include <malloc/malloc.h>
+# define HAS_MALLOC_USABLE_SIZE
 # define malloc_usable_size malloc_size
 #elif defined(__FreeBSD__)
 # include <malloc_np.h>
+# define HAS_MALLOC_USABLE_SIZE
 #elif defined(_WINDOWS)
 # include <malloc.h>
+# define HAS_MALLOC_USABLE_SIZE
 # define malloc_usable_size _msize
 #endif
 


### PR DESCRIPTION
Add a cmake option `USE_MALLOC_USABLE_SIZE` (defaults to `TRUE`) as [suggested](https://github.com/Z3Prover/z3/issues/6890#issuecomment-1713347718) to address known issues with third-party allocators (#6890). 

I'm tempted to set this to `FALSE` by default. Is there evidence that `malloc_usable_size` actually improves performance? The only thing I could find seems [speculative](https://github.com/Z3Prover/z3/pull/6321#issuecomment-1237439487), and lots of people are patching to remove it (see the mentions at the end [here](https://github.com/Z3Prover/z3/pull/6321)).  