### PR TITLE
[snapshot-regression-fix] smt: fix MBQI ho_var term-enumeration blowup causing timeout on iss-6174/small-2

### DIFF
--- a/src/smt/smt_model_finder.cpp
+++ b/src/smt/smt_model_finder.cpp
@@ -1413,8 +1413,6 @@ namespace smt {
                 // add other possible relevant functions such as equality over srt, Boolean operators
 
                 ast_mark visited;
-                tn.add_production(m.mk_true());
-                tn.add_production(m.mk_false());
                 for (enode *n : ctx->enodes()) {
                     if (!ctx->is_relevant(n))
                         continue;


### PR DESCRIPTION
## Summary

Fixes a model-finder (MBQI) **timeout regression** surfaced by the `snapshot-regression` corpus.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/2663
- **Benchmark:** `iss-6174/small-2.smt2` (`inputs/issues/iss-6174/` in `Z3Prover/bench`)
- **Harness options:** `-T:20`

## Reported divergence

The snapshot workflow reported (recorded oracle **expected** vs **current** z3):

```diff
--- small-2.expected.out (expected)
+++ produced (current z3)
@@ -1,5 +1,5 @@
 sat
 sat
-unknown
+sat
 (error "line 14 column 0: unexpected character")
 (error "line 14 column 1: unexpected character")
```

## What I found

The third `check-sat` asserts `(or x2 x27)` together with

```
(forall ((r (Array (Array Bool Bool) (Array Bool Bool))))
  (and x2 (= (store x r (store ar a true)) (store (store x r5 ar) r ar))))
```

This is **genuinely SAT** (witness `x2 = true`, `a = const false`, `ar = const true`, `x = const ar`; both sides of the array equality reduce to `(store x r ar)` for every `r`). So three distinct behaviours are in play:

| build | 3rd `check-sat` | note |
|---|---|---|
| recorded oracle (`*.expected.out`, captured pre-feature) | `unknown` | sound but incomplete — stale |
| Nightly under test (the reported divergence) | `sat` | **correct** — a benign completeness improvement |
| current z3 `master` HEAD (`6fd303c4b`) | **`timeout`** | **NEW regression** — worse than both |

So the reported `unknown`→`sat` change is itself a *benign* improvement. But while reproducing it I found that **current HEAD no longer returns `sat` at all — it hangs and hits the timeout**. That hang is the real bug this PR fixes.

## Root cause

Commit `6fd303c4b` ("set the auf flag to false in all cases") bundled two changes in `src/smt/smt_model_finder.cpp`:

1. removing an `else` so `m_is_auf = false` is set unconditionally (the titled change), and
2. adding `true`/`false` as productions to the bottom-up term enumeration used by `ho_var::populate_inst_sets`:

```cpp
ast_mark visited;
tn.add_production(m.mk_true());
tn.add_production(m.mk_false());
```

For a quantified array-sorted variable whose sort nests Booleans (here `r : (Array (Array Bool Bool) (Array Bool Bool))`), those Boolean leaves let the `bottom_up_enumerator` build a combinatorial blowup of intermediate terms across all sorts. The existing `unsigned max_count = 20;` bound only limits how many *target-sort* terms are *consumed*, not the internal work needed to *produce* them — so `find_next()` keeps raising the cost level and generating terms until the solver times out.

**Bisection** (each variant rebuilt and run on `iss-6174/small-2.smt2`, `-T:20`):

| variant | 3rd `check-sat` |
|---|---|
| parent `6fd303c4b~1` | `sat` (~7.6s) |
| HEAD with **only** hunk 2 (auf flag) | `sat` (~7.7s) |
| HEAD with **only** hunk 1 (true/false productions) | **`timeout`** |
| HEAD (both, as shipped) | **`timeout`** |

Hunk 1 alone reproduces the hang; the auf-flag change is benign.

## Fix

Revert only the two `add_production` lines, keeping the maintainer's auf-flag change intact:

```diff
@@ -1413,8 +1413,6 @@ namespace smt {
                 // add other possible relevant functions such as equality over srt, Boolean operators
 
                 ast_mark visited;
-                tn.add_production(m.mk_true());
-                tn.add_production(m.mk_false());
                 for (enode *n : ctx->enodes()) {
```

Removing enumeration candidates is sound: it can only shrink the instantiation set, never make a sound procedure unsound.

## Validation (rebuilt z3 — step 5)

Built the patched `./z3` (`./configure && make -C build`) and re-ran with the harness options:

- `iss-6174/small-2.smt2` → `sat sat sat` in **~7.5s** (was `sat sat timeout`).
- **Independent model check:** a separate file that pins the witness model above and asserts the *negation* of the quantifier body for a fresh `r` returns `unsat`, confirming the `sat` answer corresponds to a **valid model** (not a soundness slip).
- Sibling `iss-6174/small.smt2` → `sat sat sat` (~7.7s).
- Prior snapshot-fix corpus `iss-5753/*` (which introduced the `max_count` bound): all **oracle-tracked** benchmarks pass quickly and unchanged. The only three that time out (`small-10/11/23`) have **no `*.expected.out`** (untracked) and already time out on unmodified HEAD; this patch only *removes* enumeration candidates, so it cannot introduce them.

## Honest caveats

- The patched output is `sat` (correct), which **still differs from the recorded oracle `unknown`** on the third line. That mismatch is pre-existing oracle staleness — the oracle predates the term-enumeration feature that legitimately solves this instance. Per the corpus guardrails I did **not** modify the oracle; a maintainer may wish to refresh `iss-6174/small-2.expected.out` (and `small.expected.out`) to `sat`.
- This PR's scope is strictly the **timeout regression** (current HEAD hanging); it does not try to force the output back to `unknown`, which would require crippling the model finder.

Opened as a **draft** for human review.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28155153380) · 3.6K AIC · ⌖ 84.9 AIC · ⊞ 41.2K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.60, model: claude-opus-4.8, id: 28155153380, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28155153380 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->