### PR TITLE
js: Adding manual release methods

### DIFF
--- a/src/api/js/src/high-level/high-level.ts
+++ b/src/api/js/src/high-level/high-level.ts
@@ -1442,6 +1442,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
 
       release() {
         Z3.optimize_dec_ref(contextPtr, this.ptr);
+        this._ptr = null;
         cleanup.unregister(this);
       }
     }

--- a/src/api/js/src/high-level/high-level.ts
+++ b/src/api/js/src/high-level/high-level.ts
@@ -1203,7 +1203,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         const myAst = this.ast;
 
         Z3.inc_ref(contextPtr, myAst);
-        cleanup.register(this, () => Z3.dec_ref(contextPtr, myAst));
+        cleanup.register(this, () => Z3.dec_ref(contextPtr, myAst), this);
       }
 
       get ast(): Z3_ast {
@@ -1258,7 +1258,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         }
         this.ptr = myPtr;
         Z3.solver_inc_ref(contextPtr, myPtr);
-        cleanup.register(this, () => Z3.solver_dec_ref(contextPtr, myPtr));
+        cleanup.register(this, () => Z3.solver_dec_ref(contextPtr, myPtr), this);
       }
 
       set(key: string, value: any): void {
@@ -1351,7 +1351,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         myPtr = ptr;
         this.ptr = myPtr;
         Z3.optimize_inc_ref(contextPtr, myPtr);
-        cleanup.register(this, () => Z3.optimize_dec_ref(contextPtr, myPtr));
+        cleanup.register(this, () => Z3.optimize_dec_ref(contextPtr, myPtr), this);
       }
 
       set(key: string, value: any): void {
@@ -1446,7 +1446,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       constructor(readonly ptr: Z3_model = Z3.mk_model(contextPtr)) {
         this.ctx = ctx;
         Z3.model_inc_ref(contextPtr, ptr);
-        cleanup.register(this, () => Z3.model_dec_ref(contextPtr, ptr));
+        cleanup.register(this, () => Z3.model_dec_ref(contextPtr, ptr), this);
       }
 
       length() {
@@ -1623,7 +1623,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       constructor(readonly ptr: Z3_func_entry) {
         this.ctx = ctx;
         Z3.func_entry_inc_ref(contextPtr, ptr);
-        cleanup.register(this, () => Z3.func_entry_dec_ref(contextPtr, ptr));
+        cleanup.register(this, () => Z3.func_entry_dec_ref(contextPtr, ptr), this);
       }
 
       numArgs() {
@@ -1646,7 +1646,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       constructor(readonly ptr: Z3_func_interp) {
         this.ctx = ctx;
         Z3.func_interp_inc_ref(contextPtr, ptr);
-        cleanup.register(this, () => Z3.func_interp_dec_ref(contextPtr, ptr));
+        cleanup.register(this, () => Z3.func_interp_dec_ref(contextPtr, ptr), this);
       }
 
       elseValue(): Expr<Name> {
@@ -1946,7 +1946,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         this.ptr = myPtr;
 
         Z3.tactic_inc_ref(contextPtr, myPtr);
-        cleanup.register(this, () => Z3.tactic_dec_ref(contextPtr, myPtr));
+        cleanup.register(this, () => Z3.tactic_dec_ref(contextPtr, myPtr), this);
       }
 
       release() {
@@ -2615,7 +2615,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       constructor(readonly ptr: Z3_ast_vector = Z3.mk_ast_vector(contextPtr)) {
         this.ctx = ctx;
         Z3.ast_vector_inc_ref(contextPtr, ptr);
-        cleanup.register(this, () => Z3.ast_vector_dec_ref(contextPtr, ptr));
+        cleanup.register(this, () => Z3.ast_vector_dec_ref(contextPtr, ptr), this);
       }
 
       length(): number {
@@ -2718,7 +2718,7 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       constructor(readonly ptr: Z3_ast_map = Z3.mk_ast_map(contextPtr)) {
         this.ctx = ctx;
         Z3.ast_map_inc_ref(contextPtr, ptr);
-        cleanup.register(this, () => Z3.ast_map_dec_ref(contextPtr, ptr));
+        cleanup.register(this, () => Z3.ast_map_dec_ref(contextPtr, ptr), this);
       }
 
       [Symbol.iterator](): Iterator<[Key, Value]> {

--- a/src/api/js/src/high-level/high-level.ts
+++ b/src/api/js/src/high-level/high-level.ts
@@ -1235,6 +1235,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       toString() {
         return this.sexpr();
       }
+
+      release() {
+        Z3.dec_ref(contextPtr, this.ast);
+        cleanup.unregister(this);
+      }
     }
 
     class SolverImpl implements Solver<Name> {
@@ -1326,6 +1331,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       fromString(s: string) {
         Z3.solver_from_string(contextPtr, this.ptr, s);
         throwIfError();
+      }
+
+      release() {
+        Z3.solver_dec_ref(contextPtr, this.ptr);
+        cleanup.unregister(this);
       }
     }
 
@@ -1422,8 +1432,12 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         Z3.optimize_from_string(contextPtr, this.ptr, s);
         throwIfError();
       }
-    }
 
+      release() {
+        Z3.optimize_dec_ref(contextPtr, this.ptr);
+        cleanup.unregister(this);
+      }
+    }
 
     class ModelImpl implements Model<Name> {
       declare readonly __typename: Model['__typename'];
@@ -1594,6 +1608,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         _assertContext(sort);
         return new AstVectorImpl(check(Z3.model_get_sort_universe(contextPtr, this.ptr, sort.ptr)));
       }
+
+      release() {
+        Z3.model_dec_ref(contextPtr, this.ptr);
+        cleanup.unregister(this);
+      }
     }
 
     class FuncEntryImpl implements FuncEntry<Name> {
@@ -1655,6 +1674,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
         _assertContext(value);
         assert(this.arity() === argsVec.length(), "Number of arguments in entry doesn't match function arity");
         check(Z3.func_interp_add_entry(contextPtr, this.ptr, argsVec.ptr, value.ptr as Z3_ast));
+      }
+
+      release() {
+        Z3.func_interp_dec_ref(contextPtr, this.ptr);
+        cleanup.unregister(this);
       }
     }
 
