### PR TITLE
goal2sat: skip caching singly-referenced AST nodes

### DIFF
--- a/src/ast/rewriter/bit_blaster/bit_blaster_tpl_def.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_tpl_def.h
@@ -768,6 +768,8 @@ void bit_blaster_tpl<Cfg>::mk_smod(unsigned sz, expr * const * a_bits, expr * co
 template<typename Cfg>
 void bit_blaster_tpl<Cfg>::mk_eq(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref & out) {
     expr_ref_vector out_bits(m());
+    out_bits.reserve(sz);
+    out_bits.reset();
     for (unsigned i = 0; i < sz; ++i) {
         mk_iff(a_bits[i], b_bits[i], out);
         out_bits.push_back(out);

--- a/src/ast/rewriter/bit_blaster/bit_blaster_tpl_def.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_tpl_def.h
@@ -769,10 +769,9 @@ template<typename Cfg>
 void bit_blaster_tpl<Cfg>::mk_eq(unsigned sz, expr * const * a_bits, expr * const * b_bits, expr_ref & out) {
     expr_ref_vector out_bits(m());
     out_bits.reserve(sz);
-    out_bits.reset();
     for (unsigned i = 0; i < sz; ++i) {
         mk_iff(a_bits[i], b_bits[i], out);
-        out_bits.push_back(out);
+        out_bits[i] = out;
     }
     mk_and(out_bits.size(), out_bits.data(), out);
 }

--- a/src/sat/tactic/goal2sat.cpp
+++ b/src/sat/tactic/goal2sat.cpp
@@ -262,7 +262,7 @@ struct goal2sat::imp : public sat::sat_internalizer {
     void cache(app* t, sat::literal l) override {
         force_push();
         if (t->get_ref_count() <= 1)
-            return;
+            return;        
         m_cache_trail.push_back(t);
         // Only memoize nodes that can be revisited: a singly-referenced
         // node appears once in the goal, so it never produces a cache hit.

--- a/src/sat/tactic/goal2sat.cpp
+++ b/src/sat/tactic/goal2sat.cpp
@@ -261,16 +261,23 @@ struct goal2sat::imp : public sat::sat_internalizer {
 
     void cache(app* t, sat::literal l) override {
         force_push();
+        m_cache_trail.push_back(t);
+        // Only memoize nodes that can be revisited: a singly-referenced
+        // node appears once in the goal, so it never produces a cache hit.
+        // Skipping it keeps m_app2lit and m_lit2app in sync (both empty for
+        // such nodes) so pop()/uncache() clean up consistently.
+        if (t->get_ref_count() <= 1)
+            return;
         SASSERT(!m_app2lit.contains(t));
         SASSERT(!m_lit2app.contains(l.index()));
         m_app2lit.insert(t, l);
         m_lit2app.insert(l.index(), t);
-        m_cache_trail.push_back(t);
     }
 
     sat::literal get_cached(app* t) const override {
         sat::literal lit = sat::null_literal;
-        m_app2lit.find(t, lit);
+        if (t->get_ref_count() > 1)
+            m_app2lit.find(t, lit);
         return lit;
     }
 
@@ -279,7 +286,7 @@ struct goal2sat::imp : public sat::sat_internalizer {
         SASSERT(lit == sat::null_literal || l == lit);
         return l == lit;
     }
-    
+
     void convert_atom(expr * t, bool root, bool sign) {       
         SASSERT(m.is_bool(t));
         sat::literal  l;
@@ -346,7 +353,7 @@ struct goal2sat::imp : public sat::sat_internalizer {
 
     bool process_cached(app* t, bool root, bool sign) {
         sat::literal l = sat::null_literal;
-        if (!m_app2lit.find(t, l))
+        if (t->get_ref_count() <= 1 || !m_app2lit.find(t, l))
             return false;
         if (sign)
             l.neg();

--- a/src/sat/tactic/goal2sat.cpp
+++ b/src/sat/tactic/goal2sat.cpp
@@ -236,7 +236,7 @@ struct goal2sat::imp : public sat::sat_internalizer {
         }
         n -= m_num_scopes;
         m_num_scopes = 0;        
-        m_map.pop(n);
+        m_map.pop(n);        
         unsigned k = m_cache_lim[m_cache_lim.size() - n];
         for (unsigned i = m_cache_trail.size(); i-- > k; ) {
             app* t = m_cache_trail.get(i);

--- a/src/sat/tactic/goal2sat.cpp
+++ b/src/sat/tactic/goal2sat.cpp
@@ -261,13 +261,13 @@ struct goal2sat::imp : public sat::sat_internalizer {
 
     void cache(app* t, sat::literal l) override {
         force_push();
+        if (t->get_ref_count() <= 1)
+            return;
         m_cache_trail.push_back(t);
         // Only memoize nodes that can be revisited: a singly-referenced
         // node appears once in the goal, so it never produces a cache hit.
         // Skipping it keeps m_app2lit and m_lit2app in sync (both empty for
         // such nodes) so pop()/uncache() clean up consistently.
-        if (t->get_ref_count() <= 1)
-            return;
         SASSERT(!m_app2lit.contains(t));
         SASSERT(!m_lit2app.contains(l.index()));
         m_app2lit.insert(t, l);


### PR DESCRIPTION
On some bit-vector BMC queries most of the runtime is in goal2sat converting
the bit-blasted formula into CNF, not in bit-blasting or the SAT solver.

The cause is the Tseitin cache: goal2sat stores a literal for every boolean
subexpression in `m_app2lit` (plus a reverse entry in `m_lit2app`) so shared
subexpressions are encoded once. But after bit-blasting almost every node is
used in exactly one place, so those entries are never looked up — we pay for
millions of inserts that are never read.

The fix caches a node only when it can actually be revisited, i.e. reference
count greater than one. A node referenced once has a single parent, so it's
visited exactly once and could never produce a cache hit. Both maps are
guarded on the same condition so they stay in sync and `pop()`/`uncache()`
still clean up correctly. (Plus a small `reserve()` in `bit_blaster::mk_eq`.)

Results are unchanged — `unsat` on everything I tried, `bit_blaster` unit test
still passes — only the conversion gets faster.

### Numbers

Machine Specs: Intel i5-11400F (12 threads), 93 GB RAM, Ubuntu 22.04, g++-13, Release build. 

Run with `-st rewriter.div0_ackermann_limit=10000
model.compact=false`, one process at a time. 
The two `.smt2` files are attached below as a zip so you can reproduce.

```
                                  master    patch
byte_cursor_compare_lookup_abs    42.95s    24.44s   (-43%)
byte_cursor_compare_lookup_bmc    30.44s    20.77s   (-32%)
```

Breaking the first test run down by phase (`-v:10`) shows the win is entirely in the
conversion — bit-blast and SAT solving don't move, and their stats are identical:

```
                        master    patch
bit-blast                6.04s     6.01s
goal2sat -> CNF         ~32.5s    ~13.8s
SAT solve                5.17s     5.18s
```

(benchmarks: [bench.zip](https://github.com/user-attachments/files/28967389/bench.zip) attached)
