### PR TITLE
Typescript typedef and doc fixes

### DIFF
--- a/src/api/js/src/high-level/types.ts
+++ b/src/api/js/src/high-level/types.ts
@@ -125,6 +125,7 @@ export type CheckSatResult = 'sat' | 'unsat' | 'unknown';
 /** @hidden */
 export interface ContextCtor {
   <Name extends string>(name: Name, options?: Record<string, any>): Context<Name>;
+  new <Name extends string>(name: Name, options?: Record<string, any>): Context<Name>;
 }
 
 export interface Context<Name extends string = 'main'> {

--- a/src/api/js/src/node.ts
+++ b/src/api/js/src/node.ts
@@ -11,7 +11,7 @@ export * from './low-level/types.__GENERATED__';
  * The main entry point to the Z3 API
  *
  * ```typescript
- * import { init, sat } from 'z3-solver';
+ * import { init } from 'z3-solver';
  *
  * const { Context } = await init();
  * const { Solver, Int } = new Context('main');
@@ -22,7 +22,7 @@ export * from './low-level/types.__GENERATED__';
  * const solver = new Solver();
  * solver.add(x.add(2).le(y.sub(10))); // x + 2 <= y - 10
  *
- * if (await solver.check() !== sat) {
+ * if (await solver.check() !== 'sat') {
  *   throw new Error("couldn't find a solution")
  * }
  * const model = solver.model();


### PR DESCRIPTION
The first example in the npm docs suggest that you can use Z3 in Node like this:

```js
const { init } = require('z3-solver');
const { Context } = await init();
const { Solver, Int, And } = new Context('main');
```

but if you use Typescript, that code gives a type error:

```
z3testnode.ts:3:30 - error TS7009: 'new' expression, whose target lacks a construct signature, implicitly has an 'any' type.

3 const { Solver, Int, And } = new Context("main");
                               ~~~~~~~~~~~~~~~~~~~


Found 1 error in z3testnode.ts:3
```

and you're forced to rewrite the code to be this instead:

```js
const { Solver, Int, And } = Context('main');
```

This PR fixes the type definitions so Typescript allows `new Context` to be used, consistent with the examples.

---

Second, this PR fixes a tsdoc example which used a nonexistent `sat` import instead of the string "sat".