### PR TITLE
Fix floating-point division normalization

### DIFF
--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -962,7 +962,6 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     const mpz & lz_modulus = m_mpf_manager.m_powers2(ebits);
     SASSERT(ebits <= sbits);
 
-    expr_ref a_sgn(m), a_sig(m), a_exp(m), a_lz(m), b_sgn(m), b_sig(m), b_exp(m), b_lz(m);
     bool needs_wide_lz = m_mpz_manager.lt(lz_modulus, mpz(sbits));
     unsigned exp_bits = ebits + 2;
     if (needs_wide_lz) {
@@ -976,8 +975,31 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
         exp_bits = m_mpz_manager.log2(max_exp) + 2;
     }
     unsigned lz_bits = needs_wide_lz ? exp_bits : ebits;
-    unpack_with_lz_width(x, a_sgn, a_sig, a_exp, a_lz, true, lz_bits);
-    unpack_with_lz_width(y, b_sgn, b_sig, b_exp, b_lz, true, lz_bits);
+
+    expr_ref a_sgn(m), a_sig(m), a_exp(m), a_lz(m), b_sgn(m), b_sig(m), b_exp(m), b_lz(m);
+    unpack(x, a_sgn, a_sig, a_exp, a_lz, false);
+    unpack(y, b_sgn, b_sig, b_exp, b_lz, false);
+
+    // Division needs the exact leading-zero count in its exponent arithmetic.
+    // Keep this local: unpack's ebits-wide count can wrap when sbits > 2^ebits.
+    expr_ref zero_sig(m), a_sig_is_zero(m), b_sig_is_zero(m);
+    zero_sig = m_bv_util.mk_numeral(0, sbits);
+    m_simp.mk_eq(zero_sig, a_sig, a_sig_is_zero);
+    m_simp.mk_eq(zero_sig, b_sig, b_sig_is_zero);
+
+    expr_ref zero_lz(m), a_lz_raw(m), b_lz_raw(m);
+    zero_lz = m_bv_util.mk_numeral(0, lz_bits);
+    mk_leading_zeros(a_sig, lz_bits, a_lz_raw);
+    mk_leading_zeros(b_sig, lz_bits, b_lz_raw);
+    m_simp.mk_ite(a_sig_is_zero, zero_lz, a_lz_raw, a_lz);
+    m_simp.mk_ite(b_sig_is_zero, zero_lz, b_lz_raw, b_lz);
+
+    SASSERT(lz_bits <= sbits);
+    expr_ref a_shift(m), b_shift(m);
+    a_shift = m_bv_util.mk_zero_extend(sbits - lz_bits, a_lz);
+    b_shift = m_bv_util.mk_zero_extend(sbits - lz_bits, b_lz);
+    a_sig = m_bv_util.mk_bv_shl(a_sig, a_shift);
+    b_sig = m_bv_util.mk_bv_shl(b_sig, b_shift);
 
     unsigned extra_bits = sbits+2;
     expr_ref a_sig_ext(m), b_sig_ext(m);
@@ -995,14 +1017,8 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     res_sgn = m_bv_util.mk_bv_xor({a_sgn, b_sgn});
 
     expr_ref a_lz_ext(m), b_lz_ext(m);
