### PR TITLE
Daily Test Coverage Improver: Fix coverage report generation

### DIFF
--- a/.github/actions/daily-test-improver/coverage-steps/action.yml
+++ b/.github/actions/daily-test-improver/coverage-steps/action.yml
@@ -126,8 +126,8 @@ runs:
       shell: bash
       run: |
         echo "Generating HTML coverage report" >> coverage-steps.log
-        # Generate basic HTML coverage report
-        gcovr --html coverage.html --gcov-ignore-parse-errors --gcov-executable "llvm-cov gcov" . 2>&1 | tee -a coverage-steps.log
+        # Generate basic HTML coverage report with merge-mode fix
+        gcovr --html coverage.html --merge-mode-functions=separate --gcov-ignore-parse-errors --gcov-executable "llvm-cov gcov" . 2>&1 | tee -a coverage-steps.log
         echo "Basic coverage report generated as coverage.html" >> coverage-steps.log
         
     # Generate detailed coverage report
@@ -136,8 +136,8 @@ runs:
       run: |
         echo "Generating detailed HTML coverage report" >> coverage-steps.log
         mkdir -p cov-details
-        # Generate detailed HTML coverage report focused on src directory
-        gcovr --html-details cov-details/coverage.html --gcov-ignore-parse-errors --gcov-executable "llvm-cov gcov" -r src --object-directory build 2>&1 | tee -a coverage-steps.log || echo "Detailed coverage generation had issues, basic report still available" >> coverage-steps.log
+        # Generate detailed HTML coverage report focused on src directory with merge-mode fix
+        gcovr --html-details cov-details/coverage.html --merge-mode-functions=separate --gcov-ignore-parse-errors --gcov-executable "llvm-cov gcov" -r src --object-directory build 2>&1 | tee -a coverage-steps.log || echo "Detailed coverage generation had issues, basic report still available" >> coverage-steps.log
         echo "Detailed coverage report generated in cov-details/ directory" >> coverage-steps.log
         
     # Generate text summary of coverage
@@ -145,7 +145,7 @@ runs:
       shell: bash
       run: |
         echo "Generating text coverage summary" >> coverage-steps.log
-        gcovr --gcov-ignore-parse-errors --gcov-executable "llvm-cov gcov" . 2>&1 | tee coverage-summary.txt | tee -a coverage-steps.log
+        gcovr --merge-mode-functions=separate --gcov-ignore-parse-errors --gcov-executable "llvm-cov gcov" . 2>&1 | tee coverage-summary.txt | tee -a coverage-steps.log
         echo "Coverage summary saved to coverage-summary.txt" >> coverage-steps.log
         
     # Upload coverage reports as artifact


### PR DESCRIPTION
## Summary

This PR fixes the coverage report generation issue identified in the Daily Test Coverage Improver workflow. The problem was that `gcovr` was failing with merge conflicts when processing C++ template destructors that appeared on multiple lines.

## Problem Found

The coverage steps were failing with this error:
```
AssertionError: Got function (redacted)&lt;(redacted)&gt;::(redacted)) on multiple lines: 87, 116.
You can run gcovr with --merge-mode-functions=MERGE_MODE.
```

## Actions Taken

- Added `--merge-mode-functions=separate` flag to all three `gcovr` commands in the coverage action
- Updated basic HTML report generation
- Updated detailed HTML report generation  
- Updated text summary generation

## Changes in Test Coverage Achieved

**(redacted) Coverage report generation completely failed - no reports generated
**(redacted) Coverage reports generate successfully, showing data like:
- `build/src/ackermannization/ackermannization_params.hpp`: 50% coverage (3/6 lines)
- `build/src/api/dll/gparams_register_modules.cpp`: 100% coverage (58/58 lines)
- `build/src/params/sat_params.hpp`: 98% coverage (193/197 lines)

This fix enables proper measurement and improvement of test coverage across the Z3 codebase.

## Validation Commands

To validate the fix works:
```bash
# Generate coverage summary
gcovr --merge-mode-functions=separate --gcov-ignore-parse-errors --gcov-executable &quot;llvm-cov gcov&quot; .

# Generate HTML report
gcovr --html coverage.html --merge-mode-functions=separate --gcov-ignore-parse-errors --gcov-executable &quot;llvm-cov gcov&quot; .
```

## Future Improvement Areas

Based on the initial coverage data, areas for future test improvement include:
- API commands (`build/src/api/api_commands.cpp`: 0% coverage)
- API log macros (`build/src/api/api_log_macros.cpp`: 0% coverage)
- Real closure parameters (`build/src/math/realclosure/rcf_params.hpp`: 0% coverage)
- Model evaluator parameters (50% coverage)
- Pattern inference parameters (50% coverage)

&lt;details&gt;
&lt;summary&gt;Workflow Details&lt;/summary&gt;

### Bash Commands Run
- `git checkout -b fix-coverage-merge-mode`
- `gcovr --merge-mode-functions=separate --gcov-ignore-parse-errors --gcov-executable &quot;llvm-cov gcov&quot; . 2&gt;&amp;1 | head -20`
- `git add .github/actions/daily-test-improver/coverage-steps/action.yml`
- `git commit --author &quot;Daily Test Coverage Improver &lt;github-actions[bot]`@users`.noreply.github.com&gt;&quot; -m &quot;Fix coverage report generation with merge-mode-functions=separate&quot;`

### Web Searches Performed
None

### Web Pages Fetched
None

&lt;/details&gt;

&gt; AI-generated content by [Daily Test Coverage Improver](https://github.com/Z3Prover/z3/actions/runs/17770833510) may contain mistakes.


> Generated by Agentic Workflow [Run](https://github.com/Z3Prover/z3/actions/runs/17770833510)