### PR TITLE
Bazel: expose `z3_static` target for working macOS, win32 builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,13 @@
 common --enable_bzlmod
 common --noenable_workspace
 
+# Specifies...
+#   --config=windows on Windows hosts
+#   --config=linux on Linux hosts
+#   --config=macos on macOS hosts
+# NOTE: We assume our host and target platforms are identical.
+common --enable_platform_specific_config
+
 # Use C++20.
 build --cxxopt=-std=c++20
 build --host_cxxopt=-std=c++20

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,10 +17,42 @@ filegroup(
 )
 
 cmake(
-    name = "z3",
-    generate_args = ["-G Ninja"],
+    name = "z3_dynamic",
+    generate_args = [
+        "-G Ninja", 
+        "-D Z3_EXPORTED_TARGETS=",  # prevents installation, leaving symlinks between dylibs intact on copy
+    ],
     lib_source = ":all_files",
     out_binaries = ["z3"],
-    out_shared_libs = ["libz3.so"],
+    out_shared_libs = select({
+        "@platforms//os:linux": ["libz3.so"],
+        # "@platforms//os:osx": ["libz3.dylib"],    # FIXME: this is not working, libz3<version>.dylib is not copied
+        # "@platforms//os:windows": ["z3.dll"],     # TODO: test this
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cmake(
+    name = "z3_static",
+    generate_args = [
+        "-G Ninja", 
+        "-D BUILD_SHARED_LIBS=OFF",
+        "-D Z3_BUILD_LIBZ3_SHARED=OFF",
+    ],
+    lib_source = ":all_files",
+    out_binaries = ["z3"],
+    out_static_libs = select({
+        "@platforms//os:linux": ["libz3.a"],
+        "@platforms//os:osx": ["libz3.a"],
+        # "@platforms//os:windows": ["z3.lib"],     # TODO: test this
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "z3",
+    actual = ":z3_dynamic",
     visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,3 +17,5 @@ bazel_dep(
     version = "8.0.1",
     dev_dependency = True,
 )
+
+bazel_dep(name = "platforms", version = "0.0.11")


### PR DESCRIPTION
The current Bazel build files introduced in #7646 do not work on macOS or Windows. The current implementation expects `libz3.so` to be produced by the CMake build. However, on macOS and Windows, we produce `libz3.dylib` and `z3.dll` respectively.

Updating the Bazel build file to output `libz3.dylib` on macOS and `z3.dll` on Windows reveals more issues. On macOS, exposing `libz3.dylib` is insufficient because running executables linked against this dylib causes a runtime error, complaining that `libz3<version>.dylib` is not found. (**TODO:** report test results on Windows)

One solution is to specify both `libz3.dylib` and `libz3<version>.dylib` in the list of output shared libraries exposed by the `cmake` rule in the Bazel build. However, Bazel [cannot depend on the contents of a VERSION file to determine CMake's outputs](https://stackoverflow.com/questions/56007307/read-local-file-content-in-bazel-build-system), meaning we'd have to hard-code the current Z3 version in the Bazel file and keep it in-sync with the rest of the project. Brittle.

A simpler workaround is to also expose the statically-linked libraries also produced by Z3. This is what I've done in this PR.

---

This PR adds the `z3_static` Bazel target to the `BUILD.bazel` file. This allows consumption of Z3 as a static library using the Bazel build system. It also unblocks users on macOS and Windows until the default `z3_dynamic` target can be fixed on those platforms.