### PR TITLE
Build Z3 through Bazel natively

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
 
 package(default_applicable_licenses = [":license"])
@@ -11,48 +11,92 @@ license(
 
 exports_files(["LICENSE.txt"])
 
+PYG_FILES = [
+    f.removeprefix("src/").removesuffix(".pyg")
+    for f in glob(["**/*.pyg"])
+]
+
 filegroup(
-    name = "all_files",
-    srcs = glob(["**"]),
+    name = "z3_c_headers",
+    srcs = glob(["src/api/z3_*.h"]),
 )
 
-cmake(
+[
+    genrule(
+        name = name,
+        srcs = ["src/%s.pyg" % name],
+        outs = [name + ".hpp"],
+        cmd = "$(location //scripts:pyg2hpp) $(location src/%s.pyg) $$(dirname $@)" % name,
+        tools = ["//scripts:pyg2hpp"],
+    )
+    for name in PYG_FILES
+]
+
+genrule(
+    name = "api_log_macros",
+    srcs = [":z3_c_headers"],
+    outs = [
+        "api/api_commands.cpp",
+        "api/api_log_macros.cpp",
+        "api/api_log_macros.h",
+    ],
+    cmd = "$(location //scripts:update_api) --api_output_dir $$(dirname $(location api/api_log_macros.h)) $(locations :z3_c_headers)",
+    tools = ["//scripts:update_api"],
+)
+
+genrule(
+    name = "ast_pattern_database",
+    srcs = ["src/ast/pattern/database.smt2"],
+    outs = ["ast/pattern/database.h"],
+    cmd = "$(location //scripts:mk_pat_db) $(location src/ast/pattern/database.smt2) $@",
+    tools = ["//scripts:mk_pat_db"],
+)
+
+genrule(
+    name = "util_z3_version",
+    srcs = ["//scripts:VERSION.txt"],
+    outs = ["util/z3_version.h"],
+    cmd = "$(location //scripts:mk_version_h_simple) $(location //scripts:VERSION.txt) $@",
+    tools = ["//scripts:mk_version_h_simple"],
+)
+
+cc_library(
+    name = "z3",
+    srcs = glob(
+        include = [
+            "src/**/*.cpp",
+            "src/**/*.h",
+        ],
+        exclude = [
+            "src/api/julia/**/*",
+            "src/test/**/*",
+        ],
+    ) + PYG_FILES + [
+        ":api_log_macros",
+        ":ast_pattern_database",
+        ":util_z3_version",
+    ],
+    hdrs = [
+        "src/api/c++/z3++.h",
+        ":z3_c_headers",
+    ],
+    defines = ["_MP_INTERNAL"],
+    includes = [
+        "src",
+        "src/api",
+        "src/api/c++",
+    ],
+    textual_hdrs = ["src/util/trace_tags.def"],
+    visibility = ["//visibility:public"],
+)
+
+# For compatibility with older versions of the BUILD file.
+alias(
     name = "z3_dynamic",
-    generate_args = [
-        "-G Ninja", 
-        "-D Z3_EXPORTED_TARGETS=",  # prevents installation, leaving symlinks between dylibs intact on copy
-    ],
-    lib_source = ":all_files",
-    out_binaries = ["z3"],
-    out_shared_libs = select({
-        "@platforms//os:linux": ["libz3.so"],
-        # "@platforms//os:osx": ["libz3.dylib"],    # FIXME: this is not working, libz3<version>.dylib is not copied
-        "@platforms//os:windows": ["libz3.dll"],
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
-    visibility = ["//visibility:public"],
-)
-
-cmake(
-    name = "z3_static",
-    generate_args = [
-        "-G Ninja", 
-        "-D BUILD_SHARED_LIBS=OFF",
-        "-D Z3_BUILD_LIBZ3_SHARED=OFF",
-    ],
-    lib_source = ":all_files",
-    out_binaries = ["z3"],
-    out_static_libs = select({
-        "@platforms//os:linux": ["libz3.a"],
-        "@platforms//os:osx": ["libz3.a"],
-        "@platforms//os:windows": ["libz3.lib"],     # MSVC with Control Flow Guard enabled by default
-        "//conditions:default": ["@platforms//:incompatible"],
-    }),
-    visibility = ["//visibility:public"],
+    actual = "z3",
 )
 
 alias(
-    name = "z3",
-    actual = ":z3_dynamic",
-    visibility = ["//visibility:public"],
+    name = "z3_static",
+    actual = "z3",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,8 +4,9 @@ module(
     bazel_compatibility = [">=7.0.0"],
 )
 
-bazel_dep(name = "rules_foreign_cc", version = "0.14.0")
+bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "2.0.0")
 
 # Enables formatting all Bazel files (.bazel, .bzl) by running:
 # ```bash
@@ -18,4 +19,6 @@ bazel_dep(
     dev_dependency = True,
 )
 
-bazel_dep(name = "platforms", version = "0.0.11")
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.defaults(python_version = "3.12")
+python.toolchain(python_version = "3.12")

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+exports_files(
+    ["VERSION.txt"],
+    visibility = ["//:__pkg__"],
+)
+
+py_library(
+    name = "mk_genfile_common",
+    srcs = ["mk_genfile_common.py"],
+    imports = ["."],
+)
+
+py_binary(
+    name = "mk_pat_db",
+    srcs = ["mk_pat_db.py"],
+    visibility = ["//:__pkg__"],
+    deps = [":mk_genfile_common"],
+)
+
+py_binary(
+    name = "mk_version_h_simple",
+    srcs = ["mk_version_h_simple.py"],
+    visibility = ["//:__pkg__"],
+)
+
+py_binary(
+    name = "pyg2hpp",
+    srcs = ["pyg2hpp.py"],
+    visibility = ["//:__pkg__"],
+    deps = [":mk_genfile_common"],
+)
+
+py_binary(
+    name = "update_api",
+    srcs = ["update_api.py"],
+    visibility = ["//:__pkg__"],
+)

--- a/scripts/mk_version_h_simple.py
+++ b/scripts/mk_version_h_simple.py
@@ -1,0 +1,19 @@
+"""
+Create a copy of util/z3_version.h that is solely based on the contents of
+scripts/VERSION.txt, and not the commit hash of the current source
+checkout. This is used when building Z3 through Bazel.
+"""
+
+import sys
+
+with open(sys.argv[1]) as f:
+    version = f.read().strip()
+    version_parts = version.split(".")
+with open(sys.argv[2], "w") as f:
+    f.write(f"""
+#define Z3_MAJOR_VERSION {version_parts[0]}
+#define Z3_MINOR_VERSION {version_parts[1]}
+#define Z3_BUILD_NUMBER {version_parts[2]}
+#define Z3_REVISION_NUMBER {version_parts[3]}
+#define Z3_FULL_VERSION "Z3 {version}"
+""")


### PR DESCRIPTION
Right now Z3 ships with a BUILD.bazel file. However, by the looks of it it's slightly pointless. It merely invokes CMake using rules_foreign_cc. This takes away most of the benefits of using Bazel, such as fine-grained caching and being able to parallelize builds across multiple machines.

In my case I've observed the existing rules_foreign_cc based build to be very slow and also not reproducible. Let's solve this by replacing BUILD.bazel with one that simply declares a cc_library() target. We name this one "z3", so that it's possible to depend on it using "@z3".

For compatibility we let "z3_dynamic" and "z3_static" be aliases pointing to the new "z3" target.