### PR TITLE
Add __enter__ and __exit__ methods to Optimize class in Python API

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -7991,6 +7991,13 @@ class Optimize(Z3PPObject):
         if self._on_models_id is not None:
             del _on_models[self._on_models_id]
 
+    def __enter__(self):
+        self.push()
+        return self
+
+    def __exit__(self, *exc_info):
+        self.pop()
+
     def set(self, *args, **keys):
         """Set a configuration option.
         The method `help()` return a string containing all available options.


### PR DESCRIPTION
This PR is a natural follow-up to https://github.com/Z3Prover/z3/pull/7025.

It enables the use of the with statement for the Optimize class to concisely call push() and pop(). This works similarly to the Solver class.