### PR TITLE
[snapshot-regression-fix] smt_model_finder: bound ho_var term enumeration to avoid MBQI timeout (iss-6270/small.smt2)

### DIFF
--- a/src/smt/smt_model_finder.cpp
+++ b/src/smt/smt_model_finder.cpp
@@ -1435,7 +1435,19 @@ namespace smt {
                     }
                 }
                 
+                // Bound the number of enumerated terms inserted into the
+                // instantiation set.  enum_terms performs a bottom-up
+                // enumeration that, for recursive sorts (e.g. arrays,
+                // datatypes, uninterpreted functions ranging over the target
+                // sort), keeps making progress indefinitely.  Without a bound
+                // this loop seeds the instantiation set with an unbounded
+                // number of terms, blowing up the MBQI search and timing out.
+                unsigned const max_terms = 20;
+                unsigned count = 0;
                 for (auto t : tn.enum_terms(srt)) {
+                    if (count >= max_terms)
+                        break;
+                    ++count;
                     unsigned generation = 0; // todo - inherited from sub-term of t?
                     TRACE(model_finder, tout << "ho_var: adding term " << mk_ismt2_pp(t, m)
                                                    << " to instantiation set of S" << std::endl;);


### PR DESCRIPTION
## Summary

Fixes an MBQI performance regression: a quantified arrays + datatypes + UF benchmark that previously solved instantly now times out.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/2665
- **Benchmark:** `iss-6270/small.smt2` (lives at `inputs/issues/iss-6270/` in `Z3Prover/bench`)
- **Divergence:** recorded oracle `sat` → current nightly `timeout` (per-file budget `-T:20`)

### Divergence diff (from the discussion)

```diff
--- small.expected.out (expected)
+++ produced (current z3)
@@ -1 +1 @@
-sat
+timeout
```

## Root cause

`git log -S` on the responsible lines points at commit `5699142f5` ("Term enumeration (#9908)"). That change routes array-sorted quantified variables through the new `ho_var` qinfo in `src/smt/smt_model_finder.cpp` instead of the previous `m_info->m_is_auf = false` fallback. `ho_var::populate_inst_sets` then seeds the instantiation set by iterating the **entire** `term_enumeration::enum_terms()` stream:

```cpp
for (auto t : tn.enum_terms(srt)) {
    unsigned generation = 0;
    ...
    S->insert(t, generation);
}
```

`enum_terms` is a bottom-up enumerator (`src/ast/rewriter/term_enumeration.cpp`) that yields terms of increasing cost. For recursive target sorts — arrays, datatypes, or uninterpreted functions ranging over the target sort, all of which occur in this benchmark — the enumerator keeps making progress indefinitely (`bottom_up_enumerator::find_next` only reaches `State::Done` when no further sort-productive terms exist). The loop therefore inserts an unbounded number of terms into the instantiation set, blowing up the MBQI search until the `-T:20` budget expires.

## Fix

Bound the number of enumerated terms consumed by `ho_var::populate_inst_sets` to a small fixed count, so the loop is guaranteed to terminate while still seeding the instantiation set with a finite set of candidate terms:

```cpp
unsigned const max_terms = 20;
unsigned count = 0;
for (auto t : tn.enum_terms(srt)) {
    if (count >= max_terms)
        break;
    ++count;
    unsigned generation = 0;
    ...
    S->insert(t, generation);
}
```

The change is local to `populate_inst_sets` (12 added lines, no other code touched). Since the pre-feature behaviour for these variables was `m_is_auf = false` (no enumeration at all), a bounded seed is strictly a superset of the old candidate set; bounding only affects which model MBQI seeds toward and cannot turn a previously-sound result unsound (the extra terms are ground candidate instantiations).

Note: `20` is a heuristic bound chosen to restore the benchmark while keeping a useful seed; a maintainer may prefer a different limit or a cost-based cap. Flagging this for review.

## Validation

Built the patched `./z3` checkout (Release: `python3 scripts/mk_make.py -b build` + `make -C build`, clean build, no new warnings) and re-ran the failing benchmark with the same options the snapshot capture uses:

- **Before fix** (master HEAD `500ca4643`): `z3 -T:20 inputs/issues/iss-6270/small.smt2` → `timeout` at 20.00s.
- **After fix:** same command → `sat` in ~0.01s, **exactly matching** the recorded `small.expected.out` oracle (`diff` against the oracle is empty).

Opened as a **draft** for human review.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28078345945) · 2.8K AIC · ⌖ 82.2 AIC · ⊞ 41.2K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.60, model: claude-opus-4.8, id: 28078345945, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28078345945 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->