### PR TITLE
Fixed tests by making methods public for finite sets

### DIFF
--- a/src/ast/rewriter/finite_set_rewriter.h
+++ b/src/ast/rewriter/finite_set_rewriter.h
@@ -34,12 +34,7 @@ where the signature is defined in finite_set_decl_plugin.h.
 */
 class finite_set_rewriter {
     finite_set_util  m_util;
-    // Rewrite rules for set operations
-    br_status mk_union(unsigned num_args, expr * const * args, expr_ref & result);
-    br_status mk_intersect(unsigned num_args, expr * const * args, expr_ref & result);
-    br_status mk_difference(expr * arg1, expr * arg2, expr_ref & result);
-    br_status mk_subset(expr * arg1, expr * arg2, expr_ref & result);
-public:
+    public:
     finite_set_rewriter(ast_manager & m, params_ref const & p = params_ref()):
         m_util(m) {
     }
@@ -50,5 +45,11 @@ public:
 
     br_status mk_app_core(func_decl * f, unsigned num_args, expr * const * args, expr_ref & result);
     
+    // Rewrite rules for set operations
+    br_status mk_union(unsigned num_args, expr * const * args, expr_ref & result);
+    br_status mk_intersect(unsigned num_args, expr * const * args, expr_ref & result);
+    br_status mk_difference(expr * arg1, expr * arg2, expr_ref & result);
+    br_status mk_subset(expr * arg1, expr * arg2, expr_ref & result);
+
 };
 


### PR DESCRIPTION
The tests fail because they use the methods from `finite_set_rewriter` which are private. To fix the tests, I made them public.