### PR TITLE
Add -V:level command-line option

### DIFF
--- a/src/sat/sat_asymm_branch.cpp
+++ b/src/sat/sat_asymm_branch.cpp
@@ -49,12 +49,12 @@ namespace sat {
         report(asymm_branch & a):
             m_asymm_branch(a),
             m_elim_literals(a.m_elim_literals),
-            m_elim_learned_literals(a.m_elim_learned_literals),            
+            m_elim_learned_literals(a.m_elim_learned_literals),
             m_tr(a.m_tr),
             m_units(a.s.init_trail_size()) {
             m_watch.start();
         }
-        
+
         ~report() {
             m_watch.stop();
             IF_VERBOSE(2,
@@ -64,13 +64,16 @@ namespace sat {
                        unsigned elim_lits = (num_total - num_learned);
                        unsigned tr = (m_asymm_branch.m_tr - m_tr);
                        verbose_stream() << " (sat-asymm-branch";
-                       if (elim_lits > 0)   verbose_stream() << " :elim-literals " << elim_lits; 
+                       if (elim_lits > 0)   verbose_stream() << " :elim-literals " << elim_lits;
                        if (num_learned > 0) verbose_stream() << " :elim-learned-literals " << num_learned;
                        if (num_units > 0)   verbose_stream() << " :units " << num_units;
                        if (tr > 0)          verbose_stream() << " :hte " << tr;
-                       verbose_stream() << " :cost " << m_asymm_branch.m_counter;
-                       verbose_stream() << mem_stat();
-                       verbose_stream() << m_watch << ")\n";);
+                       if (!get_verbosity_plain()) {
+                           verbose_stream() << " :cost " << m_asymm_branch.m_counter;
+                           verbose_stream() << mem_stat();
+                           verbose_stream() << m_watch;
+                       }
+                       verbose_stream() << ")\n";);
         }
     };
 
@@ -87,15 +90,15 @@ namespace sat {
             process(&big, s.m_clauses);
             process(&big, s.m_learned);
             process_bin(big);
-            s.propagate(false); 
+            s.propagate(false);
             if (s.m_inconsistent)
                 break;
             unsigned num_elim = m_elim_literals + m_tr - elim;
             IF_VERBOSE(4, verbose_stream() << "(sat-asymm-branch-step :elim " << num_elim << ")\n";);
             if (num_elim == 0)
                 break;
-        }        
-        IF_VERBOSE(4, if (m_elim_learned_literals > eliml0) 
+        }
+        IF_VERBOSE(4, if (m_elim_learned_literals > eliml0)
                           verbose_stream() << "(sat-asymm-branch :elim " << m_elim_learned_literals - eliml0 << ")\n";);
         return m_elim_literals > elim0;
     }
@@ -105,8 +108,8 @@ namespace sat {
         unsigned elim = m_elim_literals;
         process(nullptr, s.m_clauses);
         if (learned) process(nullptr, s.m_learned);
-        s.propagate(false); 
-        IF_VERBOSE(4, if (m_elim_learned_literals > eliml0) 
+        s.propagate(false);
+        IF_VERBOSE(4, if (m_elim_learned_literals > eliml0)
                           verbose_stream() << "(sat-asymm-branch :elim " << m_elim_learned_literals - eliml0 << ")\n";);
         return m_elim_literals > elim;
     }
@@ -133,7 +136,7 @@ namespace sat {
                     ++it2;
                     continue;
                 }
-                s.checkpoint();                
+                s.checkpoint();
                 if (big ? !process_sampled(*big, c) : !process(c)) {
                     continue; // clause was removed
                 }
@@ -152,8 +155,8 @@ namespace sat {
             throw ex;
         }
     }
