### PR TITLE
[snapshot-regression-fix] Fix array lambda final-check livelock on nested arrays (iss-6364)

### DIFF
--- a/src/smt/smt_internalizer.cpp
+++ b/src/smt/smt_internalizer.cpp
@@ -671,10 +671,9 @@ namespace smt {
         SASSERT(is_lambda(q));
         if (e_internalized(q)) 
             return;
-        auto e = mk_enode(q, true, /* do suppress args */
+        mk_enode(q, true, /* do suppress args */
                     false,    /* it is a term, so it should not be merged with true/false */
                     true);
-        apply_sort_cnstr(q, e);
     }
 
     bool context::has_lambda() {


### PR DESCRIPTION
## Summary

Fixes a snapshot-regression divergence tracked in Z3Prover/bench discussion https://github.com/Z3Prover/bench/discussions/2985.

- **Benchmark:** `iss-6364/small-5.smt2` (`inputs/issues/iss-6364/` in `Z3Prover/bench`)
- **Kind:** `diff`
- **Recorded oracle (expected):** `sat`
- **Current z3 (before this fix):** `timeout`

### Divergence diff

```diff
--- expected
+++ current
-sat
+timeout
```

## Root cause

Bisection identified commit `63259d8a4` ("add missing registration of lambdas with legacy array solver, add missing beta reduction axiom") as the first bad commit. That change added, in `internalize_lambda` (smt_internalizer.cpp), a call to `apply_sort_cnstr(q, e)` which registers lambda enodes as array-theory variables in the legacy array solver (`theory_array_full`).

For this benchmark — a quantified formula over nested arrays `(Array Int (Array Int Real))` — that registration makes the array theory attempt select-over-lambda beta-reduction / interface reasoning during `final_check`, which never converges: statistics show ~4,000,000 `final-checks` with only 1 quantifier instantiation, bounded axiom counts, and 6 decisions. This is a non-terminating final-check livelock rather than an axiom explosion, so the solver times out instead of returning `sat`.

## Fix

Revert the lambda→array-solver registration in `internalize_lambda`, restoring the pre-`63259d8a4` behaviour where lambda enodes are not registered as array-theory variables. This is a minimal, surgical change (2 lines) that eliminates the livelock.

> Note (draft for human review): this reverts the registration the culprit commit added to close a completeness gap for some lambda-array cases. The added beta-reduction axiom code remains but is dormain without the registration. A maintainer should confirm whether the completeness case that motivated `63259d8a4` needs a more targeted re-implementation that avoids this livelock.

## Validation

Built the `./z3` checkout and re-ran the failing benchmark with the freshly built binary using the snapshot capture options (`-T:20`):

```
$ ./build/z3 -T:20 inputs/issues/iss-6364/small-5.smt2
sat
```

The rebuilt z3 now returns `sat`, matching the recorded `small-5.expected.out` oracle (confirmed across repeated runs).




> [!WARNING]
> <details>
> <summary>Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `pypi.org`
>> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/29141292662) · 916.5 AIC · ⌖ 24.1 AIC · ⊞ 8.9K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.63, model: claude-opus-4.8, id: 29141292662, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/29141292662 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->