### PR TITLE
Daily Backlog Burner: Remove Windows-only guard from hashtable unit tests

### DIFF
--- a/src/test/hashtable.cpp
+++ b/src/test/hashtable.cpp
@@ -17,7 +17,6 @@ Author:
 Revision History:
 
 --*/
-#ifdef _WINDOWS
 #include<iostream>
 #include<unordered_set>
 #include<stdlib.h>
@@ -236,7 +235,3 @@ void tst_hashtable() {
     test_hashtable_operators();
     std::cout << "All tests passed!" << std::endl;
 }
-#else
-void tst_hashtable() {
-}
-#endif


### PR DESCRIPTION
## Summary

This PR addresses issue #1163 (Unit tests need clean up) by removing the `#ifdef _WINDOWS` guard from the hashtable unit tests, enabling these tests to run on all platforms including Linux CI.

## Problem

The hashtable tests in `src/test/hashtable.cpp` were wrapped in `#ifdef _WINDOWS` preprocessor guards, which meant they only ran on Windows builds. This limited CI coverage and prevented these important tests from running on Linux and other platforms.

## Solution

- **Removed `#ifdef _WINDOWS` guard**: Tests now run on all platforms
- **Cleaned up conditional compilation**: Eliminated the empty `#else` branch for non-Windows platforms
- **Verified compilation**: Confirmed the tests compile successfully on Linux

## Testing

- ✅ Verified `src/test/hashtable.cpp` compiles successfully without the Windows guard
- ✅ Tests use proper `VERIFY`/`ENSURE` macros that correctly exit on failure
- ✅ No functional changes to test logic, only removed platform restrictions

## Impact

This change immediately improves CI test coverage by enabling hashtable tests to run on Linux builds. This addresses one of the key issues mentioned in #1163 where tests had unnecessary platform guards limiting coverage.

## Next Steps

This is the first step in a broader unit test modernization effort. Future work could include:
- Removing similar Windows-only guards from other test files
- Evaluating the feasibility of migrating to a modern C++ testing framework
- Addressing other test infrastructure improvements mentioned in #1163

## Related Issues

- Addresses part of issue #1163: Unit tests need clean up
- Contributes to Phase 2 goals from the Daily Backlog Burner roadmap (issue #7897)

&gt; AI-generated content by [Daily Backlog Burner](https://github.com/Z3Prover/z3/actions/runs/17784119650) may contain mistakes.


> Generated by Agentic Workflow [Run](https://github.com/Z3Prover/z3/actions/runs/17784119650)