### PR TITLE
Mark fixed_eq literals as relevant

### DIFF
--- a/src/smt/theory_bv.cpp
+++ b/src/smt/theory_bv.cpp
@@ -441,6 +441,8 @@ namespace smt {
         app* o1 = get_enode(v1)->get_expr();
         app* o2 = get_enode(v2)->get_expr();
         literal oeq = mk_eq(o1, o2, true);
+        ctx.mark_as_relevant(oeq);
+
         unsigned sz = get_bv_size(v1);
         TRACE("bv", 
               tout << mk_pp(o1, m) << " = " << mk_pp(o2, m) << " " 


### PR DESCRIPTION
This fixed two version of a [problematic query](https://github.com/user-attachments/files/18560424/april2nd.zip) for me for me.
Previously, both versions terminated in a few seconds with relevancy=1 and =0, and timed out after an hour with relevancy=2. 

In this particular case, not marking `oeq` as relevant prevents the equality from being propagated to the egraph structure. This in turn leads to a much longer justification for the same equality. I investigated one conflict including the equality, which popped 59 levels with the shorter justification and only one level with the longer justification. 

