### PR TITLE
Fix reversed precondition assertion in grobner::pop_scope

### DIFF
--- a/src/math/grobner/grobner.cpp
+++ b/src/math/grobner/grobner.cpp
@@ -98,7 +98,7 @@ void grobner::push_scope() {
 }
 
 void grobner::pop_scope(unsigned num_scopes) {
-    SASSERT(num_scopes >= get_scope_level());
+    SASSERT(num_scopes <= get_scope_level());
     unsigned new_lvl = get_scope_level() - num_scopes;
     scope & s        = m_scopes[new_lvl];
     unfreeze_equations(s.m_equations_to_unfreeze_lim);


### PR DESCRIPTION
### What it does

Fixes an inverted precondition assertion in `grobner::pop_scope` (`src/math/grobner/grobner.cpp`).

```cpp
void grobner::pop_scope(unsigned num_scopes) {
    SASSERT(num_scopes >= get_scope_level());          // was reversed
    unsigned new_lvl = get_scope_level() - num_scopes; // requires num_scopes <= level
    ...
    m_scopes.shrink(new_lvl);
}
```

`get_scope_level()` returns `m_scopes.size()` (grobner.h). The body computes
`new_lvl = get_scope_level() - num_scopes` and calls `m_scopes.shrink(new_lvl)`,
which is only well-defined when `num_scopes <= get_scope_level()`. The assertion
stated the opposite (`>=`), so in debug builds it would fire on any valid partial
pop (e.g. popping one of several scopes) while failing to catch the unsigned
underflow it was meant to guard against. Changed to `<=`.

### Evidence

- `get_scope_level() const { return m_scopes.size(); }` (`src/math/grobner/grobner.h`).
- Compiled the translation unit with MSVC and `Z3DEBUG` defined (so the `SASSERT`
  is active): builds cleanly.

### What we did not verify

This is a debug-only (`SASSERT`) correctness fix and has no effect on release
builds. No behavioral test was added.