### PR TITLE
smt: skip m_watches probe for unwatched literals in relevancy propagator

### DIFF
--- a/src/smt/smt_relevancy.cpp
+++ b/src/smt/smt_relevancy.cpp
@@ -141,6 +141,13 @@ namespace smt {
         typedef list<relevancy_eh *>   relevancy_ehs;
         obj_map<expr, relevancy_ehs *> m_relevant_ehs;
         obj_map<expr, relevancy_ehs *> m_watches[2];
+        // Over-approximating membership filter for m_watches: contains a superset
+        // of the expr ids that have (or ever had) a watch list for the given phase.
+        // It is monotonic (never cleared on erase/pop), so it can only yield false
+        // positives, never false negatives. This lets get_watches() skip the
+        // obj_map pointer-hash probe for the common unwatched-literal case at the
+        // assign_eh hotspot.
+        uint_set                       m_is_watched[2];
         struct eh_trail {
             enum class kind { POS_WATCH, NEG_WATCH, HANDLER };
             kind   m_kind;
@@ -185,17 +192,23 @@ namespace smt {
         }
 
         relevancy_ehs * get_watches(expr * n, bool val) {
+            unsigned idx = val ? 1 : 0;
+            if (!m_is_watched[idx].contains(n->get_id()))
+                return nullptr;
             relevancy_ehs * r = nullptr;
-            m_watches[val ? 1 : 0].find(n, r);
-            SASSERT(m_watches[val ? 1 : 0].contains(n) || r == 0);
+            m_watches[idx].find(n, r);
+            SASSERT(m_watches[idx].contains(n) || r == 0);
             return r;
         }
 
         void set_watches(expr * n, bool val, relevancy_ehs * ehs) {
+            unsigned idx = val ? 1 : 0;
             if (ehs == nullptr)
-                m_watches[val ? 1 : 0].erase(n);
-            else
-                m_watches[val ? 1 : 0].insert(n, ehs);
+                m_watches[idx].erase(n);
+            else {
+                m_watches[idx].insert(n, ehs);
+                m_is_watched[idx].insert(n->get_id());
+            }
         }
 
         void push_trail(eh_trail const & t) {


### PR DESCRIPTION
## Summary

Small, **safe** micro-optimization at the relevancy propagator's `assign_eh` hot path.

Every assigned literal currently probes `obj_map<expr*, relevancy_ehs*> m_watches[val]` in `get_watches()`, even though **most literals have no watch**. That probe is a pointer-hash lookup into a scattered bucket — a likely cache miss — paid on the common no-watch case.

This PR adds a monotonic over-approximating membership filter `uint_set m_is_watched[2]` parallel to `m_watches`, so `get_watches()` can early-return `nullptr` when the id isn't in the filter, skipping the map probe entirely.

## Why it's safe (no behavior change)

The filter is **monotonic**: an id is inserted when a watch list is created (`set_watches`) and **never cleared** on erase/pop. So it always stays a **superset** of the live watch keys:

- id **absent** ⇒ provably no watch ⇒ safe fast-path skip.
- id **present but watch since removed** ⇒ false positive ⇒ falls through to the normal `m_watches.find()`, which correctly returns `nullptr`.

There are **no false negatives**, so observable solver behavior is unchanged. (Never clearing it is deliberate: precise clearing would require scoped push/pop bookkeeping on the trail — reintroducing the very cost we're removing and risking a correctness-breaking false negative.)

Memory overhead is negligible: `uint_set` is a dense bitset sized to the largest watched id (≈ `max_id/8` bytes per phase, ~tens of KB in practice), destroyed with the propagator.

## Validation

- **Correctness:** identical results across the full 60-file ABVFP (SV-COMP UltimateAutomizer) corpus with `model_validate=true` — baseline vs patched, byte-for-byte the same answers.
- **Build:** CMake + Ninja, Release.

## Honest note on impact ⚠️

**The gain is small.** On the available benchmarks, `assign_eh` is only **~1% of whole-program self-time** (measured via sampling on the heaviest ABVFP file: 37/3406 samples ≈ 1.09%). A cache-friendly cut to a ~1% function yields only ~0–1% wall-time — within measurement noise here. The dominant costs on these problems are theory `push_scope_eh`/backtracking and `bcp`, not relevancy.

So this is offered as a **low-risk, correctness-preserving cache/allocation win at a named hot path**, *not* as a large speedup. Reviewers who consider even micro-optimizations at hot paths worthwhile may find it a clean, self-contained change (23 lines, one file); those who require a measurable whole-program win may prefer to pass.

Context / origin: Z3Prover/bench#3007.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
