### PR TITLE
fix #8023: don't skip axiom clauses with non-base-level satisfying li…

### DIFF
--- a/src/smt/theory_seq.cpp
+++ b/src/smt/theory_seq.cpp
@@ -2976,7 +2976,7 @@ void theory_seq::add_axiom(literal_vector & lits) {
     TRACE(seq, ctx.display_literals_verbose(tout << "assert " << lits << " :", lits) << "\n";);
 
     for (literal lit : lits)
-        if (ctx.get_assignment(lit) == l_true) 
+        if (ctx.get_assignment(lit) == l_true && ctx.get_assign_level(lit) == 0) 
             return;
 
     for (literal lit : lits)


### PR DESCRIPTION
…terals

The add_axiom optimization that skips adding clauses when a literal is already true was unsound: the satisfying literal could be retracted by backtracking, leaving the axiom clause missing. This caused the solver to miss propagations, e.g., not propagating indexof(a,s) = -1 when contains(a,s) becomes false after backtracking.

Fix: only skip the clause if the satisfying literal is assigned at base level (scope 0), where it can never be retracted.