### PR TITLE
Expose `mk_re_allchar` in OCaml API

### DIFF
--- a/src/api/ml/z3.ml
+++ b/src/api/ml/z3.ml
@@ -1298,6 +1298,7 @@ struct
   let mk_re_union ctx args = Z3native.mk_re_union ctx (List.length args) args
   let mk_re_concat ctx args = Z3native.mk_re_concat ctx (List.length args) args
   let mk_re_range = Z3native.mk_re_range
+  let mk_re_allchar = Z3native.mk_re_allchar
   let mk_re_loop = Z3native.mk_re_loop
   let mk_re_intersect ctx args = Z3native.mk_re_intersect ctx (List.length args) args
   let mk_re_complement = Z3native.mk_re_complement

--- a/src/api/ml/z3.mli
+++ b/src/api/ml/z3.mli
@@ -2023,6 +2023,9 @@ sig
   (** regular expression for the range between two characters *)
   val mk_re_range : context -> Expr.expr -> Expr.expr -> Expr.expr
 
+  (** the regular expression matching any single character of the given sort *)
+  val mk_re_allchar : context -> Sort.sort -> Expr.expr
+
   (** bounded loop regular expression *)
   val mk_re_loop : context -> Expr.expr -> int -> int -> Expr.expr
 


### PR DESCRIPTION
Noticed it was missing. 