### PR TITLE
Fix two bugs in Python examples

### DIFF
--- a/examples/python/bincover.py
+++ b/examples/python/bincover.py
@@ -195,7 +195,7 @@ class BinCoverSolver(UserPropagateBase):
         assert isinstance(value, BitVecNumRef)
         bin_index = value.as_long()
         if bin_index >= len(self.bins):
-            return NOne
+            return None
         return self.bins[bin_index]
 
     def _add_item2bin(self, item, bin):

--- a/examples/python/complex/complex.py
+++ b/examples/python/complex/complex.py
@@ -81,7 +81,7 @@ class ComplexExpr:
         other = _to_complex(other)
         return And(self.r == other.r, self.i == other.i)
 
-    def __neq__(self, other):
+    def __ne__(self, other):
         return Not(self.__eq__(other))
 
     def simplify(self):


### PR DESCRIPTION
- bincover.py: typo `NOne` -> `None` in _value2bin fallback path (would raise NameError if bin_index is out of range).

- complex/complex.py: rename `__neq__` to `__ne__`. Python has no `__neq__` dunder, so `!=` was not using the intended definition. 