### PR TITLE
Preserve fingerprint in trace

### DIFF
--- a/src/smt/qi_queue.cpp
+++ b/src/smt/qi_queue.cpp
@@ -188,7 +188,7 @@ namespace smt {
 
     void qi_queue::display_instance_profile(fingerprint * f, quantifier * q, unsigned num_bindings, enode * const * bindings, unsigned proof_id, unsigned generation) {
         if (m.has_trace_stream()) {
-            m.trace_stream() << "[instance] 0x0";
+            m.trace_stream() << "[instance] " << f->get_data_hash();
             if (m.proofs_enabled())
                 m.trace_stream() << " #" << proof_id;
             m.trace_stream() << " ; " << generation;

--- a/src/smt/smt_quantifier.cpp
+++ b/src/smt/smt_quantifier.cpp
@@ -240,7 +240,7 @@ namespace smt {
              vector<std::tuple<enode *, enode *>> & used_enodes) {
 
             if (pat == nullptr) {
-                trace_stream() << "[inst-discovered] MBQI 0x0 #" << q->get_id();
+                trace_stream() << "[inst-discovered] MBQI " << f->get_data_hash() << " #" << q->get_id();
                 for (unsigned i = 0; i < num_bindings; ++i) {
                     trace_stream() << " #" << bindings[num_bindings - i - 1]->get_owner_id();
                 }
@@ -266,7 +266,7 @@ namespace smt {
                 }
 
                 // At this point all relevant equalities for the match are logged.
-                out << "[new-match] " << static_cast<void*>(f) << " #" << q->get_id() << " #" << pat->get_id();
+                out << "[new-match] " << f->get_data_hash() << " #" << q->get_id() << " #" << pat->get_id();
                 for (unsigned i = 0; i < num_bindings; i++) {
                     // I don't want to use mk_pp because it creates expressions for pretty printing.
                     // This nasty side-effect may change the behavior of Z3.


### PR DESCRIPTION
Commits https://github.com/Z3Prover/z3/commit/554191885eca4a97a2e5ff2af52a4d16f513ba61 and https://github.com/Z3Prover/z3/commit/23c4728d684141b53b25d4236ef47870786e331a break the trace file since it requires linking a `[new-match]` to a later `[instance]` (with potentially other `[new-match]` between).

This PR tries to achieve the same thing as those commits (removing the platform dependent value due to the pointer cast) while preserving a unique link between the two lines. @NikolajBjorner is `get_data_hash` the correct thing to use to uniquely identify a fingerprint/new match?