### PR TITLE
Fix incorrect unsat on regex equality with a free RegLan variable (#10137)

### DIFF
--- a/src/smt/seq_regex.cpp
+++ b/src/smt/seq_regex.cpp
@@ -423,6 +423,32 @@ namespace smt {
         return true;
     }
 
+    // A regex sub-term is "interpreted" when it is produced by the seq/re
+    // decl-plugin (re.++, re.*, str.to_re, re.allchar, re.range, ...).  An
+    // uninterpreted RegLan constant/variable (e.g. `(declare-const pre RegLan)`)
+    // is ground in the AST sense but the derivative/emptiness procedure cannot
+    // process it: mk_derivative leaves a symbolic re.derivative term and the
+    // emptiness closure diverges or derives a spurious conflict (issue #10137).
+    bool seq_regex::has_uninterp_re(expr* r) {
+        family_id fid = u().get_family_id();
+        ptr_vector<expr> todo;
+        expr_mark visited;
+        todo.push_back(r);
+        while (!todo.empty()) {
+            expr* e = todo.back();
+            todo.pop_back();
+            if (visited.is_marked(e))
+                continue;
+            visited.mark(e, true);
+            if (u().is_re(e) && (!is_app(e) || to_app(e)->get_family_id() != fid))
+                return true;
+            if (is_app(e))
+                for (expr* arg : *to_app(e))
+                    todo.push_back(arg);
+        }
+        return false;
+    }
+
     expr_ref seq_regex::symmetric_diff(expr* r1, expr* r2) {
         expr_ref r(m);
         if (r1 == r2)
@@ -531,6 +557,18 @@ namespace smt {
                 break;
             }
         }
+        // The derivative-based emptiness closure below is only sound and
+        // terminating for regexes built from interpreted regex constructors.
+        // When the symmetric difference still contains an uninterpreted regex
+        // variable there is no way to decide language equivalence:
+        // mk_derivative leaves a symbolic re.derivative term, the closure never
+        // canonicalizes, and it may loop forever or derive a spurious conflict
+        // (incorrect unsat, issue #10137).  The equation r1 = r2 is satisfiable
+        // by assigning the free regex, and congruence closure already
+        // propagates membership through the shared enode, so skip the
+        // extensional axiom in this case.
+        if (has_uninterp_re(r))
+            return;
         expr_ref emp(re().mk_empty(r->get_sort()), m);
         expr_ref f(m.mk_fresh_const("re.char", seq_sort), m); 
         expr_ref is_empty = sk().mk_is_empty(r, r, f);
@@ -563,6 +601,13 @@ namespace smt {
                 break;
             }
         }
+        // See propagate_eq: the derivative closure only decides regexes built
+        // from interpreted constructors.  For a symmetric difference that
+        // contains an uninterpreted regex variable the disequality is
+        // satisfiable by assigning the free regex, so skip the extensional
+        // axiom rather than risk non-termination (issue #10137).
+        if (has_uninterp_re(r))
+            return;
         expr_ref emp(re().mk_empty(r->get_sort()), m);
         expr_ref n(m.mk_fresh_const("re.char", seq_sort), m);
         expr_ref is_non_empty = sk().mk_is_non_empty(r, r, n);

--- a/src/smt/seq_regex.h
+++ b/src/smt/seq_regex.h
@@ -157,6 +157,12 @@ namespace smt {
 
         expr_ref symmetric_diff(expr* r1, expr* r2);
 
+        // Returns true if r contains a regex sub-term that is not built from
+        // the interpreted regex constructors (e.g. an uninterpreted RegLan
+        // constant/variable).  Such regexes are outside the decidable fragment
+        // handled by the derivative/emptiness machinery.
+        bool has_uninterp_re(expr* r);
+
         expr_ref is_nullable_wrapper(expr* r);
         expr_ref mk_derivative_wrapper(expr* hd, expr* r);
 


### PR DESCRIPTION
## Problem

Fixes #10137. Z3 returns incorrect `unsat` on a satisfiable regex formula when `proof=true`:

```smt2
(declare-const pre RegLan)
(assert (= pre (re.++ (re.++ (re.* re.allchar) (str.to_re "@")) (str.to_re "a"))))
(check-sat)
```

`sat` by default, but `unsat` with `proof=true`. `pre` is a free `RegLan` constant, so the formula is trivially satisfiable.

## Root cause

`seq_regex::propagate_eq` / `propagate_ne` turn a `RegLan` (dis)equality `r1 = r2` into an extensional `is_empty`/`is_non_empty` check of the symmetric difference and decide it with the derivative/emptiness closure. That closure is only sound and terminating for regexes built from **interpreted** regex constructors.

When one side is an uninterpreted `RegLan` constant, the symmetric difference contains a free regex term: `mk_derivative` leaves a symbolic `re.derivative` node, the closure never canonicalizes, and it either **loops forever** (timeout under `check-sat-using smt`) or **derives a spurious conflict** (incorrect `unsat`). `proof=true` merely exposes it by skipping the `solve-eqs` preprocessing that would otherwise eliminate `pre`.

The existing `is_ground` guards do not catch this because an uninterpreted constant is *ground* in the AST sense (no De Bruijn variables).

## Fix

- Add `has_uninterp_re`, which detects a regex sub-term not produced by the seq/re decl-plugin (i.e. an uninterpreted `RegLan` constant/variable).
- In `propagate_eq`/`propagate_ne`, skip the extensional axiom when the symmetric difference contains such a term.

Skipping is sound: the (dis)equality is satisfiable by assigning the free regex, and congruence closure still propagates membership through the shared enode. Removing the axiom can only avoid an undecidable emptiness query — it cannot introduce `unsat`.

## Validation

- Reproducer now returns `sat` with and without `proof=true` and under `check-sat-using smt`, with a validated model (`model_validate=true`).
- Ground regex equality/disequality reasoning unchanged (`a=b`→unsat, `a=a`→sat, `re.none=""`→unsat, `(re.* re.allchar)=re.all`→sat, `a!=b`→sat, `a!=a`→unsat).
- All 17 string/regex regressions in the test suite match expected output; all 92 unit tests pass.