### PR TITLE
Expose `Seq.mk_re_diff` in ocaml bindings

### DIFF
--- a/src/api/ml/z3.ml
+++ b/src/api/ml/z3.ml
@@ -1322,6 +1322,7 @@ struct
   let mk_re_loop = Z3native.mk_re_loop
   let mk_re_intersect ctx args = Z3native.mk_re_intersect ctx (List.length args) args
   let mk_re_complement = Z3native.mk_re_complement
+  let mk_re_diff = Z3native.mk_re_diff
   let mk_re_empty = Z3native.mk_re_empty
   let mk_re_full = Z3native.mk_re_full
   let mk_char = Z3native.mk_char

--- a/src/api/ml/z3.mli
+++ b/src/api/ml/z3.mli
@@ -2067,6 +2067,9 @@ sig
   (** the regular expression complement *)
   val mk_re_complement : context -> Expr.expr -> Expr.expr
 
+  (** the regular expression difference *)
+  val mk_re_diff : context -> Expr.expr -> Expr.expr -> Expr.expr
+
   (** the regular expression that accepts no sequences *)
   val mk_re_empty : context -> Sort.sort -> Expr.expr
 


### PR DESCRIPTION
Noticed it was missing