@@ -1923,6 +1947,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
 
         Z3.tactic_inc_ref(contextPtr, myPtr);
         cleanup.register(this, () => Z3.tactic_dec_ref(contextPtr, myPtr));
+      }
+
+      release() {
+        Z3.tactic_dec_ref(contextPtr, this.ptr);
+        cleanup.unregister(this);
       }
     }
 
@@ -2675,6 +2704,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
       sexpr(): string {
         return check(Z3.ast_vector_to_string(contextPtr, this.ptr));
       }
+
+      release() {
+        Z3.ast_vector_dec_ref(contextPtr, this.ptr);
+        cleanup.unregister(this);
+      }
     }
 
     class AstMapImpl<Key extends AnyAst<Name>, Value extends AnyAst<Name>> implements AstMap<Name, Key, Value> {
@@ -2733,6 +2767,11 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
 
       sexpr(): string {
         return check(Z3.ast_map_to_string(contextPtr, this.ptr));
+      }
+
+      release() {
+        Z3.ast_map_dec_ref(contextPtr, this.ptr);
+        cleanup.unregister(this);
       }
     }
 

--- a/src/api/js/src/high-level/types.ts
+++ b/src/api/js/src/high-level/types.ts
@@ -703,6 +703,11 @@ export interface Optimize<Name extends string = 'main'> {
 
   model(): Model<Name>;
 
+  /**
+   * Manually decrease the reference count of the optimize
+   * This is automatically done when the optimize is garbage collected,
+   * but calling this eagerly can help release memory sooner.
+   */
   release(): void;
 }
 
@@ -839,13 +844,6 @@ export interface FuncInterp<Name extends string = 'main'> {
   entry(i: number): FuncEntry<Name>;
 
   addEntry(args: Expr<Name>[], value: Expr<Name>): void;
-
-  /**
-   * Manually decrease the reference count of the func interp
-   * This is automatically done when the func interp is garbage collected,
-   * but calling this eagerly can help release memory sooner.
-   */
-  release(): void;
 }
 
 /** @hidden */
@@ -1630,13 +1628,6 @@ export interface Tactic<Name extends string = 'main'> {
 
   readonly ctx: Context<Name>;
   readonly ptr: Z3_tactic;
-
-  /**
-   * Manually decrease the reference count of the tactic
-   * This is automatically done when the tactic is garbage collected,
-   * but calling this eagerly can help release memory sooner.
-   */
-  release(): void;
 }
 
 /** @hidden */
