### PR TITLE
[snapshot-regression-fix] Bound higher-order term enumeration in smt_model_finder (fixes iss-5446/bug-5 timeout regression)

### DIFF
--- a/src/smt/smt_model_finder.cpp
+++ b/src/smt/smt_model_finder.cpp
@@ -1435,7 +1435,11 @@ namespace smt {
                     }
                 }
                 
+                unsigned max_count = 20;
+                unsigned count = 0;
                 for (auto t : tn.enum_terms(srt)) {
+                    if (count++ >= max_count)
+                        break; // term enumeration over a recursive sort is unbounded; cap the sample.
                     unsigned generation = 0; // todo - inherited from sub-term of t?
                     TRACE(model_finder, tout << "ho_var: adding term " << mk_ismt2_pp(t, m)
                                                    << " to instantiation set of S" << std::endl;);


### PR DESCRIPTION
## Summary

Fixes a divergence found by the `snapshot-regression` workflow in `Z3Prover/bench`.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/2659
- **Benchmark:** `iss-5446/bug-5.smt2` (`inputs/issues/iss-5446/` in `Z3Prover/bench`)
- **Divergence:** recorded oracle `unsat`, current z3 `timeout` (per-file budget `20s`)

### Divergence diff

```diff
--- bug-5.expected.out (expected)
+++ produced (current z3)
@@ -1 +1 @@
-unsat
+timeout
```

## Root cause

The benchmark asserts an existential over an array-sorted variable together with `(_ map foo)` and a nested `forall`, so model finding reaches an array-sorted (higher-order) universally quantified variable.

Commit `5699142f5` ("Term enumeration", #9908) replaced the previous handling of such variables (`m_info->m_is_auf = false`) with the new `ho_var::populate_inst_sets` in `src/smt/smt_model_finder.cpp`. That method calls `term_enumeration::enum_terms(srt)` to populate the variable's instantiation set.

`term_enumeration` is a bottom-up enumerative term generator: it yields terms of increasing cost and only stops once the grammar becomes non-productive (`State::Done`). For a recursive sort such as `(Array Int Int Int)` with productions like `(_ map foo)`, `store`, and `select`, the grammar stays productive at every cost level, so `enum_terms` produces an effectively unbounded stream and the loop spins until the solver times out. A verbose trace (`-v:10`) confirms a single `ho_var::populate_inst_sets: 70 (Array Int Int Int)` entry immediately followed by the timeout.

The original code bounded the sample with a local `unsigned max_count = 20;`, but that line was removed in `cb3d05806` ("fix build warnings") because the variable was unused — which inadvertently left the loop unbounded.

## Fix

Reinstate the bound: stop after at most `max_count = 20` enumerated terms when populating the instantiation set.

```cpp
unsigned max_count = 20;
unsigned count = 0;
for (auto t : tn.enum_terms(srt)) {
    if (count++ >= max_count)
        break; // term enumeration over a recursive sort is unbounded; cap the sample.
    unsigned generation = 0; // todo - inherited from sub-term of t?
    ...
    S->insert(t, generation);
}
```

This preserves the intent of #9908 (sampling candidate array terms for the higher-order variable) while preventing the unbounded enumeration. It only ever reduces the work done in `populate_inst_sets`, so it cannot introduce new timeouts. Before #9908 these array-sorted variables contributed no enumerated terms at all, so a bounded sample is conservative with respect to the behaviour that produced the recorded oracle.

## Validation

Built the `./z3` checkout (`make -C build -j16`) and re-ran the benchmark with the same option the snapshot capture uses:

```
$ ./build/z3 -T:20 inputs/issues/iss-5446/bug-5.smt2
unsat        # previously: timeout (~20s); now 0.013s
```

The output now matches the recorded `iss-5446/bug-5.expected.out` oracle (`unsat`).

Additional checks with the rebuilt binary:
- all 5 `iss-5446/bug-*.smt2` benchmarks match their recorded oracles;
- 18 sampled array + quantifier benchmarks (the same `ho_var` code path) that have recorded oracles all still match;
- basic `sat`/`unsat` and quantifier (`model_finder`) smoke tests pass.

Opened as a **draft** for human review.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28078340344) · 2.7K AIC · ⌖ 306.3 AIC · ⊞ 41.2K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.60, model: claude-opus-4.8, id: 28078340344, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28078340344 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->