### PR TITLE
[snapshot-regression-fix] Restore terminal "giveup" detection in the parallel tactic (pqffd)

### DIFF
--- a/src/solver/parallel_tactical.cpp
+++ b/src/solver/parallel_tactical.cpp
@@ -91,6 +91,20 @@ static bool is_cancellation_exception(char const* msg) {
     return msg && (strstr(msg, "canceled") != nullptr || strstr(msg, "cancelled") != nullptr);
 }
 
+// A solver may return l_undef for a fundamental reason ("giveup") rather than
+// because it exhausted its resource budget. For example, the finite-domain
+// solver gives up when it is handed interpreted functions it cannot bit-blast.
+// In that case neither splitting the search space into more cubes nor raising
+// the per-thread conflict budget can ever change the answer, so the whole
+// portfolio must stop and report unknown instead of spinning until the
+// wall-clock timeout. These reasons are reported by inc_sat_solver with a
+// distinctive prefix.
+static bool is_giveup_reason(std::string const& reason) {
+    static const std::string giveup("(sat.giveup"), incomplete("(incomplete");
+    return reason.compare(0, giveup.size(), giveup) == 0
+        || reason.compare(0, incomplete.size(), incomplete) == 0;
+}
+
 /* ------------------------------------------------------------------ */
 /* parallel_solver – the core portfolio engine                         */
 /* ------------------------------------------------------------------ */
@@ -133,6 +147,7 @@ class parallel_solver {
             is_running,
             is_sat,
             is_unsat,
+            is_giveup,
             is_exception_msg,
             is_exception_code
         };
