### PR TITLE
lp: avoid per-call join allocation in explain_fixed_column

### DIFF
--- a/src/math/lp/lar_solver.cpp
+++ b/src/math/lp/lar_solver.cpp
@@ -1125,8 +1125,10 @@ namespace lp {
 
     void lar_solver::explain_fixed_column(unsigned j, explanation& ex) {
         SASSERT(column_is_fixed(j));
-        auto* deps = get_bound_constraint_witnesses_for_column(j);
-        for (auto ci : flatten(deps))
+        const column& ul = m_imp->m_columns[j];
+        m_imp->m_tmp_dependencies.reset();
+        m_imp->m_dependencies.linearize(ul.lower_bound_witness(), ul.upper_bound_witness(), m_imp->m_tmp_dependencies);
+        for (auto ci : m_imp->m_tmp_dependencies)
             ex.push_back(ci);
     }
 

--- a/src/util/dependency.h
+++ b/src/util/dependency.h
@@ -234,6 +234,22 @@ public:
         m_todo.reset();
     }
 
+    // Linearize the union of two dependencies without allocating a join node.
+    void linearize(dependency * d1, dependency * d2, vector<value, false> & vs) const {
+        SASSERT(m_todo.empty());
+        if (d1) {
+            d1->mark();
+            m_todo.push_back(d1);
+        }
+        if (d2 && !d2->is_marked()) {
+            d2->mark();
+            m_todo.push_back(d2);
+        }
+        if (!m_todo.empty())
+            linearize_todo(m_todo, vs);
+        m_todo.reset();
+    }
+
     void linearize(ptr_vector<dependency>& deps, vector<value, false> & vs) const {
         if (deps.empty())
             return;
@@ -331,6 +347,10 @@ public:
 
     void linearize(dependency * d, vector<value, false> & vs) const {
         return m_dep_manager.linearize(d, vs);
+    }    
+
+    void linearize(dependency * d1, dependency * d2, vector<value, false> & vs) const {
+        return m_dep_manager.linearize(d1, d2, vs);
     }    
 
     static vector<value, false> const& s_linearize(dependency* d, vector<value, false>& vs) {


### PR DESCRIPTION
## Motivation

`lar_solver::explain_fixed_column` was reported as the top self-time hotspot (~25%) by a DeepScan profile of `regex-equivalence/mut_0080.smt2` (Z3Prover/bench#2723). It is called once per fixed column per row from `lp_bound_propagator::explain_fixed_in_row`, so it fires very frequently during bound propagation / conflict explanation.

Each call did:

```cpp
auto* deps = get_bound_constraint_witnesses_for_column(j); // mk_join(lower, upper)
for (auto ci : flatten(deps)) ex.push_back(ci);
```

For a fixed column both bound witnesses are normally non-null and distinct, so `mk_join` allocates a fresh `join` dependency node **every call**. That node comes from the `u_dependency_manager` region whose `deallocate()` is a no-op, so it is never reclaimed during solving (it is only freed on `pop_scope`). `flatten`/`linearize` then walks that throwaway node plus its two children.

## Change

The intermediate `join` node carries no information — we only want to linearize the union of the two witness DAGs. This PR adds a two-dependency `linearize(d1, d2, vs)` overload to `dependency_manager` (forwarded through `scoped_dependency_manager`) that walks both DAGs directly, reusing the existing mark-based de-duplication, with **no allocation**. `explain_fixed_column` now calls it on the two witnesses directly.

The `d2 && !d2->is_marked()` seeding reproduces `mk_join`'s `d1 == d2` dedup, and null witnesses are skipped, so the produced explanation is identical to before.

## Results (`mut_0080.smt2`, `model_validate=true -st`)

| stat | master | this PR | Δ |
|---|---|---|---|
| result | sat | sat | identical |
| `:num-allocs` | 673,633,310 | 444,637,556 | **−34%** |
| `:max-memory` | 44.16 MB | 33.60 MB | **−24%** |
| conflicts / propagations / arith-* / added-eqs | — | — | byte-for-byte identical |

Every behavioral counter is unchanged — this is purely an allocation optimization.

**Local before/after profile** (macOS `sample`, standalone solve reproduced via a `(reset)` loop, ~13.5k samples each): the `explain_fixed_column` self-time and the `linearize_todo` walk it drives each dropped **~39%** (combined 10.82% → 6.67%), while an unrelated control frame (`operator*(rational)`) stayed flat (3.63% → 3.60%), confirming the profiles are comparable.

**Ramon QF_LIA_small** (`-T:20 model_validate=true`): no sat↔unsat divergence, 0 errors; only timeout-boundary flips. CPU over the 4410 commonly-solved instances −1.3%, with the explanation-heavy `prp-*` family individually −10% to −16%.

Refs Z3Prover/bench#2723.
