### PR TITLE
Use '--tags' rather than '--long' for `git describe`

### DIFF
--- a/cmake/git_utils.cmake
+++ b/cmake/git_utils.cmake
@@ -202,7 +202,7 @@ function(get_git_head_describe GIT_DOT_FILE OUTPUT_VAR)
     COMMAND
       "${GIT_EXECUTABLE}"
       "describe"
-      "--long"
+      "--tags"
     WORKING_DIRECTORY
       "${GIT_WORKING_DIR}"
     RESULT_VARIABLE


### PR DESCRIPTION
This PR changes the CMake-based build system to use `git describe --tags` rather than `git describe --long`.

This changes it such that:

```
echo -e "import z3\nprint(z3.Z3_get_full_version())" | python3
```

Now gives:

```
4.15.4.0 3e216dbb2078e9b6d79f5b8f65a54d1ba31f5289 z3-4.15.3-36-g3e216dbb2
```

Previously, it gave:

```
4.15.4.0 3e216dbb2078e9b6d79f5b8f65a54d1ba31f5289 z3-4.8.4-9644-g3e216dbb2
```

Closes #6823