### PR TITLE
Fix out of bounds error in OCaml API (#7665)

### DIFF
--- a/src/api/ml/z3.ml
+++ b/src/api/ml/z3.ml
@@ -1617,7 +1617,7 @@ struct
     let g i = Z3native.model_get_const_decl (gc x) x i in
     List.init (n_funcs + n_consts) (fun i ->
       if i < n_funcs then f i
-      else g i
+      else g (i - n_funcs)
     )
 
   let eval (x:model) (t:expr) (completion:bool) =


### PR DESCRIPTION
This PR fixes issue #7665 with a one-line change.

It corrects a regression introduced by #7133 while keeping all improvements made in that PR. This restores the original observable behavior and resolves the issue.