### PR TITLE
Prevent unsound lia2card elimination across recfun definitions

### DIFF
--- a/src/tactic/arith/lia2card_tactic.cpp
+++ b/src/tactic/arith/lia2card_tactic.cpp
@@ -24,6 +24,8 @@ Notes:
 #include "ast/rewriter/expr_safe_replace.h"
 #include "ast/ast_util.h"
 #include "ast/ast_pp_util.h"
+#include "ast/decl_collector.h"
+#include "ast/recfun_decl_plugin.h"
 #include "tactic/tactical.h"
 #include "params/tactic_params.hpp"
 #include "ast/simplifiers/bound_manager.h"
@@ -178,13 +180,29 @@ public:
         }
     }
 
+    void mark_recfun_dependent_consts(goal const& g, expr_mark& unsafe_vars) {
+        decl_collector dc(m);
+        for (unsigned i = 0; i < g.size(); ++i)
+            dc.visit(g.form(i));
+        recfun::util rec(m);
+        for (func_decl* f : dc.get_rec_decls()) {
+            expr_ref rhs(rec.get_def(f).get_rhs(), m);
+            for (expr* term : subterms::all(rhs)) {
+                if (is_uninterp_const(term))
+                    unsafe_vars.mark(term);
+            }
+        }
+    }
+
     void operator()(goal_ref const & g, goal_ref_buffer & result) override {
         m_bounds.reset();
         m_mc.reset();
         expr_ref_vector axioms(m);
         expr_safe_replace rep(m);
+        expr_mark unsafe_vars;
 
         tactic_report report("lia2card", *g);
+        mark_recfun_dependent_consts(*g, unsafe_vars);
 
         bound_manager bounds(m);
         for (unsigned i = 0; i < g->size(); ++i)
@@ -197,6 +215,7 @@ public:
             rational lo, hi;
             if (a.is_int(x) &&
                 is_uninterp_const(x) &&
+                !unsafe_vars.is_marked(x) &&
                 bounds.has_lower(x, lo, s1) && !s1 && lo.is_unsigned() &&
                 bounds.has_upper(x, hi, s2) && !s2 && hi.is_unsigned() && hi.get_unsigned() - lo.get_unsigned() <= m_max_range) {
                 expr_ref b = mk_bounded(axioms, to_app(x), lo.get_unsigned(), hi.get_unsigned());

--- a/src/test/fpa.cpp
+++ b/src/test/fpa.cpp
@@ -95,8 +95,22 @@ static void test_recfun_defined_function_soundness() {
         false);
 }
 
+static void test_recfun_defined_function_lia2card_soundness() {
+    run_fp_test(
+        "(set-option :model_validate true)\n"
+        "(declare-fun fixedAdd () Int)\n"
+        "(declare-fun variableAdd () Int)\n"
+        "(define-fun-rec $$add$$ ((a Int) (b Int)) Int\n"
+        "  (ite (= 0 b) 2 (- a (+ 0 (- fixedAdd b)))))\n"
+        "(assert (= fixedAdd 0))\n"
+        "(assert (= 1 ($$add$$ 1 3)))\n"
+        "(check-sat-using (then lia2card smt))\n",
+        false);
+}
+
 void tst_fpa() {
     test_fp_to_real_denormal();
     test_to_fp_from_real_interval();
     test_recfun_defined_function_soundness();
+    test_recfun_defined_function_lia2card_soundness();
 }


### PR DESCRIPTION
Prevent lia2card from erasing bounded constants that still flow through recfun definitions

Problem

`lia2card` can replace a bounded integer constant even when that constant still appears in the RHS of a recursive function that is reachable from the current goal.

On current master, this turns an unsatisfiable query into `sat` plus model-validation failure:

```smt2
(set-option :model_validate true)
(declare-fun fixedAdd () Int)
(declare-fun variableAdd () Int)
(define-fun-rec $$add$$ ((a Int) (b Int)) Int
  (ite (= 0 b) 2 (- a (+ 0 (- fixedAdd b)))))
(assert (= fixedAdd 0))
(assert (= 1 ($$add$$ 1 3)))
(check-sat-using (then lia2card smt))
```

Current result:

```text
sat
(error "line 8 column 36: an invalid model was generated")
```

Root cause

`lia2card` sees `fixedAdd` as a bounded uninterpreted integer constant and rewrites `(= fixedAdd 0)` away.

`apply lia2card` on the repro currently produces:

```text
true
(= 1 ($$add$$ 1 3))
```

That rewrite is not sound here because `fixedAdd` still constrains `$$add$$` through the recfun body. The weakened goal becomes satisfiable, and model reconstruction later rebuilds an inconsistent model.

Change

- collect recfun declarations reachable from the current goal
- traverse their RHS definitions
- mark uninterpreted constants from those definitions as unsafe for bounded replacement
- skip `lia2card` replacement for those constants

Tests

Added a focused regression in `src/test/fpa.cpp`:

```smt2
(set-option :model_validate true)
(declare-fun fixedAdd () Int)
(declare-fun variableAdd () Int)
(define-fun-rec $$add$$ ((a Int) (b Int)) Int
  (ite (= 0 b) 2 (- a (+ 0 (- fixedAdd b)))))
(assert (= fixedAdd 0))
(assert (= 1 ($$add$$ 1 3)))
(check-sat-using (then lia2card smt))
```

Validation

- `./test-z3 /seq fpa`
- the direct minimal `lia2card` repro now returns `unsat`
- `apply lia2card` on the minimal repro now preserves `(= fixedAdd 0)` instead of rewriting it to `true`

Non-regression smoke

- `x = 0` without recfuns still rewrites to `true`
- bounded 0/1 integer constraints still compile to cardinality form


Closes #9855
