### PR TITLE
Fix assertion violation in q_mbi diagnostic output

### DIFF
--- a/src/sat/smt/q_mbi.cpp
+++ b/src/sat/smt/q_mbi.cpp
@@ -499,8 +499,12 @@ namespace q {
                 IF_VERBOSE(0,
                     verbose_stream() << mk_pp(s, m) << " := " << (*m_model)(s) << "\n";
                 verbose_stream() << term << " := " << (*m_model)(term) << "\n";
-                verbose_stream() << value << " -> " << (*m_model)(ctx.values2root()[(*m_model)(term)]->get_expr()) << "\n";
-                verbose_stream() << (*m_model)(s) << " -> " << (*m_model)(ctx.values2root()[(*m_model)(s)]->get_expr()) << "\n";
+                euf::enode* nr = nullptr;
+                auto const& v2r = ctx.values2root();
+                if (v2r.find((*m_model)(term), nr))
+                    verbose_stream() << value << " -> " << (*m_model)(nr->get_expr()) << "\n";
+                if (v2r.find((*m_model)(s), nr))
+                    verbose_stream() << (*m_model)(s) << " -> " << (*m_model)(nr->get_expr()) << "\n";
                 verbose_stream() << *m_model << "\n";);
             }
             eqs.push_back(eq);


### PR DESCRIPTION
The IF_VERBOSE(0,...) block at line 498 in q_mbi.cpp used operator[] on values2root map which asserts the key exists. When the model evaluation of the inverted term produces a value not present in the EUF values2root map, this crashes.

Use find() instead to handle the missing key gracefully, since this is diagnostic output and the missing key is expected when the model inversion produces inconsistent results.

Fixes assertion violation from #7027 (obj_hashtable.h line 168/174) with forall/array/eq2ineq combination.