### PR TITLE
Set default behaviour to exit on error in CLI mode

### DIFF
--- a/src/shell/smtlib_frontend.cpp
+++ b/src/shell/smtlib_frontend.cpp
@@ -160,6 +160,11 @@ unsigned read_smtlib2_commands(char const * file_name) {
     signal(SIGINT, on_ctrl_c);
     cmd_context ctx;
 
+    // Fail safe when used from the command line - if there's an error exit(1).
+    // We don't want to do this when used as a library because it would kill
+    // the entire process.
+    ctx.set_exit_on_error(true);
+
     ctx.set_solver_factory(mk_smt_strategic_solver_factory());
     install_dl_cmds(ctx);
     install_dbg_cmds(ctx);


### PR DESCRIPTION
This changes the default `error-behaviour` to `immediate-exit` for smtlib2 when running in CLI mode. This makes it fail-safe. There's no reason to ignore errors in CLI mode and it may lead to accidentally "verified" proofs if the user makes an easy mistake.

This does not change the default when used via an API because `immediate-exit` calls `_Exit(1)` and that isn't a good thing for a library to do.

Fixes #7528 