### PR TITLE
Finite Sets: Simplify expressions before range local check

### DIFF
--- a/src/smt/theory_finite_set.h
+++ b/src/smt/theory_finite_set.h
@@ -135,6 +135,7 @@ namespace smt {
 
         finite_set_util           u;
         finite_set_axioms         m_axioms;
+        th_rewriter               m_rw;
         th_union_find             m_find;
         theory_clauses            m_clauses;
         theory_finite_set_size m_cardinality_solver;


### PR DESCRIPTION
While implementing the metamorphic fuzzer for finite sets I stumbled upon performance issues when set ranges intersected. For example:

```
(declare-const s (FiniteSet Int))

(assert (not (set.subset (set.range 1 2) s)))
(assert (not (set.subset (set.range 2 3) s)))

(assert (not (set.in 1 s)))

(check-sat)
```

This does not terminate within reasonable time (>1 min; appears to not terminate). However, replacing `(set.range 1 2)` with `(set.range 1 1)` results in `SAT` immediately.

I am not sure what causes the bug exactly but I (and Claude) think there is some amplification of unsimplified terms when testing range membership. This patch simplifies the expression before checking containment and simplifies the `lo`/`hi` boundary expressions afterwards. The program above now results in `SAT` in <1s.

If you need more details and/or test cases let me know!

