### PR TITLE
Create fresh values for finite set using bitvector

### DIFF
--- a/src/model/finite_set_value_factory.cpp
+++ b/src/model/finite_set_value_factory.cpp
@@ -38,7 +38,7 @@ expr * finite_set_value_factory::get_fresh_value(sort * s) {
 
     // take the bitmask of next_index to determine which elements to include
     // i.e. if next_index = 13 = 1101_2, then we include elements values_e[0], values_e[2], and values_e[3]
-    // new elements for sort s are created on the fly
+    // new elements for element sort are created on the fly
     int num_shifts = 0;
     auto r = u.mk_empty(s);
     // check the rightmost bit of next_index


### PR DESCRIPTION
This approach looks at the `next_index` as a bitvector, and creates a set $R$, where $x_i\in R \Leftrightarrow$ i-th bit in `next_index` is $1$, when $x_i$ is the i-th element of the sort of the set (credits to @CEisenhofer who proposed this during class).

I would be happy to discuss whether this approach is suitable.

Advantages
- handles infinite-domain element-sorts well (I think the implementation which was hinted at would only return singleton sets in that case)

Disadvantages
- can at most create as many singleton sets/use as many values of the element sort as the number of bits of `unsigned int`.