### PR TITLE
[snapshot-regression-fix] Fix optimization regression: keep infinitesimal (epsilon) LP optimum for open bounds

### DIFF
--- a/src/opt/opt_solver.cpp
+++ b/src/opt/opt_solver.cpp
@@ -358,9 +358,25 @@ namespace opt {
 
         // 
         // check that "val" obtained from optimization hint is a valid bound.
+        //
+        // A hint with a non-zero infinitesimal denotes an *open* (strict)
+        // optimum: the objective approaches "val" but no concrete model attains
+        // it (e.g. minimizing a real x subject to x > 0, whose infimum is the
+        // unattained 0, reported as "epsilon").  check_bound validates a hint by
+        // asserting the objective is >= val (mk_ge) and searching for a model
+        // that reaches it, but mk_ge cannot faithfully encode the infinitesimal
+        // (a negative infinitesimal is dropped, a positive one becomes a strict
+        // bound), so this search always fails spuriously for an open optimum.
+        // In that case the arithmetic relaxation value is exact, so accept the
+        // hint rather than discarding the true optimum and falling back to an
+        // attainable - and therefore strictly worse - model value (issue #5314).
+        // Hints without an infinitesimal (such as the integer objective of
+        // #10028) are still validated normally, preserving that fix.
         // 
         auto check_bound = [&]() {
             SASSERT(has_shared);
+            if (!val.get_infinitesimal().is_zero())
+                return true;
             return bound_value(i, val) && l_true == m_context.check(0, nullptr);
         };
 


### PR DESCRIPTION
## Summary

Fixes a Z3 optimization regression where an **open (strict) real optimum** was reported as an attainable model value instead of its correct infinitesimal (`epsilon`) value.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/3051
- **Benchmark:** `iss-5314/bug-1.smt2` (from `Z3Prover/bench`, derived from z3 issue #5314)
- **Regressing commit:** `fdc32d0e6` ("Fix inconsistent optimization result with unvalidated LP bound (#10028)")

The benchmark is minimal:

```smt2
(set-logic ALL)
(declare-fun x () Real)
(assert (> x 0.0))
(minimize x)
(check-sat)
(get-objectives)
```

The infimum of `x` subject to `x > 0` is `0`, and it is **not attained**, so the correct answer is the infinitesimal `epsilon` (`0 + ε`).

## Divergence

```diff
--- bug-1.expected.out (expected)
+++ produced (current z3)
@@ -1,4 +1,4 @@
 sat
 (objectives
- (x epsilon)
+ (x 1)
 )
```

## Root cause

For `(minimize x)` z3 internally **maximizes `-x`**. The arithmetic (LP) relaxation returns the correct open supremum as a hint: `val = 0 - ε` (an `inf_eps` with a non-zero, here negative, infinitesimal).

`opt_solver::maximize_objective` validates this hint with `check_bound()`, which asserts the objective is `>= val` via `mk_ge(i, val)` and looks for a model that reaches it. But `mk_ge` **cannot faithfully encode an infinitesimal bound**:

```cpp
inf_eps val = _val;
if (val.get_infinitesimal().is_neg()) {
    val = inf_eps(val.get_rational());   // negative infinitesimal is dropped
}
```

So it drops the negative infinitesimal and asserts `-x >= 0` (i.e. `x <= 0`), which contradicts `x > 0`. The validation search is therefore **spuriously UNSAT** — an open optimum can never be attained by a concrete model, so this check always yields a false negative for infinitesimal bounds.

Before `fdc32d0e6`, the hint `val` was committed to `m_objective_values` up front, so this false negative was masked. That commit (correctly, for #10028) stopped committing the hint before validation — but as a side effect, on the false-negative path `m_objective_values` is now left holding the concrete model value (`x = 1`) instead of the true infinitesimal optimum, and `optsmt::geometric_lex` reports it as the answer. Hence `(x 1)` instead of `(x epsilon)`.

## Fix

`src/opt/opt_solver.cpp` — treat a hint carrying a **non-zero infinitesimal** as valid inside `check_bound()`. Such a value denotes an open bound that no concrete model can attain and that `mk_ge` cannot represent, so the arithmetic relaxation value is exact and must be kept:

```cpp
auto check_bound = [&]() {
    SASSERT(has_shared);
    if (!val.get_infinitesimal().is_zero())
        return true;
    return bound_value(i, val) && l_true == m_context.check(0, nullptr);
};
```

This is minimal and preserves the #10028 fix: that issue's objective is an **integer**, which never carries an infinitesimal, so the guard does not fire and its hint is still validated (and rejected/model-fallback) exactly as before.

## Validation

The fix was validated by **rebuilding z3 from this checkout and re-running the benchmark** (not fabricated):

- Rebuilt `./z3` (`make -C build -j$(nproc)`), Z3 4.17.0.
- Re-ran the benchmark with the same budget the snapshot capture uses:
  `z3 -T:20 inputs/issues/iss-5314/bug-1.smt2` now prints exactly:

  ```
  sat
  (objectives
   (x epsilon)
  )
  ```

  — a byte-for-byte match with the recorded `bug-1.expected.out` oracle (empty `diff`).

Additional sanity checks with the rebuilt binary:

- `maximize x` s.t. `x <= 5` → `(x 5)`; s.t. `x < 5` → `(x (+ 5 (* -1 epsilon)))` (open bound, correct).
- `minimize x` s.t. `x > 2` → `(x (+ 2 epsilon))` (same category as this fix, correct).
- `minimize`/`maximize` integer objectives (`x >= 3` → `3`, `x <= 7` → `7`) unchanged.
- Shared-symbol **integer** objective through a `distinct` with > 32 arguments (the #10028 encoding path) still returns a consistent optimum — the guard does not fire for integer objectives.

## Notes / uncertainty

The change restores the pre-`fdc32d0e6` behavior specifically for infinitesimal (open) optima, where `check_bound` is structurally unable to validate the bound and always fails. For a hypothetical shared-symbol **real** objective whose LP relaxation produced an infinitesimal over-estimate, this trusts the relaxation value — but that matches the long-standing pre-regression behavior and cannot affect #10028 (integer). Opened as a **draft** for maintainer review.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28731229655) · 658.5 AIC · ⌖ 38.6 AIC · ⊞ 8.9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 28731229655, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28731229655 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->