### PR TITLE
Add missing Java API for `as-array` 

### DIFF
--- a/src/api/java/Context.java
+++ b/src/api/java/Context.java
@@ -1999,6 +1999,19 @@ public class Context implements AutoCloseable {
                 Native.mkArrayDefault(nCtx(), array.getNativeObject()));
     }
 
+    /**                                                                                                                                                                                                          * Create an as-array expression from a function declaration.
+     * @param f the function declaration to lift into an array.
+     *          Must have exactly one domain sort.
+     * @see #mkTermArray(Expr)
+     * @see #mkMap(FuncDecl, Expr[])
+     **/
+    public final <D extends Sort, R extends Sort> ArrayExpr<D, R> mkAsArray(FuncDecl<R> f)
+    {
+        checkContextMatch(f);
+        return (ArrayExpr<D, R>) Expr.create(this, Native.mkAsArray(nCtx(), f.getNativeObject()));
+    }
+
+
     /**
      * Create Extentionality index. Two arrays are equal if and only if they are equal on the index returned by MkArrayExt.
      **/


### PR DESCRIPTION
There is no method in `Context.java` for the `(as-array ...)` primitive supported by Z3's array theory. Every time I need to use this primitive I'd need to call `Native.mkAsArray(...)` and then manually wrap/unwrap the native AST. This PR adds a method in `Context.java` that exposes the `Native.mkAsArray(...)` primitive. 

I made the changes on my own fork which contained a few historical commits I upstreamed last year, but they should go away when squashed. Many thanks in advance for reviewing this PR!