### PR TITLE
Fix setup_relevancy for relevancy-dependent case split strategies

### DIFF
--- a/src/smt/smt_setup.cpp
+++ b/src/smt/smt_setup.cpp
@@ -834,6 +834,13 @@ namespace smt {
     // there are some other cases where relevancy propagation is harmful.
     //
     void setup::setup_relevancy(static_features& st) {
+        // the case split queue has been constructed by now.
+        // it is not safe to disable relevancy if the case split stragegy is relevancy-dependent.
+        if (m_params.m_case_split_strategy == CS_RELEVANCY || 
+            m_params.m_case_split_strategy == CS_RELEVANCY_ACTIVITY || 
+            m_params.m_case_split_strategy == CS_RELEVANCY_GOAL)
+            return;
+
         if (st.m_has_bv && !st.m_has_fpa && st.m_num_quantifiers == 0)
              m_params.m_relevancy_lvl = 0;           
     }


### PR DESCRIPTION
Quantifier-free bitvector problems break with `auto_config=false smt.case_split=3`, `4` and `5`. This is because `setup_relevancy` silently disables relevancy, and does so after the sanity checks in `mk_case_split_queue`.

Below is a short `unsat` example that is fixed by the commit.

Before the fix, relevancy-dependent strategies returned `sat` with most random random seeds, `unsat` with some. Also, moving the first assertion to the end made the query consistently `unsat`.

```
(declare-const x (_ BitVec 32))
(declare-const y Int)
(declare-const z Bool)

(assert (or  (= #x00000000 x) (= 0 y)))

(assert (bvslt #x00000000 x))    
(assert (< 0 y))

(check-sat)
```