@@ -187,6 +202,7 @@ class parallel_solver {
 
         unsigned     m_exception_code = 0;
         std::string  m_exception_msg;
+        std::string  m_unknown_reason;
         model_ref    m_model;
         expr_ref_vector m_unsat_core;
         std::atomic<bool> m_canceled = false;
@@ -486,6 +502,7 @@ class parallel_solver {
             m_model = nullptr;
             m_unsat_core.reset();
             m_canceled = false;
+            m_unknown_reason.clear();
         }
 
         void set_sat(ast_translation& l2g, model& mdl) {
@@ -511,6 +528,19 @@ class parallel_solver {
             SASSERT(m_unsat_core.empty());
             for (expr* c : core)
                 m_unsat_core.push_back(l2g(c));
+            cancel_background_threads();
+        }
+
+        void set_giveup(std::string const& reason) {
+            std::scoped_lock lock(mux);
+            if (m_state != state::is_running) return;
+            IF_VERBOSE(1, verbose_stream() << "Batch manager setting GIVEUP.\n");
+            m_state = state::is_giveup;
+            m_unknown_reason = reason;
+            // Surface the reason the solver gave up on, matching the behavior of
+            // the prior parallel tactic so that the user still sees why the
+            // result is unknown (the snapshot oracle captures this line).
+            IF_VERBOSE(0, verbose_stream() << reason << "\n");
             cancel_background_threads();
         }
 
@@ -941,6 +971,7 @@ class parallel_solver {
                 throw default_exception("par2: inconsistent end state");
             case state::is_sat:             return l_true;
             case state::is_unsat:           return l_false;
+            case state::is_giveup:          return l_undef;
             case state::is_exception_msg:
                 throw default_exception(m_exception_msg.c_str());
             case state::is_exception_code:
@@ -954,6 +985,8 @@ class parallel_solver {
         model_ref& get_model() { return m_model; }
 
         expr_ref_vector const& get_unsat_core() const { return m_unsat_core; }
+
+        std::string const& get_unknown_reason() const { return m_unknown_reason; }
 
         void collect_statistics(statistics& st) const {
             st.update("parallel-num-cubes", m_stats.m_num_cubes);
@@ -1215,6 +1248,18 @@ class parallel_solver {
                 switch (r) {
 
                 case l_undef: {
+                    // A fundamental "giveup" (e.g. the finite-domain solver was
+                    // handed interpreted functions it cannot bit-blast) cannot be
+                    // resolved by splitting into more cubes or raising the conflict
+                    // budget: every cube hits the same wall and the portfolio would
+                    // spin until the wall-clock timeout. Detect it and report
+                    // unknown for the whole search instead.
+                    std::string reason = s->reason_unknown();
+                    if (is_giveup_reason(reason)) {
+                        LOG_WORKER(1, " giveup: " << reason << "\n");
+                        b.set_giveup(reason);
+                        return;
+                    }
                     update_max_thread_conflicts();
                     LOG_WORKER(1, " found undef cube\n");
                     if (m_config.m_max_cube_depth <= cube.size())
@@ -2046,6 +2091,10 @@ public:
         st.copy(m_stats);
     }
 
+    std::string const& get_reason_unknown() const {
+        return m_batch_manager.get_unknown_reason();
+    }
+
     void reset_statistics() {
         m_stats.reset();
     }
@@ -2128,6 +2177,7 @@ public:
         case l_undef:
             if (!m.inc())
                 throw tactic_exception(Z3_CANCELED_MSG);
+            g->set_reason_unknown(ps.get_reason_unknown());
             break;
         }
 


### PR DESCRIPTION
## Summary

Fixes a regression in the parallel tactic where a benchmark that should report `unknown` in well under a second instead spins until the wall-clock timeout.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/2733
- **Benchmark:** `iss-2922/bug-1.smt2` (uses `(check-sat-using pqffd)`)
- **Kind:** `diff`
- **z3 under test:** `z3-4.17.0-x64-glibc-2.39` (Nightly)

## Divergence

The recorded oracle (193 B) shows z3 giving up quickly with a reason, then `unknown`, then a `get-model` error. Current z3 instead produces only `timeout` (8 B):

```diff
--- bug-1.expected.out (expected)
+++ produced (current z3)
@@ -1,6 +1 @@
-(sat.giveup interpreted functions sent to SAT solver (declare-fun = (a a) Bool)
-(declare-fun is (a) Bool)
-(declare-fun is (a) Bool)
-)
-unknown
-(error "line 8 column 10: model is not available")
+timeout
```

## Root cause

The parallel tactic rewrite in commit `612fab1c9` ("Parallel tactic (#9824) (#9825)", +1970/−673 on `src/solver/parallel_tactical.cpp`) dropped the old **terminal giveup** detection.

Before that commit, the worker explicitly inspected `reason_unknown()` and stopped the whole search when a sub-solver gave up for a fundamental reason:

```cpp
bool giveup() {
    ...
    std::string r = get_solver().reason_unknown();
    inc = "(incomplete";  m_giveup |= r.compare(0, inc.size(), inc) == 0;
    inc = "(sat.giveup";  m_giveup |= r.compare(0, inc.size(), inc) == 0;
    if (m_giveup) IF_VERBOSE(0, verbose_stream() << r << "\n");
    return m_giveup;
}
...
if (s.giveup()) { report_undef(s, s.get_solver().reason_unknown()); return; }
```

The new `worker::run()` loop treats **every** `l_undef` as resource-limited: it raises the per-thread conflict budget and splits the search into more cubes. But when the finite-domain solver is handed interpreted functions it cannot bit-blast, it returns `l_undef` with reason `(sat.giveup interpreted functions sent to SAT solver ...)`. No amount of splitting or extra conflicts can ever change that answer, so the portfolio keeps retrying identical sub-problems until the `-T:20` budget elapses — producing `timeout` instead of a fast `unknown`.

## Fix

Re-introduce giveup detection in the new architecture (`src/solver/parallel_tactical.cpp`, +50 lines, single file):

- A small `is_giveup_reason()` helper recognises the terminal `(sat.giveup` / `(incomplete` prefixes reported by `inc_sat_solver`.
- In the worker's `l_undef` case, **before** raising conflicts or splitting, read `reason_unknown()`; if it is a giveup reason, stop the whole portfolio via a new `batch_manager::set_giveup()`.
- `set_giveup()` records the reason, prints it at verbosity 0 (matching the prior tactic, which the snapshot oracle captures), sets a new terminal `is_giveup` state, and cancels the background threads. It is guarded by the batch-manager mutex and the `is_running` check so exactly one worker prints once and a single terminal verdict wins.
- `get_result()` maps `is_giveup` to `l_undef`; the reason is propagated to the goal in `parallel_tactic::operator()` so `check-sat-using` surfaces `unknown` with the reason.

## Validation

Built the patched checkout and re-ran the benchmark with the same options the snapshot capture uses:

- `cd z3 && ./configure && make -C build -j8` → build succeeded (`Z3 version 4.17.0 - 64 bit`).
- `z3 -T:20 inputs/issues/iss-2922/bug-1.smt2` now matches the recorded oracle **byte-for-byte** (193 B, identical `sha256`), and completes in **~0.5 s** instead of timing out at 20 s.
- Sanity checks: a normal `pqffd` SAT instance still returns `sat` with a correct model; a genuine resource-limited `l_undef` (empty/other reason) still falls through to the existing split-and-retry logic — only terminal giveup reasons short-circuit.

Opened as a **draft** for human review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28313245727) · 3.5K AIC · ⌖ 114.2 AIC · ⊞ 41.2K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.60, model: claude-opus-4.8, id: 28313245727, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28313245727 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->