### PR TITLE
update unit_lim to the correct value

### DIFF
--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -134,7 +134,7 @@ namespace smt {
                     dst = tr(unit_trail.get(j));
                     pctx.assert_expr(dst);
                 }
-                unit_lim[i] = sz;
+                unit_lim[i] = pctx.assigned_literals().size();
             }
             IF_VERBOSE(1, verbose_stream() << "(smt.thread :units " << sz << ")\n");
         };


### PR DESCRIPTION
In z3's co-processing, the units from every thread will be shared at the end of each round.

https://github.com/Z3Prover/z3/blob/3896e1822755365ad496b71318c6108934d70385/src/smt/smt_parallel.cpp#L110-L138

The code will share the units indexed from `unit_lim[i]` to `pctxs[i].assigned_literals().size()`. However, after the sharing, new `unit_lim[i]` will be set to `unit_trail.size()`, which is usually larger than current `pctxs[i].assigned_literals().size()`. As a result, the units indexed from `pctxs[i].assigned_literals().size()` to `unit_trail.size()` will not be shared in the future.

To fix this problem, the new `unit_lim[i]` should just be the number of current units in this thread(`pctxs[i].assigned_literals().size()`)