### PR TITLE
Suggest eval in ModelRef.__getitem__ error

### DIFF
--- a/src/api/python/z3/z3.py
+++ b/src/api/python/z3/z3.py
@@ -6849,7 +6849,7 @@ class ModelRef(Z3PPObject):
         if isinstance(idx, SortRef):
             return self.get_universe(idx)
         if z3_debug():
-            _z3_assert(False, "Integer, Z3 declaration, or Z3 constant expected")
+            _z3_assert(False, "Integer, Z3 declaration, or Z3 constant expected. Use model.eval instead for complicated expressions")
         return None
 
     def decls(self):


### PR DESCRIPTION
This improves the previously cryptic error message. I searched multiple websites before Google AI suggested using `model.eval(arr[0])` for getting solutions out of arrays.