### PR TITLE
CI: validate libz3.dylib architecture on macOS to prevent #9662 regression

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,6 +45,19 @@ jobs:
       - name: Build
         run: python scripts/mk_unix_dist.py --dotnet-key=$GITHUB_WORKSPACE/resources/z3.snk --arch=x64
             
+      - name: Validate libz3.dylib and z3 architecture (must be x86_64)
+        run: |
+          set -e
+          for f in build-dist/libz3.dylib build-dist/z3; do
+            ARCH=$(lipo -archs "$f")
+            echo "$f architecture: $ARCH"
+            if [ "$ARCH" != "x86_64" ]; then
+              echo "ERROR: $f has arch '$ARCH', expected 'x86_64' (see issue #9662)"
+              exit 1
+            fi
+          done
+          echo "OK: macOS x64 artifacts are x86_64"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1
         with:
@@ -68,6 +81,19 @@ jobs:
       - name: Build
         run: python scripts/mk_unix_dist.py --dotnet-key=$GITHUB_WORKSPACE/resources/z3.snk --arch=arm64
             
+      - name: Validate libz3.dylib and z3 architecture (must be arm64)
+        run: |
+          set -e
+          for f in build-dist/libz3.dylib build-dist/z3; do
+            ARCH=$(lipo -archs "$f")
+            echo "$f architecture: $ARCH"
+            if [ "$ARCH" != "arm64" ]; then
+              echo "ERROR: $f has arch '$ARCH', expected 'arm64' (see issue #9662)"
+              exit 1
+            fi
+          done
+          echo "OK: macOS arm64 artifacts are arm64"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1
         with:
@@ -101,6 +127,17 @@ jobs:
           Z3_DIR=$(find . -maxdepth 1 -type d -name "z3-*" | head -n 1)
           echo "Z3_DIR=$Z3_DIR" >> $GITHUB_ENV
       
+      - name: Validate shipped libz3.dylib architecture (must be x86_64)
+        run: |
+          set -e
+          DYLIB="artifacts/$Z3_DIR/bin/libz3.dylib"
+          ARCH=$(lipo -archs "$DYLIB")
+          echo "Shipped $DYLIB architecture: $ARCH"
+          if [ "$ARCH" != "x86_64" ]; then
+            echo "ERROR: x64 nightly zip contains '$ARCH' libz3.dylib (see issue #9662)"
+            exit 1
+          fi
+
       - name: Test install_name_tool with headerpad
         run: |
           cd artifacts/$Z3_DIR/bin
@@ -149,6 +186,17 @@ jobs:
           Z3_DIR=$(find . -maxdepth 1 -type d -name "z3-*" | head -n 1)
           echo "Z3_DIR=$Z3_DIR" >> $GITHUB_ENV
       
+      - name: Validate shipped libz3.dylib architecture (must be arm64)
+        run: |
+          set -e
+          DYLIB="artifacts/$Z3_DIR/bin/libz3.dylib"
+          ARCH=$(lipo -archs "$DYLIB")
+          echo "Shipped $DYLIB architecture: $ARCH"
+          if [ "$ARCH" != "arm64" ]; then
+            echo "ERROR: arm64 nightly zip contains '$ARCH' libz3.dylib (see issue #9662)"
+            exit 1
+          fi
+
       - name: Test install_name_tool with headerpad
         run: |
           cd artifacts/$Z3_DIR/bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,19 @@ jobs:
       - name: Build
         run: python scripts/mk_unix_dist.py --dotnet-key=$GITHUB_WORKSPACE/resources/z3.snk --arch=x64
       
+      - name: Validate libz3.dylib and z3 architecture (must be x86_64)
+        run: |
+          set -e
+          for f in build-dist/libz3.dylib build-dist/z3; do
+            ARCH=$(lipo -archs "$f")
+            echo "$f architecture: $ARCH"
+            if [ "$ARCH" != "x86_64" ]; then
+              echo "ERROR: $f has arch '$ARCH', expected 'x86_64' (see issue #9662)"
+              exit 1
+            fi
+          done
+          echo "OK: macOS x64 artifacts are x86_64"
+
       - name: Clone z3test
         run: git clone https://github.com/z3prover/z3test z3test
       
