### PR TITLE
ci(nightly): authenticate clone of private Z3Prover/bench repo

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -245,16 +245,39 @@ jobs:
       - name: Test
         run: python z3test/scripts/test_benchmarks.py build-dist/z3 z3test/regressions/smt2
       - name: Clone bench (for issue-oracle smoke test)
+        # continue-on-error: true keeps a missing/expired BENCH_REPO_TOKEN
+        # or a transient outage on Z3Prover/bench from failing the
+        # nightly build. The next step still won't run successfully if
+        # the bench/ directory is absent, but it also has
+        # continue-on-error, so the worst case is a noisy annotation
+        # rather than a red build. Re-evaluate removing this once the
+        # secret is verified to be present and stable in CI.
         continue-on-error: true
-        run: |
-          # Sparse clone: bench is ~12 GB total but only scripts/ and
-          # inputs/issues/ (~800 MB) are needed by the oracle. The
-          # smoke-test runs on a sampled subset of iss-* dirs (see
-          # next step), so even this 800 MB pull is upper-bounded
-          # at the clone level rather than runtime.
-          git clone --depth 1 --filter=blob:none --sparse \
-            https://github.com/Z3Prover/bench bench
-          git -C bench sparse-checkout set scripts inputs/issues
+        # Z3Prover/bench is a PRIVATE repo, so the default GITHUB_TOKEN
+        # (which is scoped to this repository only) cannot read it.
+        # Authentication is provided by the BENCH_REPO_TOKEN secret,
+        # which must be a PAT (or GitHub App installation token) with
+        # `contents: read` permission on Z3Prover/bench. Without it,
+        # the previous unauthenticated `git clone` failed with
+        # "could not read Username for 'https://github.com'".
+        #
+        # Sparse clone: bench is ~12 GB total but only scripts/ and
+        # inputs/issues/ (~800 MB) are needed by the oracle. The
+        # smoke-test runs on a sampled subset of iss-* dirs (see
+        # next step), so even this 800 MB pull is upper-bounded
+        # at the clone level rather than runtime. Cone-mode
+        # sparse-checkout pulls everything recursively under those
+        # two top-level dirs; `fetch-depth: 1` keeps history minimal.
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: Z3Prover/bench
+          token: ${{ secrets.BENCH_REPO_TOKEN }}
+          path: bench
+          sparse-checkout: |
+            scripts
+            inputs/issues
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Run issue-oracle smoke test
         # continue-on-error: true means this step can NEVER red the


### PR DESCRIPTION
## Problem

The Ubuntu nightly job ([run 26927938635](https://github.com/Z3Prover/z3/actions/runs/26927938635/job/79441695358)) and every nightly before it have been emitting two stale error annotations:

1. **`Clone bench (for issue-oracle smoke test)`** — exit 128:
   ```
   Cloning into 'bench'...
   fatal: could not read Username for 'https://github.com': No such device or address
   Process completed with exit code 128.
   ```
2. **`Run issue-oracle smoke test`** — exit 2:
   ```
   python: can't open file '/home/runner/work/z3/z3/bench/scripts/issues_check_oracle.py': [Errno 2] No such file or directory
   ```
   …because the previous step never created `bench/`.

Both steps have `continue-on-error: true`, so the job stayed green, but the smoke test never actually ran and the annotations were noise that hid real failures.

## Root cause

`Z3Prover/bench` is a **private** repository (verified via `gh api repos/Z3Prover/bench` → `"private":true`). The unauthenticated `git clone https://github.com/Z3Prover/bench` on the headless runner triggers an interactive credential prompt that dies immediately. The default `GITHUB_TOKEN` is scoped to this repo only and cannot read `bench`.

## Fix

Replace the manual `git clone` with `actions/checkout@v6.0.2`, authenticated via a new repository secret `BENCH_REPO_TOKEN` (PAT or GitHub App installation token with `contents: read` on `Z3Prover/bench`):

```yaml
uses: actions/checkout@v6.0.2
with:
  repository: Z3Prover/bench
  token: ${{ secrets.BENCH_REPO_TOKEN }}
  path: bench
  sparse-checkout: |
    scripts
    inputs/issues
  fetch-depth: 1
  persist-credentials: false
```

Cone-mode `sparse-checkout` keeps the download bounded to the ~800 MB the oracle needs (vs. ~12 GB total). `persist-credentials: false` avoids leaving the PAT in the local git config since no subsequent step talks back to `bench`. Verified `Z3Prover/bench` does **not** use Git LFS (the only `.gitattributes` entry is for `*.lock.yml` workflows).

## Action required before merging

Set the **`BENCH_REPO_TOKEN`** repository secret on `Z3Prover/z3` to a token with `contents: read` on `Z3Prover/bench`. Without it, `actions/checkout` will fail with a missing-required-input error (still absorbed by `continue-on-error: true` for now — see below).

## Why `continue-on-error: true` is kept

Per explicit instruction, `continue-on-error: true` is **retained** on the clone step until the secret is verified present and stable. A follow-up PR should remove it so token rot is surfaced loudly rather than silently rotting the smoke test.

## Validation

- YAML lints clean (`python -m yaml`).
- Diff is scoped to the single step in `.github/workflows/nightly.yml`; no other workflow or source code is touched.
- The downstream smoke-test step is unchanged and continues to consume `bench/scripts/issues_check_oracle.py` and `bench/inputs/issues` from the new checkout path.