### PR TITLE
[snapshot-regression-fix] lp: restore deterministic integer heuristic gates by default (random_hammers=false)

### DIFF
--- a/src/math/lp/lp_params_helper.pyg
+++ b/src/math/lp/lp_params_helper.pyg
@@ -14,6 +14,6 @@ def_module_params(module_name='lp',
                           ('lcube', BOOL, True, 'use the largest cube test for integer feasibility'),
                           ('lcube_flips', UINT, 16, 'maximal number of coordinate flips when repairing the rounded largest cube center, only relevant when lcube is true'),
                           ('int_hammer_period', UINT, 4, 'period (in final_check calls) for the integer cut/cube heuristics (find_cube, hnf, gomory); a smaller value calls them more often'),
-                          ('random_hammers', BOOL, True, 'draw the periodic integer heuristic gates (find_cube, lcube, hnf, gomory, dio) at random with the same 1/period rate instead of a deterministic every-k-th-call modulus'),
+                          ('random_hammers', BOOL, False, 'draw the periodic integer heuristic gates (find_cube, lcube, hnf, gomory, dio) at random with the same 1/period rate instead of a deterministic every-k-th-call modulus'),
                          ))
                          

--- a/src/math/lp/lp_settings.h
+++ b/src/math/lp/lp_settings.h
@@ -267,7 +267,7 @@ private:
     unsigned         m_dio_calls_period = 4;
     unsigned         m_dio_calls_period_decrease = 2;
     bool             m_dio_run_gcd = true;
-    bool             m_random_hammers = true;
+    bool             m_random_hammers = false;
     bool             m_lcube = true;
     unsigned         m_lcube_flips = 16;
 public:


### PR DESCRIPTION
## Summary

Fixes a snapshot-regression divergence reported in `Z3Prover/bench` discussion
https://github.com/Z3Prover/bench/discussions/3047

- **Benchmark:** `iss-3072/bug-1.smt2` (dillig-family nonlinear integer arithmetic; `(set-logic ALL)`, `div` by variables)
- **Divergence kind:** `diff` — recorded oracle `sat`, current z3 `timeout`
- **z3 under test:** `z3-4.17.0-x64-glibc-2.39` (Nightly)
- **Budget:** per-file `20s`

### Divergence diff (from the discussion)

```diff
--- bug-1.expected.out (expected)
+++ produced (current z3)
@@ -1 +1 @@
-sat
+timeout
```

## Root cause

Commit 57fb71900 (#9958) introduced the `lp.random_hammers` parameter with default
`true`. This changed the periodic integer heuristic gates (`find_cube`, `lcube`,
`hnf`, `gomory`, `dio`) in `int_solver.cpp` from a deterministic
`m_number_of_calls % period == 0` schedule to a randomized draw
(`settings().random_next(period) == 0`) via the new `hit_period()` helper.

The randomized schedule is seeded from `smt.random_seed` (default `0`). The draw is
geometric, so the gap between two firings of a given heuristic is unbounded. For this
benchmark the **default seed** produces a pathological interleaving: z3 keeps
branching (`:arith-branch` 63 vs 26, `:final-checks` 78+ vs 49) without ever hitting
the productive cut/cube sequence, and no longer converges within the 20s budget.

Empirically pinpointed with the freshly built binary:

| configuration | result |
| --- | --- |
| default HEAD (`random_hammers=true`, seed 0) | **timeout** |
| `lp.random_hammers=false` | **sat** in ~5.4s |
| `lp.random_hammers=true` seed 1 / 555 / 12345 | sat in ~0.1s |
| `lp.random_hammers=true` seed 42 | sat in ~5.1s |

So this is a heuristic-scheduling regression, not a soundness bug: the answer is still
correct (`sat`) whenever it is found. The snapshot capture runs with empty `z3_opts`,
so the **compiled default** is what regressed.

## Fix

Restore the previously shipped **deterministic** gate schedule as the default by
flipping `random_hammers` to `false`, in the authoritative `.pyg` and the matching
`lp_settings.h` field initializer. The randomized mode is fully preserved as an
opt-in via `lp.random_hammers=true` (e.g. for the aggregate evaluation in #9958).

```
 src/math/lp/lp_params_helper.pyg | 2 +-
 src/math/lp/lp_settings.h        | 2 +-
```

## Validation (rebuilt + reran)

Built this checkout (`./configure && make -C build -j`) and re-ran the failing
benchmark with the same option the snapshot capture uses:

```
$ z3 -T:20 inputs/issues/iss-3072/bug-1.smt2
sat            # ~5.4s, matches the recorded oracle
```

- Default (this fix): `sat`, deterministic across repeated runs.
- Forcing the old behavior back on (`lp.random_hammers=true`): `timeout` — confirming
  the default flip is exactly what resolves the divergence.

## Note for reviewers

This is a **draft**. It reverts the *default* of an intentional, aggregate-evaluated
heuristic (#9958 reported a net QF_LIA improvement, evaluated with
`smt.random_seed=555`). I measured only the regressing benchmark plus a handful of
seeds, not the full QF_LIA set. The conservative choice here is to default to the
known-good deterministic schedule and keep randomization opt-in; a maintainer may
instead prefer to keep randomization on but bound its worst-case starvation gap, or
accept the per-instance variance. Please weigh the aggregate tradeoff.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28731228121) · 657.1 AIC · ⌖ 38.5 AIC · ⊞ 8.9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 28731228121, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28731228121 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->