### PR TITLE
[snapshot-regression-fix] Fix MBQI non-termination regression on bare array quantifier variable (iss-6523)

### DIFF
--- a/src/smt/smt_model_finder.cpp
+++ b/src/smt/smt_model_finder.cpp
@@ -2180,12 +2180,7 @@ namespace smt {
                         process_app(to_app(curr));
                     }
                     else if (is_var(curr)) {
-                        if (m_array_util.is_array(curr)) {
-                            insert_qinfo(alloc(ho_var, m, to_var(curr)->get_idx()));
-                        }
-                        else {
-                            m_info->m_is_auf = false;  // unexpected occurrence of variable.
-                        }
+                        m_info->m_is_auf = false; // unexpected occurrence of variable.
                     }
                     else {
                         SASSERT(is_lambda(curr));


### PR DESCRIPTION
## Summary

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/2666
- **Benchmark:** `iss-6523/small-40.smt2` (corpus `Z3Prover/bench`, `inputs/issues/iss-6523/`)
- **Z3 release under test:** 4.17.0 (current `master`)

The snapshot-regression corpus flagged an output divergence (recorded oracle vs. current z3):

```diff
-unsat
+timeout
```

The recorded oracle is `unsat`; current z3 times out at `-T:20` — i.e. MBQI no longer terminates on this benchmark.

## Root cause

The regression was introduced by #9908 ("Term enumeration"), commit `5699142f5`, in `src/smt/smt_model_finder.cpp`. That change rerouted a *bare* occurrence of an array-sorted quantified variable into a new `ho_var` qinfo:

```cpp
else if (is_var(curr)) {
    if (m_array_util.is_array(curr)) {
        insert_qinfo(alloc(ho_var, m, to_var(curr)->get_idx()));   // new in #9908
    }
    else {
        m_info->m_is_auf = false;  // unexpected occurrence of variable.
    }
}
```

`ho_var::populate_inst_sets` inserts *every* relevant array-sorted enode (plus terms produced by `term_enumeration`) into the variable's instantiation set, and it is re-run on every MBQI round. The benchmark asserts (essentially):

```smt2
(forall ((va (Array Bool Bool))) (select va (= va v)))
```

`va` occurs bare inside the equality `(= va v)`. Each MBQI round instantiates `va` with the array enodes currently in its instantiation set; those instantiations create new `(= <array> v)` equalities, which trigger array **extensionality** axioms, which create fresh array enodes — which are re-inserted on the next round. The result is an unbounded MBQI ↔ array-theory feedback loop (observed at `-T:60`: hundreds of final-checks, >1k extensionality axioms / array splits, ~30 billion allocations), and the solver never terminates. `ho_var::populate_inst_sets` is confirmed active on this benchmark via `-v:3`.

## Fix

Restore the pre-#9908 behaviour for this branch — a bare occurrence of a quantified variable falls back to `m_is_auf = false`, which selects the complete model-construction path that produced the oracle:

```cpp
else if (is_var(curr)) {
    m_info->m_is_auf = false; // unexpected occurrence of variable.
}
```

This is the **sole** `alloc(ho_var, ...)` site, so the change cleanly neutralises the regressive path while leaving the `ho_var` / `term_enumeration` scaffolding in place for a future, properly bounded implementation. Note that bounding `term_enumeration` alone is **not** sufficient here: the explosion is driven by the per-round insertion of extensionality-generated array enodes (lines that copy relevant array enodes into the inst-set), not solely by enumerated terms.

## Validation

- Rebuilt the checkout: `./configure && make -C build -j$(nproc)` → `Z3 was successfully built` (v4.17.0).
- Re-ran the failing benchmark with the exact snapshot capture command:
  `z3 -T:20 inputs/issues/iss-6523/small-40.smt2` → **`unsat`** in ~0.02s (previously `timeout`), matching the recorded `small-40.expected.out` oracle.
- Smoke-tested basic solving (`Int` sat + model, `Array`/`select` sat) — behaviour unchanged.

Opened as a **draft** for human review. I'm confident this resolves the regression and is safe (it restores long-standing behaviour for this branch), but the maintainers may prefer to re-land the higher-order term-enumeration feature with a guarded/bounded population strategy rather than gating it off for the bare-array-variable case.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28078346879) · 2.3K AIC · ⌖ 77.6 AIC · ⊞ 41.2K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.60, model: claude-opus-4.8, id: 28078346879, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28078346879 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->