### PR TITLE
fix: replace 33 bare except clauses with except Exception

### DIFF
--- a/doc/mk_api_doc.py
+++ b/doc/mk_api_doc.py
@@ -407,7 +407,7 @@ try:
         if subprocess.call([DOXYGEN_EXE, doxygen_config_file]) != 0:
             print("ERROR: doxygen returned nonzero return code")
             exit(1)
-    except:
+    except Exception:
         print("ERROR: failed to execute 'doxygen', make sure doxygen (http://www.doxygen.org) is available in your system.")
         exit(1)
     print("Generated Doxygen based documentation")

--- a/doc/mk_go_doc.py
+++ b/doc/mk_go_doc.py
@@ -283,7 +283,7 @@ def generate_godoc_markdown(go_cmd, go_api_path, output_dir):
         print(f"Error generating godoc markdown: {e}")
         try:
             os.chdir(orig_dir)
-        except:
+        except Exception:
             pass
         return False
 

--- a/scripts/mk_nuget_task.py
+++ b/scripts/mk_nuget_task.py
@@ -72,7 +72,7 @@ def replace(src, dst):
     """
     try:
         os.remove(dst)
-    except:
+    except Exception:
         pass
     shutil.move(src, dst)
     
@@ -110,13 +110,13 @@ def unpack(packages, symbols, arch):
                         zip_ref.extract(file1, f"{tmp}")
                         replace(f"{tmp}/{file1}", f"out/lib/netstandard2.0/{b}")
                         found_path = True
-                    except:
+                    except Exception:
                         pass
                     try:
                         zip_ref.extract(file2, f"{tmp}")
                         replace(f"{tmp}/{file2}", f"out/lib/netstandard2.0/{b}")
                         found_path = True
-                    except:
+                    except Exception:
                         pass
                     if not found_path:
                         print(f"Could not find file path {file1} nor {file2}")

--- a/scripts/mk_unix_dist.py
+++ b/scripts/mk_unix_dist.py
@@ -188,7 +188,7 @@ def mk_z3():
     with cd(BUILD_DIR):
         try:
             return subprocess.call(['make', '-j', MAKEJOBS])
-        except:
+        except Exception:
             return 1
 
 def get_os_name():
@@ -277,7 +277,7 @@ def mk_zip():
                 zipout.write(os.path.join(root, f))
         if is_verbose():
             print("Generated '%s'" % zfname)
-    except:
+    except Exception:
         pass
     os.chdir(old)
 

--- a/scripts/mk_unix_dist_cmake.py
+++ b/scripts/mk_unix_dist_cmake.py
@@ -20,7 +20,7 @@ from fnmatch import fnmatch
 def getenv(name, default):
     try:
         return os.environ[name].strip(' "\'')
-    except:
+    except Exception:
         return default
 
 BUILD_DIR = 'build-dist'
@@ -155,7 +155,7 @@ def get_git_hash():
     try:
         branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
         r = check_output(['git', 'show-ref', '--abbrev=12', 'refs/heads/%s' % branch])
-    except:
+    except Exception:
         raise MKException("Failed to retrieve git hash")
     ls = r.split(' ')
     if len(ls) != 2:
@@ -210,11 +210,11 @@ def exec_cmds(cmds):
     res = 0
     try:
         res = subprocess.call(['sh', cmd_file])
-    except:
+    except Exception:
         res = 1
     try:
         os.remove(cmd_file)
-    except:
+    except Exception:
         pass
     return res
 
@@ -246,7 +246,7 @@ def mk_zip():
                 zipout.write(os.path.join(root, f))
         if is_verbose():
             print("Generated '%s'" % zfname)
-    except:
+    except Exception:
         pass
     os.chdir(old)
 

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -22,7 +22,7 @@ import subprocess
 def getenv(name, default):
     try:
         return os.environ[name].strip(' "\'')
-    except:
+    except Exception:
         return default
 
 CXX=getenv("CXX", None)
@@ -133,7 +133,7 @@ def git_hash():
     try:
         branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
         r = check_output(['git', 'show-ref', '--abbrev=12', 'refs/heads/%s' % branch])
-    except:
+    except Exception:
         raise MKException("Failed to retrieve git hash")
     ls = r.split(' ')
     if len(ls) != 2:
@@ -197,7 +197,7 @@ class TempFile:
         try:
             self.name  = name
             self.fname = open(name, 'w')
-        except:
+        except Exception:
             raise MKException("Failed to create temporary file '%s'" % self.name)
 
     def add(self, s):
@@ -210,7 +210,7 @@ class TempFile:
         self.fname.close()
         try:
             os.remove(self.name)
-        except:
+        except Exception:
             pass
 
 def exec_cmd(cmd):
@@ -235,7 +235,7 @@ def exec_cmd(cmd):
     null = open(os.devnull, 'wb')
     try:
         return subprocess.call(cmd, stdout=null, stderr=null)
-    except:
+    except Exception:
         # Failed to create process
         return 1
     finally:
@@ -402,7 +402,7 @@ def check_java():
         subprocess.call([JAVAC, 'Hello.java', '-verbose', '-source', '1.8', '-target', '1.8' ], stdout=oo.fname, stderr=eo.fname)
         oo.commit()
         eo.commit()
-    except:
+    except Exception:
         raise MKException('Found, but failed to run Java compiler at %s' % (JAVAC))
 
     os.remove('Hello.class')
@@ -459,7 +459,7 @@ def test_csc_compiler(c):
     try:
         rmf('hello.cs')
         rmf('hello.exe')
-    except:
+    except Exception:
         pass
     return r == 0
 
@@ -490,7 +490,7 @@ def check_ml():
         rmf('hello.cmx')
         rmf('a.out')
         rmf('hello.o')
-    except:
+    except Exception:
         pass
     find_ml_lib()
     find_ocaml_find()
@@ -512,7 +512,7 @@ def find_ml_lib():
     try:
         subprocess.call([OCAMLC, '-where'], stdout=t.fname, stderr=null)
         t.commit()
-    except:
+    except Exception:
         raise MKException('Failed to find Ocaml library; please set OCAML_LIB')
     finally:
         null.close()
@@ -756,7 +756,7 @@ def parse_options():
                                                ['build=', 'debug', 'silent', 'x64', 'arm64=', 'help', 'makefiles', 'showcpp', 'vsproj', 'guardcf', 'no-guardcf',
                                                 'trace', 'dotnet', 'dotnet-key=', 'assembly-version=', 'staticlib', 'prefix=', 'gmp', 'java', 'parallel=', 'gprof', 'js',
                                                 'githash=', 'git-describe', 'x86', 'ml', 'optimize', 'pypkgdir=', 'python', 'staticbin', 'log-sync', 'single-threaded'])
-    except:
+    except Exception:
         print("ERROR: Invalid command line option")
         display_help(1)
 
@@ -999,7 +999,7 @@ def is_clang_in_gpp_form(cc):
     str = check_output([cc, '--version'])
     try:
        version_string = str.encode('utf-8')
-    except:
+    except Exception:
        version_string = str
     clang = 'clang'.encode('utf-8')
     return version_string.find(clang) != -1

--- a/scripts/mk_win_dist.py
+++ b/scripts/mk_win_dist.py
@@ -166,7 +166,7 @@ def check_vc_cmd_prompt():
     try:
         DEVNULL = open(os.devnull, 'wb')
         subprocess.call(['cl'], stdout=DEVNULL, stderr=DEVNULL)
-    except:
+    except Exception:
         raise MKException("You must execute the mk_win_dist.py script on a Visual Studio Command Prompt")
 
 def exec_cmds(cmds):
@@ -179,11 +179,11 @@ def exec_cmds(cmds):
     res = 0
     try:
         res = subprocess.call(cmd_file, shell=True)
-    except:
+    except Exception:
         res = 1
     try:
         os.erase(cmd_file)
-    except:
+    except Exception:
         pass
     return res
 
@@ -248,7 +248,7 @@ def mk_zip(x64):
                 zipout.write(os.path.join(root, f))
         if is_verbose():
             print("Generated '%s'" % zfname)
-    except:
+    except Exception:
         pass
     os.chdir(old)
 

--- a/scripts/mk_win_dist_cmake.py
+++ b/scripts/mk_win_dist_cmake.py
@@ -20,7 +20,7 @@ from fnmatch import fnmatch
 def getenv(name, default):
     try:
         return os.environ[name].strip(' "\'')
-    except:
+    except Exception:
         return default
 
 BUILD_DIR = 'build-dist'
@@ -187,7 +187,7 @@ def get_git_hash():
     try:
         branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
         r = check_output(['git', 'show-ref', '--abbrev=12', 'refs/heads/%s' % branch])
-    except:
+    except Exception:
         raise MKException("Failed to retrieve git hash")
     ls = r.split(' ')
     if len(ls) != 2:
@@ -245,7 +245,7 @@ def check_vc_cmd_prompt():
     try:
         DEVNULL = open(os.devnull, 'wb')
         subprocess.call(['cl'], stdout=DEVNULL, stderr=DEVNULL)
-    except:
+    except Exception:
         raise MKException("You must execute the mk_win_dist.py script on a Visual Studio Command Prompt")
 
 def exec_cmds(cmds):
@@ -258,11 +258,11 @@ def exec_cmds(cmds):
     res = 0
     try:
         res = subprocess.call(cmd_file, shell=True)
-    except:
+    except Exception:
         res = 1
     try:
         os.erase(cmd_file)
-    except:
+    except Exception:
         pass
     return res
 
@@ -305,7 +305,7 @@ def mk_zip(arch):
                 zipout.write(os.path.join(root, f))
         if is_verbose():
             print("Generated '%s'" % zfname)
-    except:
+    except Exception:
         pass
     os.chdir(old)
 


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.