### PR TITLE
[snapshot-regression-fix] Fix unsound collapse of symbolic re.range bounds to empty language

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -4126,30 +4126,39 @@ br_status seq_rewriter::mk_re_range(expr* lo, expr* hi, expr_ref& result) {
         is_empty = true;
     if (max_length(hi) == std::make_pair(true, rational(0)))
         is_empty = true;
-    if (!is_empty) {
-        if (str().is_string(lo, slo) && slo.length() == 1) 
-            clo = slo[0];    
-        else if (str().is_unit(lo, lo1) && m_util.is_const_char(lo1, clo))
-            ;
-        else
-            is_empty = true;
-    }
-    if (!is_empty) {
-        if (str().is_string(hi, shi) && shi.length() == 1)
-            chi = shi[0];
-        else if (str().is_unit(hi, hi1) && m_util.is_const_char(hi1, chi))
-            ;
-        else
-            is_empty = true;
-    }
-
-    // clo/chi are only meaningful once both bounds were extracted; an early
-    // is_empty (from the length checks) leaves them at their default 0, so the
-    // is_empty return must come before the singleton/ordering checks below.
-    if (!is_empty && clo > chi)
-        is_empty = true;
-
+    // A bound whose length is provably not 1 forces the whole range to denote
+    // the empty language, regardless of the other endpoint.
     if (is_empty) {
+        sort* srt = re().mk_re(lo->get_sort());
+        result = re().mk_empty(srt);
+        return BR_DONE;
+    }
+
+    // Resolve each bound to a concrete character. A bound that is not a
+    // constant single character (e.g. a symbolic term such as an ite) cannot
+    // be decided here: leave the range untouched for the theory solver rather
+    // than assuming it denotes the empty language. Collapsing a symbolic range
+    // to empty is unsound, since the bound may evaluate to a valid character.
+    bool lo_is_char = false, hi_is_char = false;
+    if (str().is_string(lo, slo) && slo.length() == 1) {
+        clo = slo[0];
+        lo_is_char = true;
+    }
+    else if (str().is_unit(lo, lo1) && m_util.is_const_char(lo1, clo))
+        lo_is_char = true;
+
+    if (str().is_string(hi, shi) && shi.length() == 1) {
+        chi = shi[0];
+        hi_is_char = true;
+    }
+    else if (str().is_unit(hi, hi1) && m_util.is_const_char(hi1, chi))
+        hi_is_char = true;
+
+    if (!lo_is_char || !hi_is_char)
+        return BR_FAILED;
+
+    // Both endpoints are concrete characters: apply the exact semantics.
+    if (clo > chi) {
         sort* srt = re().mk_re(lo->get_sort());
         result = re().mk_empty(srt);
         return BR_DONE;


### PR DESCRIPTION
## Summary

Fixes a **soundness regression** in the sequence/regex rewriter surfaced by the Z3 nightly snapshot-regression corpus.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/2759
- **Benchmark:** `iss-5142/small.smt2` (in `Z3Prover/bench`, under `inputs/issues/iss-5142/`)
- **Kind:** `diff` (output divergence vs. recorded oracle)

## Divergence

The recorded oracle (expected) says `sat`; current z3 master produces `unsat`:

```diff
--- expected
+++ current
@@ -1 +1 @@
-sat
+unsat
```

The benchmark is genuinely **satisfiable** — witness `a = ""`:

```smt2
(declare-fun a () String)
(assert (or (not (str.in_re a (re.* (re.range "a" "u"))))
     (str.in_re "b" (re.* (re.range "a" (ite (= a "") "z" ""))))
     (str.in_re (ite (str.in_re a (re.* (re.comp (str.to_re "")))) "z" "") (str.to_re ""))))
(assert (ite (str.in_re a (re.* (re.range "" ""))) true (str.in_re a (str.to_re (str.replace_all "" "" a)))))
(check-sat)
```

With `a = ""`, the second disjunct of assertion 1 becomes `(str.in_re "b" (re.* (re.range "a" "z")))`, which is true, and assertion 2's `ite` guard `(str.in_re "" (re.* (re.range "" "")))` is true — so both assertions hold. Returning `unsat` is therefore **unsound**.

## Root cause

The regression was introduced by the regex derivative refactor (#9965). In `seq_rewriter::mk_re_range` (`src/ast/rewriter/seq_rewriter.cpp`), the new code set `is_empty = true` whenever a bound was **not** a constant single character:

```cpp
if (str().is_string(lo, slo) && slo.length() == 1)
    clo = slo[0];
else if (str().is_unit(lo, lo1) && m_util.is_const_char(lo1, clo))
    ;
else
    is_empty = true;   // <-- unsound for symbolic bounds
```

For `(re.range "a" (ite (= a "") "z" ""))` the upper bound is a symbolic `ite`, so this rule rewrote the whole range to `re.empty`. Consequently `(re.* re.empty)` collapsed to epsilon `{""}`, `(str.in_re "b" epsilon)` became false, the `a = ""` witnessing disjunct was destroyed, and the solver concluded `unsat`. Collapsing a symbolic range to the empty language is invalid, since the bound may evaluate to a legitimate character.

The pre-refactor code returned `BR_FAILED` for such symbolic bounds (leaving the range for the theory solver); the refactor lost that behaviour.

## Fix

Only decide the range in the rewriter when **both** bounds are concrete characters; otherwise return `BR_FAILED` and let the theory solver / derivative engine (which already has a symbolic-bound fallback in `seq_derive.cpp::derive_range`) handle it:

- Provably-empty **constant** bounds are still caught up front by the existing `min_length`/`max_length` checks (→ `re.empty`).
- Both endpoints concrete: apply exact semantics — `clo > chi` → `re.empty`, `clo == chi` → `str.to_re` singleton, otherwise `BR_FAILED` (a genuine range for the theory).
- Either endpoint non-constant (e.g. an `ite`): `BR_FAILED` — no longer collapsed to empty.

The change is confined to `mk_re_range`.

## Validation

Built the modified checkout and re-ran the benchmark with the same timeout the snapshot capture uses:

```
$ make -C build -j8            # clean build succeeded
$ ./build/z3 --version
Z3 version 4.17.0 - 64 bit
$ ./build/z3 -T:20 inputs/issues/iss-5142/small.smt2
sat                            # matches the recorded oracle
```

`(get-model)` returns `a = ""`, a genuine satisfying assignment. Additional sanity checks confirmed concrete-range semantics are unchanged: in-range membership → `sat`, out-of-range → `unsat`, reversed range (`z`..`a`) → empty/`unsat`, singleton range → `sat` with the expected character.

---

Opened as a **draft** for human review by the automated snapshot-regression fixer.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28497162331) · 521 AIC · ⌖ 55.6 AIC · ⊞ 9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 28497162331, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28497162331 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->