### PR TITLE
[snapshot-regression-fix] Fix MBQI completeness regression for array-valued universal variables (iss-5336/bug-5)

### DIFF
--- a/src/smt/smt_model_finder.cpp
+++ b/src/smt/smt_model_finder.cpp
@@ -2188,10 +2188,16 @@ namespace smt {
                         process_app(to_app(curr));
                     }
                     else if (is_var(curr)) {
-                        if (m_array_util.is_array(curr)) {
-                            insert_qinfo(alloc(ho_var, m, to_var(curr)->get_idx()));
-                        }
-                        m_info->m_is_auf = false;                       
+                        // Note: array-valued universal variables are intentionally
+                        // not routed through the term-enumeration ho_var path here.
+                        // Doing so populates the variable's instantiation set with
+                        // synthesized array terms; restrict_sks_to_inst_set then
+                        // builds a large disjunction that can make the auxiliary
+                        // model-check in smt_model_checker return l_undef, discarding
+                        // the decisive instantiation that the ordinary instantiation
+                        // sets already provide. That regressed MBQI completeness
+                        // (e.g. inputs/issues/iss-5336/bug-5.smt2 went unsat -> unknown).
+                        m_info->m_is_auf = false;  // unexpected occurrence of variable.
                     }
                     else {
                         SASSERT(is_lambda(curr));


### PR DESCRIPTION
## Snapshot-regression fix: `iss-5336/bug-5.smt2` (unsat -> unknown)

Originating discussion: https://github.com/Z3Prover/bench/discussions/2979

- **Benchmark:** `iss-5336/bug-5.smt2` (`inputs/issues/iss-5336/` in `Z3Prover/bench`)
- **z3 under test:** `z3-4.17.0-x64-glibc-2.39` (Nightly)
- **Kind:** `diff`

### Divergence

The recorded oracle expects `unsat`; current z3 produces `unknown`:

```diff
--- bug-5.expected.out (expected)
+++ produced (current z3)
@@ -1 +1 @@
-unsat
+unknown
```

The benchmark asserts (with `smt.ematching` disabled):

```smt2
(assert (exists ((a (Array (_ BitVec 1) (_ BitVec 1))))
          (forall ((b (Array (_ BitVec 1) (_ BitVec 1))))
            (and (not (= a b)) (= (a (_ bv0 1)) (b (_ bv0 1)))))))
(check-sat)
```

This is `unsat` (instantiate the inner `forall` with `b := a` to get `(not (= a a))`), so `unknown` is a genuine MBQI completeness regression, not a benign output change.

### Root cause

The regression was introduced by the term-enumeration change ("Term enumeration (#9908)", commit `5699142f5`). In `smt_model_finder.cpp`, `process_terms_on_stack` began routing **array-valued universal variables** through a new `ho_var` qinfo:

```cpp
else if (is_var(curr)) {
    if (m_array_util.is_array(curr))
        insert_qinfo(alloc(ho_var, m, to_var(curr)->get_idx()));
    m_info->m_is_auf = false;
}
```

`ho_var::populate_inst_sets` fills the variable's instantiation set not only with relevant same-sort enodes but also with up to ~20 *synthesized/enumerated* array terms. For this benchmark the enode scan finds no usable same-sort term, so it inserts only the synthesized terms.

Downstream in `smt_model_checker::check`, after the unrestricted auxiliary check finds a counterexample (`b != a`), `restrict_sks_to_inst_set` builds a large disjunction over that polluted instantiation set. The **restricted** auxiliary check then returns `l_undef` (the enumerated array terms + lambda definitions make it incomplete). The MBQI loop breaks with no new instances and falls through to `complete_cex`, which selects a useless synthesized lambda for `b` instead of the decisive `b := a`. Result: `unknown` after one round.

### Fix

Do not route array-valued universal variables through the `ho_var` term-enumeration path; keep the pre-existing behaviour of only setting `m_is_auf = false`. Without the synthesized-term pollution, `b`'s instantiation set (populated by the ordinary qinfo) still contains the exists-skolem `a`; the restricted check returns `l_true`, `add_instance` recovers `b := a` via `get_inv`, and MBQI closes to `unsat` in one round.

```diff
diff --git a/src/smt/smt_model_finder.cpp b/src/smt/smt_model_finder.cpp
@@ -2188,10 +2188,16 @@ namespace smt {
                         process_app(to_app(curr));
                     }
                     else if (is_var(curr)) {
-                        if (m_array_util.is_array(curr)) {
-                            insert_qinfo(alloc(ho_var, m, to_var(curr)->get_idx()));
-                        }
-                        m_info->m_is_auf = false;
+                        // array-valued universal variables are intentionally NOT
+                        // routed through the term-enumeration ho_var path here.
+                        m_info->m_is_auf = false;  // unexpected occurrence of variable.
                     }
```

The `ho_var` class itself is left defined but now unused (its only instantiation site is removed). It is intentionally kept in place so a maintainer can refine/re-enable term-enumeration for array-valued universal variables without the completeness loss.

### Validation

The fix was validated by **rebuilding z3 and re-running the benchmark**, exactly as the snapshot capture does (`z3 -T:20 <file>`, stdout+stderr combined, byte-compared to the oracle):

- Before (unpatched HEAD, `f15584cda`): `unknown`
- After (this change): `unsat` — **byte-exact** match to `bug-5.expected.out`.
- All 22 `inputs/issues/iss-5336/*.smt2` benchmarks with recorded oracles still match byte-exactly.
- A random sample of ~80 other quantifier benchmarks with oracles was checked; the fix introduced **no** new divergences (the 2 mismatches in the sample also occur on unpatched HEAD, i.e. they are pre-existing and unrelated to this change).

### Honesty / caveats

- This change **disables** the term-enumeration routing for array-valued *universal* variables specifically; it does not attempt to repair `ho_var`/`restrict_sks_to_inst_set` to cooperate. The `ho_var` class is left as (currently) dead code for a maintainer to revisit.
- The `term_enumeration` unit tests (`src/test/term_enumeration.cpp`) exercise the enumerator class directly and are unaffected.
- I did **not** run z3's full regression/test suite (impractical here); validation was the targeted benchmark plus the corpus sample described above.

---
Fixes the divergence tracked in Z3Prover/bench discussion #2979.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28641267197) · 914.5 AIC · ⌖ 46.1 AIC · ⊞ 8.9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 28641267197, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28641267197 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->