### PR TITLE
smt: reset give-up state when escalating final_check level

### DIFF
--- a/src/smt/smt_context.cpp
+++ b/src/smt/smt_context.cpp
@@ -4175,6 +4175,14 @@ namespace smt {
                 if (level >= max_level || result == FC_DONE || can_propagate())
                     break;
                 ++level;
+                // Re-evaluate at the higher level: clear the give-up state
+                // accumulated at lower levels so a level that succeeds is
+                // not masked by a previous FC_GIVEUP. See e.g. theory_lra
+                // whose level 2 invokes the full nlsat (m_nra.check) that
+                // is skipped at level 1.
+                result = FC_DONE;
+                f      = OK;
+                m_incomplete_theories.reset();
             }
         }
 


### PR DESCRIPTION
theory_lra reports num_final_check_levels()==2: full nlsat (m_nra.check) only runs at level >= 2. When a level-1 round-trip ends with FC_GIVEUP and the loop escalates to level 2, the previously accumulated 'result', 'f', and 'm_incomplete_theories' were retained, so a subsequent successful (FC_DONE) round at level 2 was still reported as (incomplete (theory arithmetic)). Reset that state on each level escalation.

It seems to be a bug introduced with the loop in inal_check_status context::final_check() - according to Claude. 