### PR TITLE
Avoid empty ref buffer cleanup warning

### DIFF
--- a/src/util/ref_buffer.h
+++ b/src/util/ref_buffer.h
@@ -106,7 +106,8 @@ public:
     }
 
     void reset() {
-        dec_range_ref(m_buffer.begin(), m_buffer.end());
+        if (!m_buffer.empty())
+            dec_range_ref(m_buffer.begin(), m_buffer.end());
         m_buffer.reset();
     }
 


### PR DESCRIPTION
Make the empty ref_buffer reset path explicit before scanning its inline pointer storage. This avoids the optimizing compiler's false-positive -Wmaybe-uninitialized warning in realclosure builds while preserving reference-count cleanup for non-empty buffers.