### PR TITLE
Bugfix: post-build sanity check when an old version of ocaml-z3 is installed

### DIFF
--- a/src/api/ml/CMakeLists.txt
+++ b/src/api/ml/CMakeLists.txt
@@ -255,6 +255,7 @@ set(z3ml_example_src ${PROJECT_SOURCE_DIR}/examples/ml/ml_example.ml)
 add_custom_command(
   TARGET build_z3_ocaml_bindings POST_BUILD
   COMMAND "${OCAMLFIND}" ocamlc
+    -cclib "${libz3_path}/libz3${so_ext}"
     -o "${z3ml_bin}/ml_example.byte"
     -package zarith
     -linkpkg
@@ -270,6 +271,7 @@ add_custom_command(
 add_custom_command(
   TARGET build_z3_ocaml_bindings POST_BUILD
   COMMAND "${OCAMLFIND}" ocamlopt
+    -cclib "${libz3_path}/libz3${so_ext}"
     -o "${z3ml_bin}/ml_example"
     -package zarith
     -linkpkg


### PR DESCRIPTION
These two lines are a post-build sanity check to test whether `ml_example` can be built in native and bytecode.

It works fine with z3 standalone, whether for 4.14.1 and 4.15.3. No OCaml packages will be installed for this test.

However, if the user has a pre-installed ocaml-z3 package in the opam, which is common for OCaml users, these commands will implicitly load the libz3 in the opam stublibs' path, instead of the locally built libz3. For this tricky reason, it hasn't been found in the previous CI. I don't update the CIs (z3 and opam z3 package) for this tricky case, but the current CI satisfies with this fix.

The fix is to enforce the project build path of libz3, regardless of whether a possible installed libz3 is in opam's switch or not.

p.s. I am working on a better understanding, abstraction, and reasoning of this problem and its fix. 
