### PR TITLE
Fix various race conditions, mostly signal-based

### DIFF
--- a/src/params/context_params.cpp
+++ b/src/params/context_params.cpp
@@ -157,6 +157,7 @@ void context_params::updt_params(params_ref const & p) {
 void context_params::collect_param_descrs(param_descrs & d) {
     insert_rlimit(d);
     insert_timeout(d);
+    insert_ctrl_c(d);
     d.insert("well_sorted_check", CPK_BOOL, "type checker", "false");
     d.insert("type_check", CPK_BOOL, "type checker (alias for well_sorted_check)", "true");
     d.insert("auto_config", CPK_BOOL, "use heuristics to automatically select solver and configure it", "true");

--- a/src/util/cancel_eh.h
+++ b/src/util/cancel_eh.h
@@ -34,15 +34,13 @@ public:
     cancel_eh(T & o): m_obj(o) {}
     ~cancel_eh() override { if (m_canceled) m_obj.dec_cancel(); if (m_auto_cancel) m_obj.auto_cancel(); }
     void operator()(event_handler_caller_t caller_id) override {
-        if (caller_id != CTRL_C_EH_CALLER)
-            signal_lock();
+        signal_lock();
         if (!m_canceled) {
             m_caller_id = caller_id;
             m_canceled = true;
             m_obj.inc_cancel(); 
         }
-        if (caller_id != CTRL_C_EH_CALLER)
-            signal_unlock();
+        signal_unlock();
     }
     bool canceled() {
         bool ret;

--- a/src/util/rlimit.cpp
+++ b/src/util/rlimit.cpp
@@ -19,16 +19,12 @@ Revision History:
 #include "util/rlimit.h"
 #include "util/common_msgs.h"
 #include "util/mutex.h"
-
-
-static DECLARE_MUTEX(g_rlimit_mux);
+#include "util/scoped_ctrl_c.h"
 
 void initialize_rlimit() {
-    ALLOC_MUTEX(g_rlimit_mux);
 }
 
 void finalize_rlimit() {
-    DEALLOC_MUTEX(g_rlimit_mux);
 }
 
 reslimit::reslimit() {
@@ -77,57 +73,66 @@ char const* reslimit::get_cancel_msg() const {
 }
 
 void reslimit::push_child(reslimit* r) {
-    lock_guard lock(*g_rlimit_mux);
+    signal_lock();
     m_children.push_back(r);    
+    signal_unlock();
 }
 
 void reslimit::pop_child() {
-    lock_guard lock(*g_rlimit_mux);
+    signal_lock();
     m_count += m_children.back()->m_count;
     m_children.back()->m_count = 0;
     m_children.pop_back();    
+    signal_unlock();
 }
 
 void reslimit::pop_child(reslimit* r) {
-    lock_guard lock(*g_rlimit_mux);
+    signal_lock();
     for (unsigned i = 0; i < m_children.size(); ++i) {
         if (m_children[i] == r) {
             m_count += r->m_count;
             r->m_count = 0;
             m_children.erase(m_children.begin() + i);
-            return;
+            break;
         }
     }
+    signal_unlock();
 }
 
 
 void reslimit::cancel() {
-    lock_guard lock(*g_rlimit_mux);
+    signal_lock();
     set_cancel(m_cancel+1);    
+    signal_unlock();
 }
 
 void reslimit::reset_cancel() {
-    lock_guard lock(*g_rlimit_mux);
+    signal_lock();
     set_cancel(0);    
+    signal_unlock();
 }
 
 void reslimit::inc_cancel() {
-    lock_guard lock(*g_rlimit_mux);
+    signal_lock();
     set_cancel(m_cancel + 1);
+    signal_unlock();
 }
 
 void reslimit::dec_cancel() {
-    lock_guard lock(*g_rlimit_mux);
+    signal_lock();
     if (m_cancel > 0) {
         set_cancel(m_cancel-1);
     }
+    signal_unlock();
 }
 
 void reslimit::set_cancel(unsigned f) {
+    signal_lock();
     m_cancel = f;
     for (unsigned i = 0; i < m_children.size(); ++i) {
         m_children[i]->set_cancel(f);
     }
+    signal_unlock();
 }
 
 
@@ -151,8 +156,9 @@ void reslimit::push_timeout(unsigned ms) {
 }
 
 void reslimit::inc_cancel(unsigned k) {
-    lock_guard lock(*g_rlimit_mux);
+    signal_lock();
     set_cancel(m_cancel + k);        
+    signal_unlock();
 }
 
 void reslimit::auto_cancel() {

--- a/src/util/scoped_ctrl_c.cpp
+++ b/src/util/scoped_ctrl_c.cpp
@@ -20,6 +20,7 @@ Revision History:
 #include <signal.h>
 #include <cstring>
 #include <mutex>
+#include "util/gparams.h"
 #include "util/scoped_ctrl_c.h"
 
 #ifdef _WINDOWS
@@ -106,6 +107,8 @@ scoped_ctrl_c::scoped_ctrl_c(event_handler & eh, bool once, bool enabled):
     m_first(true),
     m_once(once),
     m_enabled(enabled) {
+    if (gparams::get_value("ctrl_c") == "false")
+        m_enabled = false;
     if (m_enabled) {
         signal_lock();
         active_contexts.push_back(this);

--- a/src/util/scoped_ctrl_c.cpp
+++ b/src/util/scoped_ctrl_c.cpp
@@ -36,7 +36,7 @@ static struct sigaction old_sigaction;
 #endif
 static bool signal_handled = false;
 
-static void signal_lock(void) {
+void signal_lock(void) {
 #ifdef USE_SIGNAL
     context_lock.lock();
 #else
@@ -50,7 +50,7 @@ static void signal_lock(void) {
 #endif
 }
 
-static void signal_unlock(void) {
+void signal_unlock(void) {
 #ifdef USE_SIGNAL
     context_lock.unlock();
 #else

--- a/src/util/scoped_ctrl_c.cpp
+++ b/src/util/scoped_ctrl_c.cpp
@@ -12,46 +12,125 @@ Abstract:
 Author:
 
     Leonardo de Moura (leonardo) 2011-04-27.
+    Mikulas Patocka 2025-04-05. (rewritten to be thread safe)
 
 Revision History:
 
 --*/
-#include<signal.h>
+#include <signal.h>
+#include <cstring>
+#include <mutex>
 #include "util/scoped_ctrl_c.h"
 
-static scoped_ctrl_c * g_obj = nullptr;
+#ifdef _WINDOWS
+#define USE_SIGNAL
+#endif
 
-static void on_ctrl_c(int) {
-    if (g_obj->m_first) {
-        g_obj->m_cancel_eh(CTRL_C_EH_CALLER);
-        if (g_obj->m_once) {
-            g_obj->m_first = false;
-            signal(SIGINT, on_ctrl_c); // re-install the handler
-        }
+static std::mutex context_lock;
+static std::vector<scoped_ctrl_c *> active_contexts;
+#ifdef USE_SIGNAL
+static void (*old_handler)(int);
+#else
+static sigset_t context_old_set;
+static struct sigaction old_sigaction;
+#endif
+static bool signal_handled = false;
+
+static void signal_lock(void) {
+#ifdef USE_SIGNAL
+    context_lock.lock();
+#else
+    sigset_t set, old_set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGINT);
+    if (sigprocmask(SIG_BLOCK, &set, &old_set))
+        abort();
+    context_lock.lock();
+    context_old_set = old_set;
+#endif
+}
+
+static void signal_unlock(void) {
+#ifdef USE_SIGNAL
+    context_lock.unlock();
+#else
+    sigset_t old_set = context_old_set;
+    context_lock.unlock();
+    if (sigprocmask(SIG_SETMASK, &old_set, NULL))
+        abort();
+#endif
+}
+
+static void test_and_unhandle(void) {
+    if (!signal_handled)
+        return;
+    for (auto a : active_contexts) {
+        if (a->m_first)
+            return;
     }
-    else {
-        signal(SIGINT, g_obj->m_old_handler); 
-        raise(SIGINT);
+#ifdef USE_SIGNAL
+    signal(SIGINT, old_handler);
+#else
+    if (sigaction(SIGINT, &old_sigaction, NULL))
+        abort();
+#endif
+    signal_handled = false;
+}
+
+static void on_sigint(int) {
+    signal_lock();
+#ifdef USE_SIGNAL
+    if (signal_handled)
+        signal(SIGINT, on_sigint);
+#endif
+    for (auto a : active_contexts) {
+        if (a->m_first)
+            a->m_cancel_eh(CTRL_C_EH_CALLER);
+        if (a->m_once)
+            a->m_first = false;
     }
+    test_and_unhandle();
+    signal_unlock();
 }
 
 scoped_ctrl_c::scoped_ctrl_c(event_handler & eh, bool once, bool enabled):
-    m_cancel_eh(eh), 
+    m_cancel_eh(eh),
     m_first(true),
     m_once(once),
-    m_enabled(enabled),
-    m_old_scoped_ctrl_c(g_obj) {
+    m_enabled(enabled) {
     if (m_enabled) {
-        g_obj = this;
-        m_old_handler = signal(SIGINT, on_ctrl_c); 
+        signal_lock();
+        active_contexts.push_back(this);
+        if (!signal_handled) {
+#ifdef USE_SIGNAL
+            old_handler = signal(SIGINT, on_sigint);
+#else
+            struct sigaction sa;
+            memset(&sa, 0, sizeof(struct sigaction));
+            sa.sa_handler = on_sigint;
+            sigemptyset(&sa.sa_mask);
+            sa.sa_flags = SA_RESTART;
+            if (sigaction(SIGINT, &sa, &old_sigaction))
+                abort();
+#endif
+            signal_handled = true;
+        }
+        signal_unlock();
     }
 }
 
-scoped_ctrl_c::~scoped_ctrl_c() { 
+scoped_ctrl_c::~scoped_ctrl_c() {
     if (m_enabled) {
-        g_obj = m_old_scoped_ctrl_c;
-        if (m_old_handler != SIG_ERR) {
-            signal(SIGINT, m_old_handler);
+        signal_lock();
+        for (auto it = active_contexts.begin(); it != active_contexts.end(); it++) {
+            if (*it == this) {
+                active_contexts.erase(it);
+                goto found;
+            }
         }
+        abort();
+found:
+        test_and_unhandle();
+        signal_unlock();
     }
 }

--- a/src/util/scoped_ctrl_c.h
+++ b/src/util/scoped_ctrl_c.h
@@ -26,8 +26,6 @@ struct scoped_ctrl_c {
     bool m_first;
     bool m_once;
     bool m_enabled;
-    void  (STD_CALL *m_old_handler)(int);
-    scoped_ctrl_c * m_old_scoped_ctrl_c;
 public:
     // If once == true, then the cancel_eh is invoked only at the first Ctrl-C.
     // The next time, the old signal handler will take over.

--- a/src/util/scoped_ctrl_c.h
+++ b/src/util/scoped_ctrl_c.h
@@ -21,6 +21,9 @@ Revision History:
 #include "util/event_handler.h"
 #include "util/util.h"
 
+void signal_lock(void);
+void signal_unlock(void);
+
 struct scoped_ctrl_c {
     event_handler & m_cancel_eh;
     bool m_first;

--- a/src/util/scoped_timer.cpp
+++ b/src/util/scoped_timer.cpp
@@ -48,7 +48,6 @@ struct scoped_timer_state {
 
 static std::vector<scoped_timer_state*> available_workers;
 static std::mutex workers;
-static atomic<unsigned> num_workers(0);
 
 static void thread_func(scoped_timer_state *s) {
     workers.lock();
@@ -94,7 +93,6 @@ scoped_timer::scoped_timer(unsigned ms, event_handler * eh) {
         // start new thead
         workers.unlock();
         s = new scoped_timer_state;
-        ++num_workers;
         init_state(ms, eh);
         s->m_thread = std::thread(thread_func, s);
     }
@@ -122,34 +120,27 @@ scoped_timer::~scoped_timer() {
 
 void scoped_timer::initialize() {
 #ifndef _WINDOWS
-    static bool pthread_atfork_set = false;
-    if (!pthread_atfork_set) {
+    static std::atomic<bool> pthread_atfork_set = false;
+    if (!pthread_atfork_set.exchange(true)) {
         pthread_atfork(finalize, nullptr, nullptr);
-        pthread_atfork_set = true;
     }
 #endif
 }
 
 void scoped_timer::finalize() {
-    unsigned deleted = 0;
-    while (deleted < num_workers) {
-        workers.lock();
-        for (auto w : available_workers) {
-            w->work = EXITING;
-            w->cv.notify_one();
-        }
-        decltype(available_workers) cleanup_workers;
-        std::swap(available_workers, cleanup_workers);
-        workers.unlock();
-
-        for (auto w : cleanup_workers) {
-            ++deleted;
-            w->m_thread.join();
-            delete w;
-        }
+    workers.lock();
+    for (auto w : available_workers) {
+        w->work = EXITING;
+        w->cv.notify_one();
     }
-    num_workers = 0;
-    available_workers.clear();
+    decltype(available_workers) cleanup_workers;
+    std::swap(available_workers, cleanup_workers);
+    workers.unlock();
+
+    for (auto w : cleanup_workers) {
+        w->m_thread.join();
+        delete w;
+    }
 }
 
 void scoped_timer::init_state(unsigned ms, event_handler * eh) {


### PR DESCRIPTION
Hi

I reviewed the source code and found out that there are some (mostly signal-based) race conditions.

The first 3 patches fix race conditions that happen when Ctrl-C is pressed in a multithreaded program (#7603).
The 4th patch fixes a race condition when a multithreaded program calls fork while there are some threads doing calculations inside libz3.
The 5th patch adds a boolean option "ctrl_c" that can be used to disable SIGINT signal handling - it is useful when I want to use the z3 library in a program that does signal handling on its own.

Mikulas