### PR TITLE
remove ocamlfind destdir directory check

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2012,9 +2012,6 @@ class MLComponent(Component):
         if self.destdir == "":
             raise MKException('Failed to get OCaml destdir')
 
-        if not os.path.isdir(self.destdir):
-            raise MKException('The destdir reported by {ocamlfind} ({destdir}) does not exist'.format(ocamlfind=OCAMLFIND, destdir=self.destdir))
-
         self.ldconf = check_output([OCAMLFIND, 'printconf', 'ldconf'])
         if self.ldconf == "":
             raise MKException('Failed to get OCaml ldconf path')


### PR DESCRIPTION
This check causes compilation error when using directly in dune.
Somehow, $DESTDIR doesn't created automatically with ocamlfind in dune. Removing this check should make dune dependency works again.