### PR TITLE
Add versioned shared object names in Bazel rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,14 +19,23 @@ filegroup(
 cmake(
     name = "z3_dynamic",
     generate_args = [
-        "-G Ninja", 
+        "-G Ninja",
         "-D Z3_EXPORTED_TARGETS=",  # prevents installation, leaving symlinks between dylibs intact on copy
     ],
     lib_source = ":all_files",
     out_binaries = ["z3"],
     out_shared_libs = select({
-        "@platforms//os:linux": ["libz3.so"],
-        # "@platforms//os:osx": ["libz3.dylib"],    # FIXME: this is not working, libz3<version>.dylib is not copied
+        # NOTE: These will need to be manually bumped along side the version in MODULE.bazel/VERSION.txt/CMake
+        "@platforms//os:linux": [
+            "libz3.so",
+            "libz3.so.4.17",
+            "libz3.so.4.17.0.0",
+        ],
+        "@platforms//os:osx": [
+            "libz3.dylib",
+            "libz3.4.17.dylib",
+            "libz3.4.17.0.0.dylib",
+        ],
         "@platforms//os:windows": ["libz3.dll"],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
@@ -36,7 +45,7 @@ cmake(
 cmake(
     name = "z3_static",
     generate_args = [
-        "-G Ninja", 
+        "-G Ninja",
         "-D BUILD_SHARED_LIBS=OFF",
         "-D Z3_BUILD_LIBZ3_SHARED=OFF",
     ],


### PR DESCRIPTION
Adds versioned shared library names (`libz3.so.4.17`, `libz3.4.17.dylib`, etc.) alongside the unversioned ones to enable Bazel rules to locate the correct library binaries.