### PR TITLE
Add Z3_is_recursive_datatype_sort to the API

### DIFF
--- a/src/api/api_datatype.cpp
+++ b/src/api/api_datatype.cpp
@@ -443,6 +443,16 @@ extern "C" {
         Z3_CATCH;
     }
 
+    bool Z3_API Z3_is_recursive_datatype_sort(Z3_context c, Z3_sort t) {
+        Z3_TRY;
+        LOG_Z3_is_recursive_datatype_sort(c, t);
+        RESET_ERROR_CODE();
+        sort * s = to_sort(t);
+        datatype_util& dt_util = mk_c(c)->dtutil();
+        return dt_util.is_datatype(s) && dt_util.is_recursive(s);
+        Z3_CATCH_RETURN(false);
+    }
+
     unsigned Z3_API Z3_get_datatype_sort_num_constructors(Z3_context c, Z3_sort t) {
         Z3_TRY;
         LOG_Z3_get_datatype_sort_num_constructors(c, t);

--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -4589,6 +4589,13 @@ extern "C" {
     Z3_func_decl Z3_API Z3_get_tuple_sort_field_decl(Z3_context c, Z3_sort t, unsigned i);
 
     /**
+       \brief Check if \c s is a recursive datatype sort.
+
+       def_API('Z3_is_recursive_datatype_sort', BOOL, (_in(CONTEXT), _in(SORT)))
+     */
+    bool Z3_API Z3_is_recursive_datatype_sort(Z3_context c, Z3_sort s);
+
+    /**
         \brief Return number of constructors for datatype.
 
         \pre Z3_get_sort_kind(t) == Z3_DATATYPE_SORT


### PR DESCRIPTION
It does not seem to be possible to test if a datatype sort is recursive.