### PR TITLE
Centralize and document TRACE tags using X-macros

### DIFF
--- a/scripts/generate_trace_tag_docs.py
+++ b/scripts/generate_trace_tag_docs.py
@@ -1,0 +1,35 @@
+# generate_trace_tag_docs.py
+# This script generates a Markdown file from the trace_tags.def file.
+# It extracts the trace tags and their descriptions and formats them into a table.
+# The generated Markdown file can be used for documentation purposes.
+
+# Trace Tags Documentation
+
+# | Tag | Description |
+# |-----|-------------|
+# | `mam_int` | mam initialization |
+# | `mam_test` | mam test |
+# | `propagate` | propagation |
+
+import re
+
+def_file = "./src/util/trace_tags.def"
+output_md = "./trace_tags.md"
+
+with open(def_file, "r") as f:
+    lines = f.readlines()
+
+entries = []
+for line in lines:
+    match = re.match(r'X\(\s*(\w+)\s*,\s*"([^"]+)"\s*\)', line)
+    if match:
+        tag, desc = match.groups()
+        entries.append((tag, desc))
+
+with open(output_md, "w") as f:
+    f.write("# Trace Tags Documentation\n\n")
+    f.write("| Tag | Description |\n")
+    f.write("|-----|-------------|\n")
+    for tag, desc in entries:
+        f.write(f"| `{tag}` | {desc} |\n")
+

--- a/src/smt/smt_context.cpp
+++ b/src/smt/smt_context.cpp
@@ -1702,6 +1702,7 @@ namespace smt {
      */
     bool context::propagate() {
         TRACE("propagate", tout << "propagating... " << m_qhead << ":" << m_assigned_literals.size() << "\n";);
+        TRACE_NEW(TraceTag::propagate, tout << "propagating... " << m_qhead << ":" << m_assigned_literals.size() << "\n";);
         while (true) {
             if (inconsistent())
                 return false;

--- a/src/util/trace.h
+++ b/src/util/trace.h
@@ -20,6 +20,7 @@ Revision History:
 #pragma once
 
 #include<fstream>
+#include "util/trace_tags.h"
 
 #ifdef SINGLE_THREAD
 # define is_threaded() false
@@ -81,6 +82,7 @@ static inline void finalize_trace() {}
 #define STRACEBODY(CODE) CODE; tout.flush()
 
 #define TRACE(TAG, CODE) TRACE_CODE(if (is_trace_enabled(TAG)) { THREAD_LOCK(TRACEBODY(TAG, CODE)); })
+#define TRACE_NEW(TAG, CODE) TRACE_CODE(if (is_trace_enabled(to_string(TAG))) { THREAD_LOCK(TRACEBODY(to_string(TAG), CODE)); })
 
 #define STRACE(TAG, CODE) TRACE_CODE(if (is_trace_enabled(TAG)) { THREAD_LOCK(STRACEBODY(CODE)); })
 

--- a/src/util/trace_tags.def
+++ b/src/util/trace_tags.def
@@ -1,0 +1,3 @@
+X(mam_int, "mam initialization")
+X(mam_test, "mam test")
+X(propagate, "propagation")

--- a/src/util/trace_tags.h
+++ b/src/util/trace_tags.h
@@ -1,0 +1,43 @@
+#pragma once
+
+enum class TraceTag {
+#define X(tag, desc) tag,
+#include "trace_tags.def"
+#undef X
+    Count
+};
+
+// Convert TraceTag to string
+inline const char* to_string(TraceTag tag) {
+    switch (tag) {
+#define X(tag, desc) case TraceTag::tag: return #tag;
+#include "trace_tags.def"
+#undef X
+    default: return "Unknown";
+    }
+}
+
+// Return description of TraceTag
+inline const char* get_trace_tag_doc(TraceTag tag) {
+    switch (tag) {
+#define X(tag, desc) case TraceTag::tag: return desc;
+#include "trace_tags.def"
+#undef X
+    default: return "Unknown tag";
+    }
+}
+
+// Return the number of TraceTags
+inline constexpr int trace_tag_count() {
+    return static_cast<int>(TraceTag::Count);
+}
+
+// Return all TraceTags as an array
+inline const TraceTag* all_trace_tags() {
+    static TraceTag tags[] = {
+#define X(tag, desc) TraceTag::tag,
+#include "trace_tags.def"
+#undef X
+    };
+    return tags;
+}


### PR DESCRIPTION
- Introduce X-macro-based trace tag definition
- Add script to generate Markdown documentation from trace_tags.def