### PR TITLE
add tag for linux/loongarch64

### DIFF
--- a/src/api/python/setup.py
+++ b/src/api/python/setup.py
@@ -313,6 +313,7 @@ class bdist_wheel(_bdist_wheel):
                 ("linux", "x86_64"): "linux_x86_64",
                 ("linux", "aarch64"): "linux_aarch64",
                 ('linux', "riscv64"): "linux_riscv64",
+                ("linux", "loongarch64"): "linux_loongarch64",
                 # windows arm64 is not supported by pypi yet
                 ("win", "x64"): "win_amd64",
                 ("win", "x86"): "win32",


### PR DESCRIPTION
Adds linux_loongarch64 to the TAGS mapping in the build configuration to support wheel generation.