### PR TITLE
use cmake from PyPI only when system executable is not available

### DIFF
--- a/src/api/python/pyproject.toml
+++ b/src/api/python/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=70", "cmake"]
+requires = ["setuptools>=70"]
 build-backend = "setuptools.build_meta"

--- a/src/api/python/setup.py
+++ b/src/api/python/setup.py
@@ -88,6 +88,11 @@ else:
     LIBRARY_FILE = "libz3.so"
     EXECUTABLE_FILE = "z3"
 
+# check if cmake is available, and pull it in via PyPI if necessary
+SETUP_REQUIRES = []
+if not shutil.which("cmake"):
+    SETUP_REQUIRES += ["cmake"]
+
 def rmtree(tree):
     if os.path.exists(tree):
         shutil.rmtree(tree, ignore_errors=False)
@@ -327,6 +332,7 @@ setup(
     license='MIT License',
     keywords=['z3', 'smt', 'sat', 'prover', 'theorem'],
     packages=['z3'],
+    setup_requires = SETUP_REQUIRES,
     install_requires = ["importlib-resources; python_version < '3.9'"],
     include_package_data=True,
     package_data={


### PR DESCRIPTION
Rather than pulling `cmake` from PyPI unconditionally, add it to build dependencies only if the system `cmake` executable cannot be found. This eliminates an unnecessary dependency on systems featuring CMake, and ensures that whenever possible, a downstream patched CMake version is used that is more compatible with the system in question.