### PR TITLE
Return bool instead of int in extra_API for Z3_open_log

### DIFF
--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -5877,7 +5877,7 @@ extern "C" {
        \sa Z3_append_log
        \sa Z3_close_log
 
-       extra_API('Z3_open_log', INT, (_in(STRING),))
+       extra_API('Z3_open_log', BOOL, (_in(STRING),))
     */
     bool Z3_API Z3_open_log(Z3_string filename);
 


### PR DESCRIPTION
The C declaration returns `bool`.

The last of the small bool vs int things I hit.

Signed-off-by: Josh Berdine <josh@berdine.net>