### PR TITLE
Fix missing newline after attributes in benchmark_to_smtlib_string

### DIFF
--- a/src/ast/ast_smt_pp.cpp
+++ b/src/ast/ast_smt_pp.cpp
@@ -977,7 +977,7 @@ void ast_smt_pp::display_smt2(std::ostream& strm, expr* n) {
         strm << "(set-logic " << m_logic << ")\n";
     }
     if (!m_attributes.empty()) {
-        strm << "; " << m_attributes;
+        strm << "; " << m_attributes << "\n";
     }
 
 #if 0


### PR DESCRIPTION
Without this, when the attributes parameter doesn't end with a newline, the
subsequent (assert ...) statement gets concatenated to the attributes
comment line, producing invalid SMT-LIB.

Signed-off-by: Josh Berdine <josh@berdine.net>