### PR TITLE
Use the minimum generation number among matching enodes

### DIFF
--- a/src/ast/euf/euf_mam.cpp
+++ b/src/ast/euf/euf_mam.cpp
@@ -1930,10 +1930,10 @@ namespace euf {
             if (curr->get_decl() == lbl && curr->num_args() == num_expected_args) {
                 if (curr->is_cgr() && !matching_cgr)
                     matching_cgr = curr;
-                if (min_gen_match && min_gen_match->generation() > curr->generation()) {
-                     IF_VERBOSE(0, display(verbose_stream() << enode_pp(min_gen_match, m_context) << "\n" << enode_pp(cur, m_context) << "\n");
-                     UNREACHABLE(); // will exit
-                }
+                // if (min_gen_match && min_gen_match->generation() > curr->generation()) {
+                //     IF_VERBOSE(0, display(verbose_stream() << smt::enode_pp(min_gen_match, m_context) << "\n" << smt::enode_pp(cur, m_context) << "\n"));
+                //     UNREACHABLE(); // will exit
+                // }
                 if (!min_gen_match || min_gen_match->generation() > curr->generation())
                     min_gen_match = curr;
             }

--- a/src/ast/euf/euf_mam.cpp
+++ b/src/ast/euf/euf_mam.cpp
@@ -1926,28 +1926,38 @@ namespace euf {
             m_max_generation = std::max(m_max_generation, n->generation());
         }
 
+        void get_f_app(func_decl* lbl, unsigned num_expected_args, enode* curr, enode*& matching_cgr, enode*& min_gen_match) {
+            if (curr->get_decl() == lbl && curr->num_args() == num_expected_args) {
+                if (curr->is_cgr() && !matching_cgr)
+                    matching_cgr = curr;
+                if (!min_gen_match || min_gen_match->generation() > curr->generation())
+                    min_gen_match = curr;
+            }
+        }
+
         // We have to provide the number of expected arguments because we have flat-assoc applications such as +.
         // Flat-assoc applications may have arbitrary number of arguments.
         enode * get_first_f_app(func_decl * lbl, unsigned num_expected_args, enode * first) {
+            enode *matching_cgr = nullptr, *min_gen_match = nullptr;
             for (enode* curr : euf::enode_class(first)) {
-                if (curr->get_decl() == lbl && curr->is_cgr() && curr->num_args() == num_expected_args) {
-                    update_max_generation(curr, first);
-                    return curr;
-                }
+                get_f_app(lbl, num_expected_args, curr, matching_cgr, min_gen_match);
+                curr = curr->get_next();
             }
-            return nullptr;
+            if (matching_cgr)
+                update_max_generation(min_gen_match, first);                          
+            return matching_cgr;
         }
 
         enode * get_next_f_app(func_decl * lbl, unsigned num_expected_args, enode * first, enode * curr) {
             curr = curr->get_next();
+            enode *matching_cgr = nullptr, *min_gen_match = nullptr;
             while (curr != first) {
-                if (curr->get_decl() == lbl && curr->is_cgr() && curr->num_args() == num_expected_args) {
-                    update_max_generation(curr, first);
-                    return curr;
-                }
+                get_f_app(lbl, num_expected_args, curr, matching_cgr, min_gen_match);
                 curr = curr->get_next();
             }
-            return nullptr;
+            if (matching_cgr)
+                update_max_generation(min_gen_match, first);
+            return matching_cgr;
         }
 
         /**

--- a/src/ast/euf/euf_mam.cpp
+++ b/src/ast/euf/euf_mam.cpp
@@ -239,6 +239,7 @@ namespace euf {
         unsigned short m_num_args;
         unsigned       m_ireg;
         unsigned       m_oreg;
+        unsigned m_curr_generation;
     };
 
     struct get_cgr : public instruction {
@@ -1930,10 +1931,6 @@ namespace euf {
             if (curr->get_decl() == lbl && curr->num_args() == num_expected_args) {
                 if (curr->is_cgr() && !matching_cgr)
                     matching_cgr = curr;
-                // if (min_gen_match && min_gen_match->generation() > curr->generation()) {
-                //     IF_VERBOSE(0, display(verbose_stream() << smt::enode_pp(min_gen_match, m_context) << "\n" << smt::enode_pp(cur, m_context) << "\n"));
-                //     UNREACHABLE(); // will exit
-                // }
                 if (!min_gen_match || min_gen_match->generation() > curr->generation())
                     min_gen_match = curr;
             }
@@ -2577,6 +2574,7 @@ namespace euf {
                  m_backtrack_stack[m_top].m_instr              = m_pc;                                                  \
                  m_backtrack_stack[m_top].m_old_max_generation = m_curr_max_generation;                                 \
                  m_backtrack_stack[m_top].m_curr               = m_app;                                                 \
+                 const_cast<bind*>(static_cast<bind const*>(m_pc)->m_curr_generation = m_max_generation;                \
                  m_top++;
 
             BIND_COMMON();
@@ -2843,7 +2841,8 @@ namespace euf {
                            goto backtrack;                                                                                      \
                        }                                                                                                        \
                        bp.m_curr = m_app;                                                                                       \
-                       TRACE(mam_int, tout << "bind next candidate:\n" << mk_ll_pp(m_app->get_expr(), m););      \
+                       m_max_generation = m_b->m_curr_generation;                                                               \
+                       TRACE(mam_int, tout << "bind next candidate:\n" << mk_ll_pp(m_app->get_expr(), m););                     \
                        m_oreg    = m_b->m_oreg
 
             BBIND_COMMON();

--- a/src/ast/euf/euf_mam.cpp
+++ b/src/ast/euf/euf_mam.cpp
@@ -2574,7 +2574,7 @@ namespace euf {
                  m_backtrack_stack[m_top].m_instr              = m_pc;                                                  \
                  m_backtrack_stack[m_top].m_old_max_generation = m_curr_max_generation;                                 \
                  m_backtrack_stack[m_top].m_curr               = m_app;                                                 \
-                 const_cast<bind*>(static_cast<bind const*>(m_pc)->m_curr_generation = m_max_generation;                \
+                 const_cast<bind*>(static_cast<bind const*>(m_pc))->m_curr_generation = m_max_generation;                \
                  m_top++;
 
             BIND_COMMON();

--- a/src/ast/euf/euf_mam.cpp
+++ b/src/ast/euf/euf_mam.cpp
@@ -1930,6 +1930,10 @@ namespace euf {
             if (curr->get_decl() == lbl && curr->num_args() == num_expected_args) {
                 if (curr->is_cgr() && !matching_cgr)
                     matching_cgr = curr;
+                if (min_gen_match && min_gen_match->generation() > curr->generation()) {
+                     IF_VERBOSE(0, display(verbose_stream() << enode_pp(min_gen_match, m_context) << "\n" << enode_pp(cur, m_context) << "\n");
+                     UNREACHABLE(); // will exit
+                }
                 if (!min_gen_match || min_gen_match->generation() > curr->generation())
                     min_gen_match = curr;
             }

--- a/src/smt/mam.cpp
+++ b/src/smt/mam.cpp
@@ -215,6 +215,7 @@ namespace {
         unsigned short m_num_args;
         unsigned       m_ireg;
         unsigned       m_oreg;
+        unsigned       m_curr_max_generation = 0;
     };
 
     struct get_cgr : public instruction {
@@ -1886,12 +1887,10 @@ namespace {
             if (curr->get_decl() == lbl && curr->get_num_args() == num_expected_args) {
                 if (curr->is_cgr() && !matching_cgr)
                     matching_cgr = curr;
-                if (min_gen_match && min_gen_match->get_generation() > curr->get_generation()) {
-                    IF_VERBOSE(0, verbose_stream() << enode_pp(min_gen_match, m_context) << "\n" << enode_pp(curr, m_context) << "\n");
-                    UNREACHABLE(); // will exit
-                }
-                if (!min_gen_match || min_gen_match->get_generation() > curr->get_generation())
+
+                if (!min_gen_match || min_gen_match->get_generation() > curr->get_generation()) {
                     min_gen_match = curr;
+                }
             }
         }
 
@@ -1906,20 +1905,18 @@ namespace {
             }
             while (curr != first);
             if (matching_cgr)
-                update_max_generation(min_gen_match, first);                          
+                update_max_generation(min_gen_match, first);  
             return matching_cgr;
         }
 
         enode * get_next_f_app(func_decl * lbl, unsigned num_expected_args, enode * first, enode * curr) {
             curr = curr->get_next();
-            enode *matching_cgr = nullptr, *min_gen_match = nullptr;
             while (curr != first) {
-                get_f_app(lbl, num_expected_args, curr, matching_cgr, min_gen_match);
+                if (curr->get_decl() == lbl && curr->get_num_args() == num_expected_args && curr->is_cgr())
+                    return curr;
                 curr = curr->get_next();
             }
-            if (matching_cgr)
-                update_max_generation(min_gen_match, first);
-            return matching_cgr;
+            return nullptr;
         }
 
 
@@ -2485,6 +2482,7 @@ namespace {
                  m_backtrack_stack[m_top].m_old_max_generation = m_curr_max_generation;                                 \
                  m_backtrack_stack[m_top].m_old_used_enodes_size = m_curr_used_enodes_size;                             \
                  m_backtrack_stack[m_top].m_curr               = m_app;                                                 \
+                 const_cast<bind*>(static_cast<const bind*>(m_pc))->m_curr_max_generation = m_max_generation;                                   \
                  m_top++;
 
             BIND_COMMON();
@@ -2752,7 +2750,8 @@ namespace {
 #define BBIND_COMMON() m_b   = static_cast<const bind*>(bp.m_instr);                                                            \
                        m_n1  = m_registers[m_b->m_ireg];                                                                        \
                        m_app = get_next_f_app(m_b->m_label, m_b->m_num_args, m_n1, bp.m_curr); \
-                       if (m_app == 0) {                                                                                        \
+                       m_max_generation = m_b->m_curr_max_generation;                                                            \
+                       if (!m_app) {                                                                                        \
                            m_top--;                                                                                             \
                            goto backtrack;                                                                                      \
                        }                                                                                                        \

--- a/src/smt/mam.cpp
+++ b/src/smt/mam.cpp
@@ -1882,56 +1882,40 @@ namespace {
                 m_used_enodes.push_back(std::make_tuple(prev, n));
         }
 
+        void get_f_app(func_decl* lbl, unsigned num_expected_args, enode* curr, enode*& matching_cgr, enode*& min_gen_match) {
+            if (curr->get_decl() == lbl && curr->get_num_args() == num_expected_args) {
+                if (curr->is_cgr() && !matching_cgr)
+                    matching_cgr = curr;
+                if (!min_gen_match || min_gen_match->get_generation() > curr->get_generation())
+                    min_gen_match = curr;
+            }
+        }
+
         // We have to provide the number of expected arguments because we have flat-assoc applications such as +.
         // Flat-assoc applications may have arbitrary number of arguments.
         enode * get_first_f_app(func_decl * lbl, unsigned num_expected_args, enode * curr) {
             enode * first = curr;
-            enode * matching_cgr = nullptr;
-            enode * min_gen_match = nullptr;
+            enode *matching_cgr = nullptr, *min_gen_match = nullptr;
             do {
-                if (curr->get_decl() == lbl  && curr->get_num_args() == num_expected_args) {
-                    if (matching_cgr == nullptr && curr->is_cgr()) {
-                        matching_cgr = curr;
-                    }
-                    // To compute the generation the match occurs at, use the minimum generation number among all matching terms in the congruence class.
-                    // This ensures that the generation number corresponds to the shortest path of instantiations. 
-                    if (min_gen_match == nullptr || min_gen_match->get_generation() > curr->get_generation()) {
-                        min_gen_match = curr;
-                    }
-                }
+                get_f_app(lbl, num_expected_args, curr, matching_cgr, min_gen_match);
                 curr = curr->get_next();
             }
             while (curr != first);
-
-            if (matching_cgr != nullptr) {
-                update_max_generation(min_gen_match, first);
-                return matching_cgr;
-            }
-
-            return nullptr;
+            if (matching_cgr)
+                update_max_generation(min_gen_match, first);                          
+            return matching_cgr;
         }
 
         enode * get_next_f_app(func_decl * lbl, unsigned num_expected_args, enode * first, enode * curr) {
             curr = curr->get_next();
-            enode * matching_cgr = nullptr;
-            enode * min_gen_match = nullptr;
+            enode *matching_cgr = nullptr, *min_gen_match = nullptr;
             while (curr != first) {
-                if (curr->get_decl() == lbl  && curr->get_num_args() == num_expected_args) {
-                    if (matching_cgr == nullptr && curr->is_cgr()) {
-                        matching_cgr = curr;
-                    }
-                    if (min_gen_match == nullptr || min_gen_match->get_generation() > curr->get_generation()) {
-                        min_gen_match = curr;
-                    }
-                }
+                get_f_app(lbl, num_expected_args, curr, matching_cgr, min_gen_match);
                 curr = curr->get_next();
             }
-            if (matching_cgr != nullptr) {
+            if (matching_cgr)
                 update_max_generation(min_gen_match, first);
-                return matching_cgr;
-            }
-
-            return nullptr;
+            return matching_cgr;
         }
 
 

--- a/src/smt/mam.cpp
+++ b/src/smt/mam.cpp
@@ -1886,28 +1886,54 @@ namespace {
         // Flat-assoc applications may have arbitrary number of arguments.
         enode * get_first_f_app(func_decl * lbl, unsigned num_expected_args, enode * curr) {
             enode * first = curr;
+            enode * matching_cgr = nullptr;
+            enode * min_gen_match = nullptr;
             do {
-                if (curr->get_decl() == lbl && curr->is_cgr() && curr->get_num_args() == num_expected_args) {
-                    update_max_generation(curr, first);
-                    return curr;
+                if (curr->get_decl() == lbl  && curr->get_num_args() == num_expected_args) {
+                    if (matching_cgr == nullptr && curr->is_cgr()) {
+                        matching_cgr = curr;
+                    }
+                    // To compute the generation the match occurs at, use the minimum generation number among all matching terms in the congruence class.
+                    // This ensures that the generation number corresponds to the shortest path of instantiations. 
+                    if (min_gen_match == nullptr || min_gen_match->get_generation() > curr->get_generation()) {
+                        min_gen_match = curr;
+                    }
                 }
                 curr = curr->get_next();
             }
             while (curr != first);
+
+            if (matching_cgr != nullptr) {
+                update_max_generation(min_gen_match, first);
+                return matching_cgr;
+            }
+
             return nullptr;
         }
 
         enode * get_next_f_app(func_decl * lbl, unsigned num_expected_args, enode * first, enode * curr) {
             curr = curr->get_next();
+            enode * matching_cgr = nullptr;
+            enode * min_gen_match = nullptr;
             while (curr != first) {
-                if (curr->get_decl() == lbl && curr->is_cgr() && curr->get_num_args() == num_expected_args) {
-                    update_max_generation(curr, first);
-                    return curr;
+                if (curr->get_decl() == lbl  && curr->get_num_args() == num_expected_args) {
+                    if (matching_cgr == nullptr && curr->is_cgr()) {
+                        matching_cgr = curr;
+                    }
+                    if (min_gen_match == nullptr || min_gen_match->get_generation() > curr->get_generation()) {
+                        min_gen_match = curr;
+                    }
                 }
                 curr = curr->get_next();
             }
+            if (matching_cgr != nullptr) {
+                update_max_generation(min_gen_match, first);
+                return matching_cgr;
+            }
+
             return nullptr;
         }
+
 
         /**
            \brief Execute the is_cgr instruction.

--- a/src/smt/mam.cpp
+++ b/src/smt/mam.cpp
@@ -1886,6 +1886,10 @@ namespace {
             if (curr->get_decl() == lbl && curr->get_num_args() == num_expected_args) {
                 if (curr->is_cgr() && !matching_cgr)
                     matching_cgr = curr;
+                if (min_gen_match && min_gen_match->get_generation() > curr->get_generation()) {
+                    IF_VERBOSE(0, verbose_stream() << enode_pp(min_gen_match, m_context) << "\n" << enode_pp(curr, m_context) << "\n");
+                    UNREACHABLE(); // will exit
+                }
                 if (!min_gen_match || min_gen_match->get_generation() > curr->get_generation())
                     min_gen_match = curr;
             }


### PR DESCRIPTION
This patch is meant to improve stability. It ensures that the generation number corresponds to the shortest path of instantiations for the term to be created. This essentially prevents cases where the generation number is determined by some high-generation term that sticks around after backtracking.