### PR TITLE
Add Iterators as acceptable arguments to functions

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -54,7 +54,7 @@ import io
 import math
 import copy
 if sys.version_info.major >= 3:
-    from typing import Iterable
+    from typing import Iterable, Iterator
 
 from collections.abc import Callable
 from typing import (
@@ -155,6 +155,8 @@ def _get_args(args):
             return args[0]
         elif len(args) == 1 and (isinstance(args[0], set) or isinstance(args[0], AstVector)):
             return [arg for arg in args[0]]
+        elif len(args) == 1 and isinstance(args[0], Iterator):
+            return list(args[0])
         else:
             return args
     except TypeError:  # len is not necessarily defined when args is not a sequence (use reflection?)


### PR DESCRIPTION
Allow users to use generator expressions as arguments to z3 objects.

I think it makes the syntax a little cleaner. Removes a lot of those square brackets.

Examples:

```python
s = Solver()

X = [[Int(f"{row} {col}") for col in range(9)] for row in range(9)]

s.add(Distinct(row) for row in X)
# vs
s.add([Distinct(row) for row in X])
```