### PR TITLE
mk_util.py: fix --gprof option

### DIFF
--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -2686,8 +2686,6 @@ def mk_config():
             CPPFLAGS     = '%s -DZ3DEBUG -D_DEBUG' % CPPFLAGS
         else:
             CXXFLAGS     = '%s -O3' % CXXFLAGS
-            if GPROF:
-                CXXFLAGS     += '-fomit-frame-pointer'
             CPPFLAGS     = '%s -DNDEBUG -D_EXTERNAL_RELEASE' % CPPFLAGS
         if is_CXX_clangpp():
             CXXFLAGS   = '%s -Wno-unknown-pragmas -Wno-overloaded-virtual -Wno-unused-value' % CXXFLAGS


### PR DESCRIPTION
The addition of -fomit-frame-pointer was missing a space (which broke the command line), but also this option should be added only if -pg is *not* given, as they are incompatible. So, just remove this line to fix the --gprof flag in configure.

Also, this option is implied by any level of `-O`, so there is no need to pass it explicitly in most cases. It could be added to debug, non-profile builds, but I'm not sure that's useful.