@@ -75,6 +88,19 @@ jobs:
       - name: Build
         run: python scripts/mk_unix_dist.py --dotnet-key=$GITHUB_WORKSPACE/resources/z3.snk --arch=arm64
       
+      - name: Validate libz3.dylib and z3 architecture (must be arm64)
+        run: |
+          set -e
+          for f in build-dist/libz3.dylib build-dist/z3; do
+            ARCH=$(lipo -archs "$f")
+            echo "$f architecture: $ARCH"
+            if [ "$ARCH" != "arm64" ]; then
+              echo "ERROR: $f has arch '$ARCH', expected 'arm64' (see issue #9662)"
+              exit 1
+            fi
+          done
+          echo "OK: macOS arm64 artifacts are arm64"
+
       - name: Clone z3test
         run: git clone https://github.com/z3prover/z3test z3test
       
@@ -111,6 +137,17 @@ jobs:
           Z3_DIR=$(find . -maxdepth 1 -type d -name "z3-*" | head -n 1)
           echo "Z3_DIR=$Z3_DIR" >> $GITHUB_ENV
       
+      - name: Validate shipped libz3.dylib architecture (must be x86_64)
+        run: |
+          set -e
+          DYLIB="artifacts/$Z3_DIR/bin/libz3.dylib"
+          ARCH=$(lipo -archs "$DYLIB")
+          echo "Shipped $DYLIB architecture: $ARCH"
+          if [ "$ARCH" != "x86_64" ]; then
+            echo "ERROR: x64 release zip contains '$ARCH' libz3.dylib (see issue #9662)"
+            exit 1
+          fi
+
       - name: Test install_name_tool with headerpad
         run: |
           cd artifacts/$Z3_DIR/bin
@@ -159,6 +196,17 @@ jobs:
           Z3_DIR=$(find . -maxdepth 1 -type d -name "z3-*" | head -n 1)
           echo "Z3_DIR=$Z3_DIR" >> $GITHUB_ENV
       
+      - name: Validate shipped libz3.dylib architecture (must be arm64)
+        run: |
+          set -e
+          DYLIB="artifacts/$Z3_DIR/bin/libz3.dylib"
+          ARCH=$(lipo -archs "$DYLIB")
+          echo "Shipped $DYLIB architecture: $ARCH"
+          if [ "$ARCH" != "arm64" ]; then
+            echo "ERROR: arm64 release zip contains '$ARCH' libz3.dylib (see issue #9662)"
+            exit 1
+          fi
+
       - name: Test install_name_tool with headerpad
         run: |
           cd artifacts/$Z3_DIR/bin


### PR DESCRIPTION
Fixes the root cause of how issue #9662 went unnoticed: the macOS code fix already landed in master (c4acd2a4, PR #8696), but no CI step verified that the released libz3.dylib actually matches the architecture tag in the zip / wheel name. Between 4.15.5 and 4.16.0, x86_64-tagged zips and PyPI wheels silently shipped an arm64 libz3.dylib, breaking every Intel Mac user.

## What this PR adds

In both `release.yml` and `nightly.yml`:

1. **Post-build check** in `mac-build-x64` and `mac-build-arm64` — uses `lipo -archs` on `build-dist/libz3.dylib` and `build-dist/z3` to fail the job immediately if either has the wrong architecture.
2. **Shipped-artifact check** inside the existing `validate-macos-headerpad-x64` / `-arm64` jobs (which already unzip the uploaded `z3-*-osx*.zip`) — additionally verifies the `libz3.dylib` inside the final zip that gets attached to the release.

No code changes to Z3 itself; the build-script fix for the actual regression is already on master.

Refs #9662 (the macOS x86_64 dylib issue) and the earlier related fix #8696.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>