### PR TITLE
Fix NLSAT check_assignment soundness bug (issue #9139)

### DIFF
--- a/src/math/lp/nra_solver.cpp
+++ b/src/math/lp/nra_solver.cpp
@@ -64,8 +64,10 @@ struct solver::imp {
         m_lp2nl.reset();
     }
 
-    // Create polynomial definition for variable v used in setup_assignment_solver.
-    // Side-effects: updates m_vars2mon when v is a monic variable.
+    // Create polynomial definition for variable v used in setup_solver_poly.
+    // The definition recursively expands monic and term variables into
+    // polynomials in leaf variables, scaled by an integer denominator
+    // tracked in `denominators` to keep the coefficients integral.
     void mk_definition(unsigned v, polynomial_ref_vector &definitions, vector<rational>& denominators) {
         auto &pm = m_nlsat->pm();
         polynomial::polynomial_ref p(pm);
@@ -98,44 +100,6 @@ struct solver::imp {
         }
         definitions.push_back(p);
         denominators.push_back(den);
-    }
-
-    // Create polynomial definition for variable v used in setup_assignment_solver.
-    // Side-effects: updates m_vars2mon when v is a monic variable.
-    void mk_definition_assignment(unsigned v, polynomial_ref_vector &definitions) {
-        auto &pm = m_nlsat->pm();
-        polynomial::polynomial_ref p(pm);
-        if (m_nla_core.emons().is_monic_var(v)) {
-            auto const &m = m_nla_core.emons()[v];
-            auto vars = m.vars();
-            std::sort(vars.begin(), vars.end());
-            m_vars2mon.insert(vars, v);
-            for (auto v2 : vars) {
-                auto pv = definitions.get(v2);
-                if (!p)
-                    p = pv;
-                else
-                    p = pm.mul(p, pv);
-            }
-        }
-        else if (lra.column_has_term(v)) {
-            rational den(1);
-            for (auto const& [w, coeff] : lra.get_term(v))
-                den = lcm(den, denominator(coeff));
-            for (auto const& [w, coeff] : lra.get_term(v)) {
-                auto pw = definitions.get(w);
-                polynomial::polynomial_ref term(pm);
-                term = pm.mul(den * coeff, pw);
-                if (!p)
-                    p = term;
-                else
-                    p = pm.add(p, term);
-            }
-        }
-        else {
-            p = pm.mk_polynomial(lp2nl(v));
-        }
-        definitions.push_back(p);
     }
 
     void setup_solver_poly() {
@@ -316,8 +280,8 @@ struct solver::imp {
         m_literal2constraint.reset();
         m_vars2mon.reset();
         m_coi.init();
-        auto &pm = m_nlsat->pm();
-        polynomial_ref_vector definitions(pm);
+        // Create an NLSAT polyvar for each LRA variable and seed the
+        // assignment from the current LRA model.
         for (unsigned v = 0; v < lra.number_of_vars(); ++v) {
             auto j = m_nlsat->mk_var(lra.var_is_int(v));
             VERIFY(j == v);
@@ -325,29 +289,46 @@ struct solver::imp {
             scoped_anum a(am());
             am().set(a, m_nla_core.val(v).to_mpq());
             m_values->push_back(a);
-            mk_definition_assignment(v, definitions);
+            if (m_nla_core.emons().is_monic_var(v)) {
+                auto const &m = m_nla_core.emons()[v];
+                auto vars = m.vars();
+                std::sort(vars.begin(), vars.end());
+                m_vars2mon.insert(vars, v);
+            }
         }
 
+        // Add LRA constraints using polyvars directly (no recursive
+        // substitution of term/monic definitions). This keeps NLSAT's
+        // polynomials in a form that can be inverted back to LRA terms
+        // unambiguously in add_lemma / process_polynomial_check_assignment.
         for (auto ci : m_coi.constraints()) {
             auto &c = lra.constraints()[ci];
             auto &pm = m_nlsat->pm();
             auto k = c.kind();
             auto rhs = c.rhs();
             auto lhs = c.coeffs();
+            auto sz = lhs.size();
+            svector<polynomial::var> vars;
             rational den = denominator(rhs);
-            for (auto [coeff, v] : lhs)
-                den = lcm(den, denominator(coeff));
-            polynomial::polynomial_ref p(pm);
-            p = pm.mk_const(-den * rhs);
-
             for (auto [coeff, v] : lhs) {
-                polynomial_ref poly(pm);
-                poly = pm.mul(den * coeff, definitions.get(v));
-                p = p + poly;
+                vars.push_back(lp2nl(v));
+                den = lcm(den, denominator(coeff));
             }
+            vector<rational> coeffs;
+            for (auto kv : lhs)
+                coeffs.push_back(den * kv.first);
+            polynomial::polynomial_ref p(pm.mk_linear(sz, coeffs.data(), vars.data(), -den * rhs), pm);
             auto lit = add_constraint(p, ci, k);
             m_literal2constraint.setx(lit.index(), ci, lp::null_ci);
         }
+
+        // Assert the definitions of monic variables (v_mon = v1*v2*...).
+        for (auto const &m : m_coi.mons())
+            add_monic_eq(m_nla_core.emons()[m]);
+
+        // Assert the definitions of term variables (v_term = sum(coeff_i * v_i)).
+        for (unsigned i : m_coi.terms())
+            add_term(i);
     }
 
     void process_polynomial_check_assignment(polynomial::polynomial const* p, rational& bound, const u_map<lp::lpvar>& nl2lp, lp::lar_term& t) {
@@ -428,7 +409,6 @@ struct solver::imp {
 
     lbool add_lemma(nlsat::literal_vector const &clause) {
         u_map<lp::lpvar> nl2lp = reverse_lp2nl();
-        polynomial::manager &pm = m_nlsat->pm();
         lbool result = l_false;
         {
             nla::lemma_builder lemma(m_nla_core, __FUNCTION__);


### PR DESCRIPTION
There was an algebraic error in deleted now mk_definition_assignment: 
Fixed by Claude.
setup_assignment_solver inlined term/monic definitions via mk_definition_assignment, scaling each term polynomial by den=lcm(denominators) to keep coefficients integral but then dropping `den`. This made definitions[v] = den_v * v for some hidden den_v, which propagated multiplicatively through monic factors. The constraint encoder then substituted definitions[v] into LRA constraints as if it equaled v, silently multiplying coefficients by the hidden factor. Combined with monic/term equalities never being asserted as NLSAT clauses (they were only baked in via the broken substitution), NLSAT's linear projection produced unsound bounds like `5*j8 <= 1` instead of `j8 <= 1`, which were returned as LRA lemmas and refuted satisfiable formulas.

Rewrite setup_assignment_solver in the same three-phase shape used by setup_solver_terms:

  1. Declare one NLSAT polyvar per LRA variable (identity map), seed m_values from the LRA model, and populate m_vars2mon for the inverse mapping in process_polynomial_check_assignment.
  2. Encode each LRA constraint as a single flat linear polynomial over the leaf polyvars (local lcm rescaling cancels on both sides of the relation).
  3. Assert monic equalities (j_mon - v1*v2*... = 0) via add_monic_eq and term equalities (den*j_term - sum(coeff_i * v_i) = 0) via add_term.

Remove the now-unused mk_definition_assignment helper and an unused polynomial::manager& binding in add_lemma, and update a stale comment on mk_definition.

Verified bug1.smt2 and bug2.smt2 from the issue now return sat (with model_validate=true) in both release and debug builds, and all 90 test-z3 /a unit tests still pass.