### PR TITLE
include LICENSE.txt in wheels

### DIFF
--- a/src/api/python/setup.py
+++ b/src/api/python/setup.py
@@ -245,6 +245,7 @@ def _copy_sources():
     shutil.rmtree(SRC_DIR_LOCAL, ignore_errors=True)
     os.mkdir(SRC_DIR_LOCAL)
 
+    shutil.copy(os.path.join(SRC_DIR_REPO, 'LICENSE.txt'), ROOT_DIR)
     shutil.copy(os.path.join(SRC_DIR_REPO, 'LICENSE.txt'), SRC_DIR_LOCAL)
     shutil.copy(os.path.join(SRC_DIR_REPO, 'z3.pc.cmake.in'), SRC_DIR_LOCAL)
     shutil.copy(os.path.join(SRC_DIR_REPO, 'CMakeLists.txt'), SRC_DIR_LOCAL)


### PR DESCRIPTION
Update setup.py so that we copy LICENSE.TXT to src/api/python before creating the sdist.  Any wheels built from this sdist will now contain the LICENSE.txt file.

Fixes #7604