-    
-    
+
+
     void asymm_branch::operator()(bool force) {
         ++m_calls;
         if (m_calls <= m_asymm_branch_delay)
@@ -188,7 +191,7 @@ namespace sat {
                 if (process(big, false)) change = true;
             }
             if (m_asymm_branch) {
-                m_counter  = 0; 
+                m_counter  = 0;
                 if (process(false)) change = true;
                 m_counter = -m_counter;
             }
@@ -205,7 +208,7 @@ namespace sat {
     }
 
     /**
-       \brief try asymmetric branching on all literals in clause.        
+       \brief try asymmetric branching on all literals in clause.
     */
 
     bool asymm_branch::process_all(clause & c) {
@@ -228,8 +231,8 @@ namespace sat {
         }
     };
 
-    bool asymm_branch::is_touched(bool_var v) const { 
-        return s.m_touched[v] >= m_touch_index; 
+    bool asymm_branch::is_touched(bool_var v) const {
+        return s.m_touched[v] >= m_touch_index;
     }
 
     void asymm_branch::sort(big& big, clause const& c) {
@@ -247,10 +250,10 @@ namespace sat {
         std::sort(m_pos.begin(), m_pos.end(), cmp);
         std::sort(m_neg.begin(), m_neg.end(), cmp);
 
-        IF_VERBOSE(100, 
-                   for (literal l : m_pos) verbose_stream() << big.get_left(l) << " "; 
+        IF_VERBOSE(100,
+                   for (literal l : m_pos) verbose_stream() << big.get_left(l) << " ";
                    verbose_stream() << "\n";
-                   for (literal l : m_neg) verbose_stream() << big.get_left(l) << " "; 
+                   for (literal l : m_neg) verbose_stream() << big.get_left(l) << " ";
                    verbose_stream() << "\n";
                    );
     }
@@ -318,7 +321,7 @@ namespace sat {
                 case l_true:
                     scoped_d.del_clause();
                     return false;
-                case l_false:    
+                case l_false:
                     break;
                 default:
                     if (!m_to_delete.contains(lit)) {
@@ -352,7 +355,7 @@ namespace sat {
     bool asymm_branch::flip_literal_at(clause const& c, unsigned flip_index, unsigned& new_sz) {
         VERIFY(s.m_trail.size() == s.m_qhead);
         bool found_conflict = false;
-        unsigned i = 0, sz = c.size();        
+        unsigned i = 0, sz = c.size();
         s.push();
         for (i = 0; !found_conflict && i < sz; ++i) {
             if (i == flip_index) continue;
@@ -366,10 +369,10 @@ namespace sat {
         new_sz = i;
         return found_conflict;
     }
-    
+
     bool asymm_branch::cleanup(scoped_detach& scoped_d, clause& c, unsigned skip_idx, unsigned new_sz) {
         unsigned j = 0;
-        for (unsigned i = 0; i < new_sz; ++i) {            
+        for (unsigned i = 0; i < new_sz; ++i) {
             if (skip_idx == i) continue;
             literal l = c[i];
             switch (s.value(l)) {
@@ -386,7 +389,7 @@ namespace sat {
                 break;
             }
         }
-        new_sz = j;                
+        new_sz = j;
         return re_attach(scoped_d, c, new_sz);
     }
 
@@ -395,7 +398,7 @@ namespace sat {
         unsigned old_sz = c.size();
         m_elim_literals += old_sz - new_sz;
         if (c.is_learned()) {
-            m_elim_learned_literals += old_sz - new_sz; 
+            m_elim_learned_literals += old_sz - new_sz;
         }
 
         switch (new_sz) {
@@ -405,7 +408,7 @@ namespace sat {
         case 1:
             TRACE(asymm_branch, tout << "produced unit clause: " << c[0] << "\n";);
             s.assign_unit(c[0]);
-            s.propagate_core(false); 
+            s.propagate_core(false);
             scoped_d.del_clause();
             return false; // check_missed_propagation() may fail, since m_clauses is not in a consistent state.
         case 2:
@@ -425,11 +428,11 @@ namespace sat {
         scoped_detach scoped_d(s, c);
         sort(big, c);
         if (uhte(big, c)) {
-            // don't touch hidden tautologies. 
+            // don't touch hidden tautologies.
             // ATE takes care of them.
             return true;
         }
-        return uhle(scoped_d, big, c);        
+        return uhle(scoped_d, big, c);
     }
 
     bool asymm_branch::process(clause & c) {
@@ -456,7 +459,7 @@ namespace sat {
         // clause must not be used for propagation
         scoped_detach scoped_d(s, c);
         unsigned new_sz = c.size();
-        unsigned flip_position = m_rand(c.size()); 
+        unsigned flip_position = m_rand(c.size());
         bool found_conflict = flip_literal_at(c, flip_position, new_sz);
         SASSERT(!s.inconsistent());
         SASSERT(s.scope_lvl() == 0);
@@ -465,11 +468,11 @@ namespace sat {
             return true;
         }
         else {
-            // clause can be reduced 
+            // clause can be reduced
             return cleanup(scoped_d, c, flip_position, new_sz);
         }
     }
-    
+
     void asymm_branch::updt_params(params_ref const & _p) {
         sat_asymm_branch_params p(_p);
         m_asymm_branch         = p.asymm_branch();
@@ -485,7 +488,7 @@ namespace sat {
     void asymm_branch::collect_param_descrs(param_descrs & d) {
         sat_asymm_branch_params::collect_param_descrs(d);
     }
-    
+
     void asymm_branch::collect_statistics(statistics & st) const {
         st.update("sat elim literals", m_elim_literals);
         st.update("sat tr", m_tr);

--- a/src/sat/sat_cleaner.cpp
+++ b/src/sat/sat_cleaner.cpp
@@ -25,11 +25,11 @@ namespace sat {
 
     cleaner::cleaner(solver & _s):
         s(_s),
-        m_last_num_units(0), 
+        m_last_num_units(0),
         m_cleanup_counter(0) {
         reset_statistics();
     }
-    
+
     /**
        - Delete watch lists of assigned literals.
        - Delete satisfied binary watched binary clauses
@@ -53,7 +53,7 @@ namespace sat {
             for (; it2 != end2; ++it2) {
                 switch (it2->get_kind()) {
                 case watched::BINARY:
-                    TRACE(cleanup_bug, 
+                    TRACE(cleanup_bug,
                           tout << ~to_literal(l_idx) << " " << it2->get_literal() << "\n";
                           tout << s.value(~to_literal(l_idx)) << " " << s.value(it2->get_literal()) << "\n";
                           tout << s.was_eliminated(it2->get_literal()) << " " << s.inconsistent() << "\n";);
@@ -139,7 +139,7 @@ namespace sat {
                     s.shrink(c, sz, new_sz);
                     *it2 = *it;
                     it2++;
-                    if (!c.frozen()) {                            
+                    if (!c.frozen()) {
                         s.attach_clause(c);
                     }
                     break;
@@ -166,7 +166,11 @@ namespace sat {
                        verbose_stream() << " (sat-cleaner";
                        verbose_stream() << " :elim-literals " << (m_cleaner.m_elim_literals - m_elim_literals);
                        verbose_stream() << " :elim-clauses " << (m_cleaner.m_elim_clauses - m_elim_clauses);
-                       verbose_stream() << " :cost " << m_cleaner.m_cleanup_counter << m_watch << ")\n";);
+                       verbose_stream() << " :cost " << m_cleaner.m_cleanup_counter;
+                       if (!get_verbosity_plain()) {
+                           verbose_stream() << m_watch;
+                       }
+                       verbose_stream() << ")\n";);
         }
     };
 
@@ -219,12 +223,12 @@ namespace sat {
         CASSERT("cleaner_bug", s.check_invariant());
         return true;
     }
-    
+
     void cleaner::reset_statistics() {
         m_elim_clauses = 0;
         m_elim_literals = 0;
     }
-    
+
     void cleaner::collect_statistics(statistics & st) const {
         st.update("sat elim clauses", m_elim_clauses);
         st.update("sat elim literals", m_elim_literals);

--- a/src/sat/sat_probing.cpp
+++ b/src/sat/sat_probing.cpp
@@ -160,7 +160,7 @@ namespace sat {
 #endif
         }
         cache_bins(l, old_tr_sz);
-        
+
         s.pop(1);
 
         if (!try_lit(~l, true))
@@ -170,7 +170,7 @@ namespace sat {
             unsigned sz = s.get_wlist(~l).size();
             for (unsigned i = 0; i < sz; ++i) {
                 watch_list& wlist = s.get_wlist(~l);
-                watched & w = wlist[i];                
+                watched & w = wlist[i];
                 if (!w.is_binary_clause())
                     continue;
                 literal l2 = w.get_literal();
@@ -203,7 +203,7 @@ namespace sat {
     struct probing::report {
         probing    & p;
         stopwatch    m_watch;
-        unsigned     m_num_assigned;        
+        unsigned     m_num_assigned;
         report(probing & p):
             p(p),
             m_num_assigned(p.m_num_assigned) {
@@ -219,7 +219,10 @@ namespace sat {
                        if (!p.m_equivs.empty()) verbose_stream() << " :equivs " << p.m_equivs.size();
                        verbose_stream() << " :cost " << p.m_counter;
                        if (p.m_stopped_at != 0) verbose_stream() << " :stopped-at " << p.m_stopped_at;
-                       verbose_stream() << mem_stat() << m_watch << ")\n";);
+                       if (!get_verbosity_plain()) {
+                           verbose_stream() << mem_stat() << m_watch;
+                       }
+                       verbose_stream() << ")\n";);
         }
     };
 
@@ -288,7 +291,7 @@ namespace sat {
             elim_eqs elim(s);
             elim(uf);
         }
-        
+
         return r;
     }
 

--- a/src/sat/sat_scc.cpp
+++ b/src/sat/sat_scc.cpp
@@ -59,11 +59,12 @@ namespace sat {
             m_watch.stop();
             unsigned elim_bin = m_scc.m_num_elim_bin - m_num_elim_bin;
             unsigned num_units = m_scc.m_solver.init_trail_size() - m_trail_size;
-            IF_VERBOSE(2, 
+            IF_VERBOSE(2,
                        verbose_stream() << " (sat-scc :elim-vars " << (m_scc.m_num_elim - m_num_elim);
                        if (elim_bin > 0) verbose_stream() << " :elim-bin " << elim_bin;
                        if (num_units > 0) verbose_stream() << " :units " << num_units;
-                       verbose_stream() << m_watch << ")\n";);
+                       if (!get_verbosity_plain()) verbose_stream() << m_watch;
+                       verbose_stream() << ")\n";);
         }
     };
 
@@ -80,13 +81,13 @@ namespace sat {
         roots.resize(m_solver.num_vars(), null_literal);
         unsigned next_index = 0;
         svector<frame>   frames;
-        
+
         for (unsigned l_idx = 0; l_idx < num_lits; ++l_idx) {
             if (index[l_idx] != UINT_MAX)
                 continue;
             if (m_solver.was_eliminated(to_literal(l_idx).var()))
                 continue;
-            
+
             m_solver.checkpoint();
 
 #define NEW_NODE(LIDX) {                                                        \
@@ -147,7 +148,7 @@ namespace sat {
                             } while (l2_idx != l_idx);
                             tout << "\n";
                         });
-                    
+
                     SASSERT(!s.empty());
                     literal l = to_literal(l_idx);
                     bool_var v = l.var();
@@ -242,13 +243,13 @@ namespace sat {
         TRACE(scc_detail, m_solver.display(tout););
         CASSERT("scc_bug", m_solver.check_invariant());
 
-        if (m_scc_tr) 
+        if (m_scc_tr)
             reduce_tr();
         TRACE(scc_detail, m_solver.display(tout););
         return to_elim.size();
     }
 
-    unsigned scc::reduce_tr(bool learned) {        
+    unsigned scc::reduce_tr(bool learned) {
         init_big(learned);
         unsigned num_elim = m_big.reduce_tr(m_solver);
         m_num_elim_bin += num_elim;
@@ -266,7 +267,7 @@ namespace sat {
         st.update("sat scc elim vars", m_num_elim);
         st.update("sat scc elim binary", m_num_elim_bin);
     }
-    
+
     void scc::reset_statistics() {
         m_num_elim = 0;
         m_num_elim_bin = 0;

--- a/src/sat/sat_simplifier.cpp
+++ b/src/sat/sat_simplifier.cpp
@@ -34,28 +34,28 @@ namespace sat {
     }
 
     void use_list::insert(clause & c) {
-        for (literal l : c) 
+        for (literal l : c)
             m_use_list[l.index()].insert(c);
     }
 
     void use_list::erase(clause & c) {
-        for (literal l : c) 
+        for (literal l : c)
             m_use_list[l.index()].erase(c);
     }
 
     void use_list::erase(clause & c, literal l) {
-        for (literal l2 : c) 
+        for (literal l2 : c)
             if (l2 != l)
                 m_use_list[l2.index()].erase(c);
     }
 
     void use_list::block(clause& c) {
-        for (literal l : c) 
+        for (literal l : c)
             m_use_list[l.index()].block(c);
     }
 
     void use_list::unblock(clause& c) {
-        for (literal l : c) 
+        for (literal l : c)
             m_use_list[l.index()].unblock(c);
     }
 
@@ -74,7 +74,7 @@ namespace sat {
 
     watch_list const & simplifier::get_wlist(literal l) const { return s.get_wlist(l); }
 
-    bool simplifier::is_external(bool_var v) const { 
+    bool simplifier::is_external(bool_var v) const {
         if (!s.is_external(v))
             return s.is_assumption(v);
         if (s.is_incremental())
@@ -99,8 +99,8 @@ namespace sat {
     bool simplifier::single_threaded() const { return s.m_config.m_num_threads == 1; }
 
     bool simplifier::bce_enabled_base() const {
-        return 
-            !m_incremental_mode && !s.tracking_assumptions() && 
+        return
+            !m_incremental_mode && !s.tracking_assumptions() &&
             !m_learned_in_use_lists && m_num_calls >= m_bce_delay && single_threaded();
     }
 
@@ -110,9 +110,9 @@ namespace sat {
     bool simplifier::cce_enabled()  const { return bce_enabled_base() && (m_cce || m_acce); }
     bool simplifier::abce_enabled() const { return bce_enabled_base() && m_abce; }
     bool simplifier::bca_enabled()  const { return bce_enabled_base() && m_bca; }
-    bool simplifier::elim_vars_enabled() const { 
-        return !m_incremental_mode && !s.tracking_assumptions() && m_elim_vars && single_threaded(); 
-    }    
+    bool simplifier::elim_vars_enabled() const {
+        return !m_incremental_mode && !s.tracking_assumptions() && m_elim_vars && single_threaded();
+    }
 
     void simplifier::register_clauses(clause_vector & cs) {
         std::stable_sort(cs.begin(), cs.end(), size_lt());
@@ -190,7 +190,7 @@ namespace sat {
             return;
         if (!m_subsumption && !bce_enabled() && !bca_enabled() && !elim_vars_enabled())
             return;
-       
+
         initialize();
 
         CASSERT("sat_solver", s.check_invariant());
@@ -232,7 +232,7 @@ namespace sat {
             if (s.inconsistent())
                 return;
             if (!learned && elim_vars_enabled())
-                elim_vars();            
+                elim_vars();
             if (s.inconsistent())
                 return;
             if (!m_subsumption || m_sub_counter < 0)
@@ -276,7 +276,7 @@ namespace sat {
                     break;
                 }
             }
-            wlist.set_end(itprev);            
+            wlist.set_end(itprev);
         }
     }
 
@@ -336,10 +336,10 @@ namespace sat {
             case 0:
                 s.set_conflict();
                 for (; it != end; ++it, ++it2) {
-                    *it2 = *it;                  
+                    *it2 = *it;
                 }
                 cs.set_end(it2);
-                return;                
+                return;
             case 1:
                 s.assign_unit(c[0]);
                 c.restore(sz0);
@@ -364,7 +364,7 @@ namespace sat {
     }
 
     void simplifier::mark_all_but(clause const & c, literal l1) {
-        for (literal l2 : c) 
+        for (literal l2 : c)
             if (l2 != l1)
                 mark_visited(l2);
     }
@@ -396,7 +396,7 @@ namespace sat {
        Otherwise return false
     */
     bool simplifier::subsumes1(clause const & c1, clause const & c2, literal & l) {
-        for (literal lit : c2) 
+        for (literal lit : c2)
             mark_visited(lit);
 
         bool r = true;
@@ -414,7 +414,7 @@ namespace sat {
             }
         }
 
-        for (literal lit : c2) 
+        for (literal lit : c2)
             unmark_visited(lit);
         return r;
     }
@@ -513,7 +513,7 @@ namespace sat {
        Otherwise return false
     */
     bool simplifier::subsumes0(clause const & c1, clause const & c2) {
-        for (literal l : c2) 
+        for (literal l : c2)
             mark_visited(l);
 
         bool r = true;
@@ -640,7 +640,7 @@ namespace sat {
                 return true;
             }
         }
-        c.shrink(j);            
+        c.shrink(j);
         return false;
     }
 
@@ -665,9 +665,9 @@ namespace sat {
                 it.next();
                 remove_clause(c, true);
             }
-            cs.reset();            
+            cs.reset();
         }
-        for (unsigned i = num_clauses; i < s.m_clauses.size(); ++i) 
+        for (unsigned i = num_clauses; i < s.m_clauses.size(); ++i)
             m_use_list.insert(*s.m_clauses[i]);
     }
 
@@ -714,7 +714,7 @@ namespace sat {
             TRACE(elim_lit, tout << "clause became binary: " << c[0] << " " << c[1] << "\n";);
             c.restore(sz0);
             s.mk_bin_clause(c[0], c[1], c.is_learned());
-            m_sub_bin_todo.push_back(bin_clause(c[0], c[1], c.is_learned()));            
+            m_sub_bin_todo.push_back(bin_clause(c[0], c[1], c.is_learned()));
             remove_clause(c, sz0 != sz);
             break;
         default:
@@ -839,10 +839,17 @@ namespace sat {
             IF_VERBOSE(SAT_VB_LVL,
                        verbose_stream() << " (sat-subsumer :subsumed "
                        << (m_simplifier.m_num_subsumed - m_num_subsumed)
-                       << " :subsumption-resolution " << (m_simplifier.m_num_sub_res - m_num_sub_res)
-                       << " :threshold " << m_simplifier.m_sub_counter
-                       << mem_stat()
-                       << " :time " << std::fixed << std::setprecision(2) << m_watch.get_seconds() << ")\n";);
+                       << " :subsumption-resolution " << (m_simplifier.m_num_sub_res - m_num_sub_res););
+
+            if (!get_verbosity_plain()) {
+                IF_VERBOSE(SAT_VB_LVL,
+                           verbose_stream() << " :threshold " << m_simplifier.m_sub_counter
+                           << mem_stat() << " :time "
+                           << std::fixed << std::setprecision(2) << m_watch.get_seconds(););
+            }
+
+            IF_VERBOSE(SAT_VB_LVL,
+                       verbose_stream() << ")\n";);
         }
     };
 
@@ -945,7 +952,7 @@ namespace sat {
             clause_ante(literal l1, literal l2):
                 m_from_ri(false), m_lit1(l1), m_lit2(l2), m_clause(nullptr) {}
             clause_ante(clause& c):
-                m_from_ri(false), m_lit1(null_literal), m_lit2(null_literal), m_clause(&c) {}            
+                m_from_ri(false), m_lit1(null_literal), m_lit2(null_literal), m_clause(&c) {}
             literal lit1() const { return m_lit1; }
             literal lit2() const { return m_lit2; }
             clause* cls() const { return m_clause; }
@@ -987,7 +994,7 @@ namespace sat {
                 unsigned idx = l.index();
                 if (m_queue.contains(idx))
                     m_queue.decreased(idx);
-                else 
+                else
                     m_queue.insert(idx);
             }
             literal next() { SASSERT(!empty()); return to_literal(m_queue.erase_min()); }
@@ -1088,8 +1095,8 @@ namespace sat {
         void add_intersection(literal lit) {
             m_intersection.push_back(lit);
             m_in_intersection[lit.index()] = true;
-        }        
-        
+        }
+
         //
         // Resolve intersection
         // Find literals that are in the intersection of all resolvents with l.
@@ -1135,18 +1142,18 @@ namespace sat {
                 }
                 if (!tautology) {
                     if (first) {
-                        for (literal lit : c) 
-                            if (lit != ~l && !s.is_marked(lit)) 
+                        for (literal lit : c)
+                            if (lit != ~l && !s.is_marked(lit))
                                 add_intersection(lit);
                         first = false;
                     }
                     else {
                         m_new_intersection.reset();
-                        for (literal lit : c) 
-                            if (m_in_intersection[lit.index()]) 
+                        for (literal lit : c)
+                            if (m_in_intersection[lit.index()])
                                 m_new_intersection.push_back(lit);
                         reset_intersection();
-                        for (literal lit : m_new_intersection) 
+                        for (literal lit : m_new_intersection)
                             add_intersection(lit);
                     }
                     if (m_intersection.empty()) {
@@ -1197,7 +1204,7 @@ namespace sat {
         }
 
         bool revisit_binary(literal l1, literal l2) const {
-            return m_clause.is_binary() && 
+            return m_clause.is_binary() &&
                 ((m_clause[0] == l1 && m_clause[1] == l2) ||
                  (m_clause[0] == l2 && m_clause[1] == l1));
         }
@@ -1223,7 +1230,7 @@ namespace sat {
             for (unsigned i = 0; i < m_covered_clause.size(); ++i) {
                 literal lit = m_covered_clause[i];
                 if (m_covered_antecedent[i] == clause_ante()) s.mark_visited(lit);
-                if (s.is_marked(lit)) idx = i; 
+                if (s.is_marked(lit)) idx = i;
             }
             for (unsigned i = idx; i > 0; --i) {
                 literal lit = m_covered_clause[i];
@@ -1246,10 +1253,10 @@ namespace sat {
             for (unsigned i = 0; i <= idx; ++i) {
                 literal lit = m_covered_clause[i];
                 if (s.is_marked(lit)) {
-                    // 
-                    // Record that the resolving literal for 
+                    //
+                    // Record that the resolving literal for
                     // resolution intersection can be flipped.
-                    // 
+                    //
                     clause_ante const& ante = m_covered_antecedent[i];
                     if (ante.from_ri() && blocked != ante.lit1()) {
                         blocked = ante.lit1();
@@ -1260,7 +1267,7 @@ namespace sat {
                     s.unmark_visited(lit);
                 }
             }
-            for (literal l : m_covered_clause) VERIFY(!s.is_marked(l)); 
+            for (literal l : m_covered_clause) VERIFY(!s.is_marked(l));
             for (bool_var v = 0; v < s.s.num_vars(); ++v) VERIFY(!s.is_marked(literal(v, true)) && !s.is_marked(literal(v, false)));
 
             // unsigned sz0 = m_covered_clause.size();
@@ -1286,7 +1293,7 @@ namespace sat {
             unsigned init_size = m_covered_clause.size();
             for (; m_ala_qhead < m_covered_clause.size() && m_ala_qhead < 5*init_size && !reached_max_cost(); ++m_ala_qhead) {
                 ++m_ala_cost;
-                literal l = m_covered_clause[m_ala_qhead];                
+                literal l = m_covered_clause[m_ala_qhead];
                 for (watched & w : s.get_wlist(~l)) {
                     if (w.is_binary_non_learned_clause()) {
                         literal lit = w.get_literal();
@@ -1346,7 +1353,7 @@ namespace sat {
             for (unsigned i = 0; i < m_covered_clause.size(); ++i) {
                 literal lit = m_covered_clause[i];
                 if (resolution_intersection(lit, false)) {
-                    blocked = m_covered_clause[i];                    
+                    blocked = m_covered_clause[i];
                     minimize_covered_clause(i);
                     return true;
                 }
@@ -1372,7 +1379,7 @@ namespace sat {
         template<elim_type et>
         elim_type cce(literal& blocked, model_converter::kind& k) {
             bool first = true;
-            unsigned sz = 0, sz0 = m_covered_clause.size();     
+            unsigned sz = 0, sz0 = m_covered_clause.size();
             for (literal l : m_covered_clause) s.mark_visited(l);
             shuffle<literal>(m_covered_clause.size(), m_covered_clause.data(), s.s.m_rand);
             m_tautology.reset();
@@ -1392,10 +1399,10 @@ namespace sat {
             }
 
             /*
-             * For blocked clause elimination with asymmetric literal addition (ABCE) 
+             * For blocked clause elimination with asymmetric literal addition (ABCE)
              * it suffices to check if one of the original
              * literals in the clause is blocked modulo the additional literals added to the clause.
-             * So we record sz0, the original set of literals in the clause, mark additional literals, 
+             * So we record sz0, the original set of literals in the clause, mark additional literals,
              * and then check if any of the first sz0 literals are blocked.
              */
 
@@ -1415,7 +1422,7 @@ namespace sat {
                     }
                     else {
                         /*
-                         * tautology depends on resolution intersection. 
+                         * tautology depends on resolution intersection.
                          * literals used for resolution intersection may have to be flipped.
                          */
                         for (literal l : m_covered_clause) {
@@ -1424,7 +1431,7 @@ namespace sat {
                         }
                         minimize_covered_clause(m_covered_clause.size()-1);
                     }
-                    return ate_t;                               
+                    return ate_t;
                 }
 
                 if (first) {
@@ -1440,11 +1447,11 @@ namespace sat {
                     }
                 }
                 first = false;
-                
+
                 if (et == abce_t || et == bce_t) {
                     break;
                 }
-                
+
                 /*
                  * Add resolution intersection while checking if the clause becomes a tautology.
                  */
@@ -1466,7 +1473,7 @@ namespace sat {
             m_clause = clause_wrapper(c);
             m_covered_clause.reset();
             m_covered_antecedent.reset();
-            for (literal l : c) { 
+            for (literal l : c) {
                 m_covered_clause.push_back(l);
                 m_covered_antecedent.push_back(clause_ante());
             }
@@ -1482,9 +1489,9 @@ namespace sat {
             m_covered_clause.push_back(l2);
             m_covered_antecedent.push_back(clause_ante());
             m_covered_antecedent.push_back(clause_ante());
-            return cce<et>(blocked, k);            
+            return cce<et>(blocked, k);
         }
-        
+
         template<elim_type et>
         void cce() {
             insert_queue();
@@ -1512,7 +1519,7 @@ namespace sat {
                 if (!w.is_binary_non_learned_clause()) continue;
                 if (!select_clause<et>(2)) continue;
                 literal l2 = w.get_literal();
-                elim_type r = cce<et>(l, l2, blocked, k); 
+                elim_type r = cce<et>(l, l2, blocked, k);
                 inc_bc(r);
                 switch (r) {
                 case ate_t:
@@ -1538,7 +1545,7 @@ namespace sat {
             m_ala_cost = 0;
             m_ala_benefit = 0;
             model_converter::kind k;
-            unsigned start = s.s.m_rand(); 
+            unsigned start = s.s.m_rand();
             unsigned sz = s.s.m_clauses.size();
             for (unsigned i = 0; i < sz; ++i) {
                 clause& c = *s.s.m_clauses[(i + start) % sz];
@@ -1549,7 +1556,7 @@ namespace sat {
                 switch (r) {
                 case ate_t:
                     m_mc.add_ate(m_covered_clause);
-                    s.set_learned(c);                    
+                    s.set_learned(c);
                     break;
                 case no_t:
                     break;
@@ -1562,7 +1569,7 @@ namespace sat {
                 if (reached_max_cost()) {
                     break;
                 }
-            }            
+            }
         }
 
         void inc_bc(elim_type et) {
@@ -1588,13 +1595,13 @@ namespace sat {
             SASSERT(!s.is_external(l));
             model_converter::entry& new_entry = m_mc.mk(k, l.var());
             for (literal lit : c) {
-                if (lit != l && process_var(lit.var())) 
-                    m_queue.decreased(~lit);                
+                if (lit != l && process_var(lit.var()))
+                    m_queue.decreased(~lit);
             }
             m_mc.insert(new_entry, m_covered_clause);
             m_mc.set_clause(new_entry, c);
         }
-        
+
         void block_covered_binary(watched const& w, literal l1, literal blocked, model_converter::kind k) {
             SASSERT(!s.is_external(blocked));
             model_converter::entry& new_entry = m_mc.mk(k, blocked.var());
@@ -1626,7 +1633,7 @@ namespace sat {
         void bca(literal l) {
             m_tautology.reset();
             if (resolution_intersection(l, true)) {
-                // this literal is pure. 
+                // this literal is pure.
                 return;
             }
             for (literal l2 : m_intersection) {
@@ -1642,7 +1649,7 @@ namespace sat {
             watch_list & wlist = s.get_wlist(l);
             m_counter -= wlist.size();
             for (auto const& w : wlist) {
-                if (w.is_binary_non_learned_clause() && 
+                if (w.is_binary_non_learned_clause() &&
                     !s.is_marked(~w.get_literal()))
                     return false;
             }
@@ -1706,8 +1713,11 @@ namespace sat {
                        report(m_simplifier.m_num_cce,  m_num_cce,  " :cce ");
                        report(m_simplifier.m_num_bca,  m_num_bca,  " :bca ");
                        report(m_simplifier.m_num_acce, m_num_acce, " :acce ");
-                       verbose_stream() << mem_stat()
-                       << " :time " << std::fixed << std::setprecision(2) << m_watch.get_seconds() << ")\n";);
+                       if (!get_verbosity_plain()) {
+                           verbose_stream() << mem_stat()
+                               << " :time " << std::fixed << std::setprecision(2) << m_watch.get_seconds();
+                       }
+                       verbose_stream() << ")\n";);
         }
 
         void report(unsigned n, unsigned m, char const* s) {
@@ -1768,7 +1778,7 @@ namespace sat {
         TRACE(sat_simplifier,
               for (auto& [v, c] : tmp) tout << "(" << v << ", " << c << ") ";
               tout << "\n";);
-        for (auto& [v, c] : tmp) 
+        for (auto& [v, c] : tmp)
             r.push_back(v);
     }
 
@@ -1974,10 +1984,10 @@ namespace sat {
         }
         TRACE(sat_simplifier, tout << "eliminate " << v << ", before: " << before_clauses << " after: " << after_clauses << "\n";
               tout << "pos\n";
-              for (auto & c : m_pos_cls) 
+              for (auto & c : m_pos_cls)
                   tout << c << "\n";
               tout << "neg\n";
-              for (auto & c : m_neg_cls) 
+              for (auto & c : m_neg_cls)
                   tout << c << "\n";
               );
         m_elim_counter -= num_pos * num_neg + before_lits;
@@ -1999,7 +2009,7 @@ namespace sat {
             for (auto & c2 : m_neg_cls) {
                 m_new_cls.reset();
                 if (!resolve(c1, c2, pos_l, m_new_cls))
-                    continue;                
+                    continue;
                 TRACE(sat_simplifier, tout << c1 << "\n" << c2 << "\n-->\n" << m_new_cls << "\n";);
                 if (cleanup_clause(m_new_cls)) {
                     continue; // clause is already satisfied.
@@ -2063,28 +2073,37 @@ namespace sat {
         ~elim_var_report() {
             m_watch.stop();
             IF_VERBOSE(SAT_VB_LVL,
-                       verbose_stream() << " (sat-resolution :elim-vars "
-                       << (m_simplifier.m_num_elim_vars - m_num_elim_vars)
-                       << " :threshold " << m_simplifier.m_elim_counter
-                       << mem_stat()
-                       << " :time " << std::fixed << std::setprecision(2) << m_watch.get_seconds() << ")\n";);
+                       verbose_stream()
+                       << " (sat-resolution :elim-vars "
+                       << (m_simplifier.m_num_elim_vars - m_num_elim_vars););
+
+            if (!get_verbosity_plain()) {
+                IF_VERBOSE(SAT_VB_LVL,
+                           verbose_stream()
+                           << " :threshold " << m_simplifier.m_elim_counter
+                           << mem_stat()
+                           << " :time " << std::fixed << std::setprecision(2) << m_watch.get_seconds(););
+            }
+
+            IF_VERBOSE(SAT_VB_LVL,
+                       verbose_stream() << ")\n";);
         }
     };
 
     void simplifier::elim_vars() {
-        if (!elim_vars_enabled()) 
+        if (!elim_vars_enabled())
             return;
         elim_var_report rpt(*this);
         bool_var_vector vars;
         order_vars_for_elim(vars);
         for (bool_var v : vars) {
             checkpoint();
-            if (m_elim_counter < 0) 
+            if (m_elim_counter < 0)
                 break;
             if (is_external(v))
-                ; // skip            
-            else if (try_eliminate(v)) 
-                m_num_elim_vars++;            
+                ; // skip
+            else if (try_eliminate(v))
+                m_num_elim_vars++;
         }
 
         m_pos_cls.finalize();

--- a/src/sat/sat_solver.cpp
+++ b/src/sat/sat_solver.cpp
@@ -98,7 +98,7 @@ namespace sat {
     }
 
     void solver::del_clauses(clause_vector& clauses) {
-        for (clause * cp : clauses) 
+        for (clause * cp : clauses)
             dealloc_clause(cp);
         clauses.reset();
         ++m_stats.m_non_learned_generation;
@@ -151,7 +151,7 @@ namespace sat {
             set_conflict();
             return;
         }
-        
+
         // create new vars
         for (bool_var v = num_vars(); v < src.num_vars(); ++v) {
             bool ext  = src.m_external[v];
@@ -184,7 +184,7 @@ namespace sat {
             assign_unit(src.m_trail[i]);
         }
 
-        // copy binary clauses 
+        // copy binary clauses
         {
             unsigned sz = src.m_watches.size();
             for (unsigned l_idx = 0; l_idx < sz; ++l_idx) {
@@ -198,7 +198,7 @@ namespace sat {
                     if (l.index() > l2.index() ||
                         src.was_eliminated(l2.var()))
                         continue;
-                                        
+
                     watched w1(l2, wi.is_learned());
                     watched w2(l, wi.is_learned());
                     m_watches[(~l).index()].push_back(w1);
@@ -240,7 +240,7 @@ namespace sat {
         }
 
         m_user_scope_literals.reset();
-        for (auto lit : src.m_user_scope_literals) 
+        for (auto lit : src.m_user_scope_literals)
             assign_unit(~lit);
 
         m_mc = src.m_mc;
@@ -274,7 +274,7 @@ namespace sat {
         m_phase_birthdate[v] = 0;
         m_best_phase_birthdate[v] = 0;
         m_assigned_since_gc[v] = false;
-        m_last_conflict[v] = 0;        
+        m_last_conflict[v] = 0;
         m_last_propagation[v] = 0;
         m_participated[v] = 0;
         m_canceled[v] = 0;
@@ -287,7 +287,7 @@ namespace sat {
         m_model_is_current = false;
         m_stats.m_mk_var++;
         bool_var v = m_justification.size();
-        
+
         if (!m_free_vars.empty()) {
             v = m_free_vars.back();
             m_free_vars.pop_back();
@@ -307,7 +307,7 @@ namespace sat {
         m_external.push_back(ext);
         m_var_scope.push_back(scope_lvl());
         m_touched.push_back(0);
-        m_activity.push_back(0); 
+        m_activity.push_back(0);
         m_mark.push_back(false);
         m_lit_mark.push_back(false);
         m_lit_mark.push_back(false);
@@ -336,20 +336,20 @@ namespace sat {
         m_external[v] = true;
     }
 
-    void solver::set_eliminated(bool_var v, bool f) { 
+    void solver::set_eliminated(bool_var v, bool f) {
         if (m_eliminated[v] == f)
             return;
-        if (!f) 
+        if (!f)
             reset_var(v, m_external[v], m_decision[v]);
         else if (f && m_ext)
             m_ext->set_eliminated(v);
-        m_eliminated[v] = f; 
+        m_eliminated[v] = f;
     }
 
 
     clause* solver::mk_clause(unsigned num_lits, literal * lits, sat::status st) {
         m_model_is_current = false;
-            
+
 
         DEBUG_CODE({
                 for (unsigned i = 0; i < num_lits; ++i) {
@@ -380,17 +380,17 @@ namespace sat {
     }
 
     void solver::del_clause(clause& c) {
-        if (!c.is_learned()) 
+        if (!c.is_learned())
             m_stats.m_non_learned_generation++;
-        
-        if (c.frozen()) 
+
+        if (c.frozen())
             --m_num_frozen;
-        
-        if (!c.was_removed() && m_config.m_drat && !m_drat.is_cleaned(c)) 
+
+        if (!c.was_removed() && m_config.m_drat && !m_drat.is_cleaned(c))
             m_drat.del(c);
-        
-        dealloc_clause(&c);        
-        if (m_searching) 
+
+        dealloc_clause(&c);
+        if (m_searching)
             m_stats.m_del_clause++;
     }
 
@@ -398,8 +398,8 @@ namespace sat {
         if (m_config.m_drat && m_ext) {
             extension::scoped_drating _sd(*m_ext);
             bool unique_max;
-            m_conflict_lvl = get_max_lvl(m_not_l, m_conflict, unique_max);        
-            resolve_conflict_for_unsat_core();                
+            m_conflict_lvl = get_max_lvl(m_not_l, m_conflict, unique_max);
+            resolve_conflict_for_unsat_core();
         }
     }
 
@@ -407,10 +407,10 @@ namespace sat {
         if (!m_ext)
             return;
         extension::scoped_drating _sd(*m_ext.get());
-        if (j.get_kind() == justification::EXT_JUSTIFICATION) 
+        if (j.get_kind() == justification::EXT_JUSTIFICATION)
             fill_ext_antecedents(lit, j, false);
-        else 
-            m_drat.add(lit, m_searching);       
+        else
+            m_drat.add(lit, m_searching);
     }
 
     void solver::drat_log_clause(unsigned num_lits, literal const* lits, sat::status st) {
@@ -435,9 +435,9 @@ namespace sat {
             }
 
             ++m_stats.m_non_learned_generation;
-            if (!m_searching) 
-                m_mc.add_clause(num_lits, lits);            
-        }       
+            if (!m_searching)
+                m_mc.add_clause(num_lits, lits);
+        }
 
         switch (num_lits) {
         case 0:
@@ -453,7 +453,7 @@ namespace sat {
             return nullptr;
         case 2:
             mk_bin_clause(lits[0], lits[1], st);
-            if (redundant && m_par) 
+            if (redundant && m_par)
                 m_par->share_clause(*this, lits[0], lits[1]);
             return nullptr;
         default:
@@ -468,7 +468,7 @@ namespace sat {
 
         if (m_config.m_drat)
             m_drat.add(l1, l2, st);
-        
+
         if (redundant && !m_trim && find_binary_watch(get_wlist(~l1), ~l2) && value(l1) == l_undef) {
             assign_unit(l1);
             return;
@@ -482,9 +482,9 @@ namespace sat {
             TRACE(sat, tout << "found binary " << l1 << " " << l2 << "\n";);
             if (w0->is_learned() && !redundant) {
                 w0->set_learned(false);
-                w0 = find_binary_watch(get_wlist(~l2), l1);            
+                w0 = find_binary_watch(get_wlist(~l2), l1);
                 VERIFY(w0);
-                w0->set_learned(false);                        
+                w0->set_learned(false);
             }
             if (propagate_bin_clause(l1, l2) && !at_base_lvl() && !redundant)
                 push_reinit_stack(l1, l2);
@@ -526,7 +526,7 @@ namespace sat {
     bool solver::propagate_bin_clause(literal l1, literal l2) {
         if (value(l2) == l_false && value(l1) != l_true) {
             m_stats.m_bin_propagate++;
-            assign(l1, justification(lvl(l2), l2));            
+            assign(l1, justification(lvl(l2), l2));
             return true;
         }
         if (value(l1) == l_false && value(l2) != l_true) {
@@ -554,16 +554,16 @@ namespace sat {
         clause * r = alloc_clause(num_lits, lits, st.is_redundant());
         SASSERT(!st.is_redundant() || r->is_learned());
         bool reinit = attach_nary_clause(*r, st.is_sat() && st.is_redundant());
- 
-        if (reinit || has_variables_to_reinit(*r)) 
+
+        if (reinit || has_variables_to_reinit(*r))
             push_reinit_stack(*r);
-        if (st.is_redundant()) 
+        if (st.is_redundant())
             m_learned.push_back(r);
-        else 
+        else
             m_clauses.push_back(r);
-        if (m_config.m_drat) 
+        if (m_config.m_drat)
             m_drat.add(*r, st);
-        for (literal l : *r) 
+        for (literal l : *r)
             m_touched[l.var()] = m_touch_index;
         return r;
     }
@@ -584,7 +584,7 @@ namespace sat {
             }
 
             if (value(c[0]) == l_false) {
-                m_stats.m_propagate++; 
+                m_stats.m_propagate++;
                 unsigned level = lvl(c[0]);
                 for (unsigned i = c.size(); i-- > 2; ) {
                     level = std::max(level, lvl(c[i]));
@@ -619,7 +619,7 @@ namespace sat {
     }
 
     void solver::set_learned(clause& c, bool redundant) {
-        if (c.is_learned() != redundant) 
+        if (c.is_learned() != redundant)
             c.set_learned(redundant);
     }
 
@@ -712,7 +712,7 @@ namespace sat {
                         offset = c1.get_new_offset();
                     }
                     else {
-                        clause* c2 = alloc.copy_clause(c1); 
+                        clause* c2 = alloc.copy_clause(c1);
                         c1.mark_used();
                         if (c1.is_learned()) {
                             new_learned.push_back(c2);
@@ -870,7 +870,7 @@ namespace sat {
     }
 
     bool solver::simplify_clause(unsigned & num_lits, literal * lits) const {
-        if (at_base_lvl()) 
+        if (at_base_lvl())
             return simplify_clause_core<true>(num_lits, lits);
         else
             return simplify_clause_core<false>(num_lits, lits);
@@ -879,7 +879,7 @@ namespace sat {
     void solver::detach_bin_clause(literal l1, literal l2, bool redundant) {
         get_wlist(~l1).erase(watched(l2, redundant));
         get_wlist(~l2).erase(watched(l1, redundant));
-        if (m_config.m_drat) m_drat.del(l1, l2);       
+        if (m_config.m_drat) m_drat.del(l1, l2);
     }
 
     void solver::detach_clause(clause& c) {
@@ -912,7 +912,7 @@ namespace sat {
         SASSERT(!m_trail.contains(l) && !m_trail.contains(~l));
         TRACE(sat_assign_core, tout << l << " " << j << "\n";);
         if (j.level() == 0) {
-            if (m_config.m_drat) 
+            if (m_config.m_drat)
                 drat_log_unit(l, j);
             if (!m_trim)
                 j = justification(0); // erase justification for level 0
@@ -927,9 +927,9 @@ namespace sat {
         set_phase(v, !l.sign());
         m_assigned_since_gc[v]     = true;
         m_trail.push_back(l);
-        
+
         switch (m_config.m_branching_heuristic) {
-        case BH_VSIDS: 
+        case BH_VSIDS:
             break;
         case BH_CHB:
             m_last_propagation[v] = m_stats.m_conflicts;
@@ -945,7 +945,7 @@ namespace sat {
                 m_canceled[v] = m_stats.m_conflicts;
             }
         }
-        
+
         if (m_config.m_propagate_prefetch) {
 #if defined(__GNUC__) || defined(__clang__)
             __builtin_prefetch((const char*)((m_watches[l.index()].data())));
@@ -987,8 +987,8 @@ namespace sat {
     // -----------------------
 
     bool solver::propagate_core(bool update) {
-        if (m_ext && (!is_probing() || at_base_lvl())) 
-            m_ext->unit_propagate();    
+        if (m_ext && (!is_probing() || at_base_lvl()))
+            m_ext->unit_propagate();
         while (m_qhead < m_trail.size() && !m_inconsistent) {
             do {
                 checkpoint();
@@ -999,8 +999,8 @@ namespace sat {
                     return false;
             } while (m_qhead < m_trail.size());
 
-            if (m_ext && (!is_probing() || at_base_lvl())) 
-                m_ext->unit_propagate();            
+            if (m_ext && (!is_probing() || at_base_lvl()))
+                m_ext->unit_propagate();
         }
         if (m_inconsistent)
             return false;
@@ -1023,11 +1023,11 @@ namespace sat {
 
     void solver::propagate_clause(clause& c, bool update, unsigned assign_level, clause_offset cls_off) {
         unsigned glue;
-        SASSERT(value(c[0]) == l_undef); 
-            m_stats.m_propagate++;          
-            c.mark_used();                                          
-            assign_core(c[0], justification(assign_level, cls_off)); 
-            if (update && c.is_learned() && c.glue() > 2 && num_diff_levels_below(c.size(), c.begin(), c.glue() - 1, glue)) 
+        SASSERT(value(c[0]) == l_undef);
+            m_stats.m_propagate++;
+            c.mark_used();
+            assign_core(c[0], justification(assign_level, cls_off));
+            if (update && c.is_learned() && c.glue() > 2 && num_diff_levels_below(c.size(), c.begin(), c.glue() - 1, glue))
                 c.set_glue(glue);                                   \
     }
 
@@ -1109,7 +1109,7 @@ namespace sat {
                     break;
                 }
                 VERIFY(c[1] == not_l);
-                
+
                 unsigned undef_index = 0;
                 unsigned assign_level = curr_level;
                 unsigned max_index = 1;
@@ -1141,9 +1141,9 @@ namespace sat {
                 if (value(c[0]) == l_false)
                     assign_level = std::max(assign_level, lvl(c[0]));
 
-                if (undef_index != 0) {       
+                if (undef_index != 0) {
                     set_watch(c, undef_index, cls_off);
-                    if (value(c[0]) == l_false && num_undef == 1) {   
+                    if (value(c[0]) == l_false && num_undef == 1) {
                         std::swap(c[0], c[1]);
                         propagate_clause(c, update, assign_level, cls_off);
                     }
@@ -1280,7 +1280,7 @@ namespace sat {
         flet<bool> _searching(m_searching, true);
         m_clone = nullptr;
         if (m_mc.empty() && gparams::get_ref().get_bool("model_validate", false)) {
-            
+
             m_clone = alloc(solver, m_no_drat_params, m_rlimit);
             m_clone->copy(*this);
             m_clone->set_extension(nullptr);
@@ -1314,19 +1314,19 @@ namespace sat {
                 return l_undef;
             }
 
-            if (m_config.m_phase == PS_LOCAL_SEARCH && m_ext) {                
+            if (m_config.m_phase == PS_LOCAL_SEARCH && m_ext) {
                 bounded_local_search();
                 // exit(0);
             }
 
             log_stats();
-            if (m_config.m_max_conflicts > 0 && m_config.m_burst_search > 0) {               
+            if (m_config.m_max_conflicts > 0 && m_config.m_burst_search > 0) {
                 m_restart_threshold = m_config.m_burst_search;
                 lbool r = bounded_search();
                 log_stats();
-                if (r != l_undef) 
+                if (r != l_undef)
                     return r;
-                
+
                 pop_reinit(scope_lvl());
                 m_conflicts_since_restart = 0;
                 m_restart_threshold = m_config.m_restart_initial;
@@ -1370,9 +1370,9 @@ namespace sat {
     struct solver::scoped_ls {
         solver& s;
         scoped_ls(solver& s): s(s) {}
-        ~scoped_ls() { 
-            dealloc(s.m_local_search); 
-            s.m_local_search = nullptr; 
+        ~scoped_ls() {
+            dealloc(s.m_local_search);
+            s.m_local_search = nullptr;
         }
     };
 
@@ -1421,7 +1421,7 @@ namespace sat {
             // move higher priority variables to front
             // eg., move the first 10% variables to front
             svector<std::pair<double, bool_var>> priorities(mdl.size());
-            for (unsigned i = 0; i < mdl.size(); ++i) 
+            for (unsigned i = 0; i < mdl.size(); ++i)
                 priorities[i] = { m_local_search->get_priority(i), i };
             std::sort(priorities.begin(), priorities.end(), [](auto& x, auto& y) { return x.first > y.first; });
             for (unsigned i = priorities.size() / 10; i-- > 0; ) {
@@ -1445,10 +1445,10 @@ namespace sat {
 
     lbool solver::invoke_local_search(unsigned num_lits, literal const* lits) {
         literal_vector _lits(num_lits, lits);
-        for (literal lit : m_user_scope_literals) 
+        for (literal lit : m_user_scope_literals)
             _lits.push_back(~lit);
         scoped_ls _ls(*this);
-        if (inconsistent()) 
+        if (inconsistent())
             return l_false;
         scoped_limits scoped_rl(rlimit());
         SASSERT(m_local_search);
@@ -1500,7 +1500,7 @@ namespace sat {
         int num_extra_solvers = m_config.m_num_threads - 1;
         int num_local_search  = static_cast<int>(m_config.m_local_search_threads);
         int num_ddfw      = m_ext ? 0 : static_cast<int>(m_config.m_ddfw_threads);
-        int num_threads = num_extra_solvers + 1 + num_local_search + num_ddfw;        
+        int num_threads = num_extra_solvers + 1 + num_local_search + num_ddfw;
         vector<reslimit> lims(num_ddfw);
         scoped_ptr_vector<i_local_search> ls;
         scoped_ptr_vector<solver> uw;
@@ -1512,7 +1512,7 @@ namespace sat {
             ls.push_back(l);
         }
 
-           
+
         // set up ddfw search
         for (int i = 0; i < num_ddfw; ++i) {
             ddfw_wrapper* d = alloc(ddfw_wrapper);
@@ -1591,11 +1591,11 @@ namespace sat {
             }
             catch (z3_error & err) {
                 error_code = err.error_code();
-                ex_kind = ERROR_EX;                
+                ex_kind = ERROR_EX;
             }
             catch (z3_exception & ex) {
                 ex_msg = ex.what();
-                ex_kind = DEFAULT_EX;    
+                ex_kind = DEFAULT_EX;
             }
         };
 
@@ -1611,7 +1611,7 @@ namespace sat {
         for (auto & th : threads) {
             th.join();
         }
-        
+
         if (IS_AUX_SOLVER(finished_id)) {
             m_stats = par.get_solver(finished_id).m_stats;
         }
@@ -1682,7 +1682,7 @@ namespace sat {
         m_par_num_vars = num_vars();
         m_par_limit_in = 0;
         m_par_limit_out = 0;
-        m_par_id = id; 
+        m_par_id = id;
         m_par_syncing_clauses = false;
     }
 
@@ -1706,7 +1706,7 @@ namespace sat {
                     set_activity(next, static_cast<unsigned>(m_activity[next] * pow(0.95, static_cast<double>(age))));
                     m_canceled[next] = m_stats.m_conflicts;
                     next = m_case_split_queue.min_var();
-                    age = m_stats.m_conflicts - m_canceled[next];                    
+                    age = m_stats.m_conflicts - m_canceled[next];
                 }
             }
             next = m_case_split_queue.next_var();
@@ -1716,10 +1716,10 @@ namespace sat {
 
         return null_bool_var;
     }
-    
+
     bool solver::guess(bool_var next) {
         lbool lphase = m_ext ? m_ext->get_phase(next) : l_undef;
-        
+
         if (lphase != l_undef)
             return lphase == l_true;
         switch (m_config.m_phase) {
@@ -1779,15 +1779,15 @@ namespace sat {
         }
         push();
         m_stats.m_decision++;
-        
+
         CTRACE(sat, m_best_phase[next] != guess(next), tout << "phase " << phase << " " << m_best_phase[next] << " " << guess(next) << "\n");
 
         if (phase == l_undef)
             phase = guess(next) ? l_true: l_false;
-        
+
         literal next_lit(next, false);
         SASSERT(value(next_lit) == l_undef);
-        
+
         if (m_ext && m_ext->decide(next, phase)) {
 
             if (used_queue)
@@ -1795,7 +1795,7 @@ namespace sat {
             next_lit = literal(next, false);
             SASSERT(value(next_lit) == l_undef);
         }
-                
+
         if (phase == l_undef)
             is_pos = guess(next);
         else
@@ -1837,14 +1837,14 @@ namespace sat {
             pop_to_base_level();
             reinit_assumptions();
             lbool r = basic_search();
-            if (r != l_false) 
+            if (r != l_false)
                 return r;
             if (!m_ext->should_research(m_core))
                 return r;
         }
     }
 
-    bool solver::should_propagate() const {        
+    bool solver::should_propagate() const {
         return !inconsistent() && (m_qhead < m_trail.size() || (m_ext && m_ext->can_propagate()));
     }
 
@@ -1857,7 +1857,7 @@ namespace sat {
             case check_result::CR_CONTINUE:
                 break;
             case check_result::CR_GIVEUP:
-                m_reason_unknown = m_ext->reason_unknown();                
+                m_reason_unknown = m_ext->reason_unknown();
                 throw abort_solver();
             }
             return l_undef;
@@ -1880,25 +1880,25 @@ namespace sat {
         else {
             return false;
         }
-    }    
+    }
 
 
     void solver::init_assumptions(unsigned num_lits, literal const* lits) {
-        if (num_lits == 0 && m_user_scope_literals.empty()) 
-            return;        
+        if (num_lits == 0 && m_user_scope_literals.empty())
+            return;
 
         SASSERT(at_base_lvl());
         reset_assumptions();
         push();
 
         propagate(false);
-        if (inconsistent()) 
-            return;        
+        if (inconsistent())
+            return;
 
         TRACE(sat,
               tout << literal_vector(num_lits, lits) << "\n";
-              if (!m_user_scope_literals.empty()) 
-                  tout << "user literals: " << m_user_scope_literals << "\n";              
+              if (!m_user_scope_literals.empty())
+                  tout << "user literals: " << m_user_scope_literals << "\n";
               m_mc.display(tout);
               );
 
@@ -1915,7 +1915,7 @@ namespace sat {
             assign_scoped(lit);
         }
 
-        m_search_lvl = scope_lvl(); 
+        m_search_lvl = scope_lvl();
         SASSERT(m_search_lvl == 1);
     }
 
@@ -1969,17 +1969,17 @@ namespace sat {
             }
             init_ext_assumptions();
 
-            if (!inconsistent()) 
+            if (!inconsistent())
                 propagate(false);
             TRACE(sat,
                   tout << "consistent: " << !inconsistent() << "\n";
                   for (literal a : m_assumptions) {
                       index_set s;
-                      if (m_antecedents.find(a.var(), s)) 
-                          tout << a << ": "; display_index_set(tout, s) << "\n";                      
+                      if (m_antecedents.find(a.var(), s))
+                          tout << a << ": "; display_index_set(tout, s) << "\n";
                   }
-                  for (literal lit : m_user_scope_literals) 
-                      tout << "user " << lit << "\n";                   
+                  for (literal lit : m_user_scope_literals)
+                      tout << "user " << lit << "\n";
                   );
         }
     }
@@ -2002,7 +2002,7 @@ namespace sat {
 
     void solver::set_activity(bool_var v, unsigned new_act) {
         unsigned old_act = m_activity[v];
-        m_activity[v] = new_act; 
+        m_activity[v] = new_act;
         if (!was_eliminated(v) && value(v) == l_undef && new_act != old_act) {
             m_case_split_queue.activity_changed_eh(v, new_act > old_act);
         }
@@ -2026,7 +2026,7 @@ namespace sat {
         m_rephase.base            = m_config.m_rephase_base;
         m_rephase_lim             = 0;
         m_rephase_inc             = 0;
-        m_local_search_lim.base   = 500;        
+        m_local_search_lim.base   = 500;
 
         m_conflicts_since_restart = 0;
         m_force_conflict_analysis = false;
@@ -2078,13 +2078,13 @@ namespace sat {
         struct report {
             solver&   s;
             stopwatch m_watch;
-            report(solver& s):s(s) { 
-                m_watch.start(); 
+            report(solver& s):s(s) {
+                m_watch.start();
                 s.log_stats();
                 IF_VERBOSE(2, verbose_stream() << "(sat.simplify :simplifications " << s.m_simplifications << ")\n";);
             }
-            ~report() { 
-                m_watch.stop(); 
+            ~report() {
+                m_watch.stop();
                 s.log_stats();
             }
         };
@@ -2100,7 +2100,7 @@ namespace sat {
         if (m_ext) {
             m_ext->pre_simplify();
         }
-      
+
         m_simplifier(false);
 
         CASSERT("sat_simplify_bug", check_invariant());
@@ -2155,7 +2155,7 @@ namespace sat {
             anf();
             anf.collect_statistics(m_aux_stats);
             // TBD: throttle anf_delay based on yield
-        }        
+        }
 
         if (m_config.m_inprocess_out.is_non_empty_string()) {
             std::ofstream fout(m_config.m_inprocess_out.str());
@@ -2216,7 +2216,7 @@ namespace sat {
                 throw solver_exception("check model failed");
             }
         }
-        
+
         if (m_config.m_drat) {
             m_drat.check_model(m_model);
         }
@@ -2269,7 +2269,7 @@ namespace sat {
                     if (!w.is_binary_non_learned_clause())
                         continue;
                     literal l2 = w.get_literal();
-                    if (l.index() > l2.index()) 
+                    if (l.index() > l2.index())
                         continue;
                     if (value_at(l2, m) != l_true) {
                         IF_VERBOSE(1, verbose_stream() << "failed binary: " << l << " := " << value_at(l, m) << " " << l2 <<  " := " << value_at(l2, m) << "\n");
@@ -2315,20 +2315,23 @@ namespace sat {
         if (scope_lvl() < 2 + search_lvl()) return false;
         if (m_case_split_queue.empty()) return false;
         if (m_config.m_restart != RS_EMA) return true;
-        return 
-            m_fast_glue_avg + search_lvl() <= scope_lvl() && 
+        return
+            m_fast_glue_avg + search_lvl() <= scope_lvl() &&
             m_config.m_restart_margin * m_slow_glue_avg <= m_fast_glue_avg;
     }
 
     void solver::log_stats() {
         m_restart_logs++;
-        
+
         std::stringstream strm;
-        strm << "(sat.stats " << std::setw(6) << m_stats.m_conflicts << " " 
+        strm << "(sat.stats " << std::setw(6) << m_stats.m_conflicts << " "
              << std::setw(6) << m_stats.m_decision << " "
-             << std::setw(4) << m_stats.m_restart 
-             << mk_stat(*this)
-             << " " << std::setw(6) << std::setprecision(2) << m_stopwatch.get_current_seconds() << ")\n";
+             << std::setw(4) << m_stats.m_restart
+             << mk_stat(*this);
+        if (!get_verbosity_plain()) {
+            strm << " " << std::setw(6) << std::setprecision(2) << m_stopwatch.get_current_seconds();
+        }
+        strm << ")\n";
         std::string str = std::move(strm).str();
         svector<size_t> nums;
         for (size_t i = 0; i < str.size(); ++i) {
@@ -2338,15 +2341,15 @@ namespace sat {
             if (i < str.size()) {
                 nums.push_back(i);
             }
-        }   
+        }
         bool same = m_last_positions.size() == nums.size();
         size_t diff = 0;
         for (unsigned i = 0; i < nums.size() && same; ++i) {
             if (m_last_positions[i] > nums[i]) diff += m_last_positions[i] - nums[i];
             if (m_last_positions[i] < nums[i]) diff += nums[i] - m_last_positions[i];
         }
-        if (m_last_positions.empty() || 
-            m_restart_logs >= 20 + m_last_position_log || 
+        if (m_last_positions.empty() ||
+            m_restart_logs >= 20 + m_last_position_log ||
             (m_restart_logs >= 6 + m_last_position_log && (!same || diff > 3))) {
             m_last_position_log = m_restart_logs;
             //           conflicts          restarts          learned            gc               time
@@ -2371,20 +2374,20 @@ namespace sat {
                     for (; p1 < p + adjust[i]; ++p1) l1 << " ";
                     p1 += strlen(tag[i]);
                     l1 << tag[i];
-                }                               
+                }
             }
-            for (; p1 + 2 < str.size(); ++p1) l1 << " ";            
-            for (; p2 + 2 < str.size(); ++p2) l2 << " ";            
+            for (; p1 + 2 < str.size(); ++p1) l1 << " ";
+            for (; p2 + 2 < str.size(); ++p2) l2 << " ";
             l1 << ")\n";
             l2 << ")\n";
             IF_VERBOSE(1, verbose_stream() << l1.str() << l2.str());
             m_last_positions.reset();
             m_last_positions.append(nums);
         }
-        IF_VERBOSE(1, verbose_stream() << str);            
+        IF_VERBOSE(1, verbose_stream() << str);
     }
 
-    void solver::do_restart(bool to_base) {        
+    void solver::do_restart(bool to_base) {
         m_stats.m_restart++;
         m_restarts++;
         if (m_conflicts_since_init >= m_restart_next_out && get_verbosity_level() >= 1) {
@@ -2392,7 +2395,7 @@ namespace sat {
                 m_restart_next_out = 1;
             }
             else {
-                m_restart_next_out = std::min(m_conflicts_since_init + 50000, (3*m_restart_next_out)/2 + 1); 
+                m_restart_next_out = std::min(m_conflicts_since_init + 50000, (3*m_restart_next_out)/2 + 1);
             }
             log_stats();
         }
@@ -2400,24 +2403,24 @@ namespace sat {
         IF_VERBOSE(30, display_status(verbose_stream()););
         TRACE(sat, tout << "restart " << restart_level(to_base) << "\n";);
         pop_reinit(restart_level(to_base));
-        set_next_restart();        
+        set_next_restart();
     }
 
     unsigned solver::restart_level(bool to_base) {
         SASSERT(!m_case_split_queue.empty());
-        if (to_base || scope_lvl() == search_lvl()) 
-            return scope_lvl() - search_lvl();        
+        if (to_base || scope_lvl() == search_lvl())
+            return scope_lvl() - search_lvl();
         else {
             bool_var next = m_case_split_queue.min_var();
 
-            // Implementations of Marijn's idea of reusing the 
+            // Implementations of Marijn's idea of reusing the
             // trail when the next decision literal has lower precedence.
             // pop trail from top
 #if 0
             unsigned n = 0;
             do {
                 bool_var prev = scope_literal(scope_lvl() - n - 1).var();
-                if (m_case_split_queue.more_active(prev, next)) break;                
+                if (m_case_split_queue.more_active(prev, next)) break;
                 ++n;
             }
             while (n < scope_lvl() - search_lvl());
@@ -2484,14 +2487,14 @@ namespace sat {
         m_conflicts_since_gc++;
         m_stats.m_conflicts++;
         if (m_step_size > m_config.m_step_size_min)
-            m_step_size -= m_config.m_step_size_dec;        
+            m_step_size -= m_config.m_step_size_dec;
 
         bool unique_max;
-        m_conflict_lvl = get_max_lvl(m_not_l, m_conflict, unique_max);        
+        m_conflict_lvl = get_max_lvl(m_not_l, m_conflict, unique_max);
         justification js = m_conflict;
 
-        if (m_conflict_lvl <= 1 && (!m_assumptions.empty() || 
-                                    !m_ext_assumption_set.empty() || 
+        if (m_conflict_lvl <= 1 && (!m_assumptions.empty() ||
+                                    !m_ext_assumption_set.empty() ||
                                     !m_user_scope_literals.empty())) {
             TRACE(sat, tout << "unsat core\n";);
             resolve_conflict_for_unsat_core();
@@ -2506,10 +2509,10 @@ namespace sat {
             return l_false;
         }
 
-        // force_conflict_analysis is used instead of relying on normal propagation to assign m_not_l 
+        // force_conflict_analysis is used instead of relying on normal propagation to assign m_not_l
         // at the backtracking level. This is the case where the external theories miss propagations
         // that only get triggered after decisions.
-        
+
         if (allow_backtracking() && unique_max && !m_force_conflict_analysis) {
             TRACE(sat, tout << "unique max " << js << " " << m_not_l << "\n";);
             pop_reinit(m_scope_lvl - m_conflict_lvl + 1);
@@ -2523,7 +2526,7 @@ namespace sat {
 
         if (m_ext) {
             switch (m_ext->resolve_conflict()) {
-            case l_true:                
+            case l_true:
                 learn_lemma_and_backjump();
                 return l_undef;
             case l_undef:
@@ -2541,11 +2544,11 @@ namespace sat {
         // save space for first uip
         m_lemma.push_back(null_literal);
 
-        TRACE(sat_conflict_detail, 
-              tout << "resolve: " << m_not_l << " " 
-              << " js: " << js 
-              << " idx: " << idx 
-              << " trail: " << m_trail.size() 
+        TRACE(sat_conflict_detail,
+              tout << "resolve: " << m_not_l << " "
+              << " js: " << js
+              << " idx: " << idx
+              << " trail: " << m_trail.size()
               << " @" << m_conflict_lvl << "\n";);
 
         unsigned num_marks = 0;
@@ -2588,15 +2591,15 @@ namespace sat {
             case justification::EXT_JUSTIFICATION: {
                 fill_ext_antecedents(consequent, js, false);
                 TRACE(sat, tout << "ext antecedents: " << m_ext_antecedents << "\n";);
-                for (literal l : m_ext_antecedents)                     
-                    process_antecedent(l, num_marks);                
+                for (literal l : m_ext_antecedents)
+                    process_antecedent(l, num_marks);
                 break;
             }
             default:
                 UNREACHABLE();
                 break;
             }
-            
+
             bool_var c_var;
             while (true) {
                 consequent = m_trail[idx];
@@ -2624,7 +2627,7 @@ namespace sat {
             num_marks--;
             reset_mark(c_var);
 
-            TRACE(sat, display_justification(tout << consequent << " ", js) << "\n";);            
+            TRACE(sat, display_justification(tout << consequent << " ", js) << "\n";);
         }
         while (num_marks > 0);
 
@@ -2636,13 +2639,13 @@ namespace sat {
 
     void solver::learn_lemma_and_backjump() {
         TRACE(sat_lemma, tout << "new lemma size: " << m_lemma.size() << "\n" << m_lemma << "\n";);
-        
+
         if (m_lemma.empty()) {
             pop_reinit(m_scope_lvl);
             mk_clause_core(0, nullptr, sat::status::redundant());
             return;
         }
-        
+
         if (m_config.m_minimize_lemmas) {
             minimize_lemma();
             reset_lemma_var_marks();
@@ -2653,14 +2656,14 @@ namespace sat {
         else {
             reset_lemma_var_marks();
         }
-        
+
         unsigned backtrack_lvl = lvl(m_lemma[0]);
         unsigned backjump_lvl  = 0;
         for (unsigned i = m_lemma.size(); i-- > 1;) {
             unsigned level = lvl(m_lemma[i]);
             backjump_lvl = std::max(level, backjump_lvl);
-        }    
-        // with scope tracking and chronological backtracking, 
+        }
+        // with scope tracking and chronological backtracking,
         // consequent may not be at highest decision level.
         if (backtrack_lvl < backjump_lvl) {
             backtrack_lvl = backjump_lvl;
@@ -2672,14 +2675,14 @@ namespace sat {
                 }
             }
         }
-        
-        unsigned glue = num_diff_levels(m_lemma.size(), m_lemma.data());        
+
+        unsigned glue = num_diff_levels(m_lemma.size(), m_lemma.data());
         m_fast_glue_avg.update(glue);
         m_slow_glue_avg.update(glue);
-    
+
         // compute whether to use backtracking or backjumping
         unsigned num_scopes = m_scope_lvl - backjump_lvl;
-        
+
         if (use_backjumping(num_scopes)) {
             ++m_stats.m_backjumps;
             pop_reinit(num_scopes);
@@ -2703,8 +2706,8 @@ namespace sat {
     }
 
     bool solver::use_backjumping(unsigned num_scopes) const {
-        return 
-            num_scopes > 0 && 
+        return
+            num_scopes > 0 &&
             (num_scopes <= m_config.m_backtrack_scopes || !allow_backtracking());
     }
 
@@ -2837,7 +2840,7 @@ namespace sat {
         if (m_core.size() > 1) {
             unsigned j = 0;
             for (unsigned i = 0; i < m_core.size(); ++i) {
-                if (lvl(m_core[i]) > 0) m_core[j++] = m_core[i];            
+                if (lvl(m_core[i]) > 0) m_core[j++] = m_core[i];
             }
             m_core.shrink(j);
         }
@@ -2864,7 +2867,7 @@ namespace sat {
 
         if (not_l != null_literal) {
             level = lvl(not_l);
-        }      
+        }
         TRACE(sat, tout << "level " << not_l << " is " << level << " " << js << "\n");
 
         switch (js.get_kind()) {
@@ -2874,15 +2877,15 @@ namespace sat {
         case justification::BINARY:
             level = update_max_level(js.get_literal(), level, unique_max);
             break;
-        case justification::CLAUSE: 
-            for (literal l : get_clause(js)) 
+        case justification::CLAUSE:
+            for (literal l : get_clause(js))
                 level = update_max_level(l, level, unique_max);
             break;
         case justification::EXT_JUSTIFICATION:
-            if (not_l != null_literal) 
+            if (not_l != null_literal)
                 not_l.neg();
             fill_ext_antecedents(not_l, js, true);
-            for (literal l : m_ext_antecedents) 
+            for (literal l : m_ext_antecedents)
                 level = update_max_level(l, level, unique_max);
             break;
         default:
@@ -2983,9 +2986,9 @@ namespace sat {
         if (m_search_state == s_unsat) {
             m_trail_avg.update(m_trail.size());
         }
-        return 
+        return
             (m_phase_counter >= m_search_next_toggle) &&
-            (m_search_state == s_sat || m_trail.size() > 0.50*m_trail_avg);  
+            (m_search_state == s_sat || m_trail.size() > 0.50*m_trail_avg);
     }
 
     void solver::do_toggle_search_state() {
@@ -2995,7 +2998,7 @@ namespace sat {
             std::swap(m_fast_glue_backup, m_fast_glue_avg);
             std::swap(m_slow_glue_backup, m_slow_glue_avg);
             if (m_search_state == s_sat) {
-                m_search_unsat_conflicts += m_config.m_search_unsat_conflicts;   
+                m_search_unsat_conflicts += m_config.m_search_unsat_conflicts;
             }
             else {
                 m_search_sat_conflicts += m_config.m_search_sat_conflicts;
@@ -3052,7 +3055,7 @@ namespace sat {
             }
             break;
         case PS_SAT_CACHING:
-            if (m_search_state == s_sat) 
+            if (m_search_state == s_sat)
                 for (unsigned i = 0; i < m_phase.size(); ++i)
                     set_phase(i, m_best_phase[i]);
             break;
@@ -3089,17 +3092,17 @@ namespace sat {
         m_activity_inc = 128;
         svector<bool_var> vars;
         for (bool_var v = num_vars(); v-- > 0; ) {
-            if (!was_eliminated(v) && value(v) == l_undef) {            
+            if (!was_eliminated(v) && value(v) == l_undef) {
                 vars.push_back(v);
             }
         }
 #if 1
-        // 
-        //   exp(logits[i]) / sum(exp(logits)) 
-        // = 
-        //   exp(log(exp(logits[i]) / sum(exp(logits)))) 
-        // = 
-        //   exp(log(exp(logits[i])) - log(sum(exp(logits)))) 
+        //
+        //   exp(logits[i]) / sum(exp(logits))
+        // =
+        //   exp(log(exp(logits[i]) / sum(exp(logits))))
+        // =
+        //   exp(log(exp(logits[i])) - log(sum(exp(logits))))
         // =
         //   exp(logits[i] - lse)
         svector<double> logits(vars.size(), 0.0);
@@ -3167,11 +3170,11 @@ namespace sat {
                 m_diff_levels[lit_lvl] = true;
                 glue++;
             }
-        }       
+        }
         // reset m_diff_levels.
         for (; i-- > 0; )
             m_diff_levels[lvl(lits[i])] = false;
-        return glue < max_glue;        
+        return glue < max_glue;
     }
 
     bool solver::num_diff_false_levels_below(unsigned num, literal const* lits, unsigned max_glue, unsigned& glue) {
@@ -3195,7 +3198,7 @@ namespace sat {
                 m_diff_levels[lvl(lit)] = false;
             }
         }
-        return glue < max_glue;        
+        return glue < max_glue;
     }
 
 
@@ -3287,7 +3290,7 @@ namespace sat {
                 UNREACHABLE();
                 break;
             }
-            TRACE(sat_conflict, 
+            TRACE(sat_conflict,
                   display_justification(tout << var << " ",js) << "\n";);
         }
         return true;
@@ -3310,7 +3313,7 @@ namespace sat {
     */
     void solver::updt_lemma_lvl_set() {
         m_lvl_set.reset();
-        for (literal l : m_lemma) 
+        for (literal l : m_lemma)
             m_lvl_set.insert(lvl(l));
     }
 
@@ -3323,7 +3326,7 @@ namespace sat {
         unsigned sz   = m_lemma.size();
         unsigned num_reduced = 0;
         for (unsigned i = 1; i < sz; ++i) {
-            mark_lit(m_lemma[i]);            
+            mark_lit(m_lemma[i]);
         }
         watch_list const& wlist = get_wlist(m_lemma[0]);
         for (watched const& w : wlist) {
@@ -3381,7 +3384,7 @@ namespace sat {
     void solver::reset_lemma_var_marks() {
         if (m_config.m_branching_heuristic == BH_VSIDS) {
             update_lrb_reasoned();
-        }        
+        }
         literal_vector::iterator it  = m_lemma.begin();
         literal_vector::iterator end = m_lemma.end();
         SASSERT(!is_marked((*it).var()));
@@ -3400,7 +3403,7 @@ namespace sat {
             justification js = m_justification[m_lemma[i].var()];
             switch (js.get_kind()) {
             case justification::NONE:
-                break;                    
+                break;
             case justification::BINARY:
                 update_lrb_reasoned(js.get_literal());
                 break;
@@ -3585,7 +3588,7 @@ namespace sat {
         unsigned sz = m_active_vars.size(), j = old_num_vars;
         unsigned new_lvl = m_scopes.size() - num_scopes;
 
-        gc_reinit_stack(num_scopes);        
+        gc_reinit_stack(num_scopes);
 
         // check.check_reinit_stack();
         init_visited();
@@ -3611,7 +3614,7 @@ namespace sat {
             }
             else {
                 set_eliminated(v, true);
-                m_vars_to_free.push_back(v);                                   
+                m_vars_to_free.push_back(v);
             }
         }
         m_active_vars.shrink(j);
@@ -3624,7 +3627,7 @@ namespace sat {
         for (bool_var v : m_vars_to_free) {
             cleanup_watch(literal(v, false));
             cleanup_watch(literal(v, true));
-            
+
         }
         TRACE(sat,
             tout << "clauses to reinit: " << (m_clauses_to_reinit.size() - old_sz) << "\n";
@@ -3633,12 +3636,12 @@ namespace sat {
             tout << "free vars:         " << bool_var_vector(m_vars_to_free) << "\n";
             for (unsigned i = m_clauses_to_reinit.size(); i-- > old_sz; )
                 tout << "reinit:           " << m_clauses_to_reinit[i] << "\n";
-            display(tout););        
+            display(tout););
     }
 
     void solver::shrink_vars(unsigned v) {
-        unsigned j = 0; 
-        for (bool_var w : m_free_vars) 
+        unsigned j = 0;
+        for (bool_var w : m_free_vars)
             if (w < v)
                 m_free_vars[j++] = w;
         m_free_vars.shrink(j);
@@ -3710,7 +3713,7 @@ namespace sat {
                 m_canceled[v] = m_stats.m_conflicts;
             }
         }
-        m_trail.shrink(old_sz);        
+        m_trail.shrink(old_sz);
         DEBUG_CODE(for (literal l : m_trail) SASSERT(lvl(l.var()) <= new_lvl););
         m_qhead = m_trail.size();
         if (!m_replay_assign.empty()) IF_VERBOSE(20, verbose_stream() << "replay assign: " << m_replay_assign.size() << "\n");
@@ -3719,9 +3722,9 @@ namespace sat {
             literal lit = m_replay_assign[i];
             SASSERT(value(lit) == l_true);
             SASSERT(!m_trail.contains(lit) && !m_trail.contains(~lit));
-            m_trail.push_back(lit);            
+            m_trail.push_back(lit);
         }
-        
+
         m_replay_assign.reset();
     }
 
@@ -3742,13 +3745,13 @@ namespace sat {
                 clause & c = *(cw.get_clause());
                 detach_clause(c);
                 attach_clause(c, reinit);
-                if (reinit && !at_base_lvl()) 
+                if (reinit && !at_base_lvl())
                     // clause propagated literal, must keep it in the reinit stack.
-                    m_clauses_to_reinit[j++] = cw;                
+                    m_clauses_to_reinit[j++] = cw;
                 else if (has_variables_to_reinit(c) && !at_base_lvl())
                     m_clauses_to_reinit[j++] = cw;
-                else 
-                    c.set_reinit_stack(false);   
+                else
+                    c.set_reinit_stack(false);
             }
         }
         m_clauses_to_reinit.shrink(j);
@@ -3776,26 +3779,26 @@ namespace sat {
         if (m_user_scope_literals.empty())
             return;
         unsigned old_sz = m_user_scope_literals.size() - num_scopes;
-        bool_var max_var = m_user_scope_literals[old_sz].var();        
+        bool_var max_var = m_user_scope_literals[old_sz].var();
         m_user_scope_literals.shrink(old_sz);
 
         pop_to_base_level();
         if (m_ext)
             m_ext->user_pop(num_scopes);
-    
+
         gc_vars(max_var);
         TRACE(sat, display(tout););
 
         m_qhead = 0;
         unsigned j = 0;
-        for (bool_var v : m_free_vars) 
+        for (bool_var v : m_free_vars)
             if (v < max_var)
                 m_free_vars[j++] = v;
         m_free_vars.shrink(j);
-        m_free_vars.append(m_free_var_freeze[old_sz]); 
+        m_free_vars.append(m_free_var_freeze[old_sz]);
         m_free_var_freeze.shrink(old_sz);
         scoped_suspend_rlimit _sp(m_rlimit);
-        propagate(false);     
+        propagate(false);
     }
 
     void solver::pop_to_base_level() {
@@ -3877,7 +3880,7 @@ namespace sat {
             auto v = m_trail[i].var();
             auto d = m_stats.m_conflicts - m_last_conflict[v] + 1;
             if (d == 0) d = 1;
-            auto reward = multiplier / d;            
+            auto reward = multiplier / d;
             auto activity = m_activity[v];
             set_activity(v, static_cast<unsigned>(m_step_size * reward + ((1.0 - m_step_size) * activity)));
         }
@@ -3899,7 +3902,7 @@ namespace sat {
     //
     // -----------------------
     void solver::collect_bin_clauses(svector<bin_clause> & r, bool redundant, bool learned_only) const {
-        SASSERT(redundant || !learned_only);  
+        SASSERT(redundant || !learned_only);
         unsigned sz = m_watches.size();
         for (unsigned l_idx = 0; l_idx < sz; ++l_idx) {
             literal l = to_literal(l_idx);
@@ -3909,7 +3912,7 @@ namespace sat {
                     continue;
                 if (!redundant && w.is_learned())
                     continue;
-                else if (redundant && learned_only && !w.is_learned()) 
+                else if (redundant && learned_only && !w.is_learned())
                     continue;
                 literal l2 = w.get_literal();
                 if (l.index() > l2.index())
@@ -3926,7 +3929,7 @@ namespace sat {
     //
     // -----------------------
     bool solver::check_invariant() const {
-        if (!m_rlimit.inc()) 
+        if (!m_rlimit.inc())
             return true;
         if (m_simplifier.need_cleanup())
             return true;
@@ -3971,7 +3974,7 @@ namespace sat {
 
     void solver::display_units(std::ostream & out) const {
         unsigned level = 0;
-        for (literal lit : m_trail) {            
+        for (literal lit : m_trail) {
             if (lvl(lit) > level) {
                 level = lvl(lit);
                 out << level << ": ";
@@ -4017,8 +4020,8 @@ namespace sat {
             break;
         }
         case justification::EXT_JUSTIFICATION:
-            if (m_ext) 
-                m_ext->display_justification(out << "ext ", js.get_ext_justification_idx());            
+            if (m_ext)
+                m_ext->display_justification(out << "ext ", js.get_ext_justification_idx());
             break;
         default:
             break;
@@ -4080,7 +4083,7 @@ namespace sat {
 
     void solver::display_wcnf(std::ostream & out, unsigned sz, literal const* lits, unsigned const* weights) const {
         unsigned max_weight = 0;
-        for (unsigned i = 0; i < sz; ++i) 
+        for (unsigned i = 0; i < sz; ++i)
             max_weight += weights[i];
         ++max_weight;
 
@@ -4090,7 +4093,7 @@ namespace sat {
         out << "p wcnf " << num_vars() << " " << num_clauses() + sz << " " << max_weight << "\n";
         out << "c soft " << sz << "\n";
 
-        for (literal lit : m_trail) 
+        for (literal lit : m_trail)
             out << max_weight << " " << dimacs_lit(lit) << " 0\n";
         unsigned l_idx = 0;
         for (watch_list const& wlist : m_watches) {
@@ -4126,7 +4129,7 @@ namespace sat {
         unsigned l_idx = 0;
         for (watch_list const& wlist : m_watches) {
             literal l = to_literal(l_idx++);
-            if (!wlist.empty()) 
+            if (!wlist.empty())
                 display_watch_list(out << l << ": ", wlist) << "\n";
         }
     }
@@ -4164,7 +4167,7 @@ namespace sat {
        \brief Return true, if all literals in c are assigned to false.
     */
     bool solver::is_empty(clause const & c) const {
-        for (literal lit : c) 
+        for (literal lit : c)
             if (value(lit) != l_false)
                 return false;
         return true;
@@ -4257,18 +4260,18 @@ namespace sat {
             m_ext->find_mutexes(_lits, mutexes);
         }
         unsigned_vector ps;
-        for (literal lit : _lits) 
+        for (literal lit : _lits)
             ps.push_back(lit.index());
         mc.cliques2(ps, _mutexes);
         vector<vector<literal_vector>> sorted;
         for (auto const& mux : _mutexes) {
             literal_vector clique;
             sorted.reserve(mux.size() + 1);
-            for (auto const& idx : mux) 
+            for (auto const& idx : mux)
                 clique.push_back(to_literal(idx));
             sorted[mux.size()].push_back(clique);
         }
-        for (unsigned i = sorted.size(); i-- > 0; ) 
+        for (unsigned i = sorted.size(); i-- > 0; )
             mutexes.append(sorted[i]);
         return l_true;
     }
@@ -4562,7 +4565,7 @@ namespace sat {
                 else {
                     is_sat = bounded_search();
                     if (is_sat == l_undef) {
-                        do_restart(true);                        
+                        do_restart(true);
                         propagate(false);
                     }
                     extract_fixed_consequences(unfixed_lits, assumptions, unfixed_vars, conseq);
@@ -4656,7 +4659,7 @@ namespace sat {
         case justification::NONE:
             break;
         case justification::BINARY:
-            if (!check_domain(lit, ~js.get_literal())) 
+            if (!check_domain(lit, ~js.get_literal()))
                 return false;
             s |= m_antecedents.find(js.get_literal().var());
             break;
@@ -4664,10 +4667,10 @@ namespace sat {
             clause & c = get_clause(js);
             for (literal l : c) {
                 if (l != lit) {
-                    if (check_domain(lit, ~l) && all_found) 
-                        s |= m_antecedents.find(l.var());                    
-                    else 
-                        all_found = false;                    
+                    if (check_domain(lit, ~l) && all_found)
+                        s |= m_antecedents.find(l.var());
+                    else
+                        all_found = false;
                 }
             }
             break;
@@ -4702,11 +4705,11 @@ namespace sat {
 
     bool solver::extract_fixed_consequences1(literal lit, literal_set const& assumptions, bool_var_set& unfixed, vector<literal_vector>& conseq) {
         index_set s;
-        if (m_antecedents.contains(lit.var())) 
+        if (m_antecedents.contains(lit.var()))
             return true;
-        
-        if (assumptions.contains(lit)) 
-            s.insert(lit.index());        
+
+        if (assumptions.contains(lit))
+            s.insert(lit.index());
         else {
             if (!extract_assumptions(lit, s)) {
                 SASSERT(!m_todo_antecedents.empty());
@@ -4732,7 +4735,7 @@ namespace sat {
         m_todo_antecedents.push_back(lit);
         while (!m_todo_antecedents.empty()) {
             auto lit = m_todo_antecedents.back();
-            if (extract_fixed_consequences1(lit, assumptions, unfixed, conseq)) 
+            if (extract_fixed_consequences1(lit, assumptions, unfixed, conseq))
                 m_todo_antecedents.pop_back();
         }
     }
@@ -4797,8 +4800,12 @@ namespace sat {
         out << "  :ternary-clauses " << num_ter << "\n";
         out << "  :clauses         " << num_cls << "\n";
         out << "  :del-clause      " << m_stats.m_del_clause << "\n";
-        out << "  :avg-clause-size " << (total_cls == 0 ? 0.0 : static_cast<double>(num_lits) / static_cast<double>(total_cls)) << "\n";
-        out << "  :memory          " << std::fixed << std::setprecision(2) << mem << ")" << std::endl;
+        out << "  :avg-clause-size " << (total_cls == 0 ? 0.0 : static_cast<double>(num_lits) / static_cast<double>(total_cls));
+        if (!get_verbosity_plain()) {
+            out << "\n";
+            out << "  :memory          " << std::fixed << std::setprecision(2) << mem;
+        }
+        out << ")" << std::endl;
     }
 
     void stats::collect_statistics(statistics & st) const {
@@ -4835,7 +4842,9 @@ namespace sat {
         out << " " << std::setw(5) << (m_solver.m_learned.size() + redundant - m_solver.m_num_frozen) << "/" << redundant;
         out << " " << std::setw(3)  << m_solver.init_trail_size();
         out << " " << std::setw(7)  << m_solver.m_stats.m_gc_clause << " ";
-        out << " " << std::setw(7)  << mem_stat();
+        if (!get_verbosity_plain()) {
+            out << " " << std::setw(7)  << mem_stat();
+        }
     }
 
     std::ostream & operator<<(std::ostream & out, mk_stat const & stat) {

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -12,7 +12,7 @@ Abstract:
 Author:
 
     Leonardo de Moura (leonardo) 2006-10-10.
-    Nikolaj Bjorner   (nbjorner) 
+    Nikolaj Bjorner   (nbjorner)
 
 Revision History:
 
@@ -92,6 +92,7 @@ void display_usage() {
     std::cout << "  -h, -?      prints this message.\n";
     std::cout << "  -version    prints version number of Z3.\n";
     std::cout << "  -v:level    be verbose, where <level> is the verbosity level.\n";
+    std::cout << "  -V:level    like -v:level, but suppress timing and memory data.\n";
     std::cout << "  -nw         disable warning messages.\n";
     std::cout << "  -p          display Z3 global (and module) parameters.\n";
     std::cout << "  -pd         display Z3 global (and module) parameter descriptions.\n";
@@ -107,7 +108,7 @@ void display_usage() {
     std::cout << "  -T:timeout  set the timeout (in seconds).\n";
     std::cout << "  -t:timeout  set the soft timeout (in milli seconds). It only kills the current query.\n";
     std::cout << "  -memory:Megabytes  set a limit for virtual memory consumption.\n";
-    // 
+    //
     std::cout << "\nOutput:\n";
     std::cout << "  -st         display statistics.\n";
 #if defined(Z3DEBUG) || defined(_TRACE)
@@ -141,13 +142,13 @@ static bool is_tptp_extension(char const* ext) {
     }
     return false;
 }
-   
+
 static void parse_cmd_line_args(std::string& input_file, int argc, char ** argv) {
     long timeout = 0;
     int i = 1;
     char * eq_pos = nullptr;
     while (i < argc) {
-        char * arg = argv[i];    
+        char * arg = argv[i];
 
         if (arg[0] == '-' && arg[1] == '-' && arg[2] == 0) {
             // Little hack used to read files with strange names such as -foo.smt2
@@ -166,8 +167,8 @@ static void parse_cmd_line_args(std::string& input_file, int argc, char ** argv)
             g_input_file = input_file.c_str();
             break;
         }
-        
-        if (arg[0] == '-' 
+
+        if (arg[0] == '-'
 #ifdef _WINDOWS
             || arg[0] == '/'
 #endif
@@ -229,14 +230,14 @@ static void parse_cmd_line_args(std::string& input_file, int argc, char ** argv)
                 g_input_kind = IN_TPTP;
             }
             else if (strcmp(opt_name, "st") == 0) {
-                g_display_statistics = true; 
+                g_display_statistics = true;
                 gparams::set("stats", "true");
             }
             else if (strcmp(opt_name, "model") == 0) {
                 g_display_model = true;
             }
             else if (strcmp(opt_name, "ist") == 0) {
-                g_display_istatistics = true; 
+                g_display_istatistics = true;
             }
             else if (strcmp(opt_name, "v") == 0) {
                 if (!opt_arg)
@@ -245,6 +246,15 @@ static void parse_cmd_line_args(std::string& input_file, int argc, char ** argv)
                     error("invalid argument for -v option, it must be a non-negative integer.");
                 long lvl = strtol(opt_arg, nullptr, 10);
                 set_verbosity_level(lvl);
+            }
+            else if (strcmp(opt_name, "V") == 0) {
+                if (!opt_arg)
+                    error("option argument (-V:level) is missing.");
+                if (!validate_is_ulong(opt_arg))
+                    error("invalid argument for -V option, it must be a non-negative integer.");
+                long lvl = strtol(opt_arg, nullptr, 10);
+                set_verbosity_level(lvl);
+                set_verbosity_plain(true);
             }
             else if (strcmp(opt_name, "file") == 0) {
                 g_input_file = opt_arg;
@@ -273,7 +283,7 @@ static void parse_cmd_line_args(std::string& input_file, int argc, char ** argv)
                 exit(0);
             }
             else if (strcmp(opt_name, "pmmd") == 0) {
-                if (opt_arg) 
+                if (opt_arg)
                     gparams::display_module_markdown(std::cout, opt_arg);
                 else {
                     gparams::display_modules(std::cout);
@@ -326,9 +336,9 @@ static void parse_cmd_line_args(std::string& input_file, int argc, char ** argv)
                 else
                     help_simplifier(opt_arg, false);
             }
-            else if (strcmp(opt_name, "tacticsmd") == 0 && opt_arg) 
+            else if (strcmp(opt_name, "tacticsmd") == 0 && opt_arg)
                 help_tactic(opt_arg, true);
-            else if (strcmp(opt_name, "probes") == 0) 
+            else if (strcmp(opt_name, "probes") == 0)
                 help_probes();
             else {
                 std::cerr << "Error: invalid command line option: " << arg << "\n";
@@ -363,7 +373,7 @@ static void parse_cmd_line_args(std::string& input_file, int argc, char ** argv)
             else {
                 char * key   = argv[i];
                 *eq_pos      = 0;
-                char * value = eq_pos+1; 
+                char * value = eq_pos+1;
                 gparams::set(key, value);
             }
         }
@@ -372,9 +382,9 @@ static void parse_cmd_line_args(std::string& input_file, int argc, char ** argv)
                 g_input_kind = IN_DRAT;
                 g_drat_input_file = arg;
             }
-            else if (g_input_file) 
+            else if (g_input_file)
                 warning_msg("input file was already specified.");
-            else 
+            else
                 g_input_file = arg;
         }
         i++;
@@ -400,7 +410,7 @@ int STD_CALL main(int argc, char ** argv) {
         if (!g_input_file && !g_standard_input) {
             error("input file was not specified.");
         }
-        
+
         if (g_input_kind == IN_UNSPECIFIED) {
             g_input_kind = IN_SMTLIB_2;
             char const * ext = get_extension(g_input_file);

--- a/src/smt/smt_context_pp.cpp
+++ b/src/smt/smt_context_pp.cpp
@@ -124,7 +124,7 @@ namespace smt {
         expr_ref c = mk_or(fmls);
         out << c << "\n";
 #else
-        for (unsigned i = 0; i < num_lits; ++i) 
+        for (unsigned i = 0; i < num_lits; ++i)
             display_literal_smt2(out, lits[i]) << "\n";
 #endif
         return out;
@@ -195,7 +195,7 @@ namespace smt {
             out << "(";
             bool first = true;
             for (auto lit : *cp) {
-                if (!first) out << " "; 
+                if (!first) out << " ";
                 first = false;
                 out << lit;
             }
@@ -245,7 +245,7 @@ namespace smt {
                     auto j = get_justification(lit.var());
                     display(out << " ", j);
                 }
-                else 
+                else
                     out << "\n";
             }
         }
@@ -268,11 +268,11 @@ namespace smt {
         if (m_enodes.empty())
             return;
         unsigned count = 0;
-        for (enode * r : m_enodes) 
+        for (enode * r : m_enodes)
             if (r->is_root())
                 ++count;
-            
-        out << "equivalence classes: " << count << "\n";        
+
+        out << "equivalence classes: " << count << "\n";
         for (enode * r : m_enodes) {
             if (!r->is_root())
                 continue;
@@ -288,7 +288,7 @@ namespace smt {
 
     void context::display_app_enode_map(std::ostream & out) const {
         return;
-        // mainly useless 
+        // mainly useless
         if (!m_e_internalized_stack.empty()) {
             out << "expression -> enode:\n";
             unsigned sz = m_e_internalized_stack.size();
@@ -415,7 +415,7 @@ namespace smt {
         st.update("final checks", m_stats.m_num_final_checks);
         st.update("added eqs", m_stats.m_num_add_eq);
         st.update("mk clause", m_stats.m_num_mk_clause);
-        st.update("mk clause binary", m_stats.m_num_mk_bin_clause);        
+        st.update("mk clause binary", m_stats.m_num_mk_bin_clause);
         st.update("del clause", m_stats.m_num_del_clause);
         st.update("dyn ack", m_stats.m_num_dyn_ack);
         st.update("interface eqs", m_stats.m_num_interface_eqs);
@@ -627,7 +627,7 @@ namespace smt {
         case b_justification::AXIOM:
             out << "axiom";
             break;
-        case b_justification::BIN_CLAUSE: 
+        case b_justification::BIN_CLAUSE:
             out << "bin " << j.get_literal();
             break;
         case b_justification::CLAUSE: {
@@ -656,7 +656,7 @@ namespace smt {
         case b_justification::AXIOM:
             out << "axiom";
             break;
-        case b_justification::BIN_CLAUSE: 
+        case b_justification::BIN_CLAUSE:
             out << "bin " << j.get_literal();
             break;
         case b_justification::CLAUSE: {
@@ -718,7 +718,7 @@ namespace smt {
                 return m_scopes[0].m_assigned_literals_lim;
         };
         std::stringstream strm;
-        strm << "(smt.stats " 
+        strm << "(smt.stats "
              << std::setw(4) << m_stats.m_num_restarts << ' '
              << std::setw(6) << m_stats.m_num_conflicts << ' '
              << std::setw(6) << m_stats.m_num_decisions << ' '
@@ -726,8 +726,11 @@ namespace smt {
              << std::setw(5) << (m_aux_clauses.size() + bin_clauses) << '/' << bin_clauses << '/' << num_units() << ' '
              << std::setw(7) << m_lemmas.size() << '/' << bin_lemmas << ' '
              << std::setw(5) << m_stats.m_num_simplifications << ' '
-             << std::setw(4) << m_stats.m_num_del_clauses << ' '
-             << std::setw(7) << mem_stat() << ")\n";
+             << std::setw(4) << m_stats.m_num_del_clauses;
+        if (!get_verbosity_plain()) {
+            strm << ' ' << std::setw(7) << mem_stat();
+        }
+        strm << ")\n";
 
         std::string str = std::move(strm).str();
         svector<size_t> offsets;
@@ -738,7 +741,7 @@ namespace smt {
             if (i < str.size()) {
                 offsets.push_back(i);
             }
-        }   
+        }
         bool same = m_last_positions.size() == offsets.size();
         size_t diff = 0;
         for (unsigned i = 0; i < offsets.size() && same; ++i) {
@@ -746,7 +749,7 @@ namespace smt {
             if (m_last_positions[i] < offsets[i]) diff += offsets[i] - m_last_positions[i];
         }
 
-        if (m_last_positions.empty() || 
+        if (m_last_positions.empty() ||
             m_stats.m_num_restarts >= 20 + m_last_position_log ||
             (m_stats.m_num_restarts >= 6 + m_last_position_log && (!same || diff > 3))) {
             m_last_position_log = m_stats.m_num_restarts;
@@ -773,10 +776,10 @@ namespace smt {
                     for (; p1 < p + adjust[i]; ++p1) l1 << " ";
                     p1 += strlen(tag[i]);
                     l1 << tag[i];
-                }                               
+                }
             }
-            for (; p1 + 2 < str.size(); ++p1) l1 << " ";            
-            for (; p2 + 2 < str.size(); ++p2) l2 << " ";            
+            for (; p1 + 2 < str.size(); ++p1) l1 << " ";
+            for (; p2 + 2 < str.size(); ++p2) l2 << " ";
             l1 << ")\n";
             l2 << ")\n";
             IF_VERBOSE(2, verbose_stream() << l1.str() << l2.str());
@@ -787,4 +790,3 @@ namespace smt {
     }
 
 }
-

--- a/src/tactic/tactic.cpp
+++ b/src/tactic/tactic.cpp
@@ -37,21 +37,28 @@ struct tactic_report::imp {
         TRACE(tactic, g.display_with_proofs(tout << id << "\n"););
         SASSERT(g.is_well_formed());
     }
-        
+
     ~imp() {
         m_watch.stop();
         double end_memory = static_cast<double>(memory::get_allocation_size())/static_cast<double>(1024*1024);
         TRACE(tactic, m_goal.display(tout << m_id << "\n");
               if (m_goal.mc()) m_goal.mc()->display(tout);
               );
-        IF_VERBOSE(0, 
+
+        IF_VERBOSE(0,
                    verbose_stream() << "(" << m_id
                    << " :num-exprs " << m_goal.num_exprs()
-                   << " :num-asts " << m_goal.m().get_num_asts()
-                   << " :time " << std::fixed << std::setprecision(2) << m_watch.get_seconds()
-                   << " :before-memory " << std::fixed << std::setprecision(2) << m_start_memory
-                   << " :after-memory " << std::fixed << std::setprecision(2) << end_memory
-                   << ")\n");
+                   << " :num-asts " << m_goal.m().get_num_asts());
+        if (!get_verbosity_plain()) {
+            IF_VERBOSE(0,
+                       verbose_stream()
+                       << " :time " << std::fixed << std::setprecision(2) << m_watch.get_seconds()
+                       << " :before-memory " << std::fixed << std::setprecision(2) << m_start_memory
+                       << " :after-memory " << std::fixed << std::setprecision(2) << end_memory);
+        }
+        IF_VERBOSE(0,
+                   verbose_stream() << ")\n");
+
         IF_VERBOSE(20, m_goal.display(verbose_stream() << m_id << "\n"));
         SASSERT(m_goal.is_well_formed());
     }
@@ -71,7 +78,7 @@ tactic_report::~tactic_report() {
 
 void report_tactic_progress(char const * id, unsigned val) {
     if (val > 0) {
-        IF_VERBOSE(TACTIC_VERBOSITY_LVL, verbose_stream() << "(" << id << " " << val << ")\n");        
+        IF_VERBOSE(TACTIC_VERBOSITY_LVL, verbose_stream() << "(" << id << " " << val << ")\n");
     }
 }
 statistics_report::~statistics_report() {
@@ -112,7 +119,7 @@ public:
         ensure_tactic();
         (*m_tactic)(in, result);
     }
-    void updt_params(params_ref const& p) override { 
+    void updt_params(params_ref const& p) override {
         this->p.append(p);
         if (m_tactic) m_tactic->updt_params(p);
     }
@@ -171,7 +178,7 @@ class trace_tactic : public skip_tactic {
     char const * m_tag;
 public:
     trace_tactic(char const * tag): m_tag(tag) {}
-    
+
     void operator()(goal_ref const & in, goal_ref_buffer& result) override {
         TRACE(m_tag, in->display(tout););
         (void)m_tag;
@@ -186,7 +193,7 @@ tactic * mk_trace_tactic(char const * tag) {
 class fail_if_undecided_tactic : public skip_tactic {
 public:
     void operator()(goal_ref const & in, goal_ref_buffer& result) override {
-        if (!in->is_decided()) 
+        if (!in->is_decided())
             throw tactic_exception("undecided");
         skip_tactic::operator()(in, result);
     }
@@ -234,10 +241,10 @@ lbool check_sat(tactic & t, goal_ref & g, model_ref & md, labels_vec & labels, p
     if (r.size() > 0) {
         pr = r[0]->pr(0);
         CTRACE(tactic, pr, tout << pr << "\n";);
-    }    
+    }
 
     if (is_decided_sat(r)) {
-        model_converter_ref mc = r[0]->mc();            
+        model_converter_ref mc = r[0]->mc();
         if (mc.get()) {
             (*mc)(labels);
             model_converter2model(m, mc.get(), md);
@@ -261,7 +268,7 @@ lbool check_sat(tactic & t, goal_ref & g, model_ref & md, labels_vec & labels, p
     }
     else {
         if (models_enabled && !r.empty()) {
-            model_converter_ref mc = r[0]->mc();            
+            model_converter_ref mc = r[0]->mc();
             model_converter2model(m, mc.get(), md);
             if (mc)
                 (*mc)(labels);

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -22,6 +22,8 @@ Revision History:
 
 static unsigned g_verbosity_level = 0;
 
+static bool g_verbosity_plain = false;
+
 void set_verbosity_level(unsigned lvl) {
     g_verbosity_level = lvl;
 }
@@ -29,6 +31,17 @@ void set_verbosity_level(unsigned lvl) {
 unsigned get_verbosity_level() {
     return g_verbosity_level;
 }
+
+void set_verbosity_plain(bool p)
+{
+    g_verbosity_plain = p;
+}
+
+bool get_verbosity_plain()
+{
+    return g_verbosity_plain;
+}
+
 
 static std::ostream* g_verbose_stream = &std::cerr;
 
@@ -152,4 +165,3 @@ void escaped::display(std::ostream & out) const {
         }
     }
 }
-

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -44,7 +44,7 @@ static_assert(sizeof(int64_t) == 8, "64 bits");
 #endif
 #ifndef INT64_MAX
 #define INT64_MAX static_cast<int64_t>(0x7fffffffffffffffull)
-#endif                              
+#endif
 #ifndef UINT64_MAX
 #define UINT64_MAX 0xffffffffffffffffull
 #endif
@@ -84,7 +84,7 @@ static inline bool is_power_of_two(unsigned v) { return !(v & (v - 1)) && v; }
 
 /**
    \brief Return the next power of two that is greater than or equal to v.
-   
+
    \warning This function returns 0 for v == 0.
 */
 static inline unsigned next_power_of_two(unsigned v) {
@@ -116,12 +116,12 @@ static inline unsigned get_num_1bits(unsigned v) {
     unsigned c;
     unsigned v1 = v;
     for (c = 0; v1; ++c) {
-        v1 &= v1 - 1; 
+        v1 &= v1 - 1;
     }
 #endif
-    v = v - ((v >> 1) & 0x55555555);                    
-    v = (v & 0x33333333) + ((v >> 2) & 0x33333333);     
-    unsigned r = (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24; 
+    v = v - ((v >> 1) & 0x55555555);
+    v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
+    unsigned r = (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
     SASSERT(c == r);
     return r;
 #endif
@@ -135,11 +135,11 @@ static inline unsigned get_num_1bits(uint64_t v) {
     unsigned c;
     uint64_t v1 = v;
     for (c = 0; v1; ++c) {
-        v1 &= v1 - 1; 
+        v1 &= v1 - 1;
     }
 #endif
     v = v - (v >> 1) & 0x5555555555555555;
-    v = (v & 0x3333333333333333) + ((v >> 2) & 0x3333333333333333); 
+    v = (v & 0x3333333333333333) + ((v >> 2) & 0x3333333333333333);
     v = (v + (v >> 4)) & 0x0F0F0F0F0F0F0F0F;
     uint64_t r = (v * 0x0101010101010101) >> 56;
     SASSERT(c == r);
@@ -157,7 +157,7 @@ static inline uint64_t shift_left(uint64_t x, uint64_t y) {
     return y < 64ull ? (x << y) : 0ull;
 }
 
-template<class T, size_t N> char (*ArraySizer(T (&)[N]))[N]; 
+template<class T, size_t N> char (*ArraySizer(T (&)[N]))[N];
 // For determining the length of an array. See ARRAYSIZE() macro. This function is never actually called.
 
 #define Z3_ARRAYSIZE(a) sizeof(*ArraySizer(a))
@@ -183,19 +183,23 @@ void display(std::ostream & out, const IT & begin, const IT & end, const char * 
 
 template<typename T>
 struct delete_proc {
-    void operator()(T * ptr) { 
-    if (ptr) 
-        dealloc(ptr);    
+    void operator()(T * ptr) {
+    if (ptr)
+        dealloc(ptr);
     }
 };
 
 void set_verbosity_level(unsigned lvl);
 unsigned get_verbosity_level();
+
+void set_verbosity_plain(bool p);
+bool get_verbosity_plain();
+
 std::ostream& verbose_stream();
 void set_verbose_stream(std::ostream& str);
 
-  
-#define IF_VERBOSE(LVL, CODE) { if (get_verbosity_level() >= LVL) { THREAD_LOCK(CODE); } } ((void) 0)              
+
+#define IF_VERBOSE(LVL, CODE) { if (get_verbosity_level() >= LVL) { THREAD_LOCK(CODE); } } ((void) 0)
 
 
 
@@ -210,7 +214,7 @@ struct default_eq {
 template<typename T>
 struct ptr_eq {
     typedef T * data;
-    bool operator()(T * a1, T * a2) const { 
+    bool operator()(T * a1, T * a2) const {
         return a1 == a2;
     }
 };
@@ -218,7 +222,7 @@ struct ptr_eq {
 template<typename T>
 struct deref_eq {
     typedef T * data;
-    bool operator()(T * a1, T * a2) const { 
+    bool operator()(T * a1, T * a2) const {
         return *a1 == *a2;
     }
 };
@@ -239,18 +243,18 @@ public:
         dealloc(m_ptr);
     }
 
-    T * operator->() const { 
-        return m_ptr; 
+    T * operator->() const {
+        return m_ptr;
     }
 
-    T * get() const { 
-        return m_ptr; 
+    T * get() const {
+        return m_ptr;
     }
 
-    operator bool() const { 
+    operator bool() const {
         return m_ptr != nullptr;
     }
-    
+
     const T & operator*() const {
         return *m_ptr;
     }
@@ -348,14 +352,14 @@ public:
     unsigned get_seed() const { return m_data; }
 
     int operator()() {
-        return ((m_data = m_data * 214013L + 2531011L) >> 16) & 0x7fff; 
+        return ((m_data = m_data * 214013L + 2531011L) >> 16) & 0x7fff;
     }
 
     unsigned operator()(unsigned u) {
         unsigned r = static_cast<unsigned>((*this)());
         return r % u;
     }
-    
+
     static int max_value() {
         return 0x7fff;
     }
@@ -452,7 +456,7 @@ inline size_t megabytes_to_bytes(unsigned mb) {
     unsigned long long b = static_cast<unsigned long long>(mb) * 1024ull * 1024ull;
     size_t r = static_cast<size_t>(b);
     if (r != b)  // overflow
-        r = SIZE_MAX;    
+        r = SIZE_MAX;
     return r;
 }
 


### PR DESCRIPTION
This PR adds a new top-level command-line option "-V:level"

Same as -v:level but suppresses reporting of wall-clock timing and memory consumption data, and data that are the result of a floating-point division, so resulting logs are amenable to cross-platform diff.

The intent is that, following PRs 10163 and 10165, logs created by "-V:10" should be byte-for-byte identical on all host platforms, for example, on macOS vs Linux.

Some file committed here show changes in white-space, since my editor automatically replaced tab characters with spaces. Hope that's OK.

Running on our mlkem-native library, I now see identical behaviour and logs for all 191 SMT files between macOS and Linux. This is a huge UX improvement for our developers, where we develop and maintain proofs on macOS, but run CI on Linux machines.