### PR TITLE
[snapshot-regression-fix] Revert "distribute quantifiers over Booleans" (e-matching completeness regression)

### DIFF
--- a/src/ast/rewriter/th_rewriter.cpp
+++ b/src/ast/rewriter/th_rewriter.cpp
@@ -767,62 +767,6 @@ struct th_rewriter_cfg : public default_rewriter_cfg {
     }
 
 
-    // Distribute a quantifier over the top-level boolean connective of its body:
-    //   forall x . (A /\ B)   -->  (forall x. A) /\ (forall x. B)
-    //   forall x . ~(A \/ B)  -->  (forall x. ~A) /\ (forall x. ~B)
-    //   exists x . (A \/ B)   -->  (exists x. A) \/ (exists x. B)
-    //   exists x . ~(A /\ B)  -->  (exists x. ~A) \/ (exists x. ~B)
-    // Each rule is a validity, and the distributed sub-quantifiers give the
-    // e-matching engine finer-grained instantiation targets.
-    bool distribute_quantifier(quantifier * old_q, expr * new_body, expr_ref & result) {
-        if (old_q->get_kind() == lambda_k)
-            return false;
-        if (old_q->has_patterns())
-            return false;
-        bool is_forall = old_q->get_kind() == forall_k;
-        expr_ref_vector args(m());
-        expr * arg = nullptr;
-        if (is_forall) {
-            if (m().is_and(new_body))
-                args.append(to_app(new_body)->get_num_args(), to_app(new_body)->get_args());
-            else if (m().is_not(new_body, arg) && m().is_or(arg))
-                for (expr * e : *to_app(arg))
-                    args.push_back(m().mk_not(e));
-            else
-                return false;
-        }
-        else {
-            if (m().is_or(new_body))
-                args.append(to_app(new_body)->get_num_args(), to_app(new_body)->get_args());
-            else if (m().is_not(new_body, arg) && m().is_and(arg))
-                for (expr * e : *to_app(arg))
-                    args.push_back(m().mk_not(e));
-            else
-                return false;
-        }
-        if (args.size() < 2)
-            return false;
-        expr_ref_vector quants(m());
-        for (expr * a : args) {
-            quantifier_ref sub(m());
-            sub = m().mk_quantifier(old_q->get_kind(),
-                                    old_q->get_num_decls(),
-                                    old_q->get_decl_sorts(),
-                                    old_q->get_decl_names(),
-                                    a,
-                                    old_q->get_weight(),
-                                    old_q->get_qid(),
-                                    old_q->get_skid(),
-                                    0, nullptr, 0, nullptr);
-            quants.push_back(m_elim_unused_vars(sub));
-        }
-        if (is_forall)
-            result = m().mk_and(quants);
-        else
-            result = m().mk_or(quants);
-        return true;
-    }
-
     bool reduce_quantifier(quantifier * old_q,
                            expr * new_body,
                            expr * const * new_patterns,
@@ -873,12 +817,6 @@ struct th_rewriter_cfg : public default_rewriter_cfg {
         else if (old_q->get_kind() == lambda_k &&
                  BR_DONE == m_ar_rw.mk_lambda_core(old_q, new_body, result)) {
             // array eta-reduction: (lambda (x*) (select a x*)) --> a
-            if (m().proofs_enabled()) {
-                result_pr = m().mk_rewrite(old_q, result);
-            }
-            return true;
-        }
-        else if (distribute_quantifier(old_q, new_body, result)) {
             if (m().proofs_enabled()) {
                 result_pr = m().mk_rewrite(old_q, result);
             }


### PR DESCRIPTION
## Summary

Fixes a quantifier-reasoning regression detected by the `Z3Prover/bench` snapshot-regression corpus.

- **Originating discussion:** https://github.com/Z3Prover/bench/discussions/3198
- **Benchmark ref:** `iss-2261/bug-1.smt2` (from https://github.com/Z3Prover/z3/issues/2261)

## Divergence

The recorded oracle answers `unsat`, but current `master` answers `unknown`:

```diff
--- bug-1.expected.out (expected)
+++ produced (current z3)
@@ -1 +1 @@
-unsat
+unknown
```

This is **not** a timeout: both the old and the new binary terminate in ~0.01s. Old z3 (4.17.0) proves the goal `unsat`; current z3 returns `unknown`, i.e. it lost the ability to refute the formula. The benchmark uses `smt.mbqi=false` and `smt.ematching=true`, so the proof relies entirely on e-matching instantiation.

## Root cause

Bisection pinpoints commit `e2b9e3a6d` ("distribute quantifiers over Booleans"):

- parent `46b1c68f5` -> `unsat`
- `e2b9e3a6d` -> `unknown`

That commit added `th_rewriter_cfg::distribute_quantifier`, which rewrites a **pattern-less** quantifier over a top-level Boolean connective, e.g. `forall x. (A /\ B)  ->  (forall x. A) /\ (forall x. B)` (plus the De Morgan / exists variants). Splitting the body into separate sub-quantifiers forces z3 to re-infer patterns independently on each fragment. For this benchmark the fragmentation loses the multi-literal instantiation coverage the whole-body quantifier had, so e-matching saturates without deriving the contradiction and z3 gives up with `unknown`. The transformation is logically valid but is an e-matching **completeness** regression.

## Fix

Revert `e2b9e3a6d`, removing the `distribute_quantifier` rewrite and its call site in `reduce_quantifier` (`src/ast/rewriter/th_rewriter.cpp`, 62 deletions). The heuristic is brand-new and unreleased; reverting restores the previously-correct behaviour without affecting released functionality. If the finer-grained instantiation targets are desired, the transformation should be reintroduced behind a guard that preserves e-matching pattern coverage (e.g. only when adequate patterns can be inferred for every fragment).

## Validation

Rebuilt z3 from this branch (CMake/Ninja unavailable in the runner; built with `mk_make.py` + `make`) and re-ran the benchmark exactly as the snapshot capture does (empty `z3_opts`, `-T:20`):

- `z3 -T:20 inputs/issues/iss-2261/bug-1.smt2` -> `unsat` (matches oracle)
- 10 random seeds (`sat.random_seed=K smt.random_seed=K`, K=0..9) -> `unsat` in all 10

Before the revert the same rebuilt binary produced `unknown` for all seeds.

Created as a draft for human review.




> [!WARNING]
> <details>
> <summary>Firewall blocked 2 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `pypi.org`
> - `releaseassets.githubusercontent.com`
>> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "pypi.org"
>     - "releaseassets.githubusercontent.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Fix a Z3 snapshot-regression divergence](https://github.com/Z3Prover/bench/actions/runs/29479613574) · 454.4 AIC · ⌖ 20.3 AIC · ⊞ 10.7K · [◷](https://github.com/search?q=repo%3AZ3Prover%2Fz3+%22gh-aw-workflow-id%3A+snapshot-regression-fixer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix a Z3 snapshot-regression divergence, engine: copilot, version: 1.0.65, model: claude-opus-4.8, id: 29479613574, workflow_id: snapshot-regression-fixer, run: https://github.com/Z3Prover/bench/actions/runs/29479613574 -->

<!-- gh-aw-workflow-id: snapshot-regression-fixer -->
<!-- gh-aw-workflow-call-id: Z3Prover/bench/snapshot-regression-fixer -->