### PR TITLE
Fix build when Z3_API macro is non-empty

### DIFF
--- a/src/api/api_array.cpp
+++ b/src/api/api_array.cpp
@@ -282,15 +282,15 @@ extern "C" {
         Z3_CATCH_RETURN(nullptr);
     }
 
-    Z3_ast Z3_mk_set_member(Z3_context c, Z3_ast elem, Z3_ast set) {
+    Z3_ast Z3_API Z3_mk_set_member(Z3_context c, Z3_ast elem, Z3_ast set) {
         return Z3_mk_select(c, set, elem);
     }
 
-    Z3_ast Z3_mk_set_add(Z3_context c, Z3_ast set, Z3_ast elem) {
+    Z3_ast Z3_API Z3_mk_set_add(Z3_context c, Z3_ast set, Z3_ast elem) {
         return Z3_mk_store(c, set, elem, Z3_mk_true(c));
     }
 
-    Z3_ast Z3_mk_set_del(Z3_context c, Z3_ast set, Z3_ast elem) {
+    Z3_ast Z3_API Z3_mk_set_del(Z3_context c, Z3_ast set, Z3_ast elem) {
         return Z3_mk_store(c, set, elem, Z3_mk_false(c));
     }
 

--- a/src/api/api_ast.cpp
+++ b/src/api/api_ast.cpp
@@ -369,7 +369,7 @@ extern "C" {
         Z3_CATCH_RETURN(-1);
     }
 
-    Z3_API char const * Z3_get_symbol_string(Z3_context c, Z3_symbol s) {
+    Z3_string Z3_API Z3_get_symbol_string(Z3_context c, Z3_symbol s) {
         Z3_TRY;
         LOG_Z3_get_symbol_string(c, s);
         RESET_ERROR_CODE();
@@ -714,7 +714,7 @@ extern "C" {
         Z3_CATCH_RETURN(nullptr);
     }
 
-    Z3_sort_kind Z3_get_sort_kind(Z3_context c, Z3_sort t) {
+    Z3_sort_kind Z3_API Z3_get_sort_kind(Z3_context c, Z3_sort t) {
         LOG_Z3_get_sort_kind(c, t);
         RESET_ERROR_CODE();
         CHECK_VALID_AST(t, Z3_UNKNOWN_SORT);
@@ -1019,7 +1019,7 @@ extern "C" {
         Z3_CATCH_RETURN(nullptr);
     }
 
-    Z3_API char const * Z3_ast_to_string(Z3_context c, Z3_ast a) {
+    Z3_string Z3_API Z3_ast_to_string(Z3_context c, Z3_ast a) {
         Z3_TRY;
         LOG_Z3_ast_to_string(c, a);
         RESET_ERROR_CODE();
@@ -1045,11 +1045,11 @@ extern "C" {
         Z3_CATCH_RETURN(nullptr);
     }
 
-    Z3_API char const * Z3_sort_to_string(Z3_context c, Z3_sort s) {
+    Z3_string Z3_API Z3_sort_to_string(Z3_context c, Z3_sort s) {
         return Z3_ast_to_string(c, reinterpret_cast<Z3_ast>(s));
     }
 
-    Z3_API char const * Z3_func_decl_to_string(Z3_context c, Z3_func_decl f) {
+    Z3_string Z3_API Z3_func_decl_to_string(Z3_context c, Z3_func_decl f) {
         return Z3_ast_to_string(c, reinterpret_cast<Z3_ast>(f));
     }
 

--- a/src/api/api_context.cpp
+++ b/src/api/api_context.cpp
@@ -518,7 +518,7 @@ extern "C" {
         }
     }
 
-    Z3_API char const * Z3_get_error_msg(Z3_context c, Z3_error_code err) {
+    Z3_string Z3_API Z3_get_error_msg(Z3_context c, Z3_error_code err) {
         LOG_Z3_get_error_msg(c, err);
         return _get_error_msg(c, err);
     }

--- a/src/api/api_datatype.cpp
+++ b/src/api/api_datatype.cpp
@@ -604,7 +604,7 @@ extern "C" {
         Z3_CATCH_RETURN(nullptr);
     }
 
-    Z3_ast Z3_datatype_update_field(
+    Z3_ast Z3_API Z3_datatype_update_field(
         Z3_context c,  Z3_func_decl f, Z3_ast t, Z3_ast v) {
         Z3_TRY;
         LOG_Z3_datatype_update_field(c, f, t, v);

--- a/src/api/api_model.cpp
+++ b/src/api/api_model.cpp
@@ -422,7 +422,7 @@ extern "C" {
         Z3_CATCH_RETURN(nullptr);
     }
 
-    Z3_API char const * Z3_model_to_string(Z3_context c, Z3_model m) {
+    Z3_string Z3_API Z3_model_to_string(Z3_context c, Z3_model m) {
         Z3_TRY;
         LOG_Z3_model_to_string(c, m);
         RESET_ERROR_CODE();

--- a/src/api/api_quant.cpp
+++ b/src/api/api_quant.cpp
@@ -575,7 +575,7 @@ extern "C" {
         return (Z3_ast)(p);
     }
 
-    Z3_API char const * Z3_pattern_to_string(Z3_context c, Z3_pattern p) {
+    Z3_string Z3_API Z3_pattern_to_string(Z3_context c, Z3_pattern p) {
         return Z3_ast_to_string(c, reinterpret_cast<Z3_ast>(p));
     }
 


### PR DESCRIPTION
Z3 fails to build with VS 2022 when the macro `Z3_API` is defined as `__stdcall` due to differences between API function declarations and definitions.  This PR updates function definitions to match declarations by
  - adding the `Z3_API` macro where missing;
  - changing `Z3_API char const *` to `Z3_string Z3_API`.
