### PR TITLE
[snapshot-regression-fix] smt_parallel: enable preprocessing for quantified formulas so MBQI can solve in parallel mode

### DIFF
--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -626,7 +626,12 @@ namespace smt {
         ctx->set_logic(p.ctx.m_setup.get_logic());
         context::copy(p.ctx, *ctx, true);
         ctx->pop_to_base_lvl();
-        ctx->get_fparams().m_preprocess = false;  // avoid preprocessing lemmas that are exchanged
+        // Disable preprocessing so units/clauses exchanged between workers refer to a
+        // stable shared atom set, but keep it enabled for quantified formulas: MBQI
+        // relies on preprocessing (macro/quantifier simplification, trigger setup) and
+        // without it a satisfiable quantified formula can spin without ever finding a
+        // model the sequential solver dispatches immediately.
+        ctx->get_fparams().m_preprocess = ctx->has_quantifiers();
     }
 
     void parallel::core_minimizer_worker::cancel() {
@@ -866,7 +871,12 @@ namespace smt {
         ctx->pop_to_base_lvl();
         m_shared_units_prefix = ctx->assigned_literals().size();
         m_num_initial_atoms = ctx->get_num_bool_vars();
-        ctx->get_fparams().m_preprocess = false;  // avoid preprocessing lemmas that are exchanged
+        // Disable preprocessing so units/clauses exchanged between workers refer to a
+        // stable shared atom set, but keep it enabled for quantified formulas: MBQI
+        // relies on preprocessing (macro/quantifier simplification, trigger setup) and
+        // without it a satisfiable quantified formula can spin without ever finding a
+        // model the sequential solver dispatches immediately.
+        ctx->get_fparams().m_preprocess = ctx->has_quantifiers();
 
         parallel_params pp(p.ctx.m_params);
         m_config.m_inprocessing = false;
@@ -901,7 +911,12 @@ namespace smt {
         ctx->pop_to_base_lvl();
         m_shared_units_prefix = ctx->assigned_literals().size();
         m_num_initial_atoms = ctx->get_num_bool_vars();
-        ctx->get_fparams().m_preprocess = false;  // avoid preprocessing lemmas that are exchanged
+        // Disable preprocessing so units/clauses exchanged between workers refer to a
+        // stable shared atom set, but keep it enabled for quantified formulas: MBQI
+        // relies on preprocessing (macro/quantifier simplification, trigger setup) and
+        // without it a satisfiable quantified formula can spin without ever finding a
+        // model the sequential solver dispatches immediately.
+        ctx->get_fparams().m_preprocess = ctx->has_quantifiers();
 
         m_use_failed_literal_test = false;
     }


### PR DESCRIPTION
## Summary

Fixes a parallel-solver regression surfaced by the `snapshot-regression` corpus in `Z3Prover/bench`.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/2941
- **Benchmark:** `iss-3268/bug-1.smt2` — a satisfiable quantified array formula that sets `(set-option :smt.threads 4)`.
- **Divergence** (recorded oracle vs. current z3):

```diff
--- bug-1.expected.out (expected)
+++ produced (current z3)
@@ -1 +1 @@
-sat
+timeout
```

## Root cause

The three parallel SMT worker constructors in `src/smt/smt_parallel.cpp` (the CDCL `worker`, the `core_minimizer_worker`, and the `backbones_worker`) disable preprocessing on their per-worker context:

```cpp
ctx->get_fparams().m_preprocess = false;  // avoid preprocessing lemmas that are exchanged
```

Preprocessing is disabled so that the units/clauses workers exchange refer to a stable, shared atom set — appropriate for the quantifier-free cubing the parallel engine was designed for (`parallel.enable` is documented "for QF_BV"). But quantifier reasoning (MBQI) depends on preprocessing (macro/quantifier simplification and trigger/pattern setup). With preprocessing disabled, a worker running MBQI on a satisfiable quantified formula never converges to a model.

Evidence gathered while diagnosing `iss-3268/bug-1.smt2`:

- Sequential solving returns `sat` in **0.04 s** (`:conflicts 64`, `:quant-instantiations 1260`).
- In parallel mode every worker takes the `l_undef` / `max-conflicts-reached` path and keeps splitting/escalating; even the **empty** cube (no cube assumptions, identical formula) fails to find `sat`.
- Raising the per-cube conflict budget to an effectively unbounded value does **not** help — with unlimited budget the workers just spin inside the first `check_cube` until the 20 s wall-clock timeout. So the conflict cap / cube splitting is not the cause; the worker context itself cannot solve the formula.
- Enabling preprocessing on the worker context makes parallel mode return `sat` reliably.

## Fix

Gate worker preprocessing on whether the formula contains quantifiers:

```cpp
ctx->get_fparams().m_preprocess = ctx->has_quantifiers();
```

- **Quantifier-free problems:** `has_quantifiers()` is `false`, so `m_preprocess` stays `false` — behavior is identical to before, preserving the shared-atom-set invariant the cubing engine relies on. Zero risk for the QF_BV use case the optimization targets.
- **Quantified problems:** preprocessing is enabled so MBQI has the simplifications/triggers it needs and can find models.

Applied consistently to all three worker constructors that share the identical setting.

## Validation (built and re-ran, per step 5)

Rebuilt the checkout (`cd z3 && ./configure && make -C build -j$(nproc)`) and re-ran the failing benchmark with the same invocation the snapshot capture uses (`z3 -T:20 <file>`, combined stdout+stderr):

- **Before:** `timeout` (deterministic, 3/3).
- **After:** `sat` on **9/9** runs (parallel is nondeterministic, so repeated to confirm stability), matching the recorded `bug-1.expected.out` oracle, in ~0.4 s.
- Quantifier-free parallel solving (`smt.threads=4`) and sequential solving both verified unaffected.

Only `src/smt/smt_parallel.cpp` is changed. Opened as a draft for human review.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28646059512) · 805.6 AIC · ⌖ 39.6 AIC · ⊞ 8.9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 28646059512, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28646059512 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->