### PR TITLE
Add -repl flag and set default behaviour to exit on error

### DIFF
--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -48,6 +48,7 @@ typedef enum { IN_UNSPECIFIED, IN_SMTLIB_2, IN_DATALOG, IN_DIMACS, IN_WCNF, IN_O
 static char const * g_input_file          = nullptr;
 static char const * g_drat_input_file     = nullptr;
 static bool         g_standard_input      = false;
+static bool         g_repl                = false;
 static input_kind   g_input_kind          = IN_UNSPECIFIED;
 bool                g_display_statistics  = false;
 bool                g_display_model       = false;
@@ -85,6 +86,7 @@ void display_usage() {
     std::cout << "  -lp         use parser for a modest subset of CPLEX LP input format.\n";
     std::cout << "  -log        use parser for Z3 log input format.\n";
     std::cout << "  -in         read formula from standard input.\n";
+    std::cout << "  -repl       read formula from standard input and continue on errors.\n";
     std::cout << "  -model      display model for satisfiable SMT.\n";
     std::cout << "\nMiscellaneous:\n";
     std::cout << "  -h, -?      prints this message.\n";
@@ -198,6 +200,10 @@ static void parse_cmd_line_args(std::string& input_file, int argc, char ** argv)
             }
             else if (strcmp(opt_name, "in") == 0) {
                 g_standard_input = true;
+            }
+            else if (strcmp(opt_name, "repl") == 0) {
+                g_standard_input = true;
+                g_repl = true;
             }
             else if (strcmp(opt_name, "dimacs") == 0) {
                 g_input_kind = IN_DIMACS;

--- a/src/shell/smtlib_frontend.cpp
+++ b/src/shell/smtlib_frontend.cpp
@@ -160,6 +160,14 @@ unsigned read_smtlib2_commands(char const * file_name) {
     signal(SIGINT, on_ctrl_c);
     cmd_context ctx;
 
+    // Fail safe when reading from a file - if there's an error exit(1).
+    // We don't want to do this when used as a library because it would kill
+    // the entire process, or when using `-repl` because that would be really
+    // annoying.
+    if (!g_repl) {
+        ctx.set_exit_on_error(true);
+    }
+
     ctx.set_solver_factory(mk_smt_strategic_solver_factory());
     install_dl_cmds(ctx);
     install_dbg_cmds(ctx);


### PR DESCRIPTION
This changes the default `error-behaviour` to `immediate-exit` for smtlib2 when running in CLI mode. This makes it fail-safe. There's no reason to ignore errors in CLI mode and it may lead to accidentally "verified" proofs if the user makes an easy mistake.

This does not change the default when used via an API because `immediate-exit` calls `_Exit(1)` and that isn't a good thing for a library to do.

When passing commands via standard input there are two use cases:

* Running Z3 from another program (e.g. a compiler), in which case you don't want to ignore errors.
* Using it as a basic REPL, in which case you don't.

I added a `-repl` flag for the second use case. This also opens the door for potentially adding a "proper" REPL in future (with history, etc.).