### PR TITLE
[snapshot-regression-fix] opt: preserve strict-inequality (infinitesimal) optima in maximize_objective

### DIFF
--- a/src/opt/opt_solver.cpp
+++ b/src/opt/opt_solver.cpp
@@ -361,6 +361,21 @@ namespace opt {
         // 
         auto check_bound = [&]() {
             SASSERT(has_shared);
+            //
+            // A strict (open) optimum is represented with a non-zero
+            // infinitesimal, e.g. the supremum of 'x' subject to 'x < c' is
+            // 'c - epsilon'.  Such a bound cannot be re-validated here:
+            // mk_ge() drops the infinitesimal when constructing the bound
+            // literal (an infinitesimal is not expressible as an arithmetic
+            // atom), so 'x >= c - epsilon' is turned into the strictly
+            // stronger 'x >= c', which is unsatisfiable together with the
+            // original 'x < c' and makes this check spuriously fail.  The
+            // infinitesimal value is the exact optimum of the arithmetic
+            // relaxation, so trust it rather than discarding it in favour of
+            // an arbitrary interior model point.
+            //
+            if (!val.get_infinitesimal().is_zero())
+                return true;
             return bound_value(i, val) && l_true == m_context.check(0, nullptr);
         };
 


### PR DESCRIPTION
## Summary

Fixes a Z3 optimization regression where box/lex optimization over an **open interval** reported arbitrary feasible interior points instead of the true infimum/supremum.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/3048
- **Benchmark:** `iss-3595/bug-1.smt2` (source issue Z3Prover/z3#3595)

## Divergence

For:

```smt2
(declare-fun x () Real)
(assert (and (> x (/ 16.0 5.0)) (< x (/ 127.0 10.0))))
(minimize x)
(maximize x)
(set-option :opt.priority box)
```

the recorded oracle vs. current z3 diverge:

```diff
--- bug-1.expected.out (expected)
+++ produced (current z3)
@@ -1,5 +1,5 @@
 sat
 (objectives
- (x (+ (/ 16.0 5.0) epsilon))
- (x (+ (/ 127.0 10.0) (* (- 1.0) epsilon)))
+ (x (/ 37.0 10.0))
+ (x (/ 117.0 10.0))
 )
```

`37/10` and `117/10` are feasible **interior** points, not the infimum `16/5` (approached as `16/5 + epsilon`) or the supremum `127/10` (approached as `127/10 - epsilon`). For a strict (open) constraint the optimum is not attained by any concrete model, so it is legitimately reported with an infinitesimal.

## Root cause

Commit fdc32d0e6 ("Fix inconsistent optimization result with unvalidated LP bound", #10028 / #10040) changed `opt_solver::maximize_objective` so the arithmetic optimization hint `val` is no longer committed to `m_objective_values[i]` unless it is re-validated by the local `check_bound()` lambda. That is correct for objectives that **share symbols** with other theories (e.g. an integer objective inside the uninterpreted function used to encode a large `distinct`), where the LP hint can over-estimate an unachievable optimum.

However, `check_bound()` cannot validate a **strict/open** optimum. Such a value carries a non-zero infinitesimal (`c - epsilon` / `c + epsilon`), and `opt_solver::mk_ge()` drops the infinitesimal when constructing the bound literal (an infinitesimal is not expressible as an arithmetic atom). So validating `max x = 127/10 - epsilon` asserts the strictly stronger `x >= 127/10`, which is unsatisfiable together with the original `x < 127/10`. `check_bound()` therefore fails spuriously and the correct optimum is discarded in favour of the interior model point produced by `update_objective()`.

## Fix

In `check_bound()`, trust `val` when it has a non-zero infinitesimal: it is the exact optimum of the arithmetic relaxation and cannot be re-validated by re-asserting a (necessarily weaker, non-strict) rational bound. The zero-infinitesimal path — integer/rational objectives, including the shared-symbol case that #10028 fixed — is left unchanged, so that fix is preserved.

```cpp
auto check_bound = [&]() {
    SASSERT(has_shared);
    // A strict (open) optimum is represented with a non-zero infinitesimal...
    // mk_ge() drops the infinitesimal, turning 'x >= c - epsilon' into the
    // strictly stronger 'x >= c', which makes this check spuriously fail.
    if (!val.get_infinitesimal().is_zero())
        return true;
    return bound_value(i, val) && l_true == m_context.check(0, nullptr);
};
```

## Validation

The fix was validated by **rebuilding z3** (`./configure && make -C build`) and **re-running the benchmark** with the freshly built binary:

```
$ z3 -T:20 inputs/issues/iss-3595/bug-1.smt2
sat
(objectives
 (x (+ (/ 16.0 5.0) epsilon))
 (x (+ (/ 127.0 10.0) (* (- 1.0) epsilon)))
)
```

This now matches the recorded oracle exactly. Additional checks with the rebuilt binary:

- **Closed interval** (`>=` / `<=`): exact `16/5` / `127/10`, no spurious epsilon.
- **Integer strict** (`x > 3 && x < 10`): `4` / `9`, no epsilon.
- **Unbounded** (`x > 5`): `5 + epsilon` / `oo`.
- **Lex priority** strict interval: `127/10 - epsilon`.
- **#10028 reproducer** (integer `minimize` under `distinct`): objective value stays consistent with the achievable model value (`0`).

Created as a **draft** for human review.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28731228538) · 621.2 AIC · ⌖ 41.1 AIC · ⊞ 8.9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 28731228538, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28731228538 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->