-    if (needs_wide_lz) {
-        a_lz_ext = a_lz;
-        b_lz_ext = b_lz;
-    }
-    else {
-        a_lz_ext = m_bv_util.mk_zero_extend(exp_bits - ebits, a_lz);
-        b_lz_ext = m_bv_util.mk_zero_extend(exp_bits - ebits, b_lz);
-    }
+    a_lz_ext = m_bv_util.mk_zero_extend(exp_bits - lz_bits, a_lz);
+    b_lz_ext = m_bv_util.mk_zero_extend(exp_bits - lz_bits, b_lz);
 
     res_exp = m_bv_util.mk_bv_sub(
         m_bv_util.mk_bv_sub(a_exp_ext, a_lz_ext),
@@ -3838,15 +3854,7 @@ void fpa2bv_converter::mk_unbias(expr * e, expr_ref & result) {
 
 void fpa2bv_converter::unpack(expr * e, expr_ref & sgn, expr_ref & sig, expr_ref & exp, expr_ref & lz, bool normalize) {
     SASSERT(m_util.is_fp(e));
-    sort * srt = to_app(e)->get_decl()->get_range();
-    unpack_with_lz_width(e, sgn, sig, exp, lz, normalize, m_util.get_ebits(srt));
-}
-
-void fpa2bv_converter::unpack_with_lz_width(expr * e, expr_ref & sgn, expr_ref & sig, expr_ref & exp,
-                                            expr_ref & lz, bool normalize, unsigned lz_bits) {
-    SASSERT(m_util.is_fp(e));
     SASSERT(to_app(e)->get_num_args() == 3);
-    SASSERT(lz_bits > 0);
 
     sort * srt = to_app(e)->get_decl()->get_range();
     SASSERT(is_float(srt));
@@ -3877,8 +3885,8 @@ void fpa2bv_converter::unpack_with_lz_width(expr * e, expr_ref & sgn, expr_ref &
     mk_unbias(denormal_exp, denormal_exp);
     dbg_decouple("fpa2bv_unpack_denormal_exp", denormal_exp);
 
-    expr_ref zero_lz(m);
-    zero_lz = m_bv_util.mk_numeral(0, lz_bits);
+    expr_ref zero_e(m);
+    zero_e = m_bv_util.mk_numeral(0, ebits);
 
     if (normalize) {
         expr_ref is_sig_zero(m), zero_s(m);
@@ -3886,20 +3894,20 @@ void fpa2bv_converter::unpack_with_lz_width(expr * e, expr_ref & sgn, expr_ref &
         m_simp.mk_eq(zero_s, denormal_sig, is_sig_zero);
 
         expr_ref lz_d(m), norm_or_zero(m);
-        mk_leading_zeros(denormal_sig, lz_bits, lz_d);
+        mk_leading_zeros(denormal_sig, ebits, lz_d);
         norm_or_zero = m.mk_or(is_normal, is_sig_zero);
-        m_simp.mk_ite(norm_or_zero, zero_lz, lz_d, lz);
+        m_simp.mk_ite(norm_or_zero, zero_e, lz_d, lz);
         dbg_decouple("fpa2bv_unpack_lz", lz);
 
         expr_ref shift(m);
-        m_simp.mk_ite(is_sig_zero, zero_lz, lz, shift);
+        m_simp.mk_ite(is_sig_zero, zero_e, lz, shift);
         dbg_decouple("fpa2bv_unpack_shift", shift);
         SASSERT(is_well_sorted(m, is_sig_zero));
         SASSERT(is_well_sorted(m, shift));
-        SASSERT(m_bv_util.get_bv_size(shift) == lz_bits);
-        if (lz_bits <= sbits) {
+        SASSERT(m_bv_util.get_bv_size(shift) == ebits);
+        if (ebits <= sbits) {
             expr_ref q(m);
-            q = m_bv_util.mk_zero_extend(sbits-lz_bits, shift);
+            q = m_bv_util.mk_zero_extend(sbits-ebits, shift);
             denormal_sig = m_bv_util.mk_bv_shl(denormal_sig, q);
         }
         else {
@@ -3907,9 +3915,9 @@ void fpa2bv_converter::unpack_with_lz_width(expr * e, expr_ref & sgn, expr_ref &
             // would be zero anyways. So we can safely cut the shift variable down,
             // as long as we check the higher bits.
             expr_ref zero_ems(m), sh(m), is_sh_zero(m), sl(m), sbits_s(m), short_shift(m);
-            zero_ems = m_bv_util.mk_numeral(0, lz_bits - sbits);
+            zero_ems = m_bv_util.mk_numeral(0, ebits - sbits);
             sbits_s = m_bv_util.mk_numeral(sbits, sbits);
-            sh = m_bv_util.mk_extract(lz_bits-1, sbits, shift);
+            sh = m_bv_util.mk_extract(ebits-1, sbits, shift);
             m_simp.mk_eq(zero_ems, sh, is_sh_zero);
             short_shift = m_bv_util.mk_extract(sbits-1, 0, shift);
             m_simp.mk_ite(is_sh_zero, short_shift, sbits_s, sl);
@@ -3917,7 +3925,7 @@ void fpa2bv_converter::unpack_with_lz_width(expr * e, expr_ref & sgn, expr_ref &
         }
     }
     else
-        lz = zero_lz;
+        lz = zero_e;
 
     SASSERT(is_well_sorted(m, normal_sig));
     SASSERT(is_well_sorted(m, denormal_sig));
@@ -3932,12 +3940,10 @@ void fpa2bv_converter::unpack_with_lz_width(expr * e, expr_ref & sgn, expr_ref &
     SASSERT(is_well_sorted(m, sgn));
     SASSERT(is_well_sorted(m, sig));
     SASSERT(is_well_sorted(m, exp));
-    SASSERT(is_well_sorted(m, lz));
 
     SASSERT(m_bv_util.get_bv_size(sgn) == 1);
     SASSERT(m_bv_util.get_bv_size(sig) == sbits);
     SASSERT(m_bv_util.get_bv_size(exp) == ebits);
-    SASSERT(m_bv_util.get_bv_size(lz) == lz_bits);
 
     TRACE(fpa2bv_unpack, tout << "UNPACK SGN = " << mk_ismt2_pp(sgn, m) << std::endl; );
     TRACE(fpa2bv_unpack, tout << "UNPACK SIG = " << mk_ismt2_pp(sig, m) << std::endl; );

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -1135,9 +1135,10 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
         sig_ext = m_bv_util.mk_concat(res_sig, m_bv_util.mk_numeral(0, sig_size));
         shifted_sig = m_bv_util.mk_bv_lshr(sig_ext, underflow_shift_sized);
         unsigned sig_extract_low_bit = 2 * sig_size - (sbits + 2);
-        // The shift is at most sbits + 2^(ebits - 1) - 2. If it passes the
-        // zero padding, the leading one enters this discarded range, so
-        // discarded remains true.
+        // Finite operand bounds make underflow_shift at most
+        // sbits + 2^(ebits - 1) - 2. If it exceeds the sbits + 4 appended
+        // zero bits, res_sig's normalized leading one still lands in the range
+        // reduced into discarded, so discarded remains true.
         discarded = m.mk_app(
             m_bv_util.get_fid(), OP_BREDOR,
             m_bv_util.mk_extract(sig_extract_low_bit - 1, 0, shifted_sig));
@@ -1156,8 +1157,10 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
         underflow_retained = m_bv_util.mk_extract(sbits + 1, 2, underflow_sig);
         underflow_inc = mk_rounding_decision(
             rm, res_sgn, underflow_last, underflow_round, underflow_sticky);
-        // This path shifts by at least eight bits, so the retained significand
-        // has a leading zero and rounding cannot carry into minimum normal.
+        // exp_below_round_range implies
+        // underflow_shift >= 2 + 3*2^(ebits - 1), which is at least eight for
+        // ebits >= 2. The retained significand therefore has a leading zero,
+        // so rounding cannot carry into minimum normal.
         underflow_rounded_sig = m_bv_util.mk_bv_add(
             underflow_retained,
             m_bv_util.mk_zero_extend(sbits - 1, underflow_inc));

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -4122,21 +4122,41 @@ void fpa2bv_converter::round(sort * s, expr_ref & rm, expr_ref & sgn, expr_ref &
     SASSERT(m_bv_util.get_bv_size(sigma) == ebits+2);
     unsigned sigma_size = ebits + 2;
 
-    expr_ref sigma_neg(m), sigma_cap(m), sigma_neg_capped(m), sigma_lt_zero(m), sig_ext(m),
-        rs_sig(m), ls_sig(m), big_sh_sig(m), sigma_le_cap(m);
+    expr_ref sigma_neg(m), sigma_neg_capped(m), sigma_lt_zero(m), sig_ext(m),
+        rs_sig(m), ls_sig(m), big_sh_sig(m);
     sigma_neg = m_bv_util.mk_bv_neg(sigma);
-    sigma_cap = m_bv_util.mk_numeral(sbits+2, sigma_size);
-    sigma_le_cap = m_bv_util.mk_ule(sigma_neg, sigma_cap);
-    m_simp.mk_ite(sigma_le_cap, sigma_neg, sigma_cap, sigma_neg_capped);
+    if (log2(sbits + 2) < sigma_size) {
+        expr_ref sigma_cap(m), sigma_le_cap(m);
+        sigma_cap = m_bv_util.mk_numeral(sbits + 2, sigma_size);
+        sigma_le_cap = m_bv_util.mk_ule(sigma_neg, sigma_cap);
+        m_simp.mk_ite(sigma_le_cap, sigma_neg, sigma_cap, sigma_neg_capped);
+        dbg_decouple("fpa2bv_rnd_sigma_cap", sigma_cap);
+    }
+    else {
+        // An unrepresentable cap is at least 2^sigma_size, while negating a
+        // negative sigma yields at most 2^(sigma_size-1), so the cap cannot bind.
+        sigma_neg_capped = sigma_neg;
+    }
     dbg_decouple("fpa2bv_rnd_sigma_neg", sigma_neg);
-    dbg_decouple("fpa2bv_rnd_sigma_cap", sigma_cap);
     dbg_decouple("fpa2bv_rnd_sigma_neg_capped", sigma_neg_capped);
     sigma_lt_zero = m_bv_util.mk_sle(sigma, m_bv_util.mk_numeral(rational(-1), sigma_size));
     dbg_decouple("fpa2bv_rnd_sigma_lt_zero", sigma_lt_zero);
 
     sig_ext = m_bv_util.mk_concat(sig, m_bv_util.mk_numeral(0, sig_size));
-    rs_sig = m_bv_util.mk_bv_lshr(sig_ext, m_bv_util.mk_zero_extend(2*sig_size - sigma_size, sigma_neg_capped));
-    ls_sig = m_bv_util.mk_bv_shl(sig_ext, m_bv_util.mk_zero_extend(2*sig_size - sigma_size, sigma));
+    unsigned shift_width = 2 * sig_size;
+    expr_ref rs_shift(m), ls_shift(m);
+    if (sigma_size <= shift_width) {
+        rs_shift = m_bv_util.mk_zero_extend(shift_width - sigma_size, sigma_neg_capped);
+        ls_shift = m_bv_util.mk_zero_extend(shift_width - sigma_size, sigma);
+    }
+    else {
+        // The right count is capped at sbits+2, and a nonnegative sigma is at
+        // most sig's leading-zero count. Both are below shift_width.
+        rs_shift = m_bv_util.mk_extract(shift_width - 1, 0, sigma_neg_capped);
+        ls_shift = m_bv_util.mk_extract(shift_width - 1, 0, sigma);
+    }
+    rs_sig = m_bv_util.mk_bv_lshr(sig_ext, rs_shift);
+    ls_sig = m_bv_util.mk_bv_shl(sig_ext, ls_shift);
     m_simp.mk_ite(sigma_lt_zero, rs_sig, ls_sig, big_sh_sig);
     SASSERT(m_bv_util.get_bv_size(big_sh_sig) == 2*sig_size);
 

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -1054,9 +1054,9 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     sticky = m.mk_app(m_bv_util.get_fid(), OP_BREDOR, m_bv_util.mk_extract(extra_bits-2, 0, quotient));
     res_sig = m_bv_util.mk_concat(m_bv_util.mk_extract(extra_bits+sbits+1, extra_bits-1, quotient), sticky);
     if (sbits == 2) {
-        // At sbits == 2, the range [3*sbits+1:2*sbits+4] is [7:8], so there
-        // are no quotient bits above res_sig. Skip the invalid extract and
-        // OP_BREDOR, and use false for too_large.
+        // At sbits == 2, upper would require mk_extract(7, 8, quotient), whose
+        // high index is below its low index. res_sig already consumes every
+        // quotient bit, so too_large is false without constructing upper.
         too_large = m.mk_false();
     }
     else {
@@ -1110,13 +1110,13 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
         round_min_exp_ext = m_bv_util.mk_sign_extend(exp_bits - round_exp_bits, round_min_exp);
         round_max_exp_ext = m_bv_util.mk_sign_extend(exp_bits - round_exp_bits, round_max_exp);
 
-        expr_ref exp_above_round_range(m), exp_in_round_range(m);
+        expr_ref exp_above_round_range(m), narrowed_exp(m);
         exp_below_round_range = m_bv_util.mk_slt(res_exp, round_min_exp_ext);
         exp_above_round_range = m_bv_util.mk_slt(round_max_exp_ext, res_exp);
-        exp_in_round_range = m_bv_util.mk_extract(round_exp_bits - 1, 0, res_exp);
-        // round_max_exp has leading bits 0,1,1, selecting round's existing
-        // overflow result for the current sign and rounding mode.
-        m_simp.mk_ite(exp_above_round_range, round_max_exp, exp_in_round_range, round_exp);
+        narrowed_exp = m_bv_util.mk_extract(round_exp_bits - 1, 0, res_exp);
+        // An above-range res_exp is already an overflow. round_max_exp selects
+        // round's existing infinity or max-finite result for the sign and mode.
+        m_simp.mk_ite(exp_above_round_range, round_max_exp, narrowed_exp, round_exp);
         m_simp.mk_ite(exp_below_round_range, round_min_exp, round_exp, round_exp);
 
         expr_ref min_exp(m), min_exp_ext(m), underflow_shift(m), underflow_shift_sized(m);
@@ -1135,7 +1135,7 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
         sig_ext = m_bv_util.mk_concat(res_sig, m_bv_util.mk_numeral(0, sig_size));
         shifted_sig = m_bv_util.mk_bv_lshr(sig_ext, underflow_shift_sized);
         unsigned sig_extract_low_bit = 2 * sig_size - (sbits + 2);
-        // Finite operand bounds make underflow_shift at most
+        // res_exp >= 3 - 2^ebits - sbits makes underflow_shift at most
         // sbits + 2^(ebits - 1) - 2. If it exceeds the sbits + 4 appended
         // zero bits, res_sig's normalized leading one still lands in the range
         // reduced into discarded, so discarded remains true.
@@ -4292,8 +4292,8 @@ void fpa2bv_converter::round(sort * s, expr_ref & rm, expr_ref & sgn, expr_ref &
         ls_shift = m_bv_util.mk_zero_extend(shift_width - sigma_size, sigma);
     }
     else {
-        // The right count is capped at sbits+2, and a nonnegative sigma is at
-        // most sig's leading-zero count. Both are below shift_width.
+        // sigma_neg_capped is at most sbits+2, and a nonnegative sigma is at
+        // most lz, sig's leading-zero count. Both values are below shift_width.
         rs_shift = m_bv_util.mk_extract(shift_width - 1, 0, sigma_neg_capped);
         ls_shift = m_bv_util.mk_extract(shift_width - 1, 0, sigma);
     }

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -991,8 +991,9 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     unsigned lz_bits = needs_wide_lz ? m_mpz_manager.log2(mpz(sbits - 1)) + 1 : ebits;
 
     expr_ref a_sgn(m), a_sig(m), a_exp(m), a_lz(m), b_sgn(m), b_sig(m), b_exp(m), b_lz(m);
-    // Defer normalization only for wide-LZ formats; the shared ebits-wide count
-    // would otherwise be consumed before division can compute the exact count.
+    // Defer normalization only when the leading-zero count does not fit in
+    // ebits; otherwise unpack would consume the wrapped count before division
+    // can compute the exact value locally.
     bool normalize_before_division = !needs_wide_lz;
     unpack(x, a_sgn, a_sig, a_exp, a_lz, normalize_before_division);
     unpack(y, b_sgn, b_sig, b_exp, b_lz, normalize_before_division);
@@ -1055,8 +1056,9 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     sticky = m.mk_app(m_bv_util.get_fid(), OP_BREDOR, m_bv_util.mk_extract(extra_bits-2, 0, quotient));
     res_sig = m_bv_util.mk_concat(m_bv_util.mk_extract(extra_bits+sbits+1, extra_bits-1, quotient), sticky);
     if (sbits == 2) {
-        // The upper quotient slice has width sbits - 2, so it is empty here.
-        // The sort constructor guarantees that sbits is never below 2.
+        // The excess quotient bits would be extract [3*sbits+1:2*sbits+4],
+        // with width sbits-2. At sbits == 2, [7:8] is invalid, so skip both
+        // the extract and OP_BREDOR; the OR of no excess bits is false.
         too_large = m.mk_false();
     }
     else {
@@ -1084,7 +1086,8 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     expr_ref res_sig_shifted(m), res_exp_shifted(m);
     res_sig_shifted = m_bv_util.mk_bv_shl(res_sig, res_sig_shift_amount);
     expr_ref exp_shift_amount(m);
-    // The shifted branch's correction is at most sbits + 3, so this resize is exact.
+    // res_sig_shift_amount is the exponent decrement for left normalization.
+    // It is at most sbits+3, so resizing preserves its value.
     if (exp_bits <= sbits + 4)
         exp_shift_amount = m_bv_util.mk_extract(exp_bits - 1, 0, res_sig_shift_amount);
     else
@@ -1098,8 +1101,10 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
 
     if (exp_bits > ebits + 2) {
         // The rounder consumes an ebits+2 exponent. Keep ordinary exponents
-        // in that representation, clamp guaranteed overflow for round's
-        // existing overflow logic, and handle deeper underflow locally.
+        // in that representation. Clamping overflow to round_max_exp forces
+        // round's existing OVF1 condition; exact underflow distance must remain
+        // available because it determines retained bits, sticky, and zero versus
+        // subnormal results.
         unsigned round_exp_bits = ebits + 2;
         unsigned sig_size = sbits + 4;
         expr_ref round_exp(m), exp_below_round_range(m), underflow_result(m);
@@ -1113,6 +1118,8 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
         exp_below_round_range = m_bv_util.mk_slt(res_exp, round_min_exp_ext);
         exp_above_round_range = m_bv_util.mk_slt(round_max_exp_ext, res_exp);
         exp_in_round_range = m_bv_util.mk_extract(round_exp_bits - 1, 0, res_exp);
+        // round_max_exp has leading bits 0,1,1, so OVF1 is true and round's
+        // existing sign and rounding-mode logic selects infinity or max finite.
         m_simp.mk_ite(exp_above_round_range, round_max_exp, exp_in_round_range, round_exp);
         m_simp.mk_ite(exp_below_round_range, round_min_exp, round_exp, round_exp);
 

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -966,9 +966,9 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     unsigned sbits = m_util.get_sbits(s);
     const mpz & lz_modulus = m_mpf_manager.m_powers2(ebits);
 
-    // The ebits-wide count returned by unpack is exact when sbits <= 2^ebits.
-    // Division computes the count locally when the significand exceeds that
-    // modulus, before any normalization shift can consume a wrapped value.
+    // unpack's ebits-wide leading-zero count is exact when sbits <= 2^ebits.
+    // For wider significands, compute the count here before normalization can
+    // shift by a wrapped value.
     bool needs_wide_lz = m_mpz_manager.lt(lz_modulus, mpz(sbits));
     unsigned exp_bits = ebits + 2;
     if (needs_wide_lz) {
@@ -991,17 +991,15 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     unsigned lz_bits = needs_wide_lz ? m_mpz_manager.log2(mpz(sbits - 1)) + 1 : ebits;
 
     expr_ref a_sgn(m), a_sig(m), a_exp(m), a_lz(m), b_sgn(m), b_sig(m), b_exp(m), b_lz(m);
-    // Defer normalization only when the leading-zero count does not fit in
-    // ebits; otherwise unpack would consume the wrapped count before division
-    // can compute the exact value locally.
+    // Defer normalization when the leading-zero count does not fit in ebits;
+    // otherwise unpack would shift by a wrapped count.
     bool normalize_before_division = !needs_wide_lz;
     unpack(x, a_sgn, a_sig, a_exp, a_lz, normalize_before_division);
     unpack(y, b_sgn, b_sig, b_exp, b_lz, normalize_before_division);
 
     if (needs_wide_lz) {
-        // Division needs the exact leading-zero count in its exponent arithmetic.
-        // Keep this local: the shared unpack path must retain its ebits-wide
-        // interface, while division needs the raw significand before shifting.
+        // Compute the exact count before shifting. Keep this local because the
+        // other unpack callers rely on its ebits-wide result.
         expr_ref zero_sig(m), a_sig_is_zero(m), b_sig_is_zero(m);
         zero_sig = m_bv_util.mk_numeral(0, sbits);
         m_simp.mk_eq(zero_sig, a_sig, a_sig_is_zero);
@@ -1056,9 +1054,9 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     sticky = m.mk_app(m_bv_util.get_fid(), OP_BREDOR, m_bv_util.mk_extract(extra_bits-2, 0, quotient));
     res_sig = m_bv_util.mk_concat(m_bv_util.mk_extract(extra_bits+sbits+1, extra_bits-1, quotient), sticky);
     if (sbits == 2) {
-        // The excess quotient bits would be extract [3*sbits+1:2*sbits+4],
-        // with width sbits-2. At sbits == 2, [7:8] is invalid, so skip both
-        // the extract and OP_BREDOR; the OR of no excess bits is false.
+        // At sbits == 2, the range [3*sbits+1:2*sbits+4] is [7:8], so there
+        // are no quotient bits above res_sig. Skip the invalid extract and
+        // OP_BREDOR, and use false for too_large.
         too_large = m.mk_false();
     }
     else {
@@ -1100,11 +1098,9 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     dbg_decouple("fpa2bv_div_res_exp", res_exp);
 
     if (exp_bits > ebits + 2) {
-        // The rounder consumes an ebits+2 exponent. Keep ordinary exponents
-        // in that representation. Clamping overflow to round_max_exp forces
-        // round's existing OVF1 condition; exact underflow distance must remain
-        // available because it determines retained bits, sticky, and zero versus
-        // subnormal results.
+        // round takes an ebits+2-bit exponent. Exponents in that range stay
+        // exact. Larger exponents can use round's existing overflow path, but
+        // smaller exponents need the full shift distance for subnormal rounding.
         unsigned round_exp_bits = ebits + 2;
         unsigned sig_size = sbits + 4;
         expr_ref round_exp(m), exp_below_round_range(m), underflow_result(m);
@@ -1118,17 +1114,16 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
         exp_below_round_range = m_bv_util.mk_slt(res_exp, round_min_exp_ext);
         exp_above_round_range = m_bv_util.mk_slt(round_max_exp_ext, res_exp);
         exp_in_round_range = m_bv_util.mk_extract(round_exp_bits - 1, 0, res_exp);
-        // round_max_exp has leading bits 0,1,1, so OVF1 is true and round's
-        // existing sign and rounding-mode logic selects infinity or max finite.
+        // round_max_exp has leading bits 0,1,1, selecting round's existing
+        // overflow result for the current sign and rounding mode.
         m_simp.mk_ite(exp_above_round_range, round_max_exp, exp_in_round_range, round_exp);
         m_simp.mk_ite(exp_below_round_range, round_min_exp, round_exp, round_exp);
 
         expr_ref min_exp(m), min_exp_ext(m), underflow_shift(m), underflow_shift_sized(m);
         mk_min_exp(ebits, min_exp);
         min_exp_ext = m_bv_util.mk_sign_extend(exp_bits - ebits, min_exp);
-        // Below the rounder's signed range, the value is necessarily tiny.
-        // Round it locally: passing a value-preserving shift through round
-        // would make round's t intermediate wrap in its established width.
+        // round cannot represent this larger underflow distance in its
+        // ebits+2-bit exponent, so shift and round the significand here.
         underflow_shift = m_bv_util.mk_bv_sub(min_exp_ext, res_exp);
         underflow_shift = m_bv_util.mk_bv_sub(
             underflow_shift, m_bv_util.mk_numeral(1, exp_bits));
@@ -1141,8 +1136,8 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
         shifted_sig = m_bv_util.mk_bv_lshr(sig_ext, underflow_shift_sized);
         unsigned sig_extract_low_bit = 2 * sig_size - (sbits + 2);
         // The shift is at most sbits + 2^(ebits - 1) - 2. If it passes the
-        // zero padding, the normalized leading one remains in this low slice,
-        // so sticky is already one for any source bits shifted out entirely.
+        // zero padding, the leading one enters this discarded range, so
+        // discarded remains true.
         discarded = m.mk_app(
             m_bv_util.get_fid(), OP_BREDOR,
             m_bv_util.mk_extract(sig_extract_low_bit - 1, 0, shifted_sig));

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -959,11 +959,25 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     unsigned sbits = m_util.get_sbits(s);
     if (ebits > sbits)
         throw default_exception("division with ebits > sbits not supported");
+    const mpz & lz_modulus = m_mpf_manager.m_powers2(ebits);
     SASSERT(ebits <= sbits);
 
     expr_ref a_sgn(m), a_sig(m), a_exp(m), a_lz(m), b_sgn(m), b_sig(m), b_exp(m), b_lz(m);
-    unpack(x, a_sgn, a_sig, a_exp, a_lz, true);
-    unpack(y, b_sgn, b_sig, b_exp, b_lz, true);
+    bool needs_wide_lz = m_mpz_manager.lt(lz_modulus, mpz(sbits));
+    unsigned exp_bits = ebits + 2;
+    if (needs_wide_lz) {
+        // Exact division exponents are in
+        // [3 - 2^ebits - sbits, 2^ebits + sbits - 4].
+        scoped_mpz max_exp(m_mpz_manager);
+        m_mpz_manager.add(lz_modulus, sbits, max_exp);
+        m_mpz_manager.sub(max_exp, 4, max_exp);
+        // The lower endpoint is -(max_exp + 1), so one sign bit beyond
+        // max_exp's bit-length covers both endpoints.
+        exp_bits = m_mpz_manager.log2(max_exp) + 2;
+    }
+    unsigned lz_bits = needs_wide_lz ? exp_bits : ebits;
+    unpack_with_lz_width(x, a_sgn, a_sig, a_exp, a_lz, true, lz_bits);
+    unpack_with_lz_width(y, b_sgn, b_sig, b_exp, b_lz, true, lz_bits);
 
     unsigned extra_bits = sbits+2;
     expr_ref a_sig_ext(m), b_sig_ext(m);
@@ -974,15 +988,21 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     dbg_decouple("fpa2bv_div_b_sig_ext", b_sig_ext);
 
     expr_ref a_exp_ext(m), b_exp_ext(m);
-    a_exp_ext = m_bv_util.mk_sign_extend(2, a_exp);
-    b_exp_ext = m_bv_util.mk_sign_extend(2, b_exp);
+    a_exp_ext = m_bv_util.mk_sign_extend(exp_bits - ebits, a_exp);
+    b_exp_ext = m_bv_util.mk_sign_extend(exp_bits - ebits, b_exp);
 
     expr_ref res_sgn(m), res_sig(m), res_exp(m);
     res_sgn = m_bv_util.mk_bv_xor({a_sgn, b_sgn});
 
     expr_ref a_lz_ext(m), b_lz_ext(m);
-    a_lz_ext = m_bv_util.mk_zero_extend(2, a_lz);
-    b_lz_ext = m_bv_util.mk_zero_extend(2, b_lz);
+    if (needs_wide_lz) {
+        a_lz_ext = a_lz;
+        b_lz_ext = b_lz;
+    }
+    else {
+        a_lz_ext = m_bv_util.mk_zero_extend(exp_bits - ebits, a_lz);
+        b_lz_ext = m_bv_util.mk_zero_extend(exp_bits - ebits, b_lz);
+    }
 
     res_exp = m_bv_util.mk_bv_sub(
         m_bv_util.mk_bv_sub(a_exp_ext, a_lz_ext),
@@ -1019,7 +1039,10 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     shift_cond = m_bv_util.mk_ule(res_sig_lz, m_bv_util.mk_numeral(1, sbits + 4));
     expr_ref res_sig_shifted(m), res_exp_shifted(m);
     res_sig_shifted = m_bv_util.mk_bv_shl(res_sig, res_sig_shift_amount);
-    res_exp_shifted = m_bv_util.mk_bv_sub(res_exp, m_bv_util.mk_extract(ebits + 1, 0, res_sig_shift_amount));
+    SASSERT(exp_bits <= sbits + 4);
+    expr_ref exp_shift_amount(m);
+    exp_shift_amount = m_bv_util.mk_extract(exp_bits - 1, 0, res_sig_shift_amount);
+    res_exp_shifted = m_bv_util.mk_bv_sub(res_exp, exp_shift_amount);
     m_simp.mk_ite(shift_cond, res_sig, res_sig_shifted, res_sig);
     m_simp.mk_ite(shift_cond, res_exp, res_exp_shifted, res_exp);
 
@@ -3815,7 +3838,15 @@ void fpa2bv_converter::mk_unbias(expr * e, expr_ref & result) {
 
 void fpa2bv_converter::unpack(expr * e, expr_ref & sgn, expr_ref & sig, expr_ref & exp, expr_ref & lz, bool normalize) {
     SASSERT(m_util.is_fp(e));
+    sort * srt = to_app(e)->get_decl()->get_range();
+    unpack_with_lz_width(e, sgn, sig, exp, lz, normalize, m_util.get_ebits(srt));
+}
+
+void fpa2bv_converter::unpack_with_lz_width(expr * e, expr_ref & sgn, expr_ref & sig, expr_ref & exp,
+                                            expr_ref & lz, bool normalize, unsigned lz_bits) {
+    SASSERT(m_util.is_fp(e));
     SASSERT(to_app(e)->get_num_args() == 3);
+    SASSERT(lz_bits > 0);
 
     sort * srt = to_app(e)->get_decl()->get_range();
     SASSERT(is_float(srt));
@@ -3846,8 +3877,8 @@ void fpa2bv_converter::unpack(expr * e, expr_ref & sgn, expr_ref & sig, expr_ref
     mk_unbias(denormal_exp, denormal_exp);
     dbg_decouple("fpa2bv_unpack_denormal_exp", denormal_exp);
 
-    expr_ref zero_e(m);
-    zero_e = m_bv_util.mk_numeral(0, ebits);
+    expr_ref zero_lz(m);
+    zero_lz = m_bv_util.mk_numeral(0, lz_bits);
 
     if (normalize) {
         expr_ref is_sig_zero(m), zero_s(m);
@@ -3855,20 +3886,20 @@ void fpa2bv_converter::unpack(expr * e, expr_ref & sgn, expr_ref & sig, expr_ref
         m_simp.mk_eq(zero_s, denormal_sig, is_sig_zero);
 
         expr_ref lz_d(m), norm_or_zero(m);
-        mk_leading_zeros(denormal_sig, ebits, lz_d);
+        mk_leading_zeros(denormal_sig, lz_bits, lz_d);
         norm_or_zero = m.mk_or(is_normal, is_sig_zero);
-        m_simp.mk_ite(norm_or_zero, zero_e, lz_d, lz);
+        m_simp.mk_ite(norm_or_zero, zero_lz, lz_d, lz);
         dbg_decouple("fpa2bv_unpack_lz", lz);
 
         expr_ref shift(m);
-        m_simp.mk_ite(is_sig_zero, zero_e, lz, shift);
+        m_simp.mk_ite(is_sig_zero, zero_lz, lz, shift);
         dbg_decouple("fpa2bv_unpack_shift", shift);
         SASSERT(is_well_sorted(m, is_sig_zero));
         SASSERT(is_well_sorted(m, shift));
-        SASSERT(m_bv_util.get_bv_size(shift) == ebits);
-        if (ebits <= sbits) {
+        SASSERT(m_bv_util.get_bv_size(shift) == lz_bits);
+        if (lz_bits <= sbits) {
             expr_ref q(m);
-            q = m_bv_util.mk_zero_extend(sbits-ebits, shift);
+            q = m_bv_util.mk_zero_extend(sbits-lz_bits, shift);
             denormal_sig = m_bv_util.mk_bv_shl(denormal_sig, q);
         }
         else {
@@ -3876,9 +3907,9 @@ void fpa2bv_converter::unpack(expr * e, expr_ref & sgn, expr_ref & sig, expr_ref
             // would be zero anyways. So we can safely cut the shift variable down,
             // as long as we check the higher bits.
             expr_ref zero_ems(m), sh(m), is_sh_zero(m), sl(m), sbits_s(m), short_shift(m);
-            zero_ems = m_bv_util.mk_numeral(0, ebits - sbits);
+            zero_ems = m_bv_util.mk_numeral(0, lz_bits - sbits);
             sbits_s = m_bv_util.mk_numeral(sbits, sbits);
-            sh = m_bv_util.mk_extract(ebits-1, sbits, shift);
+            sh = m_bv_util.mk_extract(lz_bits-1, sbits, shift);
             m_simp.mk_eq(zero_ems, sh, is_sh_zero);
             short_shift = m_bv_util.mk_extract(sbits-1, 0, shift);
             m_simp.mk_ite(is_sh_zero, short_shift, sbits_s, sl);
@@ -3886,7 +3917,7 @@ void fpa2bv_converter::unpack(expr * e, expr_ref & sgn, expr_ref & sig, expr_ref
         }
     }
     else
-        lz = zero_e;
+        lz = zero_lz;
 
     SASSERT(is_well_sorted(m, normal_sig));
     SASSERT(is_well_sorted(m, denormal_sig));
@@ -3901,10 +3932,12 @@ void fpa2bv_converter::unpack(expr * e, expr_ref & sgn, expr_ref & sig, expr_ref
     SASSERT(is_well_sorted(m, sgn));
     SASSERT(is_well_sorted(m, sig));
     SASSERT(is_well_sorted(m, exp));
+    SASSERT(is_well_sorted(m, lz));
 
     SASSERT(m_bv_util.get_bv_size(sgn) == 1);
     SASSERT(m_bv_util.get_bv_size(sig) == sbits);
     SASSERT(m_bv_util.get_bv_size(exp) == ebits);
+    SASSERT(m_bv_util.get_bv_size(lz) == lz_bits);
 
     TRACE(fpa2bv_unpack, tout << "UNPACK SGN = " << mk_ismt2_pp(sgn, m) << std::endl; );
     TRACE(fpa2bv_unpack, tout << "UNPACK SIG = " << mk_ismt2_pp(sig, m) << std::endl; );
@@ -4037,7 +4070,8 @@ void fpa2bv_converter::round(sort * s, expr_ref & rm, expr_ref & sgn, expr_ref &
     SASSERT(m_bv_util.is_bv(exp) && m_bv_util.get_bv_size(exp) >= 4);
 
     SASSERT(m_bv_util.get_bv_size(sig) == sbits+4);
-    SASSERT(m_bv_util.get_bv_size(exp) == ebits+2);
+    unsigned exp_bits = m_bv_util.get_bv_size(exp);
+    SASSERT(exp_bits >= ebits + 2);
 
     expr_ref e_min(m), e_max(m);
     mk_min_exp(ebits, e_min);
@@ -4046,26 +4080,37 @@ void fpa2bv_converter::round(sort * s, expr_ref & rm, expr_ref & sgn, expr_ref &
     TRACE(fpa2bv_dbg, tout << "e_min = " << mk_ismt2_pp(e_min, m) << std::endl;
                         tout << "e_max = " << mk_ismt2_pp(e_max, m) << std::endl;);
 
-    expr_ref OVF1(m), e_top_three(m), sigm1(m), e_eq_emax_and_sigm1(m), e_eq_emax(m);
-    expr_ref e3(m), ne3(m), e2(m), e1(m), e21(m), one_1(m), h_exp(m), sh_exp(m), th_exp(m);
+    expr_ref OVF1(m), sigm1(m), e_eq_emax_and_sigm1(m), e_eq_emax(m);
+    expr_ref one_1(m);
     one_1 = m_bv_util.mk_numeral(1, 1);
-    h_exp = m_bv_util.mk_extract(ebits+1, ebits+1, exp);
-    sh_exp = m_bv_util.mk_extract(ebits, ebits, exp);
-    th_exp = m_bv_util.mk_extract(ebits-1, ebits-1, exp);
-    m_simp.mk_eq(h_exp, one_1, e3);
-    m_simp.mk_eq(sh_exp, one_1, e2);
-    m_simp.mk_eq(th_exp, one_1, e1);
-    m_simp.mk_or(e2, e1, e21);
-    m_simp.mk_not(e3, ne3);
-    m_simp.mk_and(ne3, e21, e_top_three);
 
     expr_ref ext_emax(m), t_sig(m);
-    ext_emax = m_bv_util.mk_zero_extend(2, e_max);
+    ext_emax = m_bv_util.mk_zero_extend(exp_bits - ebits, e_max);
     t_sig = m_bv_util.mk_extract(sbits+3, sbits+3, sig);
     m_simp.mk_eq(ext_emax, exp, e_eq_emax);
     m_simp.mk_eq(t_sig, one_1, sigm1);
     m_simp.mk_and(e_eq_emax, sigm1, e_eq_emax_and_sigm1);
-    m_simp.mk_or(e_top_three, e_eq_emax_and_sigm1, OVF1);
+    // Preserve the existing formula shape for legacy-width callers; the signed
+    // comparison below is needed only when division widens the exponent.
+    if (exp_bits == ebits + 2) {
+        expr_ref e_top_three(m), e3(m), ne3(m), e2(m), e1(m), e21(m);
+        expr_ref h_exp(m), sh_exp(m), th_exp(m);
+        h_exp = m_bv_util.mk_extract(ebits+1, ebits+1, exp);
+        sh_exp = m_bv_util.mk_extract(ebits, ebits, exp);
+        th_exp = m_bv_util.mk_extract(ebits-1, ebits-1, exp);
+        m_simp.mk_eq(h_exp, one_1, e3);
+        m_simp.mk_eq(sh_exp, one_1, e2);
+        m_simp.mk_eq(th_exp, one_1, e1);
+        m_simp.mk_or(e2, e1, e21);
+        m_simp.mk_not(e3, ne3);
+        m_simp.mk_and(ne3, e21, e_top_three);
+        m_simp.mk_or(e_top_three, e_eq_emax_and_sigm1, OVF1);
+    }
+    else {
+        expr_ref exp_gt_emax(m);
+        exp_gt_emax = m_bv_util.mk_slt(ext_emax, exp);
+        m_simp.mk_or(exp_gt_emax, e_eq_emax_and_sigm1, OVF1);
+    }
 
     dbg_decouple("fpa2bv_rnd_OVF1", OVF1);
 
@@ -4073,25 +4118,25 @@ void fpa2bv_converter::round(sort * s, expr_ref & rm, expr_ref & sgn, expr_ref &
     SASSERT(is_well_sorted(m, OVF1));
 
     expr_ref lz(m);
-    mk_leading_zeros(sig, ebits+2, lz); // CMW: is this always large enough?
+    mk_leading_zeros(sig, exp_bits, lz);
 
     dbg_decouple("fpa2bv_rnd_lz", lz);
 
     TRACE(fpa2bv_dbg, tout << "LZ = " << mk_ismt2_pp(lz, m) << std::endl;);
 
     expr_ref t(m);
-    t = m_bv_util.mk_bv_add(exp, m_bv_util.mk_numeral(1, ebits+2));
+    t = m_bv_util.mk_bv_add(exp, m_bv_util.mk_numeral(1, exp_bits));
     t = m_bv_util.mk_bv_sub(t, lz);
-    t = m_bv_util.mk_bv_sub(t, m_bv_util.mk_sign_extend(2, e_min));
+    t = m_bv_util.mk_bv_sub(t, m_bv_util.mk_sign_extend(exp_bits - ebits, e_min));
     dbg_decouple("fpa2bv_rnd_t", t);
     expr_ref TINY(m);
-    TINY = m_bv_util.mk_sle(t, m_bv_util.mk_numeral(rational(-1), ebits+2));
+    TINY = m_bv_util.mk_sle(t, m_bv_util.mk_numeral(rational(-1), exp_bits));
     dbg_decouple("fpa2bv_rnd_TINY", TINY);
     TRACE(fpa2bv_dbg, tout << "TINY = " << mk_ismt2_pp(TINY, m) << std::endl;);
     SASSERT(is_well_sorted(m, TINY));
 
     expr_ref beta(m);
-    beta = m_bv_util.mk_bv_add(m_bv_util.mk_bv_sub(exp, lz), m_bv_util.mk_numeral(1, ebits+2));
+    beta = m_bv_util.mk_bv_add(m_bv_util.mk_bv_sub(exp, lz), m_bv_util.mk_numeral(1, exp_bits));
 
     TRACE(fpa2bv_dbg, tout << "beta = " << mk_ismt2_pp(beta, m) << std::endl; );
     SASSERT(is_well_sorted(m, beta));
@@ -4101,8 +4146,8 @@ void fpa2bv_converter::round(sort * s, expr_ref & rm, expr_ref & sgn, expr_ref &
     dbg_decouple("fpa2bv_rnd_e_max", e_max);
 
     expr_ref sigma(m), sigma_add(m);
-    sigma_add = m_bv_util.mk_bv_sub(exp, m_bv_util.mk_sign_extend(2, e_min));
-    sigma_add = m_bv_util.mk_bv_add(sigma_add, m_bv_util.mk_numeral(1, ebits+2));
+    sigma_add = m_bv_util.mk_bv_sub(exp, m_bv_util.mk_sign_extend(exp_bits - ebits, e_min));
+    sigma_add = m_bv_util.mk_bv_add(sigma_add, m_bv_util.mk_numeral(1, exp_bits));
     m_simp.mk_ite(TINY, sigma_add, lz, sigma);
 
     dbg_decouple("fpa2bv_rnd_sigma", sigma);
@@ -4115,8 +4160,9 @@ void fpa2bv_converter::round(sort * s, expr_ref & rm, expr_ref & sgn, expr_ref &
 
     unsigned sig_size = m_bv_util.get_bv_size(sig);
     SASSERT(sig_size == sbits + 4);
-    SASSERT(m_bv_util.get_bv_size(sigma) == ebits+2);
-    unsigned sigma_size = ebits + 2;
+    SASSERT(m_bv_util.get_bv_size(sigma) == exp_bits);
+    unsigned sigma_size = exp_bits;
+    SASSERT(sigma_size <= 2 * sig_size);
 
     expr_ref sigma_neg(m), sigma_cap(m), sigma_neg_capped(m), sigma_lt_zero(m), sig_ext(m),
         rs_sig(m), ls_sig(m), big_sh_sig(m), sigma_le_cap(m);
@@ -4157,7 +4203,7 @@ void fpa2bv_converter::round(sort * s, expr_ref & rm, expr_ref & sgn, expr_ref &
     SASSERT(m_bv_util.get_bv_size(sig) == sbits+2);
 
     expr_ref ext_emin(m);
-    ext_emin = m_bv_util.mk_zero_extend(2, e_min);
+    ext_emin = m_bv_util.mk_zero_extend(exp_bits - ebits, e_min);
     m_simp.mk_ite(TINY, ext_emin, beta, exp);
     SASSERT(is_well_sorted(m, exp));
 
@@ -4199,10 +4245,10 @@ void fpa2bv_converter::round(sort * s, expr_ref & rm, expr_ref & sgn, expr_ref &
     lallbut1_sig = m_bv_util.mk_extract(sbits-1, 0, sig);
     m_simp.mk_ite(SIGovf, hallbut1_sig, lallbut1_sig, sig);
 
-    SASSERT(m_bv_util.get_bv_size(exp) == ebits + 2);
+    SASSERT(m_bv_util.get_bv_size(exp) == exp_bits);
 
     expr_ref exp_p1(m);
-    exp_p1 = m_bv_util.mk_bv_add(exp, m_bv_util.mk_numeral(1, ebits+2));
+    exp_p1 = m_bv_util.mk_bv_add(exp, m_bv_util.mk_numeral(1, exp_bits));
     m_simp.mk_ite(SIGovf, exp_p1, exp, exp);
 
     SASSERT(is_well_sorted(m, sig));
@@ -4211,7 +4257,7 @@ void fpa2bv_converter::round(sort * s, expr_ref & rm, expr_ref & sgn, expr_ref &
     dbg_decouple("fpa2bv_rnd_exp_postnormalized", exp);
 
     SASSERT(m_bv_util.get_bv_size(sig) == sbits);
-    SASSERT(m_bv_util.get_bv_size(exp) == ebits + 2);
+    SASSERT(m_bv_util.get_bv_size(exp) == exp_bits);
     SASSERT(m_bv_util.get_bv_size(e_max) == ebits);
 
     // Exponent adjustment and rounding

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -957,10 +957,7 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     // else comes the actual division.
     unsigned ebits = m_util.get_ebits(s);
     unsigned sbits = m_util.get_sbits(s);
-    if (ebits > sbits)
-        throw default_exception("division with ebits > sbits not supported");
     const mpz & lz_modulus = m_mpf_manager.m_powers2(ebits);
-    SASSERT(ebits <= sbits);
 
     bool needs_wide_lz = m_mpz_manager.lt(lz_modulus, mpz(sbits));
     unsigned exp_bits = ebits + 2;
@@ -1033,16 +1030,23 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
 
     SASSERT(m_bv_util.get_bv_size(quotient) == (sbits + sbits + extra_bits));
 
-    expr_ref sticky(m), upper(m), upper_reduced(m), too_large(m);
+    expr_ref sticky(m), too_large(m);
     sticky = m.mk_app(m_bv_util.get_fid(), OP_BREDOR, m_bv_util.mk_extract(extra_bits-2, 0, quotient));
     res_sig = m_bv_util.mk_concat(m_bv_util.mk_extract(extra_bits+sbits+1, extra_bits-1, quotient), sticky);
-    upper = m_bv_util.mk_extract(sbits + sbits + extra_bits-1, extra_bits+sbits+2, quotient);
-    upper_reduced = m.mk_app(m_bv_util.get_fid(), OP_BREDOR, upper.get());
-    too_large = m.mk_eq(upper_reduced, m_bv_util.mk_numeral(1, 1));
+    if (sbits == 2) {
+        // There are no quotient bits above the retained slice.
+        too_large = m.mk_false();
+    }
+    else {
+        expr_ref upper(m), upper_reduced(m);
+        upper = m_bv_util.mk_extract(sbits + sbits + extra_bits-1, extra_bits+sbits+2, quotient);
+        upper_reduced = m.mk_app(m_bv_util.get_fid(), OP_BREDOR, upper.get());
+        too_large = m.mk_eq(upper_reduced, m_bv_util.mk_numeral(1, 1));
+        dbg_decouple("fpa2bv_div_upper", upper);
+    }
     c8 = too_large;
     mk_ite(signs_xor, ninf, pinf, v8);
     dbg_decouple("fpa2bv_div_res_sig_p4", res_sig);
-    dbg_decouple("fpa2bv_div_upper", upper);
     dbg_decouple("fpa2bv_div_too_large", too_large);
 
     SASSERT(m_bv_util.get_bv_size(res_sig) == (sbits + 4));
@@ -1057,9 +1061,12 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     shift_cond = m_bv_util.mk_ule(res_sig_lz, m_bv_util.mk_numeral(1, sbits + 4));
     expr_ref res_sig_shifted(m), res_exp_shifted(m);
     res_sig_shifted = m_bv_util.mk_bv_shl(res_sig, res_sig_shift_amount);
-    SASSERT(exp_bits <= sbits + 4);
     expr_ref exp_shift_amount(m);
-    exp_shift_amount = m_bv_util.mk_extract(exp_bits - 1, 0, res_sig_shift_amount);
+    // The selected unsigned correction is at most sbits + 3.
+    if (exp_bits <= sbits + 4)
+        exp_shift_amount = m_bv_util.mk_extract(exp_bits - 1, 0, res_sig_shift_amount);
+    else
+        exp_shift_amount = m_bv_util.mk_zero_extend(exp_bits - (sbits + 4), res_sig_shift_amount);
     res_exp_shifted = m_bv_util.mk_bv_sub(res_exp, exp_shift_amount);
     m_simp.mk_ite(shift_cond, res_sig, res_sig_shifted, res_sig);
     m_simp.mk_ite(shift_cond, res_exp, res_exp_shifted, res_exp);
@@ -4170,7 +4177,6 @@ void fpa2bv_converter::round(sort * s, expr_ref & rm, expr_ref & sgn, expr_ref &
     SASSERT(sig_size == sbits + 4);
     SASSERT(m_bv_util.get_bv_size(sigma) == exp_bits);
     unsigned sigma_size = exp_bits;
-    SASSERT(sigma_size <= 2 * sig_size);
 
     expr_ref sigma_neg(m), sigma_cap(m), sigma_neg_capped(m), sigma_lt_zero(m), sig_ext(m),
         rs_sig(m), ls_sig(m), big_sh_sig(m), sigma_le_cap(m);
@@ -4185,8 +4191,19 @@ void fpa2bv_converter::round(sort * s, expr_ref & rm, expr_ref & sgn, expr_ref &
     dbg_decouple("fpa2bv_rnd_sigma_lt_zero", sigma_lt_zero);
 
     sig_ext = m_bv_util.mk_concat(sig, m_bv_util.mk_numeral(0, sig_size));
-    rs_sig = m_bv_util.mk_bv_lshr(sig_ext, m_bv_util.mk_zero_extend(2*sig_size - sigma_size, sigma_neg_capped));
-    ls_sig = m_bv_util.mk_bv_shl(sig_ext, m_bv_util.mk_zero_extend(2*sig_size - sigma_size, sigma));
+    expr_ref rs_shift(m), ls_shift(m);
+    if (sigma_size <= 2 * sig_size) {
+        rs_shift = m_bv_util.mk_zero_extend(2*sig_size - sigma_size, sigma_neg_capped);
+        ls_shift = m_bv_util.mk_zero_extend(2*sig_size - sigma_size, sigma);
+    }
+    else {
+        // The selected right count is capped at sbits + 2; the selected
+        // nonnegative left count is at most the significand's leading zeros.
+        rs_shift = m_bv_util.mk_extract(2*sig_size - 1, 0, sigma_neg_capped);
+        ls_shift = m_bv_util.mk_extract(2*sig_size - 1, 0, sigma);
+    }
+    rs_sig = m_bv_util.mk_bv_lshr(sig_ext, rs_shift);
+    ls_sig = m_bv_util.mk_bv_shl(sig_ext, ls_shift);
     m_simp.mk_ite(sigma_lt_zero, rs_sig, ls_sig, big_sh_sig);
     SASSERT(m_bv_util.get_bv_size(big_sh_sig) == 2*sig_size);
 

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -977,29 +977,31 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     unsigned lz_bits = needs_wide_lz ? exp_bits : ebits;
 
     expr_ref a_sgn(m), a_sig(m), a_exp(m), a_lz(m), b_sgn(m), b_sig(m), b_exp(m), b_lz(m);
-    unpack(x, a_sgn, a_sig, a_exp, a_lz, false);
-    unpack(y, b_sgn, b_sig, b_exp, b_lz, false);
+    unpack(x, a_sgn, a_sig, a_exp, a_lz, !needs_wide_lz);
+    unpack(y, b_sgn, b_sig, b_exp, b_lz, !needs_wide_lz);
 
-    // Division needs the exact leading-zero count in its exponent arithmetic.
-    // Keep this local: unpack's ebits-wide count can wrap when sbits > 2^ebits.
-    expr_ref zero_sig(m), a_sig_is_zero(m), b_sig_is_zero(m);
-    zero_sig = m_bv_util.mk_numeral(0, sbits);
-    m_simp.mk_eq(zero_sig, a_sig, a_sig_is_zero);
-    m_simp.mk_eq(zero_sig, b_sig, b_sig_is_zero);
+    if (needs_wide_lz) {
+        // Division needs the exact leading-zero count in its exponent arithmetic.
+        // Keep this local: unpack's ebits-wide count can wrap when sbits > 2^ebits.
+        expr_ref zero_sig(m), a_sig_is_zero(m), b_sig_is_zero(m);
+        zero_sig = m_bv_util.mk_numeral(0, sbits);
+        m_simp.mk_eq(zero_sig, a_sig, a_sig_is_zero);
+        m_simp.mk_eq(zero_sig, b_sig, b_sig_is_zero);
 
-    expr_ref zero_lz(m), a_lz_raw(m), b_lz_raw(m);
-    zero_lz = m_bv_util.mk_numeral(0, lz_bits);
-    mk_leading_zeros(a_sig, lz_bits, a_lz_raw);
-    mk_leading_zeros(b_sig, lz_bits, b_lz_raw);
-    m_simp.mk_ite(a_sig_is_zero, zero_lz, a_lz_raw, a_lz);
-    m_simp.mk_ite(b_sig_is_zero, zero_lz, b_lz_raw, b_lz);
+        expr_ref zero_lz(m), a_lz_raw(m), b_lz_raw(m);
+        zero_lz = m_bv_util.mk_numeral(0, lz_bits);
+        mk_leading_zeros(a_sig, lz_bits, a_lz_raw);
+        mk_leading_zeros(b_sig, lz_bits, b_lz_raw);
+        m_simp.mk_ite(a_sig_is_zero, zero_lz, a_lz_raw, a_lz);
+        m_simp.mk_ite(b_sig_is_zero, zero_lz, b_lz_raw, b_lz);
 
-    SASSERT(lz_bits <= sbits);
-    expr_ref a_shift(m), b_shift(m);
-    a_shift = m_bv_util.mk_zero_extend(sbits - lz_bits, a_lz);
-    b_shift = m_bv_util.mk_zero_extend(sbits - lz_bits, b_lz);
-    a_sig = m_bv_util.mk_bv_shl(a_sig, a_shift);
-    b_sig = m_bv_util.mk_bv_shl(b_sig, b_shift);
+        SASSERT(lz_bits <= sbits);
+        expr_ref a_shift(m), b_shift(m);
+        a_shift = m_bv_util.mk_zero_extend(sbits - lz_bits, a_lz);
+        b_shift = m_bv_util.mk_zero_extend(sbits - lz_bits, b_lz);
+        a_sig = m_bv_util.mk_bv_shl(a_sig, a_shift);
+        b_sig = m_bv_util.mk_bv_shl(b_sig, b_shift);
+    }
 
     unsigned extra_bits = sbits+2;
     expr_ref a_sig_ext(m), b_sig_ext(m);

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -964,13 +964,62 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     // else comes the actual division.
     unsigned ebits = m_util.get_ebits(s);
     unsigned sbits = m_util.get_sbits(s);
-    if (ebits > sbits)
-        throw default_exception("division with ebits > sbits not supported");
-    SASSERT(ebits <= sbits);
+    const mpz & lz_modulus = m_mpf_manager.m_powers2(ebits);
+
+    // The ebits-wide count returned by unpack is exact when sbits <= 2^ebits.
+    // Division computes the count locally when the significand exceeds that
+    // modulus, before any normalization shift can consume a wrapped value.
+    bool needs_wide_lz = m_mpz_manager.lt(lz_modulus, mpz(sbits));
+    unsigned exp_bits = ebits + 2;
+    if (needs_wide_lz) {
+        // Exact division exponents are in
+        // [3 - 2^ebits - sbits, 2^ebits + sbits - 4].
+        scoped_mpz max_exp(m_mpz_manager);
+        m_mpz_manager.add(lz_modulus, sbits, max_exp);
+        m_mpz_manager.sub(max_exp, 4, max_exp);
+        // The lower endpoint is -(max_exp + 1), so one sign bit beyond
+        // max_exp's bit-length covers both endpoints.
+        exp_bits = m_mpz_manager.log2(max_exp) + 2;
+    }
+    DEBUG_CODE({
+        scoped_mpz max_result_shift(m_mpz_manager);
+        m_mpz_manager.add(mpz(sbits), mpz(3), max_result_shift);
+        SASSERT(m_mpz_manager.lt(max_result_shift, m_mpf_manager.m_powers2(exp_bits)));
+    });
+    // The local count only needs to represent 0..sbits-1; do not reuse the
+    // wider signed exponent bit-vector for this unsigned count.
+    unsigned lz_bits = needs_wide_lz ? m_mpz_manager.log2(mpz(sbits - 1)) + 1 : ebits;
 
     expr_ref a_sgn(m), a_sig(m), a_exp(m), a_lz(m), b_sgn(m), b_sig(m), b_exp(m), b_lz(m);
-    unpack(x, a_sgn, a_sig, a_exp, a_lz, true);
-    unpack(y, b_sgn, b_sig, b_exp, b_lz, true);
+    // Defer normalization only for wide-LZ formats; the shared ebits-wide count
+    // would otherwise be consumed before division can compute the exact count.
+    bool normalize_before_division = !needs_wide_lz;
+    unpack(x, a_sgn, a_sig, a_exp, a_lz, normalize_before_division);
+    unpack(y, b_sgn, b_sig, b_exp, b_lz, normalize_before_division);
+
+    if (needs_wide_lz) {
+        // Division needs the exact leading-zero count in its exponent arithmetic.
+        // Keep this local: the shared unpack path must retain its ebits-wide
+        // interface, while division needs the raw significand before shifting.
+        expr_ref zero_sig(m), a_sig_is_zero(m), b_sig_is_zero(m);
+        zero_sig = m_bv_util.mk_numeral(0, sbits);
+        m_simp.mk_eq(zero_sig, a_sig, a_sig_is_zero);
+        m_simp.mk_eq(zero_sig, b_sig, b_sig_is_zero);
+
+        expr_ref zero_lz(m), a_lz_raw(m), b_lz_raw(m);
+        zero_lz = m_bv_util.mk_numeral(0, lz_bits);
+        mk_leading_zeros(a_sig, lz_bits, a_lz_raw);
+        mk_leading_zeros(b_sig, lz_bits, b_lz_raw);
+        m_simp.mk_ite(a_sig_is_zero, zero_lz, a_lz_raw, a_lz);
+        m_simp.mk_ite(b_sig_is_zero, zero_lz, b_lz_raw, b_lz);
+
+        SASSERT(lz_bits <= sbits);
+        expr_ref a_shift(m), b_shift(m);
+        a_shift = m_bv_util.mk_zero_extend(sbits - lz_bits, a_lz);
+        b_shift = m_bv_util.mk_zero_extend(sbits - lz_bits, b_lz);
+        a_sig = m_bv_util.mk_bv_shl(a_sig, a_shift);
+        b_sig = m_bv_util.mk_bv_shl(b_sig, b_shift);
+    }
 
     unsigned extra_bits = sbits+2;
     expr_ref a_sig_ext(m), b_sig_ext(m);
@@ -981,15 +1030,15 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     dbg_decouple("fpa2bv_div_b_sig_ext", b_sig_ext);
 
     expr_ref a_exp_ext(m), b_exp_ext(m);
-    a_exp_ext = m_bv_util.mk_sign_extend(2, a_exp);
-    b_exp_ext = m_bv_util.mk_sign_extend(2, b_exp);
+    a_exp_ext = m_bv_util.mk_sign_extend(exp_bits - ebits, a_exp);
+    b_exp_ext = m_bv_util.mk_sign_extend(exp_bits - ebits, b_exp);
 
     expr_ref res_sgn(m), res_sig(m), res_exp(m);
     res_sgn = m_bv_util.mk_bv_xor({a_sgn, b_sgn});
 
     expr_ref a_lz_ext(m), b_lz_ext(m);
-    a_lz_ext = m_bv_util.mk_zero_extend(2, a_lz);
-    b_lz_ext = m_bv_util.mk_zero_extend(2, b_lz);
+    a_lz_ext = m_bv_util.mk_zero_extend(exp_bits - lz_bits, a_lz);
+    b_lz_ext = m_bv_util.mk_zero_extend(exp_bits - lz_bits, b_lz);
 
     res_exp = m_bv_util.mk_bv_sub(
         m_bv_util.mk_bv_sub(a_exp_ext, a_lz_ext),
@@ -1002,16 +1051,24 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
 
     SASSERT(m_bv_util.get_bv_size(quotient) == (sbits + sbits + extra_bits));
 
-    expr_ref sticky(m), upper(m), upper_reduced(m), too_large(m);
+    expr_ref sticky(m), too_large(m);
     sticky = m.mk_app(m_bv_util.get_fid(), OP_BREDOR, m_bv_util.mk_extract(extra_bits-2, 0, quotient));
     res_sig = m_bv_util.mk_concat(m_bv_util.mk_extract(extra_bits+sbits+1, extra_bits-1, quotient), sticky);
-    upper = m_bv_util.mk_extract(sbits + sbits + extra_bits-1, extra_bits+sbits+2, quotient);
-    upper_reduced = m.mk_app(m_bv_util.get_fid(), OP_BREDOR, upper.get());
-    too_large = m.mk_eq(upper_reduced, m_bv_util.mk_numeral(1, 1));
+    if (sbits == 2) {
+        // The upper quotient slice has width sbits - 2, so it is empty here.
+        // The sort constructor guarantees that sbits is never below 2.
+        too_large = m.mk_false();
+    }
+    else {
+        expr_ref upper(m), upper_reduced(m);
+        upper = m_bv_util.mk_extract(sbits + sbits + extra_bits-1, extra_bits+sbits+2, quotient);
+        upper_reduced = m.mk_app(m_bv_util.get_fid(), OP_BREDOR, upper.get());
+        too_large = m.mk_eq(upper_reduced, m_bv_util.mk_numeral(1, 1));
+        dbg_decouple("fpa2bv_div_upper", upper);
+    }
     c8 = too_large;
     mk_ite(signs_xor, ninf, pinf, v8);
     dbg_decouple("fpa2bv_div_res_sig_p4", res_sig);
-    dbg_decouple("fpa2bv_div_upper", upper);
     dbg_decouple("fpa2bv_div_too_large", too_large);
 
     SASSERT(m_bv_util.get_bv_size(res_sig) == (sbits + 4));
@@ -1026,14 +1083,94 @@ void fpa2bv_converter::mk_div(sort * s, expr_ref & rm, expr_ref & x, expr_ref & 
     shift_cond = m_bv_util.mk_ule(res_sig_lz, m_bv_util.mk_numeral(1, sbits + 4));
     expr_ref res_sig_shifted(m), res_exp_shifted(m);
     res_sig_shifted = m_bv_util.mk_bv_shl(res_sig, res_sig_shift_amount);
-    res_exp_shifted = m_bv_util.mk_bv_sub(res_exp, m_bv_util.mk_extract(ebits + 1, 0, res_sig_shift_amount));
+    expr_ref exp_shift_amount(m);
+    // The shifted branch's correction is at most sbits + 3, so this resize is exact.
+    if (exp_bits <= sbits + 4)
+        exp_shift_amount = m_bv_util.mk_extract(exp_bits - 1, 0, res_sig_shift_amount);
+    else
+        exp_shift_amount = m_bv_util.mk_zero_extend(exp_bits - (sbits + 4), res_sig_shift_amount);
+    res_exp_shifted = m_bv_util.mk_bv_sub(res_exp, exp_shift_amount);
     m_simp.mk_ite(shift_cond, res_sig, res_sig_shifted, res_sig);
     m_simp.mk_ite(shift_cond, res_exp, res_exp_shifted, res_exp);
 
     dbg_decouple("fpa2bv_div_res_sig", res_sig);
     dbg_decouple("fpa2bv_div_res_exp", res_exp);
 
-    round(s, rm, res_sgn, res_sig, res_exp, v9);
+    if (exp_bits > ebits + 2) {
+        // The rounder consumes an ebits+2 exponent. Keep ordinary exponents
+        // in that representation, clamp guaranteed overflow for round's
+        // existing overflow logic, and handle deeper underflow locally.
+        unsigned round_exp_bits = ebits + 2;
+        unsigned sig_size = sbits + 4;
+        expr_ref round_exp(m), exp_below_round_range(m), underflow_result(m);
+        expr_ref round_min_exp(m), round_max_exp(m), round_min_exp_ext(m), round_max_exp_ext(m);
+        round_min_exp = m_bv_util.mk_numeral(m_mpf_manager.m_powers2(ebits + 1, true), round_exp_bits);
+        round_max_exp = m_bv_util.mk_numeral(m_mpf_manager.m_powers2.m1(ebits + 1, false), round_exp_bits);
+        round_min_exp_ext = m_bv_util.mk_sign_extend(exp_bits - round_exp_bits, round_min_exp);
+        round_max_exp_ext = m_bv_util.mk_sign_extend(exp_bits - round_exp_bits, round_max_exp);
+
+        expr_ref exp_above_round_range(m), exp_in_round_range(m);
+        exp_below_round_range = m_bv_util.mk_slt(res_exp, round_min_exp_ext);
+        exp_above_round_range = m_bv_util.mk_slt(round_max_exp_ext, res_exp);
+        exp_in_round_range = m_bv_util.mk_extract(round_exp_bits - 1, 0, res_exp);
+        m_simp.mk_ite(exp_above_round_range, round_max_exp, exp_in_round_range, round_exp);
+        m_simp.mk_ite(exp_below_round_range, round_min_exp, round_exp, round_exp);
+
+        expr_ref min_exp(m), min_exp_ext(m), underflow_shift(m), underflow_shift_sized(m);
+        mk_min_exp(ebits, min_exp);
+        min_exp_ext = m_bv_util.mk_sign_extend(exp_bits - ebits, min_exp);
+        // Below the rounder's signed range, the value is necessarily tiny.
+        // Round it locally: passing a value-preserving shift through round
+        // would make round's t intermediate wrap in its established width.
+        underflow_shift = m_bv_util.mk_bv_sub(min_exp_ext, res_exp);
+        underflow_shift = m_bv_util.mk_bv_sub(
+            underflow_shift, m_bv_util.mk_numeral(1, exp_bits));
+        SASSERT(exp_bits <= sig_size);
+        underflow_shift_sized = m_bv_util.mk_zero_extend(
+            2 * sig_size - exp_bits, underflow_shift);
+
+        expr_ref sig_ext(m), shifted_sig(m), discarded(m);
+        sig_ext = m_bv_util.mk_concat(res_sig, m_bv_util.mk_numeral(0, sig_size));
+        shifted_sig = m_bv_util.mk_bv_lshr(sig_ext, underflow_shift_sized);
+        unsigned sig_extract_low_bit = 2 * sig_size - (sbits + 2);
+        // The shift is at most sbits + 2^(ebits - 1) - 2. If it passes the
+        // zero padding, the normalized leading one remains in this low slice,
+        // so sticky is already one for any source bits shifted out entirely.
+        discarded = m.mk_app(
+            m_bv_util.get_fid(), OP_BREDOR,
+            m_bv_util.mk_extract(sig_extract_low_bit - 1, 0, shifted_sig));
+
+        expr_ref sticky_ext(m), underflow_sig(m);
+        underflow_sig = m_bv_util.mk_extract(
+            2 * sig_size - 1, sig_extract_low_bit, shifted_sig);
+        sticky_ext = m_bv_util.mk_zero_extend(sbits + 1, discarded);
+        underflow_sig = m_bv_util.mk_bv_or({underflow_sig, sticky_ext});
+
+        expr_ref underflow_sticky(m), underflow_round(m), underflow_last(m);
+        underflow_sticky = m_bv_util.mk_extract(0, 0, underflow_sig);
+        underflow_round = m_bv_util.mk_extract(1, 1, underflow_sig);
+        underflow_last = m_bv_util.mk_extract(2, 2, underflow_sig);
+        expr_ref underflow_retained(m), underflow_inc(m), underflow_rounded_sig(m);
+        underflow_retained = m_bv_util.mk_extract(sbits + 1, 2, underflow_sig);
+        underflow_inc = mk_rounding_decision(
+            rm, res_sgn, underflow_last, underflow_round, underflow_sticky);
+        // This path shifts by at least eight bits, so the retained significand
+        // has a leading zero and rounding cannot carry into minimum normal.
+        underflow_rounded_sig = m_bv_util.mk_bv_add(
+            underflow_retained,
+            m_bv_util.mk_zero_extend(sbits - 1, underflow_inc));
+
+        expr_ref underflow_exp(m), underflow_frac(m);
+        underflow_exp = m_bv_util.mk_numeral(0, ebits);
+        underflow_frac = m_bv_util.mk_extract(sbits - 2, 0, underflow_rounded_sig);
+        underflow_result = m_util.mk_fp(res_sgn, underflow_exp, underflow_frac);
+
+        round(s, rm, res_sgn, res_sig, round_exp, v9);
+        mk_ite(exp_below_round_range, underflow_result, v9, v9);
+    }
+    else {
+        round(s, rm, res_sgn, res_sig, res_exp, v9);
+    }
 
     // And finally, we tie them together.
     mk_ite(c8, v8, v9, result);

--- a/src/ast/fpa/fpa2bv_converter.h
+++ b/src/ast/fpa/fpa2bv_converter.h
@@ -207,6 +207,9 @@ protected:
     void mk_to_bv(func_decl * f, unsigned num, expr * const * args, bool is_signed, expr_ref & result);
 
 private:
+    void unpack_with_lz_width(expr * e, expr_ref & sgn, expr_ref & sig, expr_ref & exp,
+                              expr_ref & lz, bool normalize, unsigned lz_bits);
+
     void mk_nan(sort * s, expr_ref & result);
 
     void mk_nzero(sort * s, expr_ref & result);

--- a/src/ast/fpa/fpa2bv_converter.h
+++ b/src/ast/fpa/fpa2bv_converter.h
@@ -207,9 +207,6 @@ protected:
     void mk_to_bv(func_decl * f, unsigned num, expr * const * args, bool is_signed, expr_ref & result);
 
 private:
-    void unpack_with_lz_width(expr * e, expr_ref & sgn, expr_ref & sig, expr_ref & exp,
-                              expr_ref & lz, bool normalize, unsigned lz_bits);
-
     void mk_nan(sort * s, expr_ref & result);
 
     void mk_nzero(sort * s, expr_ref & result);


### PR DESCRIPTION
## Summary

Remove `mk_div`'s `ebits > sbits` rejection and preserve symbolic `fp.div`
normalization for both `ebits <= sbits` and `ebits > sbits`. When
`sbits > 2^ebits`, division uses an exact nonzero-significand leading-zero count and
sizes its signed intermediate exponent for
`[3 - 2^ebits - sbits, 2^ebits + sbits - 4]`. When `sbits <= 2^ebits`, it keeps
`unpack`'s existing normalization path.

At `sbits = 2`, the would-be upper quotient extract has high index 7 and low index 8;
`res_sig` already consumes every quotient bit, so `too_large` is false without
constructing that range. Above-range exponents use `round`'s existing infinity or
max-finite selection; below-range exponents retain the shift distance and discarded
bits needed to round subnormal results.

`round` still receives an `ebits + 2`-bit exponent and computes an
`ebits + 2`-bit `sigma`. It caps a negative `sigma` only when `sbits + 2` is
representable in that width. Otherwise `sbits + 2 >= 2^(ebits + 2)`, while
`-sigma <= 2^(ebits + 1)`, so the cap cannot bind. When `sigma` is wider than `sig_ext`'s
`2 * (sbits + 4)`-bit shift operand, `sigma_neg_capped` is at most `sbits + 2` and a
nonnegative `sigma` is at most `sig`'s leading-zero count. Both values are less than
`2 * (sbits + 4)`, so extracting that many low bits preserves them. An FP conversion
regression covers the cap case; separate multiplication, square-root, and conversion
regressions cover the wider-`sigma` branch.

[SMT-LIB FloatingPoint 2.7](https://smt-lib.org/theories-FloatingPoint.shtml) imposes no
ordering between `eb` and `sb`. Z3's AST layer separately caps `eb` at 63.

Fixes #10175.

Regression coverage: Z3Prover/z3test#63.

## Testing

- Fork CI at paired head `86cb28ab4`, merging Z3 master `43ce75ace` with source
  `784328c47` and pinning z3test `8594d141`:
  [full CI](https://github.com/1sgtpepper/z3/actions/runs/33310681302) passed 14/14 jobs and
  [standalone OCaml](https://github.com/1sgtpepper/z3/actions/runs/33310681324) passed 2/2 jobs.
- Mutation controls using the retained regression queries at their earlier filenames:
  [unpatched source](https://github.com/1sgtpepper/z3/actions/runs/32843604222),
  [`sbits = 2` quotient range](https://github.com/1sgtpepper/z3/actions/runs/32843607440),
  [division exponent decrement](https://github.com/1sgtpepper/z3/actions/runs/32843610840), and
  [`round` shift-count cap](https://github.com/1sgtpepper/z3/actions/runs/32843613738) each fail
  all eight jobs that run these regressions; the other six jobs pass.
- No local Z3 build was run; validation used fork CI.
