### PR TITLE
Adding failing IO test

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -127,6 +127,7 @@ add_executable(test-z3
   rcf.cpp
   region.cpp
   regex_range_collapse.cpp
+  scanner_io.cpp
   sat_local_search.cpp
   sat_lookahead.cpp
   sat_user_scope.cpp

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -73,6 +73,7 @@
     X(bit_blaster) \
     X(var_subst) \
     X(simple_parser) \
+    X(scanner_io) \
     X(api) \
     X(max_rev) \
     X(scaled_min) \

--- a/src/test/scanner_io.cpp
+++ b/src/test/scanner_io.cpp
@@ -1,6 +1,4 @@
 /*++
-Copyright (c) 2026 Chad Brewbaker
-
 Module Name:
 
     scanner_io.cpp

--- a/src/test/scanner_io.cpp
+++ b/src/test/scanner_io.cpp
@@ -1,0 +1,123 @@
+/*++
+Copyright (c) 2026 Chad Brewbaker
+
+Module Name:
+
+    scanner_io.cpp
+
+Abstract:
+
+    Regression test: a scanner must distinguish a FAILED input stream from an
+    EXHAUSTED one.
+
+    scanner::read_char() (src/parsers/util/scanner.cpp) does:
+
+        m_stream.read(m_buffer.data()+1, m_buffer.size()-1);
+        m_bend = 1 + static_cast<unsigned>(m_stream.gcount());
+        m_bpos = 1;
+        ...
+        } else {
+            ++m_bpos;
+            return -1;
+        }
+
+    std::istream::gcount() returns 0 when the stream is exhausted AND when the
+    read fails. So on a failed read m_bend == 1 == m_bpos, and read_char()
+    returns -1 -- the identical value it returns for a cleanly finished file.
+    bad(), fail() and exceptions() do not appear in that translation unit.
+
+    The same shape is in smt2scanner.cpp, which is the path an input FILE takes
+    (confirmed under gdb: smt2::scanner::scan -> smt2::parser::operator() ->
+    parse_smt2_commands -> read_smtlib2_commands).
+
+    Observed on Z3 5.0.0 with the read(2) failing under fault injection:
+
+        errno     stdout      exit
+        (none)    unsat       0     baseline
+        EIO       (empty)     0     no answer, reported as success
+        ENOSPC    (empty)     0     no answer, reported as success
+        EINTR     unsat       0     recovered -- libstdc++ retries
+
+    Note z3 ALREADY diagnoses a file it cannot OPEN (exit 108, "failed to open
+    file"). The gap is a file it can open and cannot read.
+
+    No wrong answer was observed: output was empty, never incorrect.
+
+--*/
+#include "parsers/util/scanner.h"
+#include "util/warning.h"
+#include <istream>
+#include <sstream>
+
+namespace {
+
+    // A streambuf that delivers `good_bytes` and then fails, the way a real
+    // stream does on EIO. underflow() returning eof() with badbit set is the
+    // portable stand-in for a device error -- no signals, no filesystem tricks,
+    // identical on every platform.
+    class failing_buf : public std::streambuf {
+        std::string m_data;
+        size_t      m_pos = 0;
+        char        m_ch  = 0;
+    public:
+        explicit failing_buf(std::string d) : m_data(std::move(d)) {}
+    protected:
+        int_type underflow() override {
+            if (m_pos < m_data.size()) {
+                m_ch = m_data[m_pos];
+                setg(&m_ch, &m_ch, &m_ch + 1);
+                return traits_type::to_int_type(m_ch);
+            }
+            return traits_type::eof();   // caller sets badbit; see below
+        }
+    };
+
+    unsigned drain(scanner & s) {
+        unsigned n = 0;
+        while (s.scan() != scanner::EOF_TOKEN && n < 10000) ++n;
+        return n;
+    }
+}
+
+void tst_scanner_io() {
+    // CONTROL -- a good stream must scan to completion, or the test proves
+    // nothing about the failing case.
+    {
+        std::istringstream good("(assert (> x 5))");
+        std::ostringstream err;
+        scanner s(good, err, true /*smt2*/, false);
+        unsigned n = drain(s);
+        ENSURE(n > 0);
+    }
+
+    // THE TEST -- a stream in a failed state must not be reported as a clean
+    // end of input. Today read_char() returns -1 for both, so the scanner
+    // reports EOF_TOKEN and the caller sees a valid, empty document.
+    {
+        std::istringstream bad("(assert (> x 5))");
+        bad.setstate(std::ios::badbit);
+        std::ostringstream err;
+        scanner s(bad, err, true /*smt2*/, false);
+
+        // The scanner has an ERROR_TOKEN in its own enum (scanner.h:37). A
+        // failed stream is exactly what it is for. Accept any signal: the
+        // error token, a message on `err`, or an exception -- anything but
+        // silence.
+        bool signalled = false;
+        try {
+            scanner::token t;
+            unsigned n = 0;
+            while ((t = s.scan()) != scanner::EOF_TOKEN && n++ < 10000) {
+                if (t == scanner::ERROR_TOKEN) { signalled = true; break; }
+            }
+            signalled = signalled || !err.str().empty();
+        }
+        catch (...) {
+            signalled = true;
+        }
+        // FAILS TODAY: read_char() returns -1 for a failed stream exactly as it
+        // does for an exhausted one, so scan() reports EOF_TOKEN and the caller
+        // sees a valid, empty document.
+        ENSURE(signalled);
+    }
+}


### PR DESCRIPTION
I ran my strace injection utility that found some silent read errors
https://github.com/chadbrewbaker/sauron

After attaching the debugger to verify it wasn't a false positive, I added this unit test to catch the silent read errors going forward. Not sure how you want to remediate. The SQLITE project uses a uniform error handler on file IO, that might help here. LEAN had similar issues: https://chadbrewbaker.github.io/2026/07/27/introducing-sauron.html