### PR TITLE
Fix missing field initializers (better).

### DIFF
--- a/cmake/compiler_warnings.cmake
+++ b/cmake/compiler_warnings.cmake
@@ -23,6 +23,7 @@ set(CLANG_ONLY_WARNINGS
   "-Wc99-extensions"
   "-Wsuggest-override"
   "-Winconsistent-missing-override"
+  "-Wno-missing-field-initializers"
 )
 set(MSVC_WARNINGS "/W3")
 


### PR DESCRIPTION
This is another PR towards the goal of getting Z3 to compile cleanly when included via FetchContents into clang-tidy, which uses a pretty strict set of warnings.

This one fixes warnings about "missing field initializers" -- struct initializers that leave some field uninitialized.

In https://github.com/Z3Prover/z3/pull/9904, I tried to do this in the code.  @nunoplopes pointed out flaws with this approach.  He outlined a more ambitious approach to fix the actual problem (use of an "entry" type when just a "key" type should be sufficient in some places).  For now, though, I think it's doesn't lose anything to just disable the warning.