### PR TITLE
Prune seq_monadic product states that can no longer reach their goal

### DIFF
--- a/src/ast/rewriter/seq_monadic.cpp
+++ b/src/ast/rewriter/seq_monadic.cpp
@@ -51,6 +51,7 @@ Author:
 
 #include "ast/rewriter/seq_monadic.h"
 #include "ast/rewriter/guard_set.h"
+#include "ast/rewriter/seq_range_collapse.h"
 #include <set>
 #include <vector>
 #include <map>
@@ -99,6 +100,93 @@ lbool seq_monadic::nullable(expr* r) {
 expr_ref_pair_vector const& seq_monadic::derivative_cofactors(expr* r) {
     ++m_stats.m_cofactor_calls;
     return m_rw.get_derive().get_cached_cofactors(m_config.m_mode, r);
+}
+
+void seq_monadic::reset_ivl_cache() {
+    for (auto& kv : m_ivl_cache)
+        dealloc(kv.m_value);
+    m_ivl_cache.reset();
+    m_ivl_pin.reset();
+}
+
+// Canonical interval form of r's derivative: the cofactor guards, translated into the
+// range algebra, refined into a sorted list of disjoint ranges, each labelled with the
+// targets reachable on it.  Adjacent ranges with identical target sets are merged, so the
+// result is the minimal ordered-ITE ("t-regex") representation of the transition relation.
+// Returns null when some guard falls outside the range algebra.
+seq_monadic::ivl_list const* seq_monadic::interval_cofactors(expr* r, expr* v0) {
+    ivl_list* res = nullptr;
+    if (m_ivl_cache.find(r, res))
+        return res && res->ok ? res : nullptr;
+
+    unsigned max_char = u().max_char();
+    res = alloc(ivl_list);
+    m_ivl_cache.insert(r, res);
+    m_ivl_pin.push_back(r);
+
+    // (lo, hi, target) triples, plus the boundary set of this state's own partition.
+    struct tr_t { unsigned lo, hi; expr* t; };
+    svector<tr_t> tr;
+    svector<unsigned> bounds;
+    bounds.push_back(0);
+    for (auto const& [g, t] : derivative_cofactors(r)) {
+        if (re().is_empty(t))
+            continue;
+        seq::range_predicate* p = nullptr;
+        if (!m_rp_cache.find(g, p)) {
+            p = m_rp_cache.fresh(max_char);
+            if (!seq::guard_to_range_predicate(u(), v0, g, *p)) {
+                m_rp_cache.insert(g, nullptr);
+                res->ok = false;
+                return nullptr;
+            }
+            m_rp_cache.insert(g, p);
+        }
+        else if (!p) {
+            res->ok = false;
+            return nullptr;
+        }
+        m_ivl_pin.push_back(t);
+        for (auto const& rg : p->ranges()) {
+            tr.push_back({ rg.first, rg.second, t });
+            bounds.push_back(rg.first);
+            if (rg.second < max_char)
+                bounds.push_back(rg.second + 1);
+        }
+    }
+    if (tr.empty())
+        return res;                            // dead state: no outgoing transition
+
+    std::sort(bounds.begin(), bounds.end());
+    bounds.shrink((unsigned)(std::unique(bounds.begin(), bounds.end()) - bounds.begin()));
+
+    ptr_vector<expr> hits;
+    for (unsigned bi = 0; bi < bounds.size(); ++bi) {
+        unsigned lo = bounds[bi];
+        unsigned hi = bi + 1 < bounds.size() ? bounds[bi + 1] - 1 : max_char;
+        hits.reset();
+        for (auto const& e : tr)
+            if (e.lo <= lo && lo <= e.hi)
+                hits.push_back(e.t);
+        if (hits.empty())
+            continue;                          // gap: no transition on this range
+        // extend the previous range when it carries exactly the same target set
+        if (!res->ranges.empty()) {
+            ivl_range& prev = res->ranges.back();
+            if (prev.hi + 1 == lo && prev.count == hits.size()) {
+                bool same = true;
+                for (unsigned k = 0; k < hits.size() && same; ++k)
+                    same = res->targets[prev.first + k] == hits[k];
+                if (same) {
+                    prev.hi = hi;
+                    continue;
+                }
+            }
+        }
+        res->ranges.push_back({ lo, hi, res->targets.size(), hits.size() });
+        res->targets.append(hits.size(), hits.data());
+    }
+    return res;
 }
 
 lbool seq_monadic::product_nonempty(svector<component> const& comps, expr_ref* witness_word) {
@@ -190,6 +278,92 @@ lbool seq_monadic::product_nonempty(svector<component> const& comps, expr_ref* w
     branches.resize(n);
     key st_key;
     bool bail = false;
+
+    // ---- interval-refinement ("t-regex merge") product --------------------------
+    // Over the character sort every cofactor guard denotes a union of ranges, so each
+    // component's derivative has a canonical ordered-interval ("t-regex") form, cached
+    // per state by interval_cofactors.  The joint transitions are then exactly the cells
+    // of the common refinement of those n interval lists, obtained by a cursor merge in
+    // O(sum_i intervals_i) -- whereas the cartesian enumeration below tries
+    // prod_i(k_i) combinations, almost all of which are pruned as empty.
+    bool const sweep_ok = u().is_char(m_elem_sort);
+    unsigned const max_char = sweep_ok ? u().max_char() : 0;
+    svector<ivl_list const*> sw_lists;
+    svector<unsigned> sw_cur, sw_odo;
+    sw_lists.resize(n);
+    sw_cur.resize(n);
+    sw_odo.resize(n);
+
+    // Returns false when some guard falls outside the range algebra, in which case the
+    // caller falls back to the cartesian enumeration for this product state.
+    auto sweep = [&]() -> bool {
+        for (unsigned i = 0; i < n; ++i) {
+            sw_lists[i] = interval_cofactors(st[i], var0);
+            if (!sw_lists[i])
+                return false;
+            if (sw_lists[i]->ranges.empty())
+                return true;                  // component is stuck: no joint transition
+            sw_cur[i] = 0;
+        }
+        uint64_t b = 0;
+        while (b <= max_char) {
+            uint64_t next = (uint64_t)max_char + 1;
+            bool covered = true, done = false;
+            for (unsigned i = 0; i < n; ++i) {
+                auto const& rs = sw_lists[i]->ranges;
+                unsigned& c = sw_cur[i];
+                while (c < rs.size() && rs[c].hi < b)
+                    ++c;
+                if (c == rs.size()) {         // this component has no transition left
+                    done = true;
+                    break;
+                }
+                if (rs[c].lo > b) {           // gap in this component: skip ahead
+                    covered = false;
+                    next = std::min(next, (uint64_t)rs[c].lo);
+                }
+                else
+                    next = std::min(next, (uint64_t)rs[c].hi + 1);
+            }
+            if (done)
+                break;
+            if (covered) {
+                // Emit every combination of the targets active on this cell.  The modes
+                // whose cofactors partition the domain give exactly one target per
+                // component; the antimirov-style modes may give several.
+                for (unsigned i = 0; i < n; ++i)
+                    sw_odo[i] = 0;
+                while (true) {
+                    for (unsigned i = 0; i < n; ++i) {
+                        auto const& r = sw_lists[i]->ranges[sw_cur[i]];
+                        cur[i] = sw_lists[i]->targets[r.first + sw_odo[i]];
+                    }
+                    key const& ck = fill_key(cur);
+                    if (visited.find(ck) == visited.end()) {
+                        visited.insert(ck);
+                        if (witness_word) {
+                            expr* e = u().mk_char((unsigned)b);
+                            m_pin.push_back(e);
+                            parent[ck] = { st_key, e };
+                        }
+                        for (unsigned j = 0; j < n; ++j)
+                            work.push_back(cur[j]);
+                    }
+                    unsigned i = n;
+                    while (i-- > 0) {
+                        if (++sw_odo[i] < sw_lists[i]->ranges[sw_cur[i]].count)
+                            break;
+                        sw_odo[i] = 0;
+                    }
+                    if (i == UINT_MAX)
+                        break;                // odometer wrapped: cell exhausted
+                }
+            }
+            b = next;
+        }
+        return true;
+    };
+
     std::function<void(unsigned, guard_set const&)> rec =
         [&](unsigned i, guard_set const& acc) {
             if (bail) return;
@@ -252,13 +426,17 @@ lbool seq_monadic::product_nonempty(svector<component> const& comps, expr_ref* w
             return l_undef;
         }
 
+        if (witness_word)
+            st_key = fill_key(st);
+
+        if (sweep_ok && sweep())
+            continue;
+
         for (unsigned i = 0; i < n; ++i)
             branches[i] = &derivative_cofactors(st[i]);
 
         // joint transitions = cartesian product of the branches with the guards
         // conjoined; prune as soon as the accumulated guard is empty, bail on unknown.
-        if (witness_word)
-            st_key = fill_key(st);
         guard_set top(m, u(), m_elem_sort, var0, &m_rp_cache);
         rec(0, top);
         if (bail)
@@ -510,6 +688,7 @@ lbool seq_monadic::decide(membership_vec const& memberships) {
     reset_search();                               // clear the caches before dropping the
     m_pin.reset();                                // pins that keep their keys alive
     m_rp_cache.maybe_reset(1u << 16);
+    reset_ivl_cache();
     m_rw.get_derive().maybe_reset_cached_cofactors(1u << 16);
     m_budget = 200000;
     m_giveup = false;

--- a/src/ast/rewriter/seq_monadic.cpp
+++ b/src/ast/rewriter/seq_monadic.cpp
@@ -189,6 +189,82 @@ seq_monadic::ivl_list const* seq_monadic::interval_cofactors(expr* r, expr* v0) 
     return res;
 }
 
+void seq_monadic::reset_atom_cache() {
+    m_atom_cache.reset();
+    m_atom_pin.reset();
+}
+
+// See atom_sig in the header for what the abstraction computes and why it is sound.
+void seq_monadic::compute_atoms(expr* t, atom_sigs& out, unsigned depth) {
+    auto const& re = u().re;
+    // An unmodelled construct may hide anything, so it saturates the over-approximation
+    // and leaves the under-approximation empty.
+    auto unknown = [&]() { out.over.saturate(); };
+    if (depth > 200) { unknown(); return; }
+    expr* a = nullptr, *b = nullptr, *c = nullptr;
+    unsigned lo = 0, hi = 0;
+    auto rec = [&](expr* e) {
+        atom_sigs s;
+        compute_atoms(e, s, depth + 1);
+        out.under |= s.under;
+        out.over |= s.over;
+    };
+    auto chr = [&](unsigned ch) { out.under.add(ch); out.over.add(ch); };
+    // Some nodes are synthesized by normalization rather than inherited: the rewriter
+    // turns comp(eps) into (re.+ re.allchar), so re.allchar can appear in a derivative of
+    // a term that never mentioned it.  Such nodes must not gate the under-approximation.
+    auto is_free = [&](expr* e) {
+        return re.is_full_char(e) || re.is_full_seq(e) || re.is_epsilon(e) || re.is_empty(e);
+    };
+    auto node = [&](expr* e) {
+        uint64_t h = 0x9E3779B9ull ^ e->get_id();
+        out.over.add(h);
+        if (!is_free(e))
+            out.under.add(h);
+    };
+
+    if (m.is_ite(t, c, a, b)) { rec(a); rec(b); return; }   // guards are freshly built predicates
+    if (re.is_concat(t, a, b) || re.is_union(t, a, b) ||
+        re.is_intersection(t, a, b) || re.is_diff(t, a, b)) { rec(a); rec(b); return; }
+    if (re.is_complement(t, a) || re.is_opt(t, a) || re.is_reverse(t, a)) { rec(a); return; }
+    if (re.is_star(t, a) || re.is_plus(t, a) ||
+        re.is_loop(t, a, lo, hi) || re.is_loop(t, a, lo)) {
+        node(a);                                            // the body survives derivation
+        rec(a);
+        return;
+    }
+    if (re.is_empty(t) || re.is_epsilon(t) || re.is_full_seq(t))
+        return;
+    if (re.is_full_char(t)) { node(t); return; }
+    if (re.is_range(t, a, b)) {
+        unsigned cl = 0, ch = 0;
+        if (!u().is_const_char(a, cl) || !u().is_const_char(b, ch)) { unknown(); return; }
+        node(t);
+        return;
+    }
+    // A string literal is not itself an atom: d(to_re("bc")) = to_re("c") is a fresh node.
+    // Its characters are, and they can only be dropped by a derivative, never added.
+    if (re.is_to_re(t, a)) {
+        zstring s;
+        if (!u().str.is_string(a, s)) { unknown(); return; }
+        for (unsigned i = 0; i < s.length(); ++i)
+            chr(s[i]);
+        return;
+    }
+    if (re.is_of_pred(t, a)) { node(t); return; }
+    unknown();
+}
+
+seq_monadic::atom_sigs seq_monadic::atoms_of(expr* t) {
+    atom_sigs s;
+    if (m_atom_cache.find(t, s))
+        return s;
+    compute_atoms(t, s, 0);
+    m_atom_pin.push_back(t);                  // keep the key alive for the cache's lifetime
+    m_atom_cache.insert(t, s);
+    return s;
+}
+
 lbool seq_monadic::product_nonempty(svector<component> const& comps, expr_ref* witness_word) {
     unsigned n = comps.size();
     if (n == 0) {
@@ -228,6 +304,29 @@ lbool seq_monadic::product_nonempty(svector<component> const& comps, expr_ref* w
     };
 
     bool undecided = false;
+    // Goal signatures are fixed for the whole search, so they are computed once here.
+    // A component without a goal accepts by nullability and cannot be filtered this way.
+    svector<atom_sig> goal_atoms;
+    bool has_goal = false;
+    goal_atoms.resize(n);
+    for (unsigned i = 0; i < n; ++i)
+        if (comps[i].target) {
+            goal_atoms[i] = atoms_of(comps[i].target).under;
+            has_goal = true;
+        }
+    // A state from which some component can no longer reach its goal is not on any path
+    // to acceptance.  Filtering these is what keeps the search from expanding, on this
+    // corpus, roughly half of the product states it otherwise visits.
+    auto cannot_reach_goal = [&]() -> bool {
+        if (!has_goal)
+            return false;
+        for (unsigned i = 0; i < n; ++i)
+            if (comps[i].target && st[i] != comps[i].target &&
+                !goal_atoms[i].subset_of(atoms_of(st[i]).over))
+                return true;
+        return false;
+    };
+
     auto is_accept = [&]() -> bool {
         for (unsigned i = 0; i < n; ++i) {
             if (comps[i].target) {
@@ -421,6 +520,13 @@ lbool seq_monadic::product_nonempty(svector<component> const& comps, expr_ref* w
                 *witness_word = reconstruct(fill_key(st));
             return l_true;
         }
+        // Checked before the nullability bail on purpose: a state that cannot reach its
+        // goal is irrelevant, so an undecidable nullability in it must not abort the
+        // whole search.  `undecided` is reset because it only concerned this state.
+        if (cannot_reach_goal()) {
+            undecided = false;
+            continue;
+        }
         if (undecided) {
             m_stats.inc_bail(bail_reason::nullability);
             return l_undef;
@@ -494,6 +600,7 @@ void seq_monadic::reset_search() {
     m_nullable_cache.reset();
     m_undef_vars = 0;
     m_live_states.reset();
+    reset_atom_cache();
 }
 
 bool seq_monadic::prepare(membership_vec const& memberships) {

--- a/src/ast/rewriter/seq_monadic.cpp
+++ b/src/ast/rewriter/seq_monadic.cpp
@@ -444,27 +444,13 @@ lbool seq_monadic::dfs_atoms(unsigned mi, unsigned i, expr* R) {
     // A variable: the last atom is a plain membership in R, otherwise the variable drives
     // the derivative automaton from R to some live state q, which splits the search.
     bool last_atom = (i + 1 == atoms.size());
-    ptr_vector<expr> targets;
-    if (last_atom)
-        targets.push_back(nullptr);
-    else {
-        auto live = m_live_states.reachable_live(R);
-        for (expr* q : live)
-            targets.push_back(q);
-        if (live.failed()) {
-            m_stats.inc_bail(
-                live.failure_reason() == seq::live_states::failure::state_cap ?
-                bail_reason::state_cap : bail_reason::resource);
-            return l_undef;
-        }
-    }
-
     unsigned vi = var_index(a.var.get());
     uint64_t pos = (static_cast<uint64_t>(mi) << 32) | i;
     uint64_t last = 0;
     bool finalize = m_last_occ.find(a.var.get(), last) && last == pos;
-    bool any_undef = false;
-    for (expr* target : targets) {
+
+    // Explores one split target; the caller stops at the first l_true.
+    auto explore = [&](expr* target) -> lbool {
         m_groups[vi].push_back(component{ a.var.get(), R, target });
         // The group's emptiness test has to be run at some point anyway; running it as
         // soon as the group is complete (or as soon as it holds several components, where
@@ -485,6 +471,19 @@ lbool seq_monadic::dfs_atoms(unsigned mi, unsigned i, expr* R) {
                 --m_undef_vars;
         }
         m_groups[vi].pop_back();
+        return r;
+    };
+
+    if (last_atom)
+        return explore(nullptr);
+
+    // The live states are consumed as they are produced, so a satisfying branch under an
+    // early state means the rest of the reachable set is never expanded.  That is what
+    // makes a root with an exponential live set tractable when a witness is found early.
+    bool any_undef = false;
+    auto live = m_live_states.reachable_live(R);
+    for (expr* q : live) {
+        lbool r = explore(q);
         if (r == l_true)
             return l_true;
         if (r == l_undef) {
@@ -492,6 +491,14 @@ lbool seq_monadic::dfs_atoms(unsigned mi, unsigned i, expr* R) {
                 return l_undef;
             any_undef = true;
         }
+    }
+    // Short of the full reachable set the unexplored split states could still hold a
+    // solution, so the l_false the loop would otherwise report is not justified.
+    if (live.failed()) {
+        m_stats.inc_bail(
+            live.failure_reason() == seq::live_states::failure::state_cap ?
+            bail_reason::state_cap : bail_reason::resource);
+        return l_undef;
     }
     return any_undef ? l_undef : l_false;
 }

--- a/src/ast/rewriter/seq_monadic.h
+++ b/src/ast/rewriter/seq_monadic.h
@@ -114,6 +114,20 @@ class seq_monadic {
     statistics      m_stats;
     obj_map<expr, expr*> m_model;           // last extracted model (var -> witness); see get_model()
     guard_set::cache m_rp_cache;             // cofactor guard -> range predicate
+    // Interval ("t-regex") form of a state's derivative cofactors over the character sort:
+    // a canonical list of disjoint ranges in increasing order, each carrying the targets
+    // reachable on that range.  Built once per state and merged by the product, so the
+    // product enumerates only the cells of the common refinement.
+    struct ivl_range { unsigned lo, hi, first, count; };
+    struct ivl_list {
+        svector<ivl_range> ranges;
+        ptr_vector<expr>   targets;   // ranges[i] owns targets[first .. first+count)
+        bool               ok = true; // false: some guard is outside the range algebra
+    };
+    obj_map<expr, ivl_list*> m_ivl_cache;
+    expr_ref_vector          m_ivl_pin;      // pins the states and targets the cache refers to
+    ivl_list const* interval_cofactors(expr* r, expr* v0);
+    void reset_ivl_cache();
     obj_pair_map<expr, expr, expr*> m_der_cache;  // memoizes der_elem per (regex, element)
     obj_map<expr, char> m_nullable_cache;   // memoizes nullability (0 false / 1 true / 2 unknown);
                                             // seq_rewriter's own cache is capped and flushed whole
@@ -236,10 +250,10 @@ public:
     seq_monadic(seq_rewriter& rw, trail_stack& undo_trail,
                 seq::transition_mode mode = seq::transition_mode::light_antimirov_tm) :
         m(rw.m()), m_rw(rw), m_thrw(rw.m()), m_undo_trail(undo_trail),
-        m_pin(rw.m()), m_config(mode), m_rp_cache(rw.m()),
+        m_pin(rw.m()), m_config(mode), m_rp_cache(rw.m()), m_ivl_pin(rw.m()),
         m_regexes(rw.m()), m_live_states(rw, mode, 1u << 12) {}
 
-    ~seq_monadic() = default;
+    ~seq_monadic() { reset_ivl_cache(); }
 
     void collect_statistics(::statistics &st) const;
 

--- a/src/ast/rewriter/seq_monadic.h
+++ b/src/ast/rewriter/seq_monadic.h
@@ -128,6 +128,42 @@ class seq_monadic {
     expr_ref_vector          m_ivl_pin;      // pins the states and targets the cache refers to
     ivl_list const* interval_cofactors(expr* r, expr* v0);
     void reset_ivl_cache();
+
+    // Goal-directed reachability filter.  Certain syntactic features of a regex can be
+    // inherited by a derivative but never created by one: the characters of a string
+    // literal (d(to_re("bc")) = to_re("c")) and the body of a star or bounded loop
+    // (d(r*) = d(r)r* and d(r{k,l}) = d(r)r{k-1,l-1} both keep r verbatim).  Hashing
+    // those features into a Bloom filter gives, for every regex t, a set atoms(t) with
+    //     atoms(d_a(t)) subset-of atoms(t)      for every character a,
+    // hence atoms(d_w(t)) subset-of atoms(t) for every word w.  So if the atoms of a goal
+    // state are not contained in those of the current state, no sequence of derivatives
+    // can turn one into the other and the goal is unreachable.
+    //
+    // The abstraction must be directional, because constructs it does not model have to
+    // be approximated in opposite directions on the two sides: the test is
+    // under(goal) subset-of over(source), so an unmodelled construct contributes
+    // everything to `over` and nothing to `under`.  Saturating both would make an
+    // unmodelled goal look unreachable and prune a live state.
+    struct atom_sig {
+        uint64_t w[4] = { 0, 0, 0, 0 };
+        void operator|=(atom_sig const& o) { for (unsigned i = 0; i < 4; ++i) w[i] |= o.w[i]; }
+        void add(uint64_t h) {
+            h *= 1099511628211ull;
+            w[(h >> 58) & 3] |= 1ull << ((h >> 6) & 63);
+        }
+        void saturate() { for (unsigned i = 0; i < 4; ++i) w[i] = ~0ull; }
+        bool subset_of(atom_sig const& o) const {
+            for (unsigned i = 0; i < 4; ++i)
+                if (w[i] & ~o.w[i]) return false;
+            return true;
+        }
+    };
+    struct atom_sigs { atom_sig under, over; };
+    obj_map<expr, atom_sigs> m_atom_cache;
+    expr_ref_vector          m_atom_pin;     // pins the keys of m_atom_cache
+    void compute_atoms(expr* t, atom_sigs& out, unsigned depth);
+    atom_sigs atoms_of(expr* t);
+    void reset_atom_cache();
     obj_pair_map<expr, expr, expr*> m_der_cache;  // memoizes der_elem per (regex, element)
     obj_map<expr, char> m_nullable_cache;   // memoizes nullability (0 false / 1 true / 2 unknown);
                                             // seq_rewriter's own cache is capped and flushed whole
@@ -251,6 +287,7 @@ public:
                 seq::transition_mode mode = seq::transition_mode::light_antimirov_tm) :
         m(rw.m()), m_rw(rw), m_thrw(rw.m()), m_undo_trail(undo_trail),
         m_pin(rw.m()), m_config(mode), m_rp_cache(rw.m()), m_ivl_pin(rw.m()),
+        m_atom_pin(rw.m()),
         m_regexes(rw.m()), m_live_states(rw, mode, 1u << 12) {}
 
     ~seq_monadic() { reset_ivl_cache(); }


### PR DESCRIPTION
Answers Nikolaj's question on #10384: *"is a cheap non-reachability check possible and beneficial? When we explore (R, Q) we take derivatives of R and check if Q is reached. Do we ensure that the current derivative can always reach Q?"*

**We did not.** `product_nonempty` tests each popped state for acceptance — for a component with a target that means syntactic equality with the target — but nothing checked that the target was still reachable. The only pruning was empty-guard, `is_empty`, and `visited`; `reachable_live` enforces liveness toward *acceptance*, never toward the specific goal Q.

## How much is wasted

Measured with an exact oracle (materialize `reachable_live` per source state and test goal membership), on ClemensRegex/generated:

| mode | product states expanded | provably cannot reach their goal |
|---|---|---|
| brz | 10.40M | 7.17M (**68.9%**) |
| light-ant | 9.95M | 6.21M (**62.4%**) |

## The check

Some features can be *inherited* by a derivative but never *created* by one:

- the **characters** of a string literal — `d(to_re("bc")) = to_re("c")`;
- the **body** of a star or bounded loop — `d(r*) = d(r)·r*` and `d(r{k,l}) = d(r)·r{k-1,l-1}` keep `r` verbatim. Note the loop *node* is not preserved, so the body is the atom.

Hashing these into a 256-bit Bloom filter gives `atoms(d_a(t)) ⊆ atoms(t)`, hence `atoms(d_w(t)) ⊆ atoms(t)` for every word `w`. If the goal's atoms are not contained in the state's, the goal is unreachable.

Two things are needed for soundness, both found by dumping counterexamples rather than by reasoning:

1. **The abstraction must be directional.** The test is `under(goal) ⊆ over(source)`; an unmodelled construct contributes everything to `over` and nothing to `under`. Saturating both sides makes an unmodelled *goal* look unreachable. Getting this wrong produced 751k false prunes.
2. **Normalization synthesizes nodes.** `mk_re_complement` turns `comp(ε)` into `(re.+ re.allchar)`, so `re.allchar` appears in derivatives of terms that never mentioned it. `re.allchar`, `re.full_seq`, `ε`, `∅` are therefore excluded from the under-approximation.

The check runs **before the nullability bail**, so a state that cannot reach its goal no longer aborts the entire search with `l_undef` merely because its nullability is undecidable. That is where the newly decided benchmarks come from.

## Results

Full regex corpus, 1545 files, two repetitions, same binary with the filter on and off:

| mode | decided | solve time |
|---|---|---|
| brz | 1472 → 1472 | 26.1s → 15.4s (**−41%**) |
| light-ant | 1469 → **1473** | 13.6s → 8.6s (**−37%**) |

Newly decided (all four agree with their expected status):
`split_membership_easy_unsat_0006` undef→unsat, `split_membership_medium_sat_0003` undef→sat, `split_membership_medium_sat_0053` timeout→sat, `split_membership_medium_unsat_0058` undef→unsat.

**Soundness checks:** across all runs, 0 benchmarks changed sat↔unsat, 0 lost a verdict, and 0 disagreed with their expected status. Baseline brz variance also drops sharply (31.6s/20.6s across reps → 15.7s/15.2s).

So the honest summary is: on this corpus the check converts mostly into **speed**, and only marginally into **completeness** (+4 files, light-ant only).

## What did not work

I also evaluated the "relevant alphabet" `A_R` — a `range_predicate` per node with `A_{R|S} = A_R ∪ A_S`, `A_{R&S} = A_R ∩ A_S`, `A_{RS} = A_R ∪ A_S`, `A_{R*} = A_R`, `A_{~R} = ⊤` plus the `~(.*p.*) = (^p)*` rewrite for a single character `p`. It is sound (0 false positives once the `∩` rule and the directional discipline are in place) but its unique contribution over the atom check is **0.6% of dead states in brz and 2.8% in light-ant**, because the atom check already carries one atom per literal character. Its only extra power is interval-subset reasoning on `re.range` leaves. Not worth the machinery, so it is not in this PR.

## Notes

- Stacked on #10384 → #10381. Please merge those first.
- 94/94 unit tests pass.
- The one residual soundness caveat worth recording: `mk_re_star` rewrites `(b*|c)* → (b|c)*`, which synthesizes a *fresh* loop body. That fires when a star is **constructed**, not during derivation (`δ(r*)` reuses the existing node), so the lemma holds — but it is the place to look first if a false prune ever shows up.
