### PR TITLE
add rewrites for hoisting constants from ite expressions

### DIFF
--- a/src/ast/rewriter/arith_rewriter.cpp
+++ b/src/ast/rewriter/arith_rewriter.cpp
@@ -830,7 +830,7 @@ br_status arith_rewriter::mk_ite_core(expr* c, expr* t, expr* e, expr_ref & resu
         if (v1 > v2)
             result = m_util.mk_add(e, m.mk_ite(c, m_util.mk_numeral(v1 - v2, is_int), m_util.mk_numeral(rational::zero(), is_int)));
         else
-            result = m_util.mk_add(e, m.mk_ite(c, m_util.mk_numeral(rational::zero(), is_int), m_util.mk_numeral(v2 - v1, is_int)));
+            result = m_util.mk_add(t, m.mk_ite(c, m_util.mk_numeral(rational::zero(), is_int), m_util.mk_numeral(v2 - v1, is_int)));
         return BR_DONE;        
     }
     expr* x, *y;

--- a/src/ast/rewriter/arith_rewriter.cpp
+++ b/src/ast/rewriter/arith_rewriter.cpp
@@ -740,6 +740,20 @@ br_status arith_rewriter::mk_le_ge_eq_core(expr * arg1, expr * arg2, op_kind kin
         case EQ: result = m.mk_ite(c, m.mk_eq(t, arg2), m.mk_eq(e, arg2)); return BR_REWRITE2;
         }
     }
+    if (m.is_ite(arg2, c, t, e) && is_numeral(t, a2) && is_numeral(arg1, a1)) {
+        switch (kind) {
+        case LE: result = a1 <= a2 ? m.mk_or(c, m_util.mk_le(arg1, e)) : m.mk_and(m.mk_not(c), m_util.mk_le(arg1, e)); return BR_REWRITE2;
+        case GE: result = a1 >= a2 ? m.mk_or(c, m_util.mk_ge(arg1, e)) : m.mk_and(m.mk_not(c), m_util.mk_ge(arg1, e)); return BR_REWRITE2;
+        case EQ: result = a1 == a2 ? m.mk_or(c, m.mk_eq(e, arg1)) : m.mk_and(m.mk_not(c), m_util.mk_eq(e, arg1)); return BR_REWRITE2;
+        }
+    }
+    if (m.is_ite(arg2, c, t, e) && is_numeral(e, a2) && is_numeral(arg1, a1)) {
+        switch (kind) {
+        case LE: result = a1 <= a2 ? m.mk_or(m.mk_not(c), m_util.mk_le(arg1, t)) : m.mk_and(c, m_util.mk_le(arg1, t)); return BR_REWRITE2;
+        case GE: result = a1 >= a2 ? m.mk_or(m.mk_not(c), m_util.mk_ge(arg1, e)) : m.mk_and(c, m_util.mk_ge(arg1, t)); return BR_REWRITE2;
+        case EQ: result = a1 == a2 ? m.mk_or(m.mk_not(c), m.mk_eq(t, arg1)) : m.mk_and(c, m_util.mk_eq(t, arg1)); return BR_REWRITE2;
+        }
+    }
     if (m_util.is_to_int(arg2) && is_numeral(arg1)) {        
         kind = inv(kind);
         std::swap(arg1, arg2);

--- a/src/ast/rewriter/arith_rewriter.h
+++ b/src/ast/rewriter/arith_rewriter.h
@@ -137,6 +137,7 @@ public:
     br_status mk_lt_core(expr * arg1, expr * arg2, expr_ref & result);
     br_status mk_ge_core(expr * arg1, expr * arg2, expr_ref & result);
     br_status mk_gt_core(expr * arg1, expr * arg2, expr_ref & result);
+    br_status mk_ite_core(expr* c, expr* t, expr* e, expr_ref & result);
 
     br_status mk_add_core(unsigned num_args, expr * const * args, expr_ref & result);
     br_status mk_mul_core(unsigned num_args, expr * const * args, expr_ref & result);

--- a/src/ast/rewriter/poly_rewriter_def.h
+++ b/src/ast/rewriter/poly_rewriter_def.h
@@ -1017,7 +1017,9 @@ bool poly_rewriter<Config>::hoist_ite(expr_ref& e) {
         ++i;
     }
     if (!pinned.empty()) {
+        TRACE("poly_rewriter", tout << e << "\n");
         e = mk_add_app(adds.size(), adds.data());
+        TRACE("poly_rewriter", tout << e << "\n");
         return true;
     }
     return false;

--- a/src/ast/rewriter/th_rewriter.cpp
+++ b/src/ast/rewriter/th_rewriter.cpp
@@ -320,7 +320,7 @@ struct th_rewriter_cfg : public default_rewriter_cfg {
                 return pull_ite_core<true>(f, to_app(args[1]), to_app(args[0]), result);
         }
         family_id fid = f->get_family_id();
-        if (num == 2 && (fid == m().get_basic_family_id() || fid == m_bv_rw.get_fid())) {
+        if (num == 2 && (fid == m().get_basic_family_id())) {
             // (f v3 (ite c v1 v2)) --> (ite v (f v3 v1) (f v3 v2))
             if (m().is_value(args[0]) && is_ite_value_tree(args[1])) 
                 return pull_ite_core<true>(f, to_app(args[1]), to_app(args[0]), result);


### PR DESCRIPTION
This pull request
- removes pushing arithmetic operations over ite operations.
- adds hoisting of constants from ite expressions using rewrites
  - ite c v1 v2 -> g * ite c (v1/g) (v2/g) where g is gcd(v1, v2) != 1
  - ite c v1 v2 -> v1 + ite c 0 (v2 - v1)
  - ite c (v1 + t) v2 -> v1 + ite c t (v2 - v1)
  - ite c v1 (v2 + t) -> v2 + ite c (v1 - v2) t
  - ite c (v1 * t) 0 -> v1 * ite c t 0
  - ite c (v1 * t) v2 -> v1 * ite c t (v2/ v1)   if v1 divides v2
   

   