### PR TITLE
[snapshot-regression-fix] smt/theory_array: don't mask FC_GIVEUP with lazy interface-equality delay (iss-5813)

### DIFF
--- a/src/smt/theory_array.cpp
+++ b/src/smt/theory_array.cpp
@@ -365,8 +365,15 @@ namespace smt {
             // instantiation to do something useful during final
             // check.
             if (m_final_check_idx % m_params.m_array_lazy_ieq_delay != 0) {
-                assert_delayed_axioms();
-                r = FC_CONTINUE;
+                // Delaying interface equalities must not mask a give-up
+                // (e.g. a lambda used as an array by a non-beta-redex parent):
+                // otherwise final check keeps returning FC_CONTINUE forever
+                // without making progress. Respect a FC_GIVEUP/FC_CONTINUE
+                // reported by the delayed axioms, and only force the lazy
+                // FC_CONTINUE when there is genuinely nothing left to do.
+                r = assert_delayed_axioms();
+                if (r == FC_DONE)
+                    r = FC_CONTINUE;
             }
             else {
                 if (mk_interface_eqs_at_final_check() == FC_CONTINUE)


### PR DESCRIPTION
## Snapshot-regression fix: `iss-5813/bug-1.smt2`

Fixes a divergence reported by the `snapshot-regression` workflow in `Z3Prover/bench`.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/2982
- **Benchmark:** `iss-5813/bug-1.smt2` (`inputs/issues/iss-5813/` in `Z3Prover/bench`)
- **z3 under test:** `z3-4.17.0-x64-glibc-2.39` (Nightly), per-file budget `20s`

### Divergence

The recorded oracle expected `unknown`, but current z3 times out:

```diff
--- bug-1.expected.out (expected)
+++ produced (current z3)
@@ -1 +1 @@
-unknown
+timeout
```

### Root cause

The benchmark applies an **uninterpreted function to a non-constant lambda**
(essentially `sum (lambda ((j Int)) ...)`). Commit `63259d8a4` ("add missing
registration of lambdas with legacy array solver, add missing beta reduction
axiom", 2026-06-29 — after the 2026-06-05 oracle snapshot) started registering
such lambda enodes with the legacy array solver (`theory_array_full`).

At final check the array solver correctly recognises that a lambda used as an
array by a **non-beta-redex parent** cannot be handled: `has_non_beta_as_array()`
returns `true`, so `theory_array_full::assert_delayed_axioms()` returns
`FC_GIVEUP` (which should make z3 answer `unknown`).

However, when `array_lazy_ieq` is enabled (it is, at runtime, with
`array_lazy_ieq_delay = 4` for this configuration), `theory_array::final_check_eh`
delays interface-equality creation like this:

```cpp
if (m_final_check_idx % m_params.m_array_lazy_ieq_delay != 0) {
    assert_delayed_axioms();   // return value DISCARDED
    r = FC_CONTINUE;           // forced, even when the theory gave up
}
```

The `FC_GIVEUP` computed by `assert_delayed_axioms()` is **discarded** and
`FC_CONTINUE` is forced on ~3 of every 4 final-check rounds. Since
`context::final_check()` returns `FC_CONTINUE` as soon as any theory does, and
nothing new is ever asserted (verified: `array-def-lambda` stays `1`,
`mk-bool-var` stays `2`, memory/vars stable), the solver spins in an infinite
final-check loop (millions of `final-checks`) and hits the timeout instead of
returning `unknown`.

### Fix

Respect the status returned by `assert_delayed_axioms()` in the lazy branch, and
only force the lazy `FC_CONTINUE` when there is genuinely nothing left to do
(`FC_DONE`):

```cpp
r = assert_delayed_axioms();
if (r == FC_DONE)
    r = FC_CONTINUE;
```

This is behaviour-preserving for arrays with legitimately pending delayed axioms
(`assert_delayed_axioms()` returns `FC_CONTINUE`, unchanged) and for ordinary
arrays with nothing to do (`FC_DONE` → forced `FC_CONTINUE`, unchanged). The only
behavioural change is that a genuine `FC_GIVEUP` is no longer masked, so the
solver terminates with `unknown` instead of looping.

### Validation (rebuilt z3 + reran the benchmark)

Built the patched `./z3` checkout and reran with the same option used by the
snapshot capture (`-T:20`):

- `iss-5813/bug-1.smt2` now returns **`unknown`** in ~0.01s (byte-for-byte match
  with `bug-1.expected.out`), previously `timeout` at 20s.
- Two minimal reproducers (uninterpreted fn applied to a non-constant lambda)
  now return `unknown` instead of timing out; constant-lambda / store controls
  still return `sat`.
- Array/lambda correctness spot-checks still pass: select-over-store,
  extensionality, select-on-lambda beta reduction, const arrays, `map`, store
  chains (`unsat`/`sat` as expected).
- Smoke-tested 60 corpus benchmarks under `inputs/issues`: 0 crashes, 0 new
  timeouts.

Created as a **draft** for human review.




> [!WARNING]
> <details>
> <summary>Firewall blocked 2 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28696741293) · 911.6 AIC · ⌖ 43.8 AIC · ⊞ 8.9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 28696741293, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28696741293 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->