### PR TITLE
fix #8185: invalid model validation with division by zero

### DIFF
--- a/src/cmd_context/cmd_context.cpp
+++ b/src/cmd_context/cmd_context.cpp
@@ -2075,8 +2075,6 @@ struct contains_underspecified_op_proc {
             throw found();
         if (n->get_family_id() == m_seq_id && m_seq.is_re(n))
             throw found();
-        if (m_arith.plugin().is_considered_uninterpreted(n->get_decl()))
-            throw found();
         func_decl_ref f_ui(m_arith.get_manager());
         if (m_arith.is_considered_uninterpreted(n->get_decl(), n->get_num_args(), n->get_args(), f_ui))
             throw found();


### PR DESCRIPTION
The model validator failed to recognize division by literal zero, e.g. (/ 1.9 0.0), as an underspecified operation. Two fixes:

1. contains_underspecified_op_proc now calls the argument-aware is_considered_uninterpreted, catching OP_DIV, OP_IDIV, OP_MOD, OP_REM when the denominator is a literal zero.

2. Always scan the original assertion for underspecified ops, not only when the evaluated result is non-false. When the evaluator defaults a missing /0 interpretation to 0, the result becomes false, hiding the underspecification.