### PR TITLE
Fix Python model_str sorting

### DIFF
--- a/src/api/python/z3/z3util.py
+++ b/src/api/python/z3/z3util.py
@@ -493,7 +493,12 @@ def model_str(m, as_str=True):
 
     if m:
         vs = [(v, m[v]) for v in m]
-        vs = sorted(vs, key=lambda a, _: str(a))
+        # Sort model entries by the variable name for determinism.
+        # "sorted" expects a key function with a single argument, but the
+        # previous implementation incorrectly declared a two-argument lambda
+        # which resulted in a TypeError when invoked.  Use a one-argument
+        # lambda that accesses the first element of the pair.
+        vs = sorted(vs, key=lambda pair: str(pair[0]))
         if as_str:
             return "\n".join(["{} = {}".format(k, v) for (k, v) in vs])
         else:

--- a/src/shell/dimacs_frontend.cpp
+++ b/src/shell/dimacs_frontend.cpp
@@ -55,6 +55,7 @@ static void display_statistics() {
 }
 
 static void on_timeout() {
+    g_display_statistics = true;
     display_statistics();
     _Exit(0);
 }

--- a/src/shell/opt_frontend.cpp
+++ b/src/shell/opt_frontend.cpp
@@ -85,6 +85,7 @@ static void STD_CALL on_ctrl_c(int) {
 }
 
 static void on_timeout() {
+    g_display_statistics = true;
     display_statistics();
     _Exit(0);
 }

--- a/src/shell/smtlib_frontend.cpp
+++ b/src/shell/smtlib_frontend.cpp
@@ -62,6 +62,7 @@ static void display_model() {
 }
 
 static void on_timeout() {
+    g_display_statistics = true;
     display_statistics();
     _Exit(0);
 }


### PR DESCRIPTION
## Summary
- avoid TypeError by fixing the lambda in `model_str`
- print statistics when Z3 times out

## Testing
- `PYTHONPATH=src/api/python python src/api/python/z3test.py z3` *(fails: ImportError: cannot import name 'z3core')*

------
https://chatgpt.com/codex/tasks/task_e_6850de32f86483309f428bdccff754e1

<!-- genaiscript begin pull-request-descriptor --><hr/>

- 🐛 Fixed a TypeError in `model_str` by updating the sorting lambda to accept a single argument, ensuring deterministic sorting of model entries by variable name.
- ⏱️ Ensured statistics are displayed upon timeout in the DIMACS, optimization, and SMT-LIB frontends by setting `g_display_statistics = true` before exiting.

> AI-generated content by [pull-request-descriptor](https://github.com/Z3Prover/z3/actions/runs/15958255203) may be incorrect. Use reactions to eval.



<!-- genaiscript end pull-request-descriptor -->

