### PR TITLE
Terminate on demand and fix rare Linux crash

### DIFF
--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -332,7 +332,7 @@ namespace smt {
         auto &lease = m_worker_leases[worker_id];
         if (!lease.node || lease.node != n || lease.epoch != epoch)
             return;
-        m_search_tree.release_worker(lease.node);
+        m_search_tree.dec_active_workers(lease.node);
         lease = {};
     }
 
@@ -358,9 +358,7 @@ namespace smt {
             g_core.push_back(expr_ref(l2g(c), m));
         }
         release_lease_unlocked(worker_id, lease.node, lease.epoch);
-        if (lease.node &&
-            m_search_tree.is_lease_valid(lease.node, lease.epoch) &&
-            !m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
+        if (lease.node && !m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
             m_search_tree.backtrack(lease.node, g_core);
 
         cancel_closed_leases_unlocked(worker_id);

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -563,7 +563,8 @@ namespace smt {
 
     bool parallel::batch_manager::get_cube(ast_translation &g2l, unsigned id, expr_ref_vector &cube, node_lease &lease) {
         cube.reset();
-        std::unique_lock<std::mutex> lock(mux);
+        std::scoped_lock lock(mux);
+        
         if (m_search_tree.is_closed()) {
             IF_VERBOSE(1, verbose_stream() << "all done\n";);
             return false;
@@ -572,16 +573,21 @@ namespace smt {
             IF_VERBOSE(1, verbose_stream() << "aborting get_cube\n";);
             return false;
         }
+        
         node *t = m_search_tree.activate_node(lease.node);
+        
         if (!t)
             return false;
+        
         IF_VERBOSE(1, m_search_tree.display(verbose_stream()); verbose_stream() << "\n";);
+        
         lease.node = t;
         lease.epoch = t->epoch();
-        lease.cancel_epoch = t->cancel_epoch();
+        lease.cancel_epoch = t->get_cancel_epoch();
         if (id >= m_worker_leases.size())
             m_worker_leases.resize(id + 1);
         m_worker_leases[id] = lease;
+        
         while (t) {
             if (cube_config::literal_is_null(t->get_literal()))
                 break;
@@ -590,6 +596,7 @@ namespace smt {
             cube.push_back(std::move(lit));
             t = t->parent();
         }
+        
         return true;
     }
 

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -117,14 +117,16 @@ namespace smt {
     }
 
     void parallel::worker::run() {
+        bool is_first_run = true;
         node_lease lease;
         expr_ref_vector cube(m);
         while (true) {
 
-            if (!b.get_cube(m_g2l, id, cube, lease)) {
+            if (!b.get_cube(m_g2l, id, cube, is_first_run, lease)) {
                 LOG_WORKER(1, " no more cubes\n");
                 return;
             }
+            is_first_run = false;
             collect_shared_clauses();
 
         check_cube_start:
@@ -571,7 +573,7 @@ namespace smt {
         }
     }
 
-    bool parallel::batch_manager::get_cube(ast_translation &g2l, unsigned id, expr_ref_vector &cube, node_lease &lease) {
+    bool parallel::batch_manager::get_cube(ast_translation &g2l, unsigned id, expr_ref_vector &cube, bool is_first_run, node_lease &lease) {
         std::scoped_lock lock(mux);
         cube.reset();
         
@@ -584,7 +586,7 @@ namespace smt {
             return false;
         }
         
-        node *t = m_search_tree.activate_best_node();
+        node *t = is_first_run ? m_search_tree.activate_root() : m_search_tree.activate_best_node();
         
         if (!t)
             return false;

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -358,7 +358,13 @@ namespace smt {
             g_core.push_back(expr_ref(l2g(c), m));
         }
         release_lease_unlocked(worker_id, lease.node, lease.epoch);
-        if (lease.node && !m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
+
+        // only backtrack if the lease is still valid (i.e., the worker has not been given a new node to work on or the lease has not been canceled by another worker)
+        // this means we can potentially delay backtracking for some unsat cubes until another worker (whose lease is valid) determines it UNSAT. 
+        // Empirically, this is better than aggressively backtracking on every unsat cube, for now.
+        if (lease.node &&
+            m_search_tree.is_lease_valid(lease.node, lease.epoch) &&
+            !m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
             m_search_tree.backtrack(lease.node, g_core);
 
         cancel_closed_leases_unlocked(worker_id);

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -358,9 +358,9 @@ namespace smt {
             g_core.push_back(expr_ref(l2g(c), m));
         }
         release_lease_unlocked(worker_id, lease.node, lease.epoch);
-        if (lease.node && !m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
-            m_search_tree.backtrack(lease.node, g_core);
-        else if (lease.node && lease.node->get_status() == search_tree::status::closed)
+        if (lease.node &&
+            m_search_tree.is_lease_valid(lease.node, lease.epoch) &&
+            !m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
             m_search_tree.backtrack(lease.node, g_core);
 
         cancel_closed_leases_unlocked(worker_id);
@@ -390,7 +390,7 @@ namespace smt {
         if (!lease.node || m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
             return;
 
-        bool did_split = m_search_tree.try_split(lease.node, lit, nlit, effort);
+        bool did_split = m_search_tree.try_split(lease.node, lit, nlit, effort, lease.epoch);
 
         if (did_split) {
             ++m_stats.m_num_cubes;

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -111,11 +111,11 @@ namespace smt {
     }
 
     void parallel::worker::run() {
-        search_tree::node<cube_config> *node = nullptr;
+        node_lease lease;
         expr_ref_vector cube(m);
         while (true) {
 
-            if (!b.get_cube(m_g2l, id, cube, node)) {
+            if (!b.get_cube(m_g2l, id, cube, lease)) {
                 LOG_WORKER(1, " no more cubes\n");
                 return;
             }
@@ -125,8 +125,18 @@ namespace smt {
             LOG_WORKER(1, " CUBE SIZE IN MAIN LOOP: " << cube.size() << "\n");
             lbool r = check_cube(cube);
 
+            if (b.lease_canceled(lease)) {
+                LOG_WORKER(1, " abandoning canceled lease\n");
+                b.abandon_lease(id, lease);
+                m.limit().reset_cancel();
+                lease = {};
+                continue;
+            }
+
             if (!m.inc()) {
-                b.set_exception("context cancelled");
+                if (b.is_batch_running()) {
+                    b.set_exception("context cancelled");
+                }
                 return;
             }
 
@@ -140,7 +150,8 @@ namespace smt {
                 auto atom = get_split_atom();
                 if (!atom)
                     goto check_cube_start;
-                b.try_split(m_l2g, id, node, atom, m_config.m_threads_max_conflicts);
+                b.try_split(m_l2g, id, lease, atom, m_config.m_threads_max_conflicts);
+                lease = {};
                 simplify();
                 break;
             }
@@ -164,7 +175,8 @@ namespace smt {
                 }
 
                 LOG_WORKER(1, " found unsat cube\n");
-                b.backtrack(m_l2g, unsat_core, node);
+                b.backtrack(m_l2g, id, unsat_core, lease);
+                lease = {};
 
                 if (m_config.m_share_conflicts)
                     b.collect_clause(m_l2g, id, mk_not(mk_and(unsat_core)));
@@ -314,18 +326,44 @@ namespace smt {
         m.limit().cancel();
     }
 
-    void parallel::batch_manager::backtrack(ast_translation &l2g, expr_ref_vector const &core,
-                                            search_tree::node<cube_config> *node) {
+    void parallel::batch_manager::release_lease_unlocked(unsigned worker_id, node* n, unsigned epoch) {
+        if (worker_id >= m_worker_leases.size())
+            return;
+        auto &lease = m_worker_leases[worker_id];
+        if (!lease.node || lease.node != n || lease.epoch != epoch)
+            return;
+        m_search_tree.release_worker(lease.node);
+        lease = {};
+    }
+
+    void parallel::batch_manager::cancel_closed_leases_unlocked(unsigned source_worker_id) {
+        for (unsigned worker_id = 0; worker_id < m_worker_leases.size(); ++worker_id) {
+            if (worker_id == source_worker_id)
+                continue;
+            auto const& lease = m_worker_leases[worker_id];
+            if (!lease.node || !m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
+                continue;
+            p.m_workers[worker_id]->cancel();
+        }
+    }
+
+    void parallel::batch_manager::backtrack(ast_translation &l2g, unsigned worker_id, expr_ref_vector const &core,
+                                            node_lease const &lease) {
         std::scoped_lock lock(mux);
         IF_VERBOSE(1, verbose_stream() << "Batch manager backtracking.\n");
         if (m_state != state::is_running)
             return;
         vector<cube_config::literal> g_core;
         for (auto c : core) {
-            expr_ref g_c(l2g(c), m);
             g_core.push_back(expr_ref(l2g(c), m));
         }
-        m_search_tree.backtrack(node, g_core);
+        release_lease_unlocked(worker_id, lease.node, lease.epoch);
+        if (lease.node && !m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
+            m_search_tree.backtrack(lease.node, g_core);
+        else if (lease.node && lease.node->get_status() == search_tree::status::closed)
+            m_search_tree.backtrack(lease.node, g_core);
+
+        cancel_closed_leases_unlocked(worker_id);
 
         IF_VERBOSE(1, m_search_tree.display(verbose_stream() << bounded_pp_exprs(core) << "\n"););
         if (m_search_tree.is_closed()) {
@@ -338,8 +376,8 @@ namespace smt {
         }
     }
 
-    void parallel::batch_manager::try_split(ast_translation &l2g, unsigned source_worker_id,
-                                        search_tree::node<cube_config> *node, expr *atom, unsigned effort) {
+    void parallel::batch_manager::try_split(ast_translation &l2g, unsigned worker_id,
+                                        node_lease const &lease, expr *atom, unsigned effort) {
         std::scoped_lock lock(mux);
         expr_ref lit(m), nlit(m);
         lit = l2g(atom);
@@ -348,13 +386,32 @@ namespace smt {
         if (m_state != state::is_running)
             return;
 
-        bool did_split = m_search_tree.try_split(node, lit, nlit, effort);
+        release_lease_unlocked(worker_id, lease.node, lease.epoch);
+        if (!lease.node || m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
+            return;
+
+        bool did_split = m_search_tree.try_split(lease.node, lit, nlit, effort);
 
         if (did_split) {
             ++m_stats.m_num_cubes;
-            m_stats.m_max_cube_depth = std::max(m_stats.m_max_cube_depth, node->depth() + 1);
+            m_stats.m_max_cube_depth = std::max(m_stats.m_max_cube_depth, lease.node->depth() + 1);
             IF_VERBOSE(1, verbose_stream() << "Batch manager splitting on literal: " << mk_bounded_pp(lit, m, 3) << "\n");
         }
+    }
+
+    void parallel::batch_manager::abandon_lease(unsigned worker_id, node_lease const &lease) {
+        std::scoped_lock lock(mux);
+        release_lease_unlocked(worker_id, lease.node, lease.epoch);
+    }
+
+    bool parallel::batch_manager::lease_canceled(node_lease const &lease) {
+        std::scoped_lock lock(mux);
+        return m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch);
+    }
+
+    bool parallel::batch_manager::is_batch_running() {
+        std::scoped_lock lock(mux);
+        return m_state == state::is_running;
     }
 
     void parallel::batch_manager::collect_clause(ast_translation &l2g, unsigned source_worker_id, expr *clause) {
@@ -400,11 +457,14 @@ namespace smt {
         try {
             r = ctx->check(asms.size(), asms.data());
         } catch (z3_error &err) {
-            b.set_exception(err.error_code());
+            if (!m.limit().is_canceled())
+                b.set_exception(err.error_code());
         } catch (z3_exception &ex) {
-            b.set_exception(ex.what());
+            if (!m.limit().is_canceled())
+                b.set_exception(ex.what());
         } catch (...) {
-            b.set_exception("unknown exception");
+            if (!m.limit().is_canceled())
+                b.set_exception("unknown exception");
         }
         asms.shrink(asms.size() - cube.size());
         LOG_WORKER(1, " DONE checking cube " << r << "\n";);
@@ -501,7 +561,7 @@ namespace smt {
         }
     }
 
-    bool parallel::batch_manager::get_cube(ast_translation &g2l, unsigned id, expr_ref_vector &cube, node *&n) {
+    bool parallel::batch_manager::get_cube(ast_translation &g2l, unsigned id, expr_ref_vector &cube, node_lease &lease) {
         cube.reset();
         std::unique_lock<std::mutex> lock(mux);
         if (m_search_tree.is_closed()) {
@@ -512,11 +572,16 @@ namespace smt {
             IF_VERBOSE(1, verbose_stream() << "aborting get_cube\n";);
             return false;
         }
-        node *t = m_search_tree.activate_node(n);
+        node *t = m_search_tree.activate_node(lease.node);
         if (!t)
             return false;
         IF_VERBOSE(1, m_search_tree.display(verbose_stream()); verbose_stream() << "\n";);
-        n = t;
+        lease.node = t;
+        lease.epoch = t->epoch();
+        lease.cancel_epoch = t->cancel_epoch();
+        if (id >= m_worker_leases.size())
+            m_worker_leases.resize(id + 1);
+        m_worker_leases[id] = lease;
         while (t) {
             if (cube_config::literal_is_null(t->get_literal()))
                 break;
@@ -532,6 +597,8 @@ namespace smt {
         m_state = state::is_running;
         m_search_tree.reset();
         m_search_tree.set_effort_unit(initial_max_thread_conflicts);
+        m_worker_leases.reset();
+        m_worker_leases.resize(p.num_threads);
     }
 
     void parallel::batch_manager::collect_statistics(::statistics &st) const {
@@ -556,7 +623,6 @@ namespace smt {
         };
         scoped_clear clear(*this);
 
-        m_batch_manager.initialize();
         m_workers.reset();
 
         smt_parallel_params pp(ctx.m_params);
@@ -573,6 +639,8 @@ namespace smt {
             m_sls_worker = alloc(sls_worker, *this);
             sl.push_child(&(m_sls_worker->limit()));
         }
+
+        m_batch_manager.initialize();
 
         // Launch threads
         vector<std::thread> threads;

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -411,11 +411,6 @@ namespace smt {
         return m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch);
     }
 
-    bool parallel::batch_manager::is_batch_running() {
-        std::scoped_lock lock(mux);
-        return m_state == state::is_running;
-    }
-
     void parallel::batch_manager::collect_clause(ast_translation &l2g, unsigned source_worker_id, expr *clause) {
         std::scoped_lock lock(mux);
         expr *g_clause = l2g(clause);

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -356,13 +356,10 @@ namespace smt {
             g_core.push_back(expr_ref(l2g(c), m));
         }
         release_lease_unlocked(worker_id, lease.node, lease.epoch);
-
-        // only backtrack if the lease is still valid (i.e., the worker has not been given a new node to work on or the lease has not been canceled by another worker)
-        // this means we can potentially delay backtracking for some unsat cubes until another worker (whose lease is valid) determines it UNSAT. 
-        // Empirically, this is better than aggressively backtracking on every unsat cube, for now.
-        if (lease.node &&
-            m_search_tree.is_lease_valid(lease.node, lease.epoch) &&
-            !m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
+        
+        // we close/backtrack regardless of whether this lease is stale or not, as long as the lease isn't canceled
+        // i.e. worker 1 splits this node, but then worker 2 determines UNSAT --> worker 2 is stale but we still close this node and backtrack
+        if (lease.node && !m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
             m_search_tree.backtrack(lease.node, g_core);
 
         cancel_closed_leases_unlocked(worker_id);

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -134,9 +134,7 @@ namespace smt {
             }
 
             if (!m.inc()) {
-                if (b.is_batch_running()) {
-                    b.set_exception("context cancelled");
-                }
+                b.set_exception("context cancelled");
                 return;
             }
 
@@ -461,14 +459,11 @@ namespace smt {
         try {
             r = ctx->check(asms.size(), asms.data());
         } catch (z3_error &err) {
-            if (!m.limit().is_canceled())
-                b.set_exception(err.error_code());
+            b.set_exception(err.error_code());
         } catch (z3_exception &ex) {
-            if (!m.limit().is_canceled())
-                b.set_exception(ex.what());
+            b.set_exception(ex.what());
         } catch (...) {
-            if (!m.limit().is_canceled())
-                b.set_exception("unknown exception");
+            b.set_exception("unknown exception");
         }
         asms.shrink(asms.size() - cube.size());
         LOG_WORKER(1, " DONE checking cube " << r << "\n";);

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -559,8 +559,8 @@ namespace smt {
     }
 
     bool parallel::batch_manager::get_cube(ast_translation &g2l, unsigned id, expr_ref_vector &cube, node_lease &lease) {
-        cube.reset();
         std::scoped_lock lock(mux);
+        cube.reset();
         
         if (m_search_tree.is_closed()) {
             IF_VERBOSE(1, verbose_stream() << "all done\n";);
@@ -571,7 +571,7 @@ namespace smt {
             return false;
         }
         
-        node *t = m_search_tree.activate_node(lease.node);
+        node *t = m_search_tree.activate_best_node();
         
         if (!t)
             return false;

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -64,6 +64,12 @@ namespace smt {
 
 namespace smt {
 
+    static bool is_cancellation_exception(char const* msg) {
+        return msg &&
+            (strstr(msg, "canceled") != nullptr ||
+             strstr(msg, "cancelled") != nullptr);
+    }
+
     void parallel::sls_worker::run() {
         ptr_vector<expr> assertions;
         p.ctx.get_assertions(assertions);
@@ -133,6 +139,10 @@ namespace smt {
             }
 
             if (!m.inc()) {
+                if (m.limit().is_canceled()) {
+                    LOG_WORKER(1, " stopping after cancellation\n");
+                    return;
+                }
                 b.set_exception("context cancelled");
                 return;
             }
@@ -457,11 +467,14 @@ namespace smt {
         try {
             r = ctx->check(asms.size(), asms.data());
         } catch (z3_error &err) {
-            b.set_exception(err.error_code());
+            if (!m.limit().is_canceled())
+                b.set_exception(err.error_code());
         } catch (z3_exception &ex) {
-            b.set_exception(ex.what());
+            if (!m.limit().is_canceled() && !is_cancellation_exception(ex.what()))
+                b.set_exception(ex.what());
         } catch (...) {
-            b.set_exception("unknown exception");
+            if (!m.limit().is_canceled())
+                b.set_exception("unknown exception");
         }
         asms.shrink(asms.size() - cube.size());
         LOG_WORKER(1, " DONE checking cube " << r << "\n";);

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -127,7 +127,6 @@ namespace smt {
 
             if (b.lease_canceled(lease)) {
                 LOG_WORKER(1, " abandoning canceled lease\n");
-                b.abandon_lease(id, lease);
                 m.limit().reset_cancel();
                 lease = {};
                 continue;
@@ -328,7 +327,7 @@ namespace smt {
         if (worker_id >= m_worker_leases.size())
             return;
         auto &lease = m_worker_leases[worker_id];
-        if (!lease.node || lease.node != n || lease.epoch != epoch)
+        if (!lease.node || lease.node != n)
             return;
         m_search_tree.dec_active_workers(lease.node);
         lease = {};
@@ -349,20 +348,25 @@ namespace smt {
     void parallel::batch_manager::backtrack(ast_translation &l2g, unsigned worker_id, expr_ref_vector const &core,
                                             node_lease const &lease) {
         std::scoped_lock lock(mux);
-        IF_VERBOSE(1, verbose_stream() << "Batch manager backtracking.\n");
+
         if (m_state != state::is_running)
             return;
-        vector<cube_config::literal> g_core;
-        for (auto c : core) {
-            g_core.push_back(expr_ref(l2g(c), m));
-        }
-        release_lease_unlocked(worker_id, lease.node, lease.epoch);
         
         // we close/backtrack regardless of whether this lease is stale or not, as long as the lease isn't canceled
         // i.e. worker 1 splits this node, but then worker 2 determines UNSAT --> worker 2 is stale but we still close this node and backtrack
-        if (lease.node && !m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
-            m_search_tree.backtrack(lease.node, g_core);
+        if (!lease.node || m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
+            return;
 
+        IF_VERBOSE(1, verbose_stream() << "Batch manager backtracking.\n");
+        
+        release_lease_unlocked(worker_id, lease.node, lease.epoch);
+        
+        vector<cube_config::literal> g_core;
+        for (auto c : core)
+            g_core.push_back(expr_ref(l2g(c), m));
+        m_search_tree.backtrack(lease.node, g_core);
+
+        // terminate on-demand the workers that are currently exploring the now-closed nodes
         cancel_closed_leases_unlocked(worker_id);
 
         IF_VERBOSE(1, m_search_tree.display(verbose_stream() << bounded_pp_exprs(core) << "\n"););
@@ -379,17 +383,18 @@ namespace smt {
     void parallel::batch_manager::try_split(ast_translation &l2g, unsigned worker_id,
                                         node_lease const &lease, expr *atom, unsigned effort) {
         std::scoped_lock lock(mux);
-        expr_ref lit(m), nlit(m);
-        lit = l2g(atom);
-        nlit = mk_not(m, lit);
         
         if (m_state != state::is_running)
             return;
 
-        release_lease_unlocked(worker_id, lease.node, lease.epoch);
         if (!lease.node || m_search_tree.is_lease_canceled(lease.node, lease.cancel_epoch))
             return;
 
+        release_lease_unlocked(worker_id, lease.node, lease.epoch);
+
+        expr_ref lit(m), nlit(m);
+        lit = l2g(atom);
+        nlit = mk_not(m, lit);
         bool did_split = m_search_tree.try_split(lease.node, lit, nlit, effort, lease.epoch);
 
         if (did_split) {
@@ -399,7 +404,7 @@ namespace smt {
         }
     }
 
-    void parallel::batch_manager::abandon_lease(unsigned worker_id, node_lease const &lease) {
+    void parallel::batch_manager::release_lease(unsigned worker_id, node_lease const &lease) {
         std::scoped_lock lock(mux);
         release_lease_unlocked(worker_id, lease.node, lease.epoch);
     }

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -335,7 +335,8 @@ namespace smt {
     }
 
     void parallel::batch_manager::cancel_closed_leases_unlocked(unsigned source_worker_id) {
-        for (unsigned worker_id = 0; worker_id < m_worker_leases.size(); ++worker_id) {
+        unsigned n = std::min(m_worker_leases.size(), p.m_workers.size());
+        for (unsigned worker_id = 0; worker_id < n; ++worker_id) {
             if (worker_id == source_worker_id)
                 continue;
             auto const& lease = m_worker_leases[worker_id];
@@ -596,7 +597,7 @@ namespace smt {
         m_search_tree.reset();
         m_search_tree.set_effort_unit(initial_max_thread_conflicts);
         m_worker_leases.reset();
-        m_worker_leases.resize(p.num_threads);
+        m_worker_leases.resize(p.m_workers.size());
     }
 
     void parallel::batch_manager::collect_statistics(::statistics &st) const {
@@ -605,7 +606,12 @@ namespace smt {
     }
 
     lbool parallel::operator()(expr_ref_vector const &asms) {
-        IF_VERBOSE(1, verbose_stream() << "Parallel SMT with " << num_threads << " threads\n";);
+        smt_parallel_params pp(ctx.m_params);
+        unsigned num_workers = std::min((unsigned)std::thread::hardware_concurrency(), ctx.get_fparams().m_threads);
+        unsigned num_sls_threads = (pp.sls() ? 1 : 0);    
+        unsigned total_threads = num_workers + num_sls_threads;
+
+        IF_VERBOSE(1, verbose_stream() << "Parallel SMT with " << total_threads << " threads\n";);
         ast_manager &m = ctx.m;
 
         if (m.has_trace_stream())
@@ -622,33 +628,31 @@ namespace smt {
         scoped_clear clear(*this);
 
         m_workers.reset();
-
-        smt_parallel_params pp(ctx.m_params);
-        m_should_run_sls = pp.sls();
         
         scoped_limits sl(m.limit());
         flet<unsigned> _nt(ctx.m_fparams.m_threads, 1);
-        SASSERT(num_threads > 1);
-        for (unsigned i = 0; i < num_threads; ++i)
+        SASSERT(num_workers > 1);
+        for (unsigned i = 0; i < num_workers; ++i)
             m_workers.push_back(alloc(worker, i, *this, asms));
         for (auto w : m_workers)
             sl.push_child(&(w->limit()));
-        if (m_should_run_sls) {
+
+        if (num_sls_threads == 1) {
             m_sls_worker = alloc(sls_worker, *this);
             sl.push_child(&(m_sls_worker->limit()));
         }
 
-        m_batch_manager.initialize();
+        IF_VERBOSE(1, verbose_stream() << "Launched " << m_workers.size() << " CDCL threads, "
+                                       << (m_sls_worker ? 1 : 0) << " SLS threads\n";);
 
+        m_batch_manager.initialize();
+        
         // Launch threads
         vector<std::thread> threads;
-        threads.resize(m_should_run_sls ? num_threads + 1 : num_threads); // +1 for sls worker
-        for (unsigned i = 0; i < num_threads; ++i)
-            threads[i] = std::thread([&, i]() { m_workers[i]->run(); });
-        
-        // the final thread runs the sls worker
-        if (m_should_run_sls)
-            threads[num_threads] = std::thread([&]() { m_sls_worker->run(); });
+        threads.resize(total_threads);
+        unsigned thread_idx = 0;
+        for (auto* w : m_workers)
+            threads[thread_idx++] = std::thread([&, w]() { w->run(); });
 
         // Wait for all threads to finish
         for (auto &th : threads)
@@ -657,7 +661,7 @@ namespace smt {
         for (auto w : m_workers)
             w->collect_statistics(ctx.m_aux_stats);
         m_batch_manager.collect_statistics(ctx.m_aux_stats);
-        if (m_should_run_sls)
+        if (m_sls_worker)
             m_sls_worker->collect_statistics(ctx.m_aux_stats);
 
         return m_batch_manager.get_result();

--- a/src/smt/smt_parallel.h
+++ b/src/smt/smt_parallel.h
@@ -45,8 +45,16 @@ namespace smt {
 
         struct node_lease {
             search_tree::node<cube_config>* node = nullptr;
-            unsigned epoch = 0;
-            unsigned cancel_epoch = 0;
+            // Version counter for structural mutations of this node (e.g., split/close).
+            // Used to detect stale leases: if a worker's lease.epoch != node.epoch,
+            // the node has changed since it was acquired and must not be mutated.
+            unsigned epoch = 0; 
+
+            // Cancellation generation counter for this node/subtree.
+            // Incremented when the node is closed; used to signal that all
+            // workers holding leases on this node (or its descendants)
+            // must abandon work immediately.
+            unsigned cancel_epoch = 0; 
         };
 
         class batch_manager {        

--- a/src/smt/smt_parallel.h
+++ b/src/smt/smt_parallel.h
@@ -43,6 +43,12 @@ namespace smt {
             expr_ref clause;
         };
 
+        struct node_lease {
+            search_tree::node<cube_config>* node = nullptr;
+            unsigned epoch = 0;
+            unsigned cancel_epoch = 0;
+        };
+
         class batch_manager {        
 
             enum state {
@@ -66,6 +72,7 @@ namespace smt {
             stats m_stats;
             using node = search_tree::node<cube_config>;
             search_tree::tree<cube_config> m_search_tree;
+            vector<node_lease> m_worker_leases;
             
             unsigned m_exception_code = 0;
             std::string m_exception_msg;
@@ -92,6 +99,8 @@ namespace smt {
             }
 
             void init_parameters_state();
+            void release_lease_unlocked(unsigned worker_id, node* n, unsigned epoch);
+            void cancel_closed_leases_unlocked(unsigned source_worker_id);
 
         public:
             batch_manager(ast_manager& m, parallel& p) : m(m), p(p), m_search_tree(expr_ref(m)) { }
@@ -104,9 +113,12 @@ namespace smt {
             void set_exception(unsigned error_code);
             void collect_statistics(::statistics& st) const;
 
-            bool get_cube(ast_translation& g2l, unsigned id, expr_ref_vector& cube, node*& n);
-            void backtrack(ast_translation& l2g, expr_ref_vector const& core, node* n);
-            void try_split(ast_translation& l2g, unsigned id, node* n, expr* atom, unsigned effort);
+            bool get_cube(ast_translation& g2l, unsigned id, expr_ref_vector& cube, node_lease& lease);
+            void backtrack(ast_translation& l2g, unsigned worker_id, expr_ref_vector const& core, node_lease const& lease);
+            void try_split(ast_translation& l2g, unsigned worker_id, node_lease const& lease, expr* atom, unsigned effort);
+            void abandon_lease(unsigned worker_id, node_lease const& lease);
+            bool lease_canceled(node_lease const& lease);
+            bool is_batch_running();
 
             void collect_clause(ast_translation& l2g, unsigned source_worker_id, expr* clause);
             expr_ref_vector return_shared_clauses(ast_translation& g2l, unsigned& worker_limit, unsigned worker_id);

--- a/src/smt/smt_parallel.h
+++ b/src/smt/smt_parallel.h
@@ -118,7 +118,7 @@ namespace smt {
             void set_exception(unsigned error_code);
             void collect_statistics(::statistics& st) const;
 
-            bool get_cube(ast_translation& g2l, unsigned id, expr_ref_vector& cube, node_lease& lease);
+            bool get_cube(ast_translation& g2l, unsigned id, expr_ref_vector& cube, bool is_first_run, node_lease& lease);
             void backtrack(ast_translation& l2g, unsigned worker_id, expr_ref_vector const& core, node_lease const& lease);
             void try_split(ast_translation& l2g, unsigned worker_id, node_lease const& lease, expr* atom, unsigned effort);
             void release_lease(unsigned worker_id, node_lease const& lease);

--- a/src/smt/smt_parallel.h
+++ b/src/smt/smt_parallel.h
@@ -104,7 +104,6 @@ namespace smt {
                 cancel_sls_worker();  
             }
 
-            void init_parameters_state();
             void release_lease_unlocked(unsigned worker_id, node* n, unsigned epoch);
             void cancel_closed_leases_unlocked(unsigned source_worker_id);
 
@@ -122,7 +121,7 @@ namespace smt {
             bool get_cube(ast_translation& g2l, unsigned id, expr_ref_vector& cube, node_lease& lease);
             void backtrack(ast_translation& l2g, unsigned worker_id, expr_ref_vector const& core, node_lease const& lease);
             void try_split(ast_translation& l2g, unsigned worker_id, node_lease const& lease, expr* atom, unsigned effort);
-            void abandon_lease(unsigned worker_id, node_lease const& lease);
+            void release_lease(unsigned worker_id, node_lease const& lease);
             bool lease_canceled(node_lease const& lease);
 
             void collect_clause(ast_translation& l2g, unsigned source_worker_id, expr* clause);

--- a/src/smt/smt_parallel.h
+++ b/src/smt/smt_parallel.h
@@ -126,7 +126,6 @@ namespace smt {
             void try_split(ast_translation& l2g, unsigned worker_id, node_lease const& lease, expr* atom, unsigned effort);
             void abandon_lease(unsigned worker_id, node_lease const& lease);
             bool lease_canceled(node_lease const& lease);
-            bool is_batch_running();
 
             void collect_clause(ast_translation& l2g, unsigned source_worker_id, expr* clause);
             expr_ref_vector return_shared_clauses(ast_translation& g2l, unsigned& worker_limit, unsigned worker_id);

--- a/src/smt/smt_parallel.h
+++ b/src/smt/smt_parallel.h
@@ -35,8 +35,6 @@ namespace smt {
 
     class parallel {
         context& ctx;
-        unsigned num_threads;
-        bool m_should_run_sls = false;
 
         struct shared_clause {
             unsigned source_worker_id;
@@ -217,9 +215,6 @@ namespace smt {
     public:
         parallel(context& ctx) : 
             ctx(ctx),
-            num_threads(std::min(
-                (unsigned)std::thread::hardware_concurrency(),
-                ctx.get_fparams().m_threads)),
             m_batch_manager(ctx.m, *this) {}
 
         lbool operator()(expr_ref_vector const& asms);

--- a/src/util/search_tree.h
+++ b/src/util/search_tree.h
@@ -10,10 +10,10 @@ Abstract:
     A binary search tree for managing the search space of a DPLL(T) solver.
     It supports splitting on atoms, backtracking on conflicts, and activating nodes.
 
-    Nodes can be in one of three states: open, closed, or active.
+    Nodes can be in one of three states: frontier, closed, or deferred.
     - Closed nodes are fully explored (both children are closed).
-    - Active nodes are currently assigned to a worker.
-    - Open nodes are unsolved and available for future activation.
+    - Deferred nodes are revisit candidates in the fallback scheduling band.
+    - Frontier nodes are unsolved and available in the primary scheduling band.
 
     Tree activation follows an SMTS-style policy: prefer nodes in lower
     accumulated-attempts bands, and then prefer deeper nodes within the same band.
@@ -24,7 +24,7 @@ Abstract:
 
     Backtracking on a conflict closes all nodes below the last node whose atom is in the conflict set.
 
-    Activation selects a best-ranked open node using accumulated attempts and depth.
+    Activation selects a best-ranked frontier node using accumulated attempts and depth.
 
 Author:
 
@@ -38,7 +38,7 @@ Author:
 
 namespace search_tree {
 
-    enum class status { open, closed, active };
+    enum class status { frontier, closed, deferred };
 
     template <typename Config> class node {
         typedef typename Config::literal literal;
@@ -53,7 +53,7 @@ namespace search_tree {
         unsigned m_cancel_epoch = 0;
 
     public:
-        node(literal const &l, node *parent) : m_literal(l), m_parent(parent), m_status(status::open) {}
+        node(literal const &l, node *parent) : m_literal(l), m_parent(parent), m_status(status::frontier) {}
         ~node() {
             dealloc(m_left);
             dealloc(m_right);
@@ -71,7 +71,7 @@ namespace search_tree {
         void split(literal const &a, literal const &b) {
             SASSERT(!Config::literal_is_null(a));
             SASSERT(!Config::literal_is_null(b));
-            if (m_status != status::active)
+            if (m_status != status::deferred)
                 return;
             SASSERT(!m_left);
             SASSERT(!m_right);
@@ -99,7 +99,7 @@ namespace search_tree {
             for (unsigned i = 0; i < indent; ++i)
                 out << " ";
             Config::display_literal(out, m_literal);
-            out << (get_status() == status::open ? " (o)" : get_status() == status::closed ? " (c)" : " (a)");
+            out << (get_status() == status::frontier ? " (f)" : get_status() == status::closed ? " (c)" : " (d)");
             out << "\n";
             if (m_left)
                 m_left->display(out, indent + 2);
@@ -120,7 +120,7 @@ namespace search_tree {
             return m_num_activations;
         }
         void mark_new_activation() {
-            set_status(status::active);
+            set_status(status::deferred);
             ++m_num_activations;
             ++m_active_workers;
         }
@@ -210,7 +210,7 @@ namespace search_tree {
         bool has_unvisited_open_node(node<Config>* cur) const {
             if (!cur || cur->get_status() == status::closed)
                 return false;
-            if (cur->get_status() == status::open && cur->num_activations() == 0)
+            if (cur->get_status() == status::frontier && cur->num_activations() == 0)
                 return true;
             return has_unvisited_open_node(cur->left()) || has_unvisited_open_node(cur->right());
         }
@@ -224,7 +224,7 @@ namespace search_tree {
         unsigned count_active_nodes(node<Config>* cur) const {
             if (!cur || cur->get_status() == status::closed)
                 return 0;
-            return (cur->get_status() == status::active ? 1 : 0) +
+            return (cur->get_status() == status::deferred ? 1 : 0) +
                    count_active_nodes(cur->left()) +
                    count_active_nodes(cur->right());
         }
@@ -243,7 +243,7 @@ namespace search_tree {
         }
 
         bool should_split(node<Config>* n, unsigned epoch) {
-            if (!n || n->epoch() != epoch || n->get_status() != status::active || !n->is_leaf())
+            if (!n || n->epoch() != epoch || n->get_status() != status::deferred || !n->is_leaf())
                 return false;
 
             unsigned num_active_nodes = count_active_nodes(m_root.get());
@@ -462,7 +462,7 @@ namespace search_tree {
             // Waiting for all workers would introduce per-node synchronization, delay
             // diversification, and let a slow worker stall progress.
             if (n->epoch() == epoch)
-                n->set_status(status::open);
+                n->set_status(status::frontier);
             
             return did_split;
         }
@@ -504,14 +504,14 @@ namespace search_tree {
             UNREACHABLE();
         }
 
-        // Try to select an open node using the select_next_node policy
-        // If there are no open nodes, try to select an active node for portfolio solving
+        // Try to select a frontier node using the primary scheduling policy.
+        // If there are no frontier nodes, try deferred nodes as a fallback band.
         node<Config>* activate_best_node() {
             candidate best;
-            select_next_node(m_root.get(), status::open, best);
+            select_next_node(m_root.get(), status::frontier, best);
             if (!best.n) {
-                IF_VERBOSE(1, verbose_stream() << "NO OPEN NODES, trying active nodes for portfolio solving\n";);
-                select_next_node(m_root.get(), status::active, best); // If no open nodes, only then consider active nodes for selection
+                IF_VERBOSE(1, verbose_stream() << "NO FRONTIER NODES, trying deferred nodes for portfolio solving\n";);
+                select_next_node(m_root.get(), status::deferred, best); // If no frontier nodes, only then consider deferred nodes for selection
             }
 
             if (!best.n)

--- a/src/util/search_tree.h
+++ b/src/util/search_tree.h
@@ -80,7 +80,7 @@ namespace search_tree {
             SASSERT(!m_right);
             m_left = alloc(node<Config>, a, this);
             m_right = alloc(node<Config>, b, this);
-            bump_epoch();
+            inc_epoch();
         }
 
         node* left() const { return m_left; }
@@ -159,13 +159,13 @@ namespace search_tree {
         unsigned epoch() const {
             return m_epoch;
         }
-        void bump_epoch() {
+        void inc_epoch() {
             ++m_epoch;
         }
         unsigned get_cancel_epoch() const {
             return m_cancel_epoch;
         }
-        void bump_cancel_epoch() {
+        void inc_cancel_epoch() {
             ++m_cancel_epoch;
         }
     };
@@ -370,8 +370,8 @@ namespace search_tree {
         void close(node<Config> *n, vector<literal> const &C) {
             if (!n || n->get_status() == status::closed)
                 return;
-            n->bump_epoch();
-            n->bump_cancel_epoch();
+            n->inc_epoch();
+            n->inc_cancel_epoch();
             n->set_status(status::closed);
             n->set_core(C);
             close(n->left(), C);

--- a/src/util/search_tree.h
+++ b/src/util/search_tree.h
@@ -80,6 +80,7 @@ namespace search_tree {
             SASSERT(!m_right);
             m_left = alloc(node<Config>, a, this);
             m_right = alloc(node<Config>, b, this);
+            bump_epoch();
         }
 
         node* left() const { return m_left; }
@@ -277,8 +278,8 @@ namespace search_tree {
             find_shallowest_timed_out_leaf_depth(cur->right(), best_depth);
         }
 
-        bool should_split(node<Config>* n) {
-            if (!n || n->get_status() != status::active || !n->is_leaf())
+        bool should_split(node<Config>* n, unsigned epoch) {
+            if (!n || n->epoch() != epoch || n->get_status() != status::active || !n->is_leaf())
                 return false;
 
             unsigned num_active_nodes = count_active_nodes(m_root.get());
@@ -474,7 +475,7 @@ namespace search_tree {
 
         // On timeout, either expand the current leaf or reopen the node for a
         // later revisit, depending on the tree-expansion heuristic.
-        bool try_split(node<Config> *n, literal const &a, literal const &b, unsigned effort) {
+        bool try_split(node<Config> *n, literal const &a, literal const &b, unsigned effort, unsigned epoch) {
             // the node could have been marked open by another thread that finished first and split
             // we still want to add the current thread's effort in this case, but not if the node was closed
             if (!n || n->get_status() == status::closed)
@@ -483,7 +484,7 @@ namespace search_tree {
             n->add_effort(effort);
             bool did_split = false;
 
-            if (should_split(n)) {
+            if (should_split(n, epoch)) {
                 n->split(a, b);
                 did_split = true;
             }
@@ -497,7 +498,8 @@ namespace search_tree {
             //
             // Waiting for all workers would introduce per-node synchronization, delay
             // diversification, and let a slow worker stall progress.
-            n->set_status(status::open);
+            if (n->epoch() == epoch)
+                n->set_status(status::open);
             
             return did_split;
         }

--- a/src/util/search_tree.h
+++ b/src/util/search_tree.h
@@ -557,6 +557,10 @@ namespace search_tree {
             n->dec_active_workers();
         }
 
+        bool is_lease_valid(node<Config>* n, unsigned epoch) const {
+            return n && n->get_status() != status::closed && n->epoch() == epoch;
+        }
+        
         bool is_lease_canceled(node<Config>* n, unsigned cancel_epoch) const {
             return !n || n->get_status() == status::closed || n->get_cancel_epoch() != cancel_epoch;
         }

--- a/src/util/search_tree.h
+++ b/src/util/search_tree.h
@@ -520,6 +520,13 @@ namespace search_tree {
             return best.n;
         }
 
+        node<Config>* activate_root() {
+            if (m_root->get_status() == status::closed)
+                return nullptr;
+            m_root->mark_new_activation();
+            return m_root.get();
+        }
+
         void dec_active_workers(node<Config>* n) {
             if (!n)
                 return;

--- a/src/util/search_tree.h
+++ b/src/util/search_tree.h
@@ -469,7 +469,6 @@ namespace search_tree {
 
         void reset() {
             m_root = alloc(node<Config>, m_null_literal, nullptr);
-            m_root->mark_new_activation();
         }
 
         // On timeout, either expand the current leaf or reopen the node for a
@@ -543,7 +542,7 @@ namespace search_tree {
         // return an active node in the tree, or nullptr if there is none
         node<Config> *activate_node(node<Config> *n) {
             if (!n) {
-                if (m_root->get_status() == status::active) {
+                if (m_root->get_status() != status::closed) {
                     m_root->mark_new_activation();
                     return m_root.get();
                 }

--- a/src/util/search_tree.h
+++ b/src/util/search_tree.h
@@ -48,6 +48,9 @@ namespace search_tree {
         vector<literal> m_core;
         unsigned m_num_activations = 0;
         unsigned m_effort_spent = 0;
+        unsigned m_active_workers = 0;
+        unsigned m_epoch = 0;
+        unsigned m_cancel_epoch = 0;
 
     public:
         node(literal const &l, node *parent) : m_literal(l), m_parent(parent), m_status(status::open) {}
@@ -137,12 +140,35 @@ namespace search_tree {
         void mark_new_activation() {
             set_status(status::active);
             ++m_num_activations;
+            ++m_active_workers;
+        }
+        void release_worker() {
+            if (m_active_workers > 0)
+                --m_active_workers;
+        }
+        unsigned active_workers() const {
+            return m_active_workers;
+        }
+        bool has_active_workers() const {
+            return m_active_workers > 0;
         }
         unsigned effort_spent() const {
             return m_effort_spent;
         }
         void add_effort(unsigned effort) {
             m_effort_spent += effort;
+        }
+        unsigned epoch() const {
+            return m_epoch;
+        }
+        void bump_epoch() {
+            ++m_epoch;
+        }
+        unsigned cancel_epoch() const {
+            return m_cancel_epoch;
+        }
+        void bump_cancel_epoch() {
+            ++m_cancel_epoch;
         }
     };
 
@@ -233,7 +259,7 @@ namespace search_tree {
         unsigned count_active_nodes(node<Config>* cur) const {
             if (!cur || cur->get_status() == status::closed)
                 return 0;
-            return (cur->get_status() == status::active ? 1 : 0) +
+            return (cur->has_active_workers() ? 1 : 0) +
                    count_active_nodes(cur->left()) +
                    count_active_nodes(cur->right());
         }
@@ -344,6 +370,8 @@ namespace search_tree {
         void close(node<Config> *n, vector<literal> const &C) {
             if (!n || n->get_status() == status::closed)
                 return;
+            n->bump_epoch();
+            n->bump_cancel_epoch();
             n->set_status(status::closed);
             n->set_core(C);
             close(n->left(), C);
@@ -447,7 +475,9 @@ namespace search_tree {
         // On timeout, either expand the current leaf or reopen the node for a
         // later revisit, depending on the tree-expansion heuristic.
         bool try_split(node<Config> *n, literal const &a, literal const &b, unsigned effort) {
-            if (!n || n->get_status() != status::active)
+            // the node could have been marked open by another thread that finished first and split
+            // we still want to add the current thread's effort in this case, but not if the node was closed
+            if (!n || n->get_status() == status::closed)
                 return false;
 
             n->add_effort(effort);
@@ -475,6 +505,8 @@ namespace search_tree {
         // conflict is given by a set of literals.
         // they are subsets of the literals on the path from root to n AND the external assumption literals
         void backtrack(node<Config> *n, vector<literal> const &conflict) {
+            if (!n)
+                return;
             if (conflict.empty()) {
                 close_with_core(m_root.get(), conflict);
                 return;
@@ -518,6 +550,20 @@ namespace search_tree {
                 }
             }
             return activate_best_node();
+        }
+
+        void release_worker(node<Config>* n) {
+            if (!n)
+                return;
+            n->release_worker();
+        }
+
+        bool is_lease_valid(node<Config>* n, unsigned epoch) const {
+            return n && n->get_status() != status::closed && n->epoch() == epoch;
+        }
+
+        bool is_lease_canceled(node<Config>* n, unsigned cancel_epoch) const {
+            return !n || n->get_status() == status::closed || n->cancel_epoch() != cancel_epoch;
         }
 
         vector<literal> const &get_core_from_root() const {

--- a/src/util/search_tree.h
+++ b/src/util/search_tree.h
@@ -68,9 +68,6 @@ namespace search_tree {
         literal const &get_literal() const {
             return m_literal;
         }
-        bool literal_is_null() const {
-            return Config::is_null(m_literal);
-        }
         void split(literal const &a, literal const &b) {
             SASSERT(!Config::literal_is_null(a));
             SASSERT(!Config::literal_is_null(b));
@@ -96,22 +93,6 @@ namespace search_tree {
                 p = p->parent();
             }
             return d;
-        }
-
-        node *find_active_node() {
-            if (m_status == status::active)
-                return this;
-            if (m_status == status::closed)
-                return nullptr;
-            node *nodes[2] = {m_left, m_right};
-            for (unsigned i = 0; i < 2; ++i) {
-                auto res = nodes[i] ? nodes[i]->find_active_node() : nullptr;
-                if (res)
-                    return res;
-            }
-            if (m_left->get_status() == status::closed && m_right->get_status() == status::closed)
-                m_status = status::closed;
-            return nullptr;
         }
 
         void display(std::ostream &out, unsigned indent) const {
@@ -224,22 +205,6 @@ namespace search_tree {
 
             select_next_node(cur->left(), target_status, best);
             select_next_node(cur->right(), target_status, best);
-        }
-
-        // Try to select an open node using the select_next_node policy
-        // If there are no open nodes, try to select an active node for portfolio solving
-        node<Config>* activate_best_node() {
-            candidate best;
-            select_next_node(m_root.get(), status::open, best);
-            if (!best.n) {
-                IF_VERBOSE(1, verbose_stream() << "NO OPEN NODES, trying active nodes for portfolio solving\n";);
-                select_next_node(m_root.get(), status::active, best); // If no open nodes, only then consider active nodes for selection
-            }
-
-            if (!best.n)
-                return nullptr;
-            best.n->mark_new_activation();
-            return best.n;
         }
 
         bool has_unvisited_open_node(node<Config>* cur) const {
@@ -539,15 +504,20 @@ namespace search_tree {
             UNREACHABLE();
         }
 
-        // return an active node in the tree, or nullptr if there is none
-        node<Config> *activate_node(node<Config> *n) {
-            if (!n) {
-                if (m_root->get_status() != status::closed) {
-                    m_root->mark_new_activation();
-                    return m_root.get();
-                }
+        // Try to select an open node using the select_next_node policy
+        // If there are no open nodes, try to select an active node for portfolio solving
+        node<Config>* activate_best_node() {
+            candidate best;
+            select_next_node(m_root.get(), status::open, best);
+            if (!best.n) {
+                IF_VERBOSE(1, verbose_stream() << "NO OPEN NODES, trying active nodes for portfolio solving\n";);
+                select_next_node(m_root.get(), status::active, best); // If no open nodes, only then consider active nodes for selection
             }
-            return activate_best_node();
+
+            if (!best.n)
+                return nullptr;
+            best.n->mark_new_activation();
+            return best.n;
         }
 
         void dec_active_workers(node<Config>* n) {

--- a/src/util/search_tree.h
+++ b/src/util/search_tree.h
@@ -143,12 +143,9 @@ namespace search_tree {
             ++m_num_activations;
             ++m_active_workers;
         }
-        void release_worker() {
+        void dec_active_workers() {
             if (m_active_workers > 0)
                 --m_active_workers;
-        }
-        unsigned active_workers() const {
-            return m_active_workers;
         }
         bool has_active_workers() const {
             return m_active_workers > 0;
@@ -554,14 +551,10 @@ namespace search_tree {
             return activate_best_node();
         }
 
-        void release_worker(node<Config>* n) {
+        void dec_active_workers(node<Config>* n) {
             if (!n)
                 return;
-            n->release_worker();
-        }
-
-        bool is_lease_valid(node<Config>* n, unsigned epoch) const {
-            return n && n->get_status() != status::closed && n->epoch() == epoch;
+            n->dec_active_workers();
         }
 
         bool is_lease_canceled(node<Config>* n, unsigned cancel_epoch) const {

--- a/src/util/search_tree.h
+++ b/src/util/search_tree.h
@@ -165,7 +165,7 @@ namespace search_tree {
         void bump_epoch() {
             ++m_epoch;
         }
-        unsigned cancel_epoch() const {
+        unsigned get_cancel_epoch() const {
             return m_cancel_epoch;
         }
         void bump_cancel_epoch() {
@@ -229,6 +229,8 @@ namespace search_tree {
             select_next_node(cur->right(), target_status, best);
         }
 
+        // Try to select an open node using the select_next_node policy
+        // If there are no open nodes, try to select an active node for portfolio solving
         node<Config>* activate_best_node() {
             candidate best;
             select_next_node(m_root.get(), status::open, best);
@@ -542,8 +544,6 @@ namespace search_tree {
         }
 
         // return an active node in the tree, or nullptr if there is none
-        // first check if there is a node to activate under n,
-        // if not, go up the tree and try to activate a sibling subtree
         node<Config> *activate_node(node<Config> *n) {
             if (!n) {
                 if (m_root->get_status() == status::active) {
@@ -565,7 +565,7 @@ namespace search_tree {
         }
 
         bool is_lease_canceled(node<Config>* n, unsigned cancel_epoch) const {
-            return !n || n->get_status() == status::closed || n->cancel_epoch() != cancel_epoch;
+            return !n || n->get_status() == status::closed || n->get_cancel_epoch() != cancel_epoch;
         }
 
         vector<literal> const &get_core_from_root() const {

--- a/src/util/search_tree.h
+++ b/src/util/search_tree.h
@@ -224,7 +224,7 @@ namespace search_tree {
         unsigned count_active_nodes(node<Config>* cur) const {
             if (!cur || cur->get_status() == status::closed)
                 return 0;
-            return (cur->has_active_workers() ? 1 : 0) +
+            return (cur->get_status() == status::active ? 1 : 0) +
                    count_active_nodes(cur->left()) +
                    count_active_nodes(cur->right());
         }


### PR DESCRIPTION
Add terminate on demand to our search tree given the new SMTS-inspired tree expansion and node selection policies. If workers W1, W2, and W3 are all working on node n, and W1 determines n UNSAT, then W1 signals W2 and W3 to terminate mid-search and select a new cube.

This is accomplished by introducing a _lease_ on each node. The lease consists of an _epoch_ and a _cancel_epoch_, both of which start at 0. 

The epoch is increased each time there is structural work on a node (splitting/closing/backtracking, NOT just adding effort). The largest epoch value on a node is its current state. If a worker has an older epoch, it's in a stale state for that node/cube. 

The cancel_epoch is incremented from 0 to 1 when the first worker determines the node UNSAT, and this signals the other workers on the node to cancel (see `cancel_closed_leases_unlocked` and `is_lease_canceled`)

Results: LIA (run-1249 vs run-1165), NIA (run-1250 vs run-1173)
http://mtzguido.tplinkdns.com:8081/z3/compare_stats.html

Finally, this PR includes a few bugfixes in the last commit that appear to fix some rare Linux-only crashes on NIA.