### PR TITLE
[snapshot-regression-fix] smt: fix seq/regex timeout regression in theory::mk_literal quantifier internalization

### DIFF
--- a/src/smt/smt_theory.cpp
+++ b/src/smt/smt_theory.cpp
@@ -152,8 +152,12 @@ namespace smt {
         expr_ref e(_e, m);
         bool is_not = m.is_not(_e, _e);
         if (!ctx.e_internalized(_e)) {
-            auto n = ctx.non_ground_internalize(_e);
-            _e = n->get_expr();            
+            if (is_quantifier(_e))
+                ctx.internalize(_e, true);
+            else {
+                auto n = ctx.non_ground_internalize(_e);
+                _e = n->get_expr();
+            }
         }
         literal lit = ctx.get_literal(_e);
         ctx.mark_as_relevant(lit);


### PR DESCRIPTION
## Summary

Fixes a performance regression in the sequence/regex solver where a benchmark that previously returned `unknown (incomplete (theory seq))` instantly now runs until the `-T:` timeout.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/3132
- **Benchmark ref:** `iss-5873/bug-1.smt2` (Z3Prover/bench)

## Divergence

```diff
--- bug-1.expected.out (expected)
+++ produced (current z3)
@@ -1,3 +1 @@
-unknown
-(error "line 12 column 25: model is not available")
-(:reason-unknown "smt tactic failed to show goal to be sat/unsat (incomplete (theory seq))")
+timeout
```

The benchmark asks whether there is a regex `R` with `R* = allchar*`:

```smt2
(declare-fun tmp_reglan0 () (RegEx String))
(assert (= (re.* tmp_reglan0) (re.* re.allchar)))
(check-sat)
```

## Root cause

Bisection points to commit `382abb786` ("disable term enumeration by default"). Z3 4.8.5, 4.13.3, 4.15.3 and the parent commit `1d425e55c` all return the quick `unknown (incomplete (theory seq))` answer; only builds including `382abb786` time out. All ten random seeds (`sat.random_seed`/`smt.random_seed` = 0..9) time out deterministically, so this is a stable regression rather than seed-dependent flakiness.

That commit changed `theory::mk_literal` to route through the new `context::non_ground_internalize` helper. For a **top-level quantifier** literal — such as the universally-quantified emptiness condition built in `seq_regex.cpp` (`th.mk_literal(mk_forall(...))`) — `non_ground_internalize` takes its non-ground proxy branch: it allocates a fresh proxy constant, asserts `proxy = <quantifier>`, and internalizes assertions, instead of internalizing the quantifier directly (the previous `ctx.internalize(_e, is_quantifier(_e))` path). This engages quantifier instantiation on a goal the seq theory used to discharge immediately as incomplete, producing the timeout.

## Fix

In `theory::mk_literal`, internalize quantifier expressions directly (as before), and only use `non_ground_internalize` for non-quantifier expressions:

```cpp
if (!ctx.e_internalized(_e)) {
    if (is_quantifier(_e))
        ctx.internalize(_e, true);
    else {
        auto n = ctx.non_ground_internalize(_e);
        _e = n->get_expr();
    }
}
```

This preserves the intended `non_ground_internalize` routing for terms with embedded quantifiers while restoring the fast path for top-level quantifier literals.

## Validation

Built this branch and re-ran the benchmark with the snapshot options (`-T:20`):

- Output now matches the recorded oracle exactly (`unknown` / `model is not available` / `incomplete (theory seq)`).
- Stable across random seeds 0, 3, 7 (all return `unknown` quickly).
- Basic sanity checks still pass (`sat`/`unsat`/regex membership).

## Note for reviewers

The minimal alternative of fully reverting the `mk_literal` change also restores the oracle, but would undo the helper's intended routing for all theories. This guarded variant keeps that routing for non-quantifier expressions. A reviewer familiar with the `non_ground_internalize` design should confirm the guard doesn't regress the higher-order matching improvements the original commit targeted.




> [!WARNING]
> <details>
> <summary>Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `pypi.org`
>> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "pypi.org"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/29184140450) · 365.8 AIC · ⌖ 21.7 AIC · ⊞ 10.7K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.65, model: claude-opus-4.8, id: 29184140450, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/29184140450 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->