### PR TITLE
[snapshot-regression-fix] Don't give up on lambda equalities in array theory final check

### DIFF
--- a/src/smt/theory_array_full.cpp
+++ b/src/smt/theory_array_full.cpp
@@ -854,7 +854,12 @@ namespace smt {
         }
         for (enode* n : m_lambdas) 
             for (enode* p : n->get_parents())
-                if (ctx.is_relevant(p) && !is_default(p) && !ctx.is_beta_redex(p, n)) {
+                if (ctx.is_relevant(p) && !is_default(p) && !m.is_eq(p->get_expr()) && !ctx.is_beta_redex(p, n)) {
+                    // An equality parent (lambda = array) is decided by the array
+                    // theory's extensionality / interface-equality reasoning, so it
+                    // does not defeat completeness and must not force a give-up.
+                    // This mirrors context::is_shared, which likewise ignores
+                    // basic-family (equality) parents when deciding sharing.
                     TRACE(array, tout << "lambda is not a beta redex " << enode_pp(p, ctx) << "\n");
                     return true;
                 }


### PR DESCRIPTION
## Summary

Fixes a Z3 **snapshot-regression** divergence tracked in
[Z3Prover/bench discussion #2987](https://github.com/Z3Prover/bench/discussions/2987).

- **benchmark:** `iss-6748/bug-2.smt2` (also fixes the sibling `iss-6748/bug-1.smt2`)
- **kind:** `diff` — completeness regression
- **divergence:** the recorded oracle expected `sat`, current z3 produced `unknown`

```diff
--- bug-2.expected.out (expected)
+++ produced (current z3)
@@ -1 +1 @@
-sat
+unknown
```

The benchmark is a quantified `exists` formula over datatypes, arrays
(`as const` / `store`) and lambdas. z3 answered `sat` at oracle-capture time
but now returns `unknown` with
`(:reason-unknown "smt tactic failed to show goal to be sat/unsat (incomplete (theory array))")`
— an incompleteness give-up, not a timeout (it happens in a few milliseconds).

## Root cause

In `theory_array_full::has_non_beta_as_array()` the array theory forces
`FC_GIVEUP` (which surfaces as `unknown`) whenever a *relevant* lambda enode has
a parent that is not a beta redex (i.e. not `select` / `map` / `store` /
`default`):

```cpp
for (enode* n : m_lambdas)
    for (enode* p : n->get_parents())
        if (ctx.is_relevant(p) && !is_default(p) && !ctx.is_beta_redex(p, n)) {
            ...
            return true;   // -> FC_GIVEUP -> unknown
        }
```

Commit `63259d8a4` (2026-06-29, *"add missing registration of lambdas with legacy
array solver, add missing beta reduction axiom"*) added
`apply_sort_cnstr(q, e)` to `context::internalize_lambda`
(`src/smt/smt_internalizer.cpp:603`). That registration is correct and desirable
— it lets the legacy array solver attach beta-reduction axioms to top-level
lambdas — but it also means a lambda that occurs **only inside an equality atom**
(`lambda = array`) is now pushed into `m_lambdas`. Its `=` parent is not a beta
redex, so `has_non_beta_as_array()` newly trips on it and the solver gives up
instead of deciding the problem. The oracle for this benchmark was captured
before `63259d8a4`, hence the divergence.

Equality between an array/lambda and another array term is **fully decided by the
array theory's extensionality / interface-equality machinery** (it introduces a
fresh diff index and beta-reduces the lambda side), so such a parent does not
actually defeat completeness. Notably `context::is_shared`
(`src/smt/smt_context.cpp`) already ignores basic-family (equality) parents when
it decides sharing — `has_non_beta_as_array()` was simply missing the symmetric
skip.

## Fix

Skip equality parents in the lambda loop of `has_non_beta_as_array()` so a bare
`lambda = array` equality no longer forces a give-up:

```diff
         for (enode* n : m_lambdas)
             for (enode* p : n->get_parents())
-                if (ctx.is_relevant(p) && !is_default(p) && !ctx.is_beta_redex(p, n)) {
+                if (ctx.is_relevant(p) && !is_default(p) && !m.is_eq(p->get_expr()) && !ctx.is_beta_redex(p, n)) {
+                    // An equality parent (lambda = array) is decided by the array
+                    // theory's extensionality / interface-equality reasoning, so it
+                    // does not defeat completeness and must not force a give-up.
+                    // This mirrors context::is_shared, which likewise ignores
+                    // basic-family (equality) parents when deciding sharing.
                     TRACE(array, tout << "lambda is not a beta redex " << enode_pp(p, ctx) << "\n");
                     return true;
                 }
```

The change is intentionally narrow: it only relaxes the `m_lambdas` loop (not the
`m_as_array` loop) and only for `=` (not the broader basic family), to minimise
any soundness surface.

## Validation

The fix was validated by **rebuilding z3 from this checkout and re-running the
benchmark** (per the snapshot-capture invocation `z3 -T:20 <file>`):

- `iss-6748/bug-2.smt2` -> `sat` ✅ (matches oracle; was `unknown`)
- `iss-6748/bug-1.smt2` -> `sat` ✅ (matches oracle; was `unknown`)
- Re-ran the fixed z3 over **all 77 lambda/array benchmarks in the corpus that
  carry an oracle**: the 2 target cases are fixed and the other 75 are unchanged.
  The 6 remaining mismatches are pre-existing at `HEAD` (they diverge with *and*
  without this change) and are unrelated to this fix.
- A small **soundness battery** exercising lambda beta-reduction *through
  equalities* (e.g. `(= (lambda ...) a)` combined with `select`) returns the
  provably-correct `unsat`/`sat` answers, confirming the beta-reduction behaviour
  introduced by `63259d8a4` still fires — this fix only turns spurious `unknown`
  results back into decided ones, it does not mask beta-reduction.
- `test-z3` unit tests for the e-graph/array plugins pass.

Opened as a **draft** for human review.

_Originating discussion: https://github.com/Z3Prover/bench/discussions/2987_




> [!WARNING]
> <details>
> <summary>Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `pypi.org`
>> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28696743420) · 513.9 AIC · ⌖ 39.3 AIC · ⊞ 8.9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 28696743420, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28696743420 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->