### PR TITLE
[snapshot-regression-fix] opt: preserve exact strict supremum/infimum optima (iss-7578)

### DIFF
--- a/src/opt/opt_solver.cpp
+++ b/src/opt/opt_solver.cpp
@@ -312,6 +312,16 @@ namespace opt {
         inf_eps val = get_optimizer().maximize(v, blocker, has_shared);
         m_context.get_model(m_model);
         inf_eps val2;
+        //
+        // 'has_shared' as returned by maximize() is false only when the
+        // arithmetic solver proved an *exact* optimum: a pure-LP optimum with
+        // no shared-symbol or integrality relaxation (theory_lra returns an
+        // exact optimum only for lp_status::OPTIMAL; theory_arith only when no
+        // shared symbols or nonlinear monomials are involved).  Capture it
+        // before it is overwritten below; it tells us whether a strict
+        // supremum hint is trustworthy enough to adopt without validation.
+        //
+        bool exact_optimum = !has_shared;
         has_shared = true;
         TRACE(opt, tout << (has_shared?"has shared":"non-shared") << " " << val << " " << blocker << "\n";
               if (m_model) tout << *m_model << "\n";);
@@ -341,6 +351,28 @@ namespace opt {
                 m_objective_values[i] = val;
             return true;
         }
+
+        //
+        // The arithmetic solver proved an exact optimum (exact_optimum) whose
+        // value is a strict supremum: a finite value carrying a non-zero
+        // infinitesimal, e.g. 'maximize a' subject to 'a < 0' yields -epsilon.
+        // Such a bound is genuinely achievable in the limit but cannot be
+        // re-validated by check_bound() below: mk_ge() has to drop the negative
+        // infinitesimal (the strict real bound 'a >= q - epsilon' is not
+        // expressible), so the subsequent assert+check is UNSAT and the hint
+        // would otherwise be discarded, leaving m_objective_values holding the
+        // strictly smaller current model value (regression from #10028;
+        // discussion Z3Prover/bench#3059).  Adopt it here.  This is restricted
+        // to proved-exact optima: for shared-symbol or relaxed hints
+        // (has_shared) the value may over-estimate the true optimum and is
+        // still deferred to validation below, so the soundness fix of #10028
+        // (and the revert of #10052) is preserved.  update_objective() only
+        // ever raises the stored value, so a genuine larger model value still
+        // wins.
+        //
+        if (exact_optimum && val.is_finite() && !val.get_infinitesimal().is_zero() &&
+            val > m_objective_values[i])
+            m_objective_values[i] = val;
 
         //
         // retrieve value of objective from current model and update 

--- a/src/smt/theory_lra.cpp
+++ b/src/smt/theory_lra.cpp
@@ -4089,6 +4089,11 @@ public:
             return value(v);
         case lp::lp_status::FEASIBLE:
             TRACE(arith, display(tout << st << " v" << v << " vi: " << vi << "\n"););
+            // FEASIBLE (as opposed to OPTIMAL) means the returned value is only
+            // a hint: the exact optimum could not be proved, e.g. integrality
+            // forced a fallback to a feasible assignment.  Flag it as shared so
+            // the optimizer validates the bound instead of adopting it eagerly.
+            has_shared = true;
             blocker = mk_gt(v);
             return value(v);
         default:
@@ -4118,8 +4123,12 @@ public:
         else {
             st = max_with_lp(v, vi, term_max);
             inf_eps nl_result;
-            if (max_with_nl(v, st, level, blocker, nl_result))
+            if (max_with_nl(v, st, level, blocker, nl_result)) {
+                // NLA returned a feasible hint rather than a proved optimum;
+                // mark it as shared so the optimizer validates it.
+                has_shared = true;
                 return nl_result;
+            }
         }
         return max_result(v, vi, st, blocker, has_shared);
     }


### PR DESCRIPTION
## Snapshot-regression fix

**Originating discussion:** https://github.com/Z3Prover/bench/discussions/3059
**Benchmark:** `iss-7578/bug-1.smt2` (`inputs/issues/iss-7578/` in `Z3Prover/bench`)
**z3 under test:** `z3-4.17.0-x64-glibc-2.39` (Nightly)

