### PR TITLE
Count regex bisim steps during leaf traversal

### DIFF
--- a/src/ast/rewriter/seq_regex_bisim.cpp
+++ b/src/ast/rewriter/seq_regex_bisim.cpp
@@ -91,7 +91,8 @@ namespace seq {
        (re.empty) leaves are dropped.
 
        Returns false if we encountered an unexpected node (e.g. a free
-       variable creeping in) — in that case the caller should bail out.
+       variable creeping in) or exhausted the step budget — in that case
+       the caller should bail out.
     */
     bool regex_bisim::collect_leaves(expr* der, expr_ref_vector& leaves) {
         ptr_vector<expr> work;
@@ -99,6 +100,8 @@ namespace seq {
         work.push_back(der);
         seen.insert(der);
         while (!work.empty()) {
+            if (++m_steps > m_step_bound)
+                return false;
             expr* e = work.back();
             work.pop_back();
             expr* c = nullptr, * t = nullptr, * f = nullptr;
@@ -221,7 +224,7 @@ namespace seq {
         m_worklist.push_back(r0);
 
         while (!m_worklist.empty()) {
-            if (++m_steps > m_step_bound)
+            if (m_steps > m_step_bound)
                 return l_undef;
 
             expr_ref r(m_worklist.back(), m);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -127,6 +127,7 @@ add_executable(test-z3
   sat_user_scope.cpp
   scoped_timer.cpp
   scoped_vector.cpp
+  seq_regex_bisim.cpp
   simple_parser.cpp
   simplex.cpp
   simplifier.cpp

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -189,6 +189,7 @@
     X(euf_arith_plugin) \
     X(sls_test) \
     X(scoped_vector) \
+    X(seq_regex_bisim) \
     X(sls_seq_plugin) \
     X(ho_matcher) \
     X(finite_set) \

--- a/src/test/seq_regex_bisim.cpp
+++ b/src/test/seq_regex_bisim.cpp
@@ -1,0 +1,37 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+--*/
+
+#include "ast/rewriter/seq_regex_bisim.h"
+#include "ast/rewriter/seq_rewriter.h"
+#include "ast/reg_decl_plugins.h"
+#include "util/debug.h"
+
+static expr_ref mk_regex_literal(ast_manager& m, seq_util& seq, char const* s) {
+    return expr_ref(seq.re.mk_to_re(seq.str.mk_string(zstring(s))), m);
+}
+
+static void test_step_bound_accounts_for_leaf_traversal() {
+    ast_manager m;
+    reg_decl_plugins(m);
+    seq_rewriter rw(m);
+    seq_util seq(m);
+
+    expr_ref re_a = mk_regex_literal(m, seq, "a");
+    expr_ref re_b = mk_regex_literal(m, seq, "b");
+    expr_ref re_c = mk_regex_literal(m, seq, "c");
+
+    expr_ref left(seq.re.mk_union(re_a, re_b), m);
+    expr_ref right(seq.re.mk_union(re_a, re_c), m);
+
+    seq::regex_bisim bisim(rw);
+    ENSURE(bisim.are_equivalent(left, right) == l_false);
+
+    bisim.set_step_bound(1);
+    ENSURE(bisim.are_equivalent(left, right) == l_undef);
+}
+
+void tst_seq_regex_bisim() {
+    test_step_bound_accounts_for_leaf_traversal();
+}


### PR DESCRIPTION
This picks up the seq_regex_bisim step-bound item from #9839 and leaves the other review suggestions out of scope.

Problem

seq_regex_bisim tracks a step budget through m_steps, but the old accounting only charged one step per outer worklist iteration.

That missed the internal work in collect_leaves(), which walks the derivative ITE/union tree. A small step bound could still traverse a larger derivative tree and return a definite answer instead of stopping with l_undef.

The new regression shows the gap with

re.union(re.to_re("a"), re.to_re("b"))
re.union(re.to_re("a"), re.to_re("c"))

Before this patch, the default run returns l_false, and step_bound = 1 also returned l_false. The second result means the bound did not cover the actual traversal work.

Change

collect_leaves() now increments m_steps for each visited derivative-tree node and bails out when the bound is exhausted.

The outer loop keeps the existing guard, but it no longer consumes an extra step itself. That makes the budget track the leaf traversal work that dominates this path.

Tests

I added a focused unit test in src/test/seq_regex_bisim.cpp and registered it in test-z3.

The test checks that the witness above still returns l_false with the default bound and returns l_undef after set_step_bound(1).

Validation

./test-z3 seq_regex_bisim /seq
./test-z3 smt_context /seq
