### PR TITLE
Add a fast-path to `_coerce_exprs`

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -1245,6 +1245,18 @@ def _coerce_expr_merge(s, a):
     else:
         return s
 
+def _check_same_sort(a, b, ctx=None):
+    if not isinstance(a, ExprRef):
+        return False
+    if not isinstance(b, ExprRef):
+        return False
+    if ctx is None:
+        ctx = a.ctx
+
+    a_sort = Z3_get_sort(ctx.ctx, a.ast)
+    b_sort = Z3_get_sort(ctx.ctx, b.ast)
+    return Z3_is_eq_sort(ctx.ctx, a_sort, b_sort)
+
 
 def _coerce_exprs(a, b, ctx=None):
     if not is_expr(a) and not is_expr(b):
@@ -1258,6 +1270,9 @@ def _coerce_exprs(a, b, ctx=None):
         a = RealVal(a, b.ctx)
     if isinstance(b, float) and isinstance(a, ArithRef):
         b = RealVal(b, a.ctx)
+
+    if _check_same_sort(a, b, ctx):
+        return (a, b)
 
     s = None
     s = _coerce_expr_merge(s, a)


### PR DESCRIPTION
When the inputs are already the same sort, we can skip most of the coercion logic and just return.

Currently, `_coerce_exprs` is by far the most expensive part of building up many common Z3 ASTs, so this fast-path is a substantial speedup for many use-cases.

# Some concrete performance numbers

## A regex crossworld solver
I encountered this while profiling [a regex-crossword solver](https://blog.nelhage.com/post/regex-crosswords-z3/) I built on Z3. That application builds an FSM transition function into a Z3 expression using a big `z3.If` ladder.

For puzzles of side-length 6,  this PR cuts the time to build the Z3 instance in Python from an average of 870ms to about 440ms, including a lot of other Python work to analyze the puzzles and build other structures.

## A microbenchmark
This simple script just measures the time to create a full NxN matrix of equality comparisons between Z3 integer constants:

```python
import z3
from time import perf_counter_ns

N = 500

xs = z3.IntVector("x", N)

a = perf_counter_ns()
cross = [[l == r for r in xs] for l in xs]
b = perf_counter_ns()
print(f"Generated {N*N} comparisons in {(b-a)/1e9:.2f}s")
```

On my M1 macbook air, before this PR, I see:
- Before this PR: `Generated 250000 comparisons in 6.28s`
- After this PR: `Generated 250000 comparisons in 1.18s`

Less than 20% of the original runtime!