### PR TITLE
seq_regex: fix ill-formed lambda capture that breaks the build on master

### DIFF
--- a/src/smt/seq_regex.cpp
+++ b/src/smt/seq_regex.cpp
@@ -99,7 +99,7 @@ namespace smt {
     }
 
     bool seq_regex::all_true(literal_vector const& lits) const {
-        return all_of(lits, [&ctx](literal lit) { return l_true == ctx.get_assignment(lit); });
+        return all_of(lits, [this](literal lit) { return l_true == ctx.get_assignment(lit); });
     }
 
     void seq_regex::add_core_literal(void* dep, literal_vector& lits) {


### PR DESCRIPTION
`master` currently does not compile.

The merged version of #10398 replaced the plain loop in `seq_regex::all_true` with

```cpp
return all_of(lits, [&ctx](literal lit) { return l_true == ctx.get_assignment(lit); });
```

`ctx` is a **data member** of `seq_regex` (`seq_regex.cpp:31`), not a variable with automatic
storage duration, so naming it in a lambda capture list is ill-formed. All three major
compilers reject it:

- MSVC: `error C2065: 'ctx': undeclared identifier`
- GCC: `error: capture of non-variable 'smt::seq_regex::ctx'`
- Clang: `error: 'ctx' in capture list does not name a variable`

This changes the capture to `this`, which is what the body actually needs in order to reach
`ctx`. The predicate itself is untouched, so there is no behavioural change.

Verified: `z3.exe` builds cleanly, and `inputs/issues/iss-9928/instance14703.smt2` — the
original soundness reproducer from #10398 — still answers `sat`.
