### PR TITLE
Add an option "ctrl_c" that can be used to disable Ctrl-C signal hand…

### DIFF
--- a/src/params/context_params.cpp
+++ b/src/params/context_params.cpp
@@ -157,6 +157,7 @@ void context_params::updt_params(params_ref const & p) {
 void context_params::collect_param_descrs(param_descrs & d) {
     insert_rlimit(d);
     insert_timeout(d);
+    insert_ctrl_c(d);
     d.insert("well_sorted_check", CPK_BOOL, "type checker", "false");
     d.insert("type_check", CPK_BOOL, "type checker (alias for well_sorted_check)", "true");
     d.insert("auto_config", CPK_BOOL, "use heuristics to automatically select solver and configure it", "true");

--- a/src/util/scoped_ctrl_c.cpp
+++ b/src/util/scoped_ctrl_c.cpp
@@ -18,6 +18,7 @@ Revision History:
 --*/
 #include<signal.h>
 #include "util/scoped_ctrl_c.h"
+#include "util/gparams.h"
 
 static scoped_ctrl_c * g_obj = nullptr;
 
@@ -41,6 +42,8 @@ scoped_ctrl_c::scoped_ctrl_c(event_handler & eh, bool once, bool enabled):
     m_once(once),
     m_enabled(enabled),
     m_old_scoped_ctrl_c(g_obj) {
+    if (gparams::get_value("ctrl_c") == "false")
+        m_enabled = false;
     if (m_enabled) {
         g_obj = this;
         m_old_handler = signal(SIGINT, on_ctrl_c); 


### PR DESCRIPTION
…ling

Add this option, so that the z3 library can be used in programs that do signal handling on their own.