### PR TITLE
Add cube tree optimization about resolving cores recursively up the path, to prune

### DIFF
--- a/src/util/search_tree.h
+++ b/src/util/search_tree.h
@@ -163,9 +163,6 @@ namespace search_tree {
         }
 
         // Given complementary sibling nodes for literals x and ¬x, sibling resolvent = (core_left ∪ core_right) \ {x, ¬x}
-        // if there are other complements in the union of the cores, they are not removed, but that is ok, because the core is
-        // strengthened, and these complements came from a higher-up branch, which will be resolved away recursively as we move up the tree
-        // in conclusion: the sibling resolvent only promises to eliminate the split variable’s literal/complement.Other complements may still appear, which is ok since they just reflect conflicts from higher up the path.
         vector<literal> compute_sibling_resolvent(node<Config>* left, node<Config>* right) {
           vector<literal> res;
 
@@ -216,7 +213,7 @@ namespace search_tree {
 
               // empty resolvent → subtree is UNSAT
               if (resolvent.empty()) {
-                  p->set_core(resolvent);  // empty core
+                  p->set_core(resolvent); // empty core
                   close_node(p);
                   p = p->parent();
                   continue;
@@ -226,10 +223,8 @@ namespace search_tree {
               if (p->has_core() && resolvent == p->get_core())
                   return;
 
-              //
               // Bubble to the highest ancestor where ALL literals in the resolvent
               // are present somewhere on the path from that ancestor to root
-              //
               node<Config>* candidate = p;
               node<Config>* attach_here = p; // fallback
 


### PR DESCRIPTION
Solving this issue: "If the core is {A, C} in in the A->B->C branch and the core is {A, !C} in the A->B->!C branch we currently still explore A->!B. This is not necessary because the resolvent of {A, C} and {A, !C} is A which means that the branch A is closed. You can go directly to !A. "

Benchmarks: 
run-0728-smt_qfnia-threads-4-recursiveresolve3-stats.md
run-0727-smt_qflia-threads-4-recursiveresolve3-stats.md

Baselines:
run-0723-smt_qfnia-threads-4-stats.md
run-0729-smt_qflia-threads-4-stats.md

QF_NIA_small: solves 2 more than baseline
QF_LIA: solves 9 more than baseline

I got 1 segfault (`terminated by signal[31mramon: signal 11 (SIGSEGV Segmentation fault)[0m`) on the QF_LIA benchmark (z3-poly-testing/inputs/QF_LIA/c10_problem__003.smt2.slack.smt2) that I'm unable to repro locally. all the code I added is under lock when called in the batch manager.