### PR TITLE
[snapshot-regression-fix] opt: fix timeout on real-valued optimization with open (strict) optima

### DIFF
--- a/src/opt/opt_solver.cpp
+++ b/src/opt/opt_solver.cpp
@@ -320,19 +320,31 @@ namespace opt {
 
         TRACE(opt, tout << "maximize " << i << " " << val << " " << m_objective_values[i] << " " << blocker << "\n";);
         //
-        // Do NOT commit 'val' to m_objective_values yet: 'val' is only an
-        // optimization hint from the arithmetic relaxation.  When the
-        // objective shares symbols with other theories (e.g. it occurs inside
-        // an uninterpreted function such as the auxiliary function used to
-        // encode large 'distinct' constraints) the hint can over-estimate the
-        // true optimum and may not be achievable by any model.  Committing it
-        // prematurely and then failing validation (check_bound below) would
+        // Do NOT commit 'val' to m_objective_values yet for INTEGER objectives:
+        // 'val' is only an optimization hint from the arithmetic relaxation.
+        // When the objective shares symbols with other theories (e.g. it occurs
+        // inside an uninterpreted function such as the auxiliary function used
+        // to encode large 'distinct' constraints) the hint can over-estimate
+        // the true optimum and may not be achievable by any model.  Committing
+        // it prematurely and then failing validation (check_bound below) would
         // leave m_objective_values holding an unachievable bound that callers
         // such as optsmt::geometric_lex report as the optimum, together with a
         // model that does not attain it (issue #10028).  The value is only
         // committed after it has been validated, or replaced by the value of
         // an actual model in update_objective().
         //
+        // Real-valued objectives are different: their optimum can be an open
+        // infimum/supremum (a strict inequality) that no model attains, so the
+        // validation below legitimately fails even though 'val' is the correct
+        // optimum.  Deferring the commit there would make saved_objective_value()
+        // report a suboptimal model value and make geometric_lex fall back to
+        // coarse +1 stepping over a possibly huge range (timeout).  Restore the
+        // pre-#10028 behavior for reals by committing the hint eagerly; only
+        // integer objectives use the deferred, validated commit.
+        //
+        bool is_int_obj = arith_util(m).is_int(m_objective_terms.get(i));
+        if (!is_int_obj && val > m_objective_values[i])
+            m_objective_values[i] = val;
 
         if (!m_model) {
             // Without a model there is nothing to validate 'val' against; keep

--- a/src/opt/optsmt.cpp
+++ b/src/opt/optsmt.cpp
@@ -256,8 +256,13 @@ namespace opt {
                 // the value of an actual model, so replace the blocker with a
                 // model-derived tightening so the search keeps making progress
                 // toward the true optimum instead of terminating prematurely
-                // (issue #10028).
-                if (!bound_valid || delta_per_step > rational::one() || (obj == last_objective && is_int)) {
+                // (issue #10028).  This only applies to integer objectives: for
+                // real objectives the optimum may be an open infimum/supremum
+                // that no model attains, so 'bound' correctly holds the LP
+                // blocker for that strict optimum and switching to coarse +1
+                // stepping (delta_per_step is pinned to 1 for reals) would fail
+                // to converge over a large range.
+                if ((!bound_valid && is_int) || delta_per_step > rational::one() || (obj == last_objective && is_int)) {
                     m_s->push();
                     ++num_scopes;
                     bound = m_s->mk_ge(obj_index, obj + inf_eps(delta_per_step));


### PR DESCRIPTION
## Summary

Fixes a regression where **real-valued optimization objectives with an open (strict-inequality) optimum** now **time out** instead of reporting the correct optimum.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/3046
- **Benchmark:** `iss-1851/bug-1.smt2` (lexicographic minimization of three `Real` objectives with strict `<` constraints; the optimum of `q2` is the open infimum `1 + epsilon`).

## Divergence

The snapshot-regression corpus recorded `sat` + objectives + model as the oracle; current z3 nightly (`z3-4.17.0-x64-glibc-2.39`) instead produces `timeout`:

```diff
--- bug-1.expected.out (expected)
+++ produced (current z3)
@@ -1,22 +1 @@
-sat
-(objectives
- (q1 1)
- (q2  (interval (+ 1.0 epsilon) 2))
- (q3 (/ 400000000000000000000000000003.0 2.0))
-)
-(
-  (define-fun q1 () Real
-    1.0)
-  (define-fun q3 () Real
-    (/ 400000000000000000000000000003.0 2.0))
-  (define-fun q2 () Real
-    2.0)
-  (define-fun s2 () Bool
-    false)
-  (define-fun s3 () Bool
-    false)
-  (define-fun s1 () Bool
-    false)
-  (define-fun s4 () Bool
-    false)
-)
+timeout
```

## Root cause

The regression was introduced by commit `fdc32d0e6` (*"Fix inconsistent optimization result with unvalidated LP bound (#10028)"*). That change:

1. In `opt_solver::maximize_objective`, **deferred committing** the LP optimization hint `val` to `m_objective_values[i]` until it is validated by `check_bound()`. On validation failure it instead keeps the model value written by `update_objective()`.
2. In `optsmt::geometric_lex`, added a `!bound_valid` term to the condition that switches the search from the LP blocker to a coarse, model-derived `mk_ge(obj + inf_eps(delta_per_step))` tightening.

For a **real** objective whose optimum is an **open infimum/supremum** (a strict inequality that no model attains), `mk_ge()` drops the negative infinitesimal, so `check_bound()` legitimately fails — the strict optimum is genuinely not attained even though `val` is the correct optimum. This leaves `bound_valid == false`, so:

- `saved_objective_value()` no longer returns the true infimum, and
- `geometric_lex` falls back to coarse **+1 stepping** (`delta_per_step` is pinned to `1` for reals) across a range on the order of `2 × 10^29`, which never converges within the time budget → **timeout**.

The `#10028` problem is **integer** (a Golomb-ruler encoding with a large `distinct`), where the deferred-commit + model-derived stepping is exactly what is needed. Both behaviors only make sense for integer objectives.

## Fix

Gate both changed behaviors on `is_int`, restoring the exact pre-`#10028` code path for real objectives while leaving the integer path unchanged:

- **`opt_solver::maximize_objective`** — commit the hint eagerly for **real** objectives (pre-`#10028` behavior); keep the deferred, validated commit for integer objectives:
  ```cpp
  bool is_int_obj = arith_util(m).is_int(m_objective_terms.get(i));
  if (!is_int_obj && val > m_objective_values[i])
      m_objective_values[i] = val;
  ```
- **`optsmt::geometric_lex`** — only take the model-derived tightening branch on an invalid bound when the objective is integer: `!bound_valid` → `(!bound_valid && is_int)`.

For integer objectives the code is byte-for-byte equivalent to the current behavior, so the `#10028` fix is fully preserved.

## Validation

The fix was validated by **rebuilding z3** (`./configure && make -C build -j$(nproc)`) and re-running the benchmark with the same options the snapshot capture uses (`z3 -T:20 inputs/issues/iss-1851/bug-1.smt2`):

- **`iss-1851/bug-1.smt2`** — output is now a **byte-exact match** with the recorded `bug-1.expected.out` oracle (`sat` + the objectives + model shown above).
- **`#10028` integer reproducer** (Golomb ruler) — a smaller instance (n=7) returns objective `25` with a consistent model (`x6 = 25`), the true optimum; the deferred/validated integer path is unchanged.
- Additional spot checks: integer `maximize`/`minimize`, real bounded `maximize`, integer `lex`, and real strict-supremum (`x < 5.0` → `5.0 - epsilon`) all produce correct results.

Opened as a **draft** for human review.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28731227714) · 598.7 AIC · ⌖ 44.7 AIC · ⊞ 8.9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 28731227714, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28731227714 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->