### PR TITLE
Fix documentation for Z3_solver_to_dimacs_string

### DIFF
--- a/src/api/z3_api.h
+++ b/src/api/z3_api.h
@@ -7656,7 +7656,7 @@ extern "C" {
 
     /**
        \brief Convert a solver into a DIMACS formatted string.
-       \sa Z3_goal_to_diamcs_string for requirements.
+       \sa Z3_goal_to_dimacs_string for requirements.
 
        def_API('Z3_solver_to_dimacs_string', STRING, (_in(CONTEXT), _in(SOLVER), _in(BOOL)))
     */


### PR DESCRIPTION
Corrected the function name in the documentation comment.

Noticed this typo while fixing doc comment parsing in the rust bindings