### PR TITLE
[snapshot-regression-fix] Fix MBQI model-construction regression on UFLIA (iss-5421)

### DIFF
--- a/src/smt/smt_model_finder.cpp
+++ b/src/smt/smt_model_finder.cpp
@@ -2675,27 +2675,16 @@ namespace smt {
             obj_map<expr, expr*> const& inv = s->get_inv_map();
             if (inv.empty())
                 continue; // nothing to do
-            expr_ref_vector eqs(m), defs(m);
-            
-            for (auto const& [val, term] : inv) {
-                if (val->get_sort() == sk->get_sort()) {
-                    if (is_lambda(term)) {
-                        eqs.push_back(m.mk_eq(sk, val));
-                        defs.push_back(m.mk_eq(val, term));
-                    }
-                    else 
-                       eqs.push_back(m.mk_eq(sk, val));
-                }
+            ptr_buffer<expr> eqs;
+            for (auto const& [val, _] : inv) {
+                if (val->get_sort() == sk->get_sort())
+                    eqs.push_back(m.mk_eq(sk, val));
             }
             if (!eqs.empty()) {
                 expr_ref new_cnstr(m);
                 new_cnstr = m.mk_or(eqs);
                 TRACE(model_finder, tout << "assert_restriction:\n" << mk_pp(new_cnstr, m) << "\n";);
                 aux_ctx->assert_expr(new_cnstr);
-                for (auto def : defs) {
-                    TRACE(model_finder, tout << "assert_def:\n" << mk_pp(def, m) << "\n";);
-                    aux_ctx->assert_expr(def);
-                }
                 asserted_something = true;
             }
         }


### PR DESCRIPTION
## Summary

Fixes an MBQI model-construction regression that caused a previously-`sat` UFLIA benchmark to now **time out**.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/2658
- **Benchmark:** `iss-5421/UFLIA_4.smt2` (from `Z3Prover/bench`)

## Divergence

The snapshot-regression corpus records `sat` as the oracle, but current `master` diverges to a timeout:

```diff
--- expected
+++ current
-sat
+timeout
```
(The leading SMT2 parse-error lines from the `?f'` apostrophe token are benign and present identically in both expected and current output.)

## Root cause

Bisection identifies commit `5699142f5` ("Term enumeration (#9908)") as the first bad commit. Within it, the change in `restrict_sks_to_inst_set` (`src/smt/smt_model_finder.cpp`) began asserting extra lambda **definition** equalities `val = term` (for inverse entries whose term is a lambda) into the auxiliary restriction context, in addition to the skolem restriction `sk = val`:

```cpp
if (is_lambda(term)) {
    eqs.push_back(m.mk_eq(sk, val));
    defs.push_back(m.mk_eq(val, term));   // extra assertion
}
...
for (auto def : defs)
    aux_ctx->assert_expr(def);
```

These extra `defs` over-constrain the auxiliary solver used during MBQI. On this benchmark the auxiliary context becomes unsatisfiable/unusable, so MBQI model construction fails (`smt.mbqi :failed`), and the solver loops in final-check (repeated restarts) until the timeout — even though a satisfying model exists.

I verified this by an isolated revert: reverting *only* this hunk (keeping the rest of the term-enumeration feature, including the `ho_var` class) restores `sat`, whereas reverting any of the other behavioral hunks (`get_inv` linear scan, `insert` closed-term change, `eval` lambda→fresh-const) individually or in combination did **not**.

## Fix

Restore the original restriction: constrain each skolem to one of its inverse values without asserting the lambda-definition equalities into the auxiliary context. This is a minimal, targeted revert of just the over-constraining part; the rest of the term-enumeration feature is untouched.

```
1 file changed, 4 insertions(+), 15 deletions(-)
```

## Validation

- Rebuilt `z3` from this branch (`python3 scripts/mk_make.py && make -C build -j16`).
- Re-ran the benchmark with the same options the snapshot capture uses:
  `z3 UFLIA_4.smt2 -T:20` → now prints `sat`, matching the recorded `UFLIA_4.expected.out` oracle exactly (`diff` clean).

Opened as a **draft** for human review.




> [!WARNING]
> <details>
> <summary>Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `pypi.org`
>> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/29072294350) · 895.8 AIC · ⌖ 23.1 AIC · ⊞ 8.9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 29072294350, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/29072294350 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->