### PR TITLE
Typescript typedef and doc fixes take 2

### DIFF
--- a/src/api/js/src/high-level/high-level.ts
+++ b/src/api/js/src/high-level/high-level.ts
@@ -3309,6 +3309,6 @@ export function createApi(Z3: Z3Core): Z3HighLevel {
     setParam,
     resetParams,
 
-    Context: createContext,
+    Context: createContext as ContextCtor,
   };
 }

--- a/src/api/js/src/high-level/types.ts
+++ b/src/api/js/src/high-level/types.ts
@@ -125,6 +125,7 @@ export type CheckSatResult = 'sat' | 'unsat' | 'unknown';
 /** @hidden */
 export interface ContextCtor {
   <Name extends string>(name: Name, options?: Record<string, any>): Context<Name>;
+  new <Name extends string>(name: Name, options?: Record<string, any>): Context<Name>;
 }
 
 export interface Context<Name extends string = 'main'> {

--- a/src/api/js/src/node.ts
+++ b/src/api/js/src/node.ts
@@ -11,7 +11,7 @@ export * from './low-level/types.__GENERATED__';
  * The main entry point to the Z3 API
  *
  * ```typescript
- * import { init, sat } from 'z3-solver';
+ * import { init } from 'z3-solver';
  *
  * const { Context } = await init();
  * const { Solver, Int } = new Context('main');
@@ -22,7 +22,7 @@ export * from './low-level/types.__GENERATED__';
  * const solver = new Solver();
  * solver.add(x.add(2).le(y.sub(10))); // x + 2 <= y - 10
  *
- * if (await solver.check() !== sat) {
+ * if (await solver.check() !== 'sat') {
  *   throw new Error("couldn't find a solution")
  * }
  * const model = solver.model();


### PR DESCRIPTION
Fixed version of https://github.com/Z3Prover/z3/pull/8073.

Includes an explicit cast in `Context: createContext as ContextCtor,` to make the type-checking work. This casts the createContext function to have a construct signature, which is fine because any function that's not picky about it's `this` binding can be called as a constructor (and because this specific function is regularly used as a constructor when used in JS following the example code).

I've checked this PR passes `npm run build:ts`.