### PR TITLE
Fix high-confidence clang-tidy warnings

### DIFF
--- a/src/ast/euf/euf_mam.cpp
+++ b/src/ast/euf/euf_mam.cpp
@@ -1942,7 +1942,6 @@ namespace euf {
             enode *matching_cgr = nullptr, *min_gen_match = nullptr;
             for (enode* curr : euf::enode_class(first)) {
                 get_f_app(lbl, num_expected_args, curr, matching_cgr, min_gen_match);
-                curr = curr->get_next();
             }
             if (matching_cgr)
                 update_max_generation(min_gen_match, first);                          

--- a/src/ast/euf/ho_matcher.cpp
+++ b/src/ast/euf/ho_matcher.cpp
@@ -575,8 +575,10 @@ namespace euf {
             unsigned i = 0;
             unsigned num_bound = 0;
             for (auto pa : pats)
-                for (auto pi : array_select_indices(pa))
+                for (auto pi : array_select_indices(pa)) {
+                    (void)pi;
                     ++num_bound;
+                }
             for (auto pa : pats) {
                 for (auto pi : array_select_indices(pa)) {
                     if (start == i) {

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -2223,7 +2223,6 @@ br_status bv_rewriter::mk_bv_not(expr * arg, expr_ref & result) {
         expr *s(nullptr), *t(nullptr);
         if (m_util.is_bv_mul(arg, s, t)) {
             // ~(-1 * x) --> (x - 1)
-            bv_size = m_util.get_bv_size(s);
             if (m_util.is_allone(s) || m_util.is_allone(t)) {
                 result = m_util.mk_bv_add(s, t);
                 return BR_REWRITE1;

--- a/src/ast/rewriter/enum2bv_rewriter.cpp
+++ b/src/ast/rewriter/enum2bv_rewriter.cpp
@@ -64,7 +64,7 @@ struct enum2bv_rewriter::imp {
             unsigned bv_size = get_bv_size(s);
             sort_ref bv_sort(m_bv.mk_sort(bv_size), m);
             if (is_unate(s))
-                return m_bv.mk_numeral(rational((1u << idx) - 1), bv_sort.get());
+                return m_bv.mk_numeral(rational::power_of_two(idx) - rational::one(), bv_sort.get());
             else 
                 return m_bv.mk_numeral(rational(idx), bv_sort.get());
         }

--- a/src/ast/rewriter/guard_set.h
+++ b/src/ast/rewriter/guard_set.h
@@ -41,13 +41,12 @@ public:
     // Lifetime contract: expr* keys are assumed to outlive the cache (their lifetime is
     // managed by the caller -- e.g. by the cofactor_cache that owns the guard expressions).
     class cache {
-        ast_manager &m;
         expr_ref_vector m_trail;
         obj_map<expr, seq::range_predicate *> m_cache;
         seq::range_predicate *m_fresh = nullptr;
 
     public:
-        cache(ast_manager &m) : m(m), m_trail(m) {}
+        cache(ast_manager &m) : m_trail(m) {}
         ~cache() {
             reset();
         }

--- a/src/ast/sls/sls_bv_engine.cpp
+++ b/src/ast/sls/sls_bv_engine.cpp
@@ -451,7 +451,7 @@ lbool sls_engine::search() {
             if (q)
             {
                 ptr_vector<func_decl> & to_evaluate2 = m_tracker.get_unsat_constants_walksat(q);
-                score = find_best_move(to_evaluate2, score, new_const, new_value, new_bit, move);
+                find_best_move(to_evaluate2, score, new_const, new_value, new_bit, move);
 
                 if (new_const != static_cast<unsigned>(-1)) {
                     func_decl * fd = to_evaluate2[new_const];

--- a/src/math/hilbert/hilbert_basis.cpp
+++ b/src/math/hilbert/hilbert_basis.cpp
@@ -1010,8 +1010,6 @@ void hilbert_basis::select_inequality() {
         unsigned non_zeros2 = get_num_nonzeros(m_ineqs[j]);
         unsigned prod2 = get_ineq_product(m_ineqs[j]);
         if (prod2 == 0) {
-            prod = prod2;
-            non_zeros = non_zeros2;
             best = j;
             break;
         }

--- a/src/math/polynomial/polynomial.cpp
+++ b/src/math/polynomial/polynomial.cpp
@@ -1737,10 +1737,9 @@ namespace polynomial {
         unsigned sz = p->size();
         if (is_const(p))
             return true;
-        monomial * m = p->m(0);
         var x = max_var(p);
         for (unsigned i = 0; i < sz; ++i) {
-            m = p->m(i);
+            monomial * m = p->m(i);
             if (m->size() == 1 && m->get_var(0) == x)
                 continue;
             if (m->size() == 0)

--- a/src/math/realclosure/realclosure.cpp
+++ b/src/math/realclosure/realclosure.cpp
@@ -4103,7 +4103,6 @@ namespace realclosure {
                 return 0;
             unsigned r = 0;
             int sign, prev_sign;
-            sign = 0;
             prev_sign = 0;
             unsigned i = 0;
             for (; i < sz; ++i) {
@@ -4125,6 +4124,7 @@ namespace realclosure {
                     break;
                 default:
                     UNREACHABLE();
+                    sign = 0;
                     break;
                 }
                 if (sign == 0)

--- a/src/math/simplex/bit_matrix.cpp
+++ b/src/math/simplex/bit_matrix.cpp
@@ -16,6 +16,7 @@ Notes:
 #include "math/simplex/bit_matrix.h"
 #include "util/stopwatch.h"
 #include "util/trace.h"
+#include "util/z3_exception.h"
 #include <cstring>
 
 
@@ -112,6 +113,8 @@ std::ostream& bit_matrix::display(std::ostream& out) {
  */
 unsigned_vector bit_matrix::gray(unsigned n) {
     SASSERT(n < 32);
+    if (n >= 32)
+        throw default_exception("Gray code bit width must be less than 32");
     if (n == 0) {
         return unsigned_vector();
     }

--- a/src/muz/clp/clp_context.cpp
+++ b/src/muz/clp/clp_context.cpp
@@ -184,7 +184,6 @@ namespace datalog {
                     }
                     break;
                 case l_undef:
-                    status = l_undef;
                     throw default_exception("undef");
                 }
                 m_solver.pop(1);

--- a/src/muz/fp/datalog_parser.cpp
+++ b/src/muz/fp/datalog_parser.cpp
@@ -1325,8 +1325,7 @@ private:
         dlexer lexer;
         m_lexer = &lexer;
         m_lexer->set_stream(&stm, nullptr);
-        dtoken tok = m_lexer->next_token();
-        tok = parse_decls(tok);
+        parse_decls(m_lexer->next_token());
         m_lexer = nullptr;
     }
 
@@ -1554,4 +1553,3 @@ parser* parser::create(context& ctx, ast_manager& m) {
 wpa_parser * wpa_parser::create(context& ctx, ast_manager & ast_manager) {
     return alloc(wpa_parser_impl, ctx);
 }
-

--- a/src/muz/fp/horn_tactic.cpp
+++ b/src/muz/fp/horn_tactic.cpp
@@ -267,15 +267,12 @@ class horn_tactic : public tactic {
             switch (is_reachable) {
             case l_true: {
                 // goal is unsat
-                if (!m_ctx.is_monotone()) {
-                    is_reachable = l_undef;
-                }
-                else if (produce_proofs) {
+                if (m_ctx.is_monotone() && produce_proofs) {
                     proof_ref proof = m_ctx.get_proof();
                     pc = proof2proof_converter(m, proof);
                     g->assert_expr(m.get_fact(proof), proof, nullptr);
                 }
-                else {
+                else if (m_ctx.is_monotone()) {
                     g->assert_expr(m.mk_false());
                 }
                 break;

--- a/src/muz/rel/dl_bound_relation.cpp
+++ b/src/muz/rel/dl_bound_relation.cpp
@@ -469,9 +469,7 @@ namespace datalog {
     void bound_relation::mk_rename_elem(uint_set2& t, unsigned col_cnt, unsigned const* cycle) {
         // [ 0 -> 2 -> 3 -> 0]
         if (col_cnt == 0) return;
-        unsigned col1, col2;
-        col1 = find(cycle[0]);
-        col2 = find(cycle[col_cnt-1]);
+        unsigned col1, col2 = find(cycle[col_cnt-1]);
         bool has_col2_lt = t.lt.contains(col2);
         t.lt.remove(col2);
         bool has_col2_le = t.le.contains(col2);
@@ -677,5 +675,4 @@ namespace datalog {
 
 
 }
-
 

--- a/src/muz/rel/dl_compiler.cpp
+++ b/src/muz/rel/dl_compiler.cpp
@@ -387,7 +387,6 @@ namespace datalog {
 
             make_rename(curr, permutation.size(), permutation.data(), curr, dealloc, acc);
             dealloc = true;
-            curr_sig = & m_reg_signatures[curr];
         }
 
         if(curr==execution_context::void_register) {
@@ -1330,4 +1329,3 @@ namespace datalog {
 
 
 }
-

--- a/src/muz/rel/dl_mk_similarity_compressor.cpp
+++ b/src/muz/rel/dl_mk_similarity_compressor.cpp
@@ -153,7 +153,7 @@ namespace datalog {
         bool m_has_parent;
         /** Parent is a constant that appears earlier in the rule and has always the same value
             as this constant. */
-        unsigned m_parent_index;
+        unsigned m_parent_index = 0;
     public:
 
         const_info(int tail_index, unsigned arg_index) 

--- a/src/muz/rel/udoc_relation.cpp
+++ b/src/muz/rel/udoc_relation.cpp
@@ -719,7 +719,6 @@ namespace datalog {
             hi1 += col1;
             unsigned col2 = column_idx(v2);
             lo2 += col2;
-            hi2 += col2;
             for (unsigned j = 0; j <= hi1-lo1; ++j) {
                 roots.push_back(lo1 + j);
                 equalities.merge(lo1 + j, lo2 + j);

--- a/src/muz/spacer/spacer_quant_generalizer.cpp
+++ b/src/muz/spacer/spacer_quant_generalizer.cpp
@@ -532,7 +532,6 @@ bool lemma_quantifier_generalizer::generalize (lemma_ref &lemma, app *term) {
     }
     if (!ub) {
         abs_cube.push_back (m_arith.mk_le(var, term));
-        ub = abs_cube.back();
     }
 
     rational init;

--- a/src/opt/opt_context.cpp
+++ b/src/opt/opt_context.cpp
@@ -1273,12 +1273,12 @@ namespace opt {
         for (unsigned i = 0; i < sz; ++i) {
             domain.push_back(args[i]->get_sort());
         }
-        char const* name = "";
+        char const* name;
         switch(ty) {
         case O_MAXIMIZE: name = "maximize"; break;
         case O_MINIMIZE: name = "minimize"; break;
         case O_MAXSMT: name = "maxsat"; break;
-        default: break;
+        default: name = ""; break;
         }
         func_decl* f = m.mk_fresh_func_decl(name,"", domain.size(), domain.data(), m.mk_bool_sort());
         m_objective_fns.insert(f, index);

--- a/src/opt/opt_cores.cpp
+++ b/src/opt/opt_cores.cpp
@@ -195,8 +195,8 @@ namespace opt {
         cores& c;
         char const* par;
         bool     is_uint = true;
-        unsigned old_uval;
-        bool     old_bval;
+        unsigned old_uval = 0;
+        bool     old_bval = false;
     public:
         scoped_update(cores& c, char const* par, unsigned old_val, unsigned new_val):
             c(c), par(par), old_uval(old_val) {

--- a/src/opt/optsmt.cpp
+++ b/src/opt/optsmt.cpp
@@ -181,7 +181,6 @@ namespace opt {
             else {
                 if (num_scopes > 0)
                     m_s->pop(num_scopes);        
-                num_scopes = 0;
                 break;
             }
         }
@@ -643,4 +642,3 @@ namespace opt {
         m_s = nullptr;
     }
 }
-

--- a/src/opt/pb_sls.cpp
+++ b/src/opt/pb_sls.cpp
@@ -648,7 +648,6 @@ namespace smt {
                 // <=>
                 // a(1-x) + b(1-y) >= -k + a + b + 1
                 sz = to_app(f2)->get_num_args();
-                args = to_app(f2)->get_args();
                 k = pb.get_k(f2);
                 SASSERT(k.is_int());
                 k.neg();

--- a/src/qe/mbp/mbp_term_graph.cpp
+++ b/src/qe/mbp/mbp_term_graph.cpp
@@ -219,7 +219,7 @@ public:
 
     unsigned get_hash() const {
         unsigned a, b, c;
-        a = b = c = get_decl_id();
+        b = c = get_decl_id();
         for (term *ch : children(this)) {
             a = ch->get_root().get_id();
             mix(a, b, c);

--- a/src/sat/sat_local_search.cpp
+++ b/src/sat/sat_local_search.cpp
@@ -566,7 +566,6 @@ namespace sat {
         bool_var v = null_bool_var;
         unsigned num_unsat = m_unsat_stack.size();
         constraint const& c = m_constraints[m_unsat_stack[m_rand() % num_unsat]];
-        bool is_core = m_unsat_stack.size() <= 10;
         if (m_rand() % 10000 <= m_noise) {
             // take this branch with 98% probability.
             // find the first one, to fast break the rest    
@@ -668,9 +667,6 @@ namespace sat {
             goto reflip;
         }
 
-        if (false && is_core && c.m_k < constraint_value(c)) {
-            goto reflip;
-        }
     }
 
     void local_search::flip_walksat(bool_var flipvar) {

--- a/src/smt/smt_for_each_relevant_expr.h
+++ b/src/smt/smt_for_each_relevant_expr.h
@@ -35,7 +35,7 @@ namespace smt {
         unsigned count_at_labels_lit(expr* n, bool polarity);
 
     public:
-        check_at_labels(ast_manager& m) : m_manager(m) {}
+        check_at_labels(ast_manager& m) : m_manager(m), m_first(false) {}
 
         /**
            \brief Check that 'n' as a formula contains at most one @ label within each and-or path.
@@ -106,5 +106,4 @@ namespace smt {
     };
 
 }
-
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -362,6 +362,9 @@ public:
     }
 
     unsigned operator()(unsigned u) {
+        SASSERT(u > 0);
+        if (u == 0)
+            return 0;
         unsigned r = static_cast<unsigned>((*this)());
         return r % u;
     }


### PR DESCRIPTION
## Summary
- fix high-confidence diagnostics from clang-tidy run 31145951167
- replace potentially overflowing shifts with guarded or arbitrary-precision operations
- remove dead stores and unused state without changing solver behavior
- initialize guarded fields and protect `random_gen` from a zero divisor

## Validation
- targeted clang analyzer checks are clean for the changed translation units
- Debug build succeeds
- unit suite: 93/94 pass; `max_rev` is the known unrelated `origin/master` regression addressed by #10447

Source run: https://github.com/Z3Prover/z3/actions/runs/31145951167