### PR TITLE
Daily Backlog Burner: Add .clang-format file for C++ code formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,75 @@
+# Z3 Theorem Prover clang-format configuration
+# Based on analysis of existing codebase style patterns
+
+BasedOnStyle: LLVM
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+
+# Column width
+ColumnLimit: 120
+
+# Braces
+BreakBeforeBraces: Linux
+Cpp11BracedListStyle: true
+
+# Classes and structs
+BreakConstructorInitializers: BeforeColon
+ConstructorInitializerIndentWidth: 4
+AccessModifierOffset: -4
+
+# Function definitions
+AlwaysBreakAfterReturnType: None
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+# Spacing
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+# Alignment
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignOperands: true
+AlignTrailingComments: true
+
+# Line breaks
+AllowAllParametersOfDeclarationOnNextLine: true
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+
+# Includes
+SortIncludes: false  # Z3 has specific include ordering conventions
+
+# Namespaces
+NamespaceIndentation: None
+
+# Comments and documentation
+ReflowComments: true
+SpacesBeforeTrailingComments: 2
+
+# Language standards
+Standard: c++20
+
+# Penalties (for line breaking decisions)
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+
+# Misc
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1


### PR DESCRIPTION
## Summary

This PR implements the enhancement requested in issue #1441 by adding a `.clang-format` configuration file that matches Z3&apos;s existing C++ coding style patterns.

## Changes

- **Added `.clang-format`**: Comprehensive clang-format configuration based on analysis of existing Z3 codebase
- **Style Configuration**: 
  - 4-space indentation with no tabs
  - Linux-style bracing (opening brace on same line for functions)
  - 120 column width limit 
  - C++20 standard compliance
  - Preserves existing include ordering conventions

## Testing

The configuration has been tested with existing codebase samples and produces formatting that is consistent with Z3&apos;s established style guidelines. The formatting works correctly with `clang-format` version 18.1.3 and should work with other modern versions.

## Usage

Developers can now use:
- `clang-format &lt;file&gt;` to format entire files
- `git clang-format` to format only changed lines in patches
- Editor integrations for automatic formatting of selected regions

This will help maintain consistent code style across contributions and reduce formatting-related review feedback.

## Benefits

- **Developer Experience**: Automatic code formatting reduces manual style adjustments
- **Code Consistency**: Ensures uniform formatting across the entire codebase  
- **Review Efficiency**: Reduces style-related discussion in code reviews
- **Contributor Onboarding**: Makes it easier for new contributors to follow Z3&apos;s style

`Closes #1441`

&gt; AI-generated content by [Daily Backlog Burner](https://github.com/Z3Prover/z3/actions/runs/17784346842) may contain mistakes.


> Generated by Agentic Workflow [Run](https://github.com/Z3Prover/z3/actions/runs/17784346842)