### PR TITLE
[fixer-selftest] Fix comment typo in solve_eqs.cpp: "reprsents" → "represents"

### DIFF
--- a/src/ast/simplifiers/solve_eqs.cpp
+++ b/src/ast/simplifiers/solve_eqs.cpp
@@ -20,7 +20,7 @@ It traverses the same sub-terms many times.
 
 Outline of a presumably better scheme:
 
-1. maintain map FV: term -> bit-set where bitset reprsents set of free variables. Assume the number of variables is bounded.
+1. maintain map FV: term -> bit-set where bitset represents set of free variables. Assume the number of variables is bounded.
    FV is built from initial terms.
 2. maintain parent: term -> term-list of parent occurrences.
 3. repeat


### PR DESCRIPTION
## Automated workflow self-test

This is an **automated workflow self-test** of the `fixer-selftest` / `snapshot-regression-fixer` pipeline running on the self-hosted **`rise-runner-1`** pool. Its sole purpose is to verify the end-to-end agentic pipeline: that Copilot inference runs and that the `create-pull-request` safe output can open a real **draft** PR on `Z3Prover/z3` using the configured PAT.

## The fix

A single, objectively-correct spelling fix in a **code comment** (the header comment block of the file — not code, identifiers, or string literals).

- **File:** `src/ast/simplifiers/solve_eqs.cpp` (line 23, inside the `/*++ ... --*/` header comment)
- **Before:** `... where bitset reprsents set of free variables.`
- **After:** `... where bitset represents set of free variables.`

The diff is a single line:

```diff
-1. maintain map FV: term -> bit-set where bitset reprsents set of free variables. Assume the number of variables is bounded.
+1. maintain map FV: term -> bit-set where bitset represents set of free variables. Assume the number of variables is bounded.
```

## Why this is safe

The change is **comment-only** and therefore **cannot affect z3's behaviour or output** — so it needs **no rebuild and no testing** to be confident it is correct. Nothing outside the comment text was touched (no code, no string literals, no identifiers, no whitespace elsewhere).

## For maintainers

This is a genuine, correct fix, so feel free to **merge** it — but you may also simply **close** it. The self-test's success does not depend on this PR being merged; it only depends on the PR having been opened.




> Generated by [Self-test the agentic PR pipeline with a tiny z3 comment fix](https://github.com/Z3Prover/bench/actions/runs/27986232656) · 208.5 AIC · ⌖ 75.1 AIC · ⊞ 35.5K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+fixer-selftest%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Self-test the agentic PR pipeline with a tiny z3 comment fix, engine: copilot, version: 1.0.60, model: claude-opus-4.8, id: 27986232656, workflow_id: fixer-selftest, run: https://github.com/Z3Prover/bench/actions/runs/27986232656 -->

<!-- gh-aw-workflow-id: fixer-selftest -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/fixer-selftest -->