### PR TITLE
fix: pass GH_TOKEN to memory safety report workflow

### DIFF
--- a/.github/workflows/memory-safety-report.md
+++ b/.github/workflows/memory-safety-report.md
@@ -17,6 +17,9 @@ permissions:
   contents: read
   discussions: write
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 network: defaults
 
 tools:


### PR DESCRIPTION
The memory safety report generator workflow was unable to download artifacts from the triggering workflow run because the gh CLI requires GH_TOKEN explicitly in the environment. This adds the env declaration to the workflow frontmatter so artifact downloads authenticate properly.

Fixes the issue reported in https://github.com/Z3Prover/z3/discussions/8908

Validated on fork: workflow run [#22876437022](https://github.com/angelica-moreira/z3/actions/runs/22876437022) completed successfully with all artifacts accessible.