### PR TITLE
seq_regex: do not raise a theory conflict from non-true literals

### DIFF
--- a/src/smt/seq_regex.cpp
+++ b/src/smt/seq_regex.cpp
@@ -98,6 +98,13 @@ namespace smt {
                                  k == bound_constraint::HI ? " <= " : " = ") << v << "\n";);
     }
 
+    bool seq_regex::all_true(literal_vector const& lits) const {
+        for (literal lit : lits)
+            if (ctx.get_assignment(lit) != l_true)
+                return false;
+        return true;
+    }
+
     void seq_regex::add_core_literal(void* dep, literal_vector& lits) {
         size_t enc = reinterpret_cast<size_t>(dep);
         if ((enc & 1) == 0) {                     // even: monadic membership literal
@@ -180,6 +187,21 @@ namespace smt {
             literal_vector lits;
             for (void* core_dep : m_monadic.core())
                 add_core_literal(core_dep, lits);
+            // A length bound in the core is materialized here as an arithmetic literal
+            // from the bound the arithmetic solver currently derives for str.len.  That
+            // derived bound is in general justified by other literals, so the literal we
+            // build for it need not itself be assigned true.  A theory conflict requires
+            // every antecedent to be true: conflict resolution silently drops one that is
+            // not, which turns the valid clause into a strictly stronger -- and unsound --
+            // one.  Assert the clause as an axiom instead, and hand the memberships to the
+            // legacy solver so that the search still makes progress.
+            if (!all_true(lits)) {
+                for (unsigned i = 0; i < lits.size(); ++i)
+                    lits[i] = ~lits[i];
+                th.add_axiom(lits);
+                enable_legacy_fallback();
+                return FC_CONTINUE;
+            }
             th.set_conflict(nullptr, lits);
             return FC_CONTINUE;
         }

--- a/src/smt/seq_regex.h
+++ b/src/smt/seq_regex.h
@@ -249,6 +249,9 @@ namespace smt {
             return reinterpret_cast<void*>(static_cast<size_t>(2 * idx + 1));
         }
         void add_core_literal(void* dep, literal_vector& lits);
+        // Whether every literal is currently assigned true, i.e. whether the negated
+        // clause is a legitimate theory conflict.
+        bool all_true(literal_vector const& lits) const;
         void propagate_accept_legacy(literal lit, expr* s, expr* r);
         void enable_legacy_fallback();
 


### PR DESCRIPTION
Fixes a soundness bug in the monadic regex solver: it can answer `unsat`
on satisfiable inputs.

Reproducer (annotated `sat`, answered `unsat`):

```
z3 smt.seq.regex_monadic=true QF_S/20230329-automatark-lu/instance14703.smt2
```

The bug is latent on master and is exercised by #10381, which changes the
search path enough to hit it. It reproduces on master as soon as the
search reaches the same state, so it is fixed here independently of that
stack.

### Root cause

`seq_regex::add_monadic_bounds` asks the arithmetic solver for the bound
it currently derives for `str.len s` and records it as a dependency of
the monadic solver:

```cpp
bool has_lo = th.lower_bound(len, lo) && ...
```

`theory_seq::lower_bound` goes to `arith_value::get_lo`, which reports
the bound the tableau has derived. That bound is justified by whatever
combination of literals the tableau used -- it is *not* justified by the
single atom `len >= lo`.

When such a dependency turns up in an unsat core, `add_core_literal`
fabricates that atom after the fact:

```cpp
lits.push_back(th.m_ax.mk_ge(b.m_len, b.m_value));
```

and the result is handed to `th.set_conflict(nullptr, lits)`.
`theory_seq::set_conflict` builds an `ext_theory_conflict_justification`,
which requires every antecedent to be assigned true.
`conflict_resolution::process_antecedent` skips an antecedent whose
assign level is not above the base level and never checks its truth
value, so a literal that is *false* is silently dropped from resolution.
The clause that actually gets learned is then strictly stronger than the
valid clause the monadic solver proved.

On the reproducer, at scope 186 `lower_bound(str.len X)` returns 12 while
the atom `(>= (str.len X) 12)` is assigned **false**, so the valid clause

```
~(X in R1) | ~(X in R2) | ~(|X| >= 12)
```

degenerates to the invalid

```
~(X in R1) | ~(X in R2)
```

which is what produces the wrong `unsat`. 4 of the 15 monadic cores on
this instance contain such a literal.

### Fix

The clause is always valid -- the monadic solver did prove the
conjunction unsat -- it is just not currently *falsified*, so it cannot
be presented as a conflict. So check whether the core is a legitimate
conflict, and if it is not, assert the clause as a theory axiom instead
and hand the memberships to the legacy regex solver.

The fallback is what guarantees progress: the axiom is already satisfied
by the non-true literal's negation, so without it the next `final_check`
would rederive the identical core forever. This reuses the existing
`enable_legacy_fallback()` escape hatch already used for `l_undef`; it is
backtrackable (`value_trail`) and is re-enabled when a new membership
arrives, so no completeness is lost.

`arith_value` exposes no justification-returning bound API, so recording
the justifying literal up front is not currently an option; the derived
bound remains useful for pruning, it just cannot be replayed as an
antecedent.

### Validation

`test-z3 /a`: 94/94 pass.

A/B over QF_S with `smt.seq.regex_monadic=true model_validate=true`,
5s timeout, comparing this fix against the same build without it:

| family | files | decided before | decided after | unsound before | unsound after |
|---|---|---|---|---|---|
| `20230329-automatark-lu` (sampled) | 5332 | 5258 | 5250 | **1** | **0** |
| `2019-Jiang/slog` (sampled) | 988 | 937 | 937 | 0 | 0 |
| `20250411-hornstr-equiv` | 552 | 543 | 543 | 0 | 0 |
| `20250410-matching` | 230 | 84 | 84 | 0 | 0 |
| `20250411-negated-predicates` | 450 | 0 | 0 | 0 | 0 |

Every verdict is identical outside automatark-lu. Within automatark-lu
the only semantic change is the fixed instance; the 8 remaining
differences are load-induced timeouts at the 5s boundary (all had
pre-fix times of 4.7-5.2s) and all 9 solve identically on both builds
when rerun at 20s without contention. Total wall time improved in every
family.

### Note for review

Worth a second opinion: it is not obvious *why* `theory_arith::get_lower`
reports 12 while the atom `(>= (str.len X) 12)` is assigned false at the
same scope. Either the derived bound was never propagated to that atom,
or it belongs to a different enode in the same equivalence class. It does
not affect this fix -- the literal is fabricated either way -- but it may
point at a second issue on the arithmetic side.