@@ -1688,12 +1679,6 @@ export interface AstVector<Name extends string = 'main', Item extends Ast<Name> 
   has(v: Item): boolean;
 
   sexpr(): string;
-  /**
-   * Manually decrease the reference count of the ast vector
-   * This is automatically done when the ast vector is garbage collected,
-   * but calling this eagerly can help release memory sooner.
-   */
-  release(): void;
 }
 
 /** @hidden */
@@ -1752,13 +1737,6 @@ export interface AstMap<
   has(key: Key): boolean;
 
   sexpr(): string;
-
-  /**
-   * Manually decrease the reference count of the ast map
-   * This is automatically done when the ast map is garbage collected,
-   * but calling this eagerly can help release memory sooner.
-   */
-  release(): void;
 }
 
 /**

--- a/src/api/js/src/high-level/types.ts
+++ b/src/api/js/src/high-level/types.ts
@@ -663,6 +663,13 @@ export interface Solver<Name extends string = 'main'> {
   check(...exprs: (Bool<Name> | AstVector<Name, Bool<Name>>)[]): Promise<CheckSatResult>;
 
   model(): Model<Name>;
+
+  /**
+   * Manually decrease the reference count of the solver
+   * This is automatically done when the solver is garbage collected,
+   * but calling this eagerly can help release memory sooner.
+   */
+  release(): void;
 }
 
 export interface Optimize<Name extends string = 'main'> {
@@ -695,8 +702,9 @@ export interface Optimize<Name extends string = 'main'> {
   check(...exprs: (Bool<Name> | AstVector<Name, Bool<Name>>)[]): Promise<CheckSatResult>;
 
   model(): Model<Name>;
-}
 
+  release(): void;
+}
 
 /** @hidden */
 export interface ModelCtor<Name extends string> {
@@ -746,6 +754,13 @@ export interface Model<Name extends string = 'main'> extends Iterable<FuncDecl<N
     decl: FuncDecl<Name, DomainSort, RangeSort>,
     defaultValue: CoercibleToMap<SortToExprMap<RangeSort, Name>, Name>,
   ): FuncInterp<Name>;
+
+  /**
+   * Manually decrease the reference count of the model
+   * This is automatically done when the model is garbage collected,
+   * but calling this eagerly can help release memory sooner.
+   */
+  release(): void;
 }
 
 /**
@@ -824,6 +839,13 @@ export interface FuncInterp<Name extends string = 'main'> {
   entry(i: number): FuncEntry<Name>;
 
   addEntry(args: Expr<Name>[], value: Expr<Name>): void;
+
+  /**
+   * Manually decrease the reference count of the func interp
+   * This is automatically done when the func interp is garbage collected,
+   * but calling this eagerly can help release memory sooner.
+   */
+  release(): void;
 }
 
 /** @hidden */
@@ -1608,6 +1630,13 @@ export interface Tactic<Name extends string = 'main'> {
 
   readonly ctx: Context<Name>;
   readonly ptr: Z3_tactic;
+
+  /**
+   * Manually decrease the reference count of the tactic
+   * This is automatically done when the tactic is garbage collected,
+   * but calling this eagerly can help release memory sooner.
+   */
+  release(): void;
 }
 
 /** @hidden */
@@ -1659,6 +1688,12 @@ export interface AstVector<Name extends string = 'main', Item extends Ast<Name> 
   has(v: Item): boolean;
 
   sexpr(): string;
+  /**
+   * Manually decrease the reference count of the ast vector
+   * This is automatically done when the ast vector is garbage collected,
+   * but calling this eagerly can help release memory sooner.
+   */
+  release(): void;
 }
 
 /** @hidden */
@@ -1717,6 +1752,13 @@ export interface AstMap<
   has(key: Key): boolean;
 
   sexpr(): string;
+
+  /**
+   * Manually decrease the reference count of the ast map
+   * This is automatically done when the ast map is garbage collected,
+   * but calling this eagerly can help release memory sooner.
+   */
+  release(): void;
 }
 
 /**


### PR DESCRIPTION
Adding methods allowing manual reference cleanup of object created by high level api. 

I was considering if it instead should be called decRef like the native api, and java api is called. https://github.com/Z3Prover/z3/blob/master/src/api/java/Solver.java#L418, or if it should be called something more intuitive to a javascript developer, for whom the concept of references is abstracted away. My suggestion in this pr is the latter. 

Also considering if we want to add runtime checks that asserts no methods can be called on objects that are released. 

Fixes #7427

@bakkot 