### PR TITLE
fix: add .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "z3test"]
+	path = z3test
+	url = https://github.com/Z3Prover/z3test.git


### PR DESCRIPTION
This PR adds a gitmodules entry for the "z3test" submodule, pointing to the correct repository.

Currently when using this repo as a submodule and running `git submodule update --init --recursive`, I get the following error:
```
fatal: No url found for submodule path '<path>/z3/z3test' in .gitmodules
```

It's worth saying I'm using the [prove-rs/z3.rs](https://github.com/prove-rs/z3.rs) Rust library as a submodule, which itself uses Z3Prover/z3 as a submodule. Because of this I need to pass the `--recursive` flag and I run into this error. Is there a reason why `.gitmodules` isn't present?