### PR TITLE
[snapshot-regression-fix] Fix lira/array regression: lambda equality and array-ext parents wrongly force "unknown"

### DIFF
--- a/src/smt/theory_array_full.cpp
+++ b/src/smt/theory_array_full.cpp
@@ -854,7 +854,16 @@ namespace smt {
         }
         for (enode* n : m_lambdas) 
             for (enode* p : n->get_parents())
-                if (ctx.is_relevant(p) && !is_default(p) && !ctx.is_beta_redex(p, n)) {
+                // Equality and array-ext parents are not genuine non-beta-redex uses:
+                // an array (dis)equality between a lambda and another array is decided by
+                // extensionality (new_diseq_eh / instantiate_extensionality), which itself
+                // introduces the array-ext witness index and the select(lambda, ext) beta
+                // redex. Together with the select-lambda beta axiom these fully axiomatize
+                // the lambda, so they must not force the solver into "unknown" the way a
+                // real uninterpreted use (e.g. an uninterpreted function applied to the
+                // lambda) does.
+                if (ctx.is_relevant(p) && !is_default(p) && !m.is_eq(p->get_expr()) &&
+                    !is_array_ext(p->get_expr()) && !ctx.is_beta_redex(p, n)) {
                     TRACE(array, tout << "lambda is not a beta redex " << enode_pp(p, ctx) << "\n");
                     return true;
                 }


### PR DESCRIPTION
Fixes a regression surfaced by the `snapshot-regression` corpus in `Z3Prover/bench`.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/2981
- **Benchmark:** `iss-5454/bug-11.smt2` (`inputs/issues/iss-5454/` in `Z3Prover/bench`)

## Divergence

The recorded oracle expected `sat`, but current z3 produces `unknown`:

```diff
--- bug-11.expected.out (expected)
+++ produced (current z3)
@@ -1 +1 @@
-sat
+unknown
```

The benchmark enables `:rewriter.expand_nested_stores true` and asserts an (existentially quantified) disequality between two 3-level nested `store` chains over an uninterpreted array, discharged with `(check-sat-using lira)`. `expand_nested_stores` rewrites the nested `store` chains into `lambda` terms, so the goal contains an array (dis)equality between two lambdas, which is dispatched to the legacy array solver (`theory_array_full`).

## Root cause

`theory_array_full::has_non_beta_as_array()` is an incompleteness guard: when it returns `true`, `assert_delayed_axioms()` forces `FC_GIVEUP`, i.e. the final result becomes `unknown`. For every lambda registered with the legacy array solver it scans the lambda's relevant parents and gives up if any parent is neither `default(lambda)` nor a beta redex (`select`/`map`/`store`).

Lambdas are now registered with the legacy array solver (so that the `select(lambda, i)` beta axiom and the `default(lambda)` axiom are emitted). Once registered, this guard starts firing on parents that are **intrinsic to the array decision procedure itself**, not genuine uninterpreted uses of the lambda:

1. `(= lambda other-array)` — the array (dis)equality atom, which is decided by extensionality (`theory_array::new_diseq_eh` -> `instantiate_extensionality`).
2. `(array-ext lambda other-array)` — the extensionality **witness index** (`OP_ARRAY_EXT`), a Skolem term introduced by that same extensionality axiom.

Extensionality asserts `select(a, ext(a,b)) != select(b, ext(a,b))`, and the select-lambda beta axiom reduces `select(lambda, ext(...))` to the lambda body. So in these two cases the lambda is fully axiomatized and the solver can decide the (dis)equality; treating them as "non-beta-as-array" and bailing out to `unknown` is overly conservative and loses completeness on satisfiable (and unsatisfiable) instances.

## Fix

Exclude `is_eq` and `is_array_ext` parents from the lambda giveup check in `has_non_beta_as_array()`:

```cpp
for (enode* n : m_lambdas)
    for (enode* p : n->get_parents())
        if (ctx.is_relevant(p) && !is_default(p) && !m.is_eq(p->get_expr()) &&
            !is_array_ext(p->get_expr()) && !ctx.is_beta_redex(p, n)) {
            ...
            return true;
        }
```

The `m_as_array` loop is intentionally left unchanged, since as-array equality is genuinely incomplete (per the existing comment in the file). A real uninterpreted use of a lambda (e.g. an uninterpreted function applied to it) still correctly triggers the guard.

## Validation

Rebuilt z3 from this branch (`./configure && make -C build -j$(nproc)`) and re-ran the benchmark with the same options the snapshot capture uses:

```
$ z3 -T:20 inputs/issues/iss-5454/bug-11.smt2
sat
```

which matches the recorded oracle. As soundness sanity checks, several nested-store lambda (dis)equality instances with known answers were run under both `(check-sat-using lira)` and the default tactic, and both paths agree:

- identical nested-store chains asserted unequal -> `unsat`
- nested stores that overwrite to a provably equal array asserted unequal -> `unsat`
- genuinely different nested stores with distinct stored values -> `sat`

Before the fix the `lira` path returned `unknown` on the benchmark; after the fix it returns `sat`, consistent with the default tactic.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28641268804) · 988.7 AIC · ⌖ 42.9 AIC · ⊞ 8.9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 28641268804, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28641268804 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->