### PR TITLE
Fix _in vs _out def_API param for Z3_solver_get_levels

### DIFF
--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -7132,7 +7132,7 @@ extern "C" {
        \brief retrieve the decision depth of Boolean literals (variables or their negations).
        Assumes a check-sat call and no other calls (to extract models) have been invoked.
        
-       def_API('Z3_solver_get_levels', VOID, (_in(CONTEXT), _in(SOLVER), _in(AST_VECTOR), _in(UINT), _in_array(3, UINT)))
+       def_API('Z3_solver_get_levels', VOID, (_in(CONTEXT), _in(SOLVER), _in(AST_VECTOR), _in(UINT), _out_array(3, UINT)))
     */
     void Z3_API Z3_solver_get_levels(Z3_context c, Z3_solver s, Z3_ast_vector literals, unsigned sz,  unsigned levels[]);
 


### PR DESCRIPTION
Signed-off-by: Josh Berdine <josh@berdine.net>