### Divergence

The benchmark maximizes a real `a` subject to `a < 0` under `opt.priority=box`.
The recorded oracle expects the strict supremum `-epsilon`, but current z3 reports
a suboptimal feasible value `-1/4`:

```diff
--- bug-1.expected.out (expected)
+++ produced (current z3)
@@ -1,5 +1,5 @@
 sat
 (objectives
- (a (* (- 1.0) epsilon))
+ (a (- (/ 1.0 4.0)))
  ((abs (to_int a)) oo)
 )
```

### Root cause

`opt_solver::maximize_objective` obtains the exact LP optimum from
`get_optimizer().maximize(...)`. For a strict real optimum the value is a finite
number carrying a non-zero infinitesimal (`-epsilon`). Since #10028 this hint is
no longer committed eagerly; it is deferred to `check_bound()`. But `check_bound()`
can never validate a strict supremum: `mk_ge()` has to drop the negative
infinitesimal (the strict real bound `a >= q - epsilon` is not expressible in the
solver), so the re-assert + check is UNSAT and the exact optimum is discarded,
leaving `m_objective_values` holding the strictly smaller current model value
(`-1/4`).

An earlier fix (#10052) re-committed the infinitesimal hint unconditionally and
was **reverted** (#10057) as unsound: for a *shared-symbol* objective the LP
relaxation only yields a hint that may strictly over-estimate the true optimum
(e.g. the Golomb-ruler case where the objective depends on the auxiliary UF that
encodes a `distinct` over more than 32 integer arguments).

### The fix

Follow the revert's prescription and gate the eager commit on a **proved-exact**
optimum:

- `src/smt/theory_lra.cpp`: the `has_shared` flag returned from `maximize()` now
  means "*not* a proved-exact optimum". Only `lp::lp_status::OPTIMAL` keeps
  `has_shared == false`; the `FEASIBLE` fallback (integrality relaxation) and the
  NLA early-return (a feasible hint, not a proved optimum) now set
  `has_shared = true`.
- `src/opt/opt_solver.cpp`: capture `exact_optimum = !has_shared` *before* the
  existing unconditional `has_shared = true` (which is kept, so all downstream
  validation is byte-identical), and adopt the value eagerly only when
  `exact_optimum && val.is_finite() && !val.get_infinitesimal().is_zero() && val > current`.

This restores the strict single-objective supremum/infimum (issue #5720,
discussion `Z3Prover/bench#3059`) while keeping shared-symbol / relaxed hints
deferred to validation, so the soundness fix of #10028 (and the revert of #10052)
is preserved. `update_objective()` only ever raises the stored value, so a genuine
larger model value still wins. The eager commit is strictly narrower than the
pre-#10028 behavior (finite strict optima with a proved-exact status only), so it
cannot introduce any unsoundness that did not already exist before #10028.

### Validation (rebuilt z3, re-ran the benchmark)

Rebuilt the patched `./z3` (`./configure && make -C build -j`) and re-ran with the
snapshot capture options (`-T:20`):

- **iss-7578**: output is now **byte-exact** with the recorded oracle
  (`(a (* (- 1.0) epsilon))`, `((abs (to_int a)) oo)`).
- **#5720** (`maximize r` s.t. `r < 1`): now `1 - epsilon` (was `0` after the
  #10052 revert).
- **Soundness — reconstructed #10057 shared-symbol counterexample** (6-mark Golomb
  ruler, real `obj > x5`, `x5` shared via a 40-argument `distinct`): the patched
  binary reports the consistent optimum `(obj (+ 17.0 epsilon))` with a consistent
  model — **not** the unsound `5 + epsilon` that #10052 produced. This is the exact
  case the previous fix got wrong.
- Basic opt sanity: non-strict `maximize` → exact value; `Int` `a < 10` → `9`;
  unbounded → `oo`; box / lex multi-objective all correct.

Opened as a **draft** for human review.




> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/28844842296) · 791.5 AIC · ⌖ 43.7 AIC · ⊞ 8.9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 28844842296, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/28844842296 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->