### PR TITLE
[snapshot-regression-fix] Fix unsound empty collapse of symbolic-bound re.range

### DIFF
--- a/src/ast/rewriter/seq_derive.cpp
+++ b/src/ast/rewriter/seq_derive.cpp
@@ -398,7 +398,9 @@ namespace seq {
 
         // Extract character values from unit strings
         expr_ref c_lo(m), c_hi(m);
-        if (u().str.is_unit_string(lo, c_lo) && u().str.is_unit_string(hi, c_hi)) {
+        bool lo_unit = u().str.is_unit_string(lo, c_lo);
+        bool hi_unit = u().str.is_unit_string(hi, c_hi);
+        if (lo_unit && hi_unit) {
             // Build range condition, simplifying trivial bounds
             unsigned lo_val = 0, hi_val = 0;
             bool lo_trivial = m_util.is_const_char(c_lo, lo_val) && lo_val == 0;
@@ -415,6 +417,38 @@ namespace seq {
             else
                 in_range = m.mk_and(m_util.mk_le(c_lo, m_ele), m_util.mk_le(m_ele, c_hi));
 
+            return mk_ite(in_range, eps, empty);
+        }
+
+        // Symbolic (non-ground) bound(s): a non-literal bound denotes a single
+        // character only when its length is 1. Encode that length constraint
+        // explicitly together with the character-order comparison so the theory
+        // solver can still decide membership instead of producing a stuck
+        // derivative. (Collapsing such a range to ∅ here would be unsound: e.g.
+        // re.range("-", y) with |y| = 1 is non-empty.)
+        expr_ref one(m_autil.mk_int(1), m);
+        expr_ref zero(m_autil.mk_int(0), m);
+        if (!u().str.is_string(lo) && hi_unit) {
+            // lo non-ground, hi unit: |lo| = 1 ∧ lo[0] ≤ ele ≤ c_hi
+            expr_ref lo_len1(m.mk_eq(u().str.mk_length(lo), one), m);
+            expr_ref lo_0(u().str.mk_nth_i(lo, zero), m);
+            expr_ref in_range(m.mk_and(lo_len1, m.mk_and(m_util.mk_le(lo_0, m_ele), m_util.mk_le(m_ele, c_hi))), m);
+            return mk_ite(in_range, eps, empty);
+        }
+        if (!u().str.is_string(hi) && lo_unit) {
+            // hi non-ground, lo unit: |hi| = 1 ∧ c_lo ≤ ele ≤ hi[0]
+            expr_ref hi_len1(m.mk_eq(u().str.mk_length(hi), one), m);
+            expr_ref hi_0(u().str.mk_nth_i(hi, zero), m);
+            expr_ref in_range(m.mk_and(hi_len1, m.mk_and(m_util.mk_le(c_lo, m_ele), m_util.mk_le(m_ele, hi_0))), m);
+            return mk_ite(in_range, eps, empty);
+        }
+        if (!u().str.is_string(lo) && !u().str.is_string(hi)) {
+            // both non-ground: |lo| = 1 ∧ |hi| = 1 ∧ lo[0] ≤ ele ≤ hi[0]
+            expr_ref lo_len1(m.mk_eq(u().str.mk_length(lo), one), m);
+            expr_ref hi_len1(m.mk_eq(u().str.mk_length(hi), one), m);
+            expr_ref lo_0(u().str.mk_nth_i(lo, zero), m);
+            expr_ref hi_0(u().str.mk_nth_i(hi, zero), m);
+            expr_ref in_range(m.mk_and(lo_len1, m.mk_and(hi_len1, m.mk_and(m_util.mk_le(lo_0, m_ele), m_util.mk_le(m_ele, hi_0)))), m);
             return mk_ite(in_range, eps, empty);
         }
 

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -4132,7 +4132,7 @@ br_status seq_rewriter::mk_re_range(expr* lo, expr* hi, expr_ref& result) {
         else if (str().is_unit(lo, lo1) && m_util.is_const_char(lo1, clo))
             ;
         else
-            is_empty = true;
+            return BR_FAILED;
     }
     if (!is_empty) {
         if (str().is_string(hi, shi) && shi.length() == 1)
@@ -4140,7 +4140,7 @@ br_status seq_rewriter::mk_re_range(expr* lo, expr* hi, expr_ref& result) {
         else if (str().is_unit(hi, hi1) && m_util.is_const_char(hi1, chi))
             ;
         else
-            is_empty = true;
+            return BR_FAILED;
     }
 
     // clo/chi are only meaningful once both bounds were extracted; an early


### PR DESCRIPTION
## Summary

Fixes a **soundness regression** in the sequence/regex solver where `re.range` with a symbolic bound was unsoundly collapsed to the empty language, causing z3 to return `unsat` for satisfiable formulas.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/2762
- **Benchmark:** `iss-6144/small-3.smt2` (in `Z3Prover/bench`)

## Divergence

The recorded oracle expects `sat`, but current z3 (Nightly `z3-4.17.0-x64-glibc-2.39`) produces `unsat`:

```diff
--- small-3.expected.out (expected)
+++ produced (current z3)
@@ -1 +1 @@
-sat
+unsat
```

The benchmark:

```smt2
(set-logic QF_SLIA)
(declare-fun x () String)
(declare-fun y () String)
(assert (= 1 (str.len y)))
(assert (str.in_re x (re.range "-" y)))
(check-sat)
```

This is satisfiable — e.g. `y = "-"`, `x = "-"` (any single character in the range `["-", y]` works).

## Root cause

Introduced by the derivative refactor #9965 ("Derive with ranges"). Two spots regressed:

1. **`seq_rewriter::mk_re_range`** collapses `(re.range lo hi)` to `re.empty` whenever a bound is not a **ground** single character. For a symbolic bound like `y` this is unsound — whether the range is empty depends on the value the solver assigns to `y`. The pre-#9965 rewriter returned `BR_FAILED` here, leaving the node for the theory solver. Once the range is rewritten to `re.empty`, `str.in_re x re.empty` is always false ⇒ spurious `unsat`.

2. **`seq::derive::derive_range`** only handles the case where **both** bounds are ground unit strings; a symbolic bound falls through to a *stuck* derivative. So even once the rewriter stops collapsing the range, the solver returns `unknown` rather than `sat`. The pre-#9965 Antimirov derivative had explicit symbolic-bound cases that were dropped in the refactor.

## Fix

Two coordinated, minimal changes restore both **soundness** and **completeness**:

- **`mk_re_range`**: return `BR_FAILED` (instead of `is_empty = true`) for a non-ground bound, leaving the range for the theory solver. All the sound checks are preserved (length bounds, constant `clo > chi` ordering, singleton `clo == chi` collapse).
- **`derive_range`**: for a non-ground bound `b`, emit the length-one constraint together with the character-order comparison — e.g. for a symbolic upper bound, `|hi| = 1 ∧ c_lo ≤ ele ≤ hi[0]` — mirroring the pre-#9965 derivative. This makes membership decidable instead of stuck. The symmetric (symbolic lower bound) and both-symbolic cases are handled too.

## Validation

Rebuilt z3 from this branch (`./configure && make -C build -j$(nproc)`) and re-ran the failing benchmark with the same options the snapshot capture uses (`-T:20`):

```
$ z3 -T:20 inputs/issues/iss-6144/small-3.smt2
sat        # now matches the recorded oracle
```

Regression checks with the rebuilt binary:
- **All 80** corpus `.smt2` files using `re.range` (that have a recorded oracle) now match their expected results — **0 diffs**.
- 38 sampled non-range regex-membership files: unchanged, all match.
- Soundness spot-checks: `|y| = 2, |x| = 1, x ∈ re.range("-", y)` → `unsat` (empty range correctly detected via the `|bound| = 1` guard); constant ranges unchanged (`'b' ∈ [a-z]` → sat, reversed `[z-a]` → unsat, out-of-range → unsat).

Opened as a **draft** for human review.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28497165692) · 543.4 AIC · ⌖ 45.2 AIC · ⊞ 9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 28497165692, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28497165692 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->