### PR TITLE
Add 2 new API functions to get depth & groundness of exprs

### DIFF
--- a/src/api/api_ast.cpp
+++ b/src/api/api_ast.cpp
@@ -425,6 +425,20 @@ extern "C" {
         RETURN_Z3(of_app(reinterpret_cast<app*>(a)));
     }
 
+    bool Z3_API Z3_is_ground(Z3_context c, Z3_ast a) {
+        LOG_Z3_is_ground(c, a);
+        RESET_ERROR_CODE();
+        CHECK_IS_EXPR(a, 0);
+        return is_ground(to_expr(a));
+    }
+
+    unsigned Z3_API Z3_get_depth(Z3_context c, Z3_ast a) {
+        LOG_Z3_get_depth(c, a);
+        RESET_ERROR_CODE();
+        CHECK_IS_EXPR(a, 0);
+        return get_depth(to_expr(a));
+    }
+
     Z3_func_decl Z3_API Z3_to_func_decl(Z3_context c, Z3_ast a) {
         LOG_Z3_to_func_decl(c, a);
         RESET_ERROR_CODE();

--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -4993,6 +4993,16 @@ extern "C" {
     bool Z3_API Z3_is_app(Z3_context c, Z3_ast a);
 
     /**
+      def_API('Z3_is_ground', BOOL, (_in(CONTEXT), _in(AST)))
+    */
+    bool Z3_API Z3_is_ground(Z3_context c, Z3_ast a);
+
+    /**
+      def_API('Z3_get_depth', UINT, (_in(CONTEXT), _in(AST)))
+    */
+    unsigned Z3_API Z3_get_depth(Z3_context c, Z3_ast a);
+
+    /**
       def_API('Z3_is_numeral_ast', BOOL, (_in(CONTEXT), _in(AST)))
     */
     bool Z3_API Z3_is_numeral_ast(Z3_context c, Z3_ast a);


### PR DESCRIPTION
Add:
 - Z3_is_ground
 - Z3_get_depth

These cannot be implemented efficiently from outside of Z3. These functions are O(1) when run internally.

That's my Xmas gift for myself this year 🎅🎅