### PR TITLE
Merge build warning fixes by davedets into Master

### DIFF
--- a/cmake/compiler_warnings.cmake
+++ b/cmake/compiler_warnings.cmake
@@ -31,6 +31,7 @@ set(CLANG_ONLY_WARNINGS
   "-Wnoctad-maybe-unsupported"
   "-Wdeprecated-copy-with-user-provided-copy"
   "-Wgnu-anonymous-struct"
+  "-Wcovered-switch-default"
 )
 
 set(MSVC_WARNINGS "/W3")

--- a/src/api/api_ast.cpp
+++ b/src/api/api_ast.cpp
@@ -431,7 +431,6 @@ extern "C" {
         case AST_QUANTIFIER: return Z3_QUANTIFIER_AST;
         case AST_SORT:       return Z3_SORT_AST;
         case AST_FUNC_DECL:  return Z3_FUNC_DECL_AST;
-        default:             return Z3_UNKNOWN_AST;
         }
         Z3_CATCH_RETURN(Z3_UNKNOWN_AST);
     }
@@ -1072,8 +1071,6 @@ extern "C" {
         case Z3_PRINT_SMTLIB2_COMPLIANT: 
             buffer << mk_ismt2_pp(to_ast(a), mk_c(c)->m());
             break;
-        default:
-            UNREACHABLE();
         }
         return mk_c(c)->mk_external_string(std::move(buffer).str());
         Z3_CATCH_RETURN(nullptr);

--- a/src/api/api_ast.cpp
+++ b/src/api/api_ast.cpp
@@ -432,6 +432,7 @@ extern "C" {
         case AST_SORT:       return Z3_SORT_AST;
         case AST_FUNC_DECL:  return Z3_FUNC_DECL_AST;
         }
+        return Z3_UNKNOWN_AST;
         Z3_CATCH_RETURN(Z3_UNKNOWN_AST);
     }
 

--- a/src/api/api_context.cpp
+++ b/src/api/api_context.cpp
@@ -514,7 +514,6 @@ extern "C" {
         case Z3_INVALID_USAGE:     return "invalid usage";
         case Z3_DEC_REF_ERROR:     return "invalid dec_ref command";
         case Z3_EXCEPTION:         return "Z3 exception";
-        default:                   return "unknown";
         }
     }
 

--- a/src/api/api_context.cpp
+++ b/src/api/api_context.cpp
@@ -515,6 +515,7 @@ extern "C" {
         case Z3_DEC_REF_ERROR:     return "invalid dec_ref command";
         case Z3_EXCEPTION:         return "Z3 exception";
         }
+        return "unknown";
     }
 
     Z3_string Z3_API Z3_get_error_msg(Z3_context c, Z3_error_code err) {

--- a/src/api/api_goal.cpp
+++ b/src/api/api_goal.cpp
@@ -66,6 +66,7 @@ extern "C" {
         case goal::OVER:    return Z3_GOAL_OVER;
         case goal::UNDER_OVER: return Z3_GOAL_UNDER_OVER;
         }
+        return Z3_GOAL_UNDER_OVER;
         Z3_CATCH_RETURN(Z3_GOAL_UNDER_OVER);
     }
 

--- a/src/api/api_goal.cpp
+++ b/src/api/api_goal.cpp
@@ -65,9 +65,6 @@ extern "C" {
         case goal::UNDER:   return Z3_GOAL_UNDER;
         case goal::OVER:    return Z3_GOAL_OVER;
         case goal::UNDER_OVER: return Z3_GOAL_UNDER_OVER;
-        default:
-            UNREACHABLE();
-            return Z3_GOAL_UNDER_OVER;
         }
         Z3_CATCH_RETURN(Z3_GOAL_UNDER_OVER);
     }

--- a/src/api/api_numeral.cpp
+++ b/src/api/api_numeral.cpp
@@ -232,6 +232,7 @@ extern "C" {
                     return "roundTowardZero";
                     break;
                 }
+                return "roundTowardZero";
             }
             else if (mk_c(c)->fpautil().is_numeral(to_expr(a), tmp)) {
                 return mk_c(c)->mk_external_string(fu.fm().to_rational_string(tmp));

--- a/src/api/api_numeral.cpp
+++ b/src/api/api_numeral.cpp
@@ -229,7 +229,6 @@ extern "C" {
                     return "roundTowardNegative";
                     break;
                 case MPF_ROUND_TOWARD_ZERO:
-                default:
                     return "roundTowardZero";
                     break;
                 }

--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -4023,7 +4023,6 @@ namespace z3 {
         case RTP: return expr(*this, Z3_mk_fpa_rtp(m_ctx));
         case RTN: return expr(*this, Z3_mk_fpa_rtn(m_ctx));
         case RTZ: return expr(*this, Z3_mk_fpa_rtz(m_ctx));
-        default: return expr(*this);
         }
     }
 

--- a/src/api/z3_replayer.cpp
+++ b/src/api/z3_replayer.cpp
@@ -66,6 +66,8 @@ struct z3_replayer::imp {
         case OBJECT_ARRAY: return "object_array";
         case FLOAT: return "float";
         }
+        UNREACHABLE();
+        return "unknown";
     }
 
 

--- a/src/api/z3_replayer.cpp
+++ b/src/api/z3_replayer.cpp
@@ -65,7 +65,6 @@ struct z3_replayer::imp {
         case SYMBOL_ARRAY: return "symbol_array";
         case OBJECT_ARRAY: return "object_array";
         case FLOAT: return "float";
-        default: UNREACHABLE(); return "unknown";
         }
     }
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -104,9 +104,6 @@ std::ostream& parameter::display(std::ostream& out) const {
     case PARAM_DOUBLE:   return out << get_double();
     case PARAM_EXTERNAL: return out << '@' << get_ext_id();
     case PARAM_ZSTRING:  return out << get_zstring();
-    default:
-        UNREACHABLE();
-        return out;
     }
 }
 
@@ -391,7 +388,6 @@ unsigned get_node_size(ast const * n) {
     case AST_APP:        return to_app(n)->get_size();
     case AST_VAR:        return to_var(n)->get_size();
     case AST_QUANTIFIER: return to_quantifier(n)->get_size();
-    default: UNREACHABLE();
     }
     return 0;
 }
@@ -457,8 +453,6 @@ bool compare_nodes(ast const * n1, ast const * n2) {
                            q2->get_no_patterns(),
                            q1->get_num_no_patterns());
     }
-    default:
-        UNREACHABLE();
     }
     return false;
 }
@@ -529,8 +523,6 @@ unsigned get_node_hash(ast const * n) {
         c = to_quantifier(n)->get_expr()->hash();
         mix(a,b,c);
         return c;
-    default:
-        UNREACHABLE();
     }
     return 0;
 }
@@ -1768,8 +1760,6 @@ ast * ast_manager::register_node_core(ast * n) {
         inc_array_ref(to_quantifier(n)->get_num_patterns(), to_quantifier(n)->get_patterns());
         inc_array_ref(to_quantifier(n)->get_num_no_patterns(), to_quantifier(n)->get_no_patterns());
         break;
-    default:
-        break;
     }
     return n;
 }
@@ -1836,8 +1826,6 @@ void ast_manager::delete_node(ast * n) {
             push_dec_array_ref(q->get_num_no_patterns(), q->get_no_patterns());
             break;
         }
-        default:
-            break;
         }
         if (m_debug_ref_count) {
             m_debug_free_indices.insert(n->m_id,0);

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -105,6 +105,8 @@ std::ostream& parameter::display(std::ostream& out) const {
     case PARAM_EXTERNAL: return out << '@' << get_ext_id();
     case PARAM_ZSTRING:  return out << get_zstring();
     }
+    UNREACHABLE();
+    return out;
 }
 
 void display_parameters(std::ostream & out, unsigned n, parameter const * p) {

--- a/src/ast/ast_lt.cpp
+++ b/src/ast/ast_lt.cpp
@@ -130,6 +130,8 @@ bool lt(ast * n1, ast * n2) {
         n2 = to_var(n2)->get_sort();
         goto start;
     }
+    UNREACHABLE();
+    return false;
 }
 
 bool is_sorted(unsigned num, expr * const * ns) {

--- a/src/ast/ast_lt.cpp
+++ b/src/ast/ast_lt.cpp
@@ -49,9 +49,6 @@ Revision History:
     case parameter::PARAM_ZSTRING:                              \
         check_zstring(p1.get_zstring(), p2.get_zstring());      \
         break;                                                  \
-    default:                                                    \
-        UNREACHABLE();                                          \
-        break;                                                  \
     }                                                           \
 }
 
@@ -132,9 +129,6 @@ bool lt(ast * n1, ast * n2) {
         n1 = to_var(n1)->get_sort();
         n2 = to_var(n2)->get_sort();
         goto start;
-    default:
-        UNREACHABLE();
-        return false;
     }
 }
 

--- a/src/ast/ast_translation.cpp
+++ b/src/ast/ast_translation.cpp
@@ -338,9 +338,6 @@ ast * ast_translation::process(ast const * _n) {
                 mk_func_decl(to_func_decl(n), fr);
                 break;
             }
-            default:
-                UNREACHABLE();
-                break;
             }
         }
     }

--- a/src/ast/decl_collector.cpp
+++ b/src/ast/decl_collector.cpp
@@ -128,8 +128,6 @@ void decl_collector::visit(ast* n) {
             }
             case AST_VAR:
                 break;
-            default:
-                UNREACHABLE();
             }
             m_visited.mark(n, true);
             m_trail.push_back(n);

--- a/src/ast/euf/euf_ac_plugin.cpp
+++ b/src/ast/euf/euf_ac_plugin.cpp
@@ -217,8 +217,6 @@ namespace euf {
             m_update_shared_trail.pop_back();
             break;
         }
-        default:
-            UNREACHABLE();
         }
     }
 

--- a/src/ast/euf/euf_arith_plugin.cpp
+++ b/src/ast/euf/euf_arith_plugin.cpp
@@ -110,8 +110,6 @@ namespace euf {
         case undo_t::undo_mul:
             m_mul.undo();
             break;
-        default:
-            UNREACHABLE();
         }
     }
         

--- a/src/ast/euf/euf_egraph.cpp
+++ b/src/ast/euf/euf_egraph.cpp
@@ -492,9 +492,6 @@ namespace euf {
             case update_record::tag_t::is_plugin_undo:
                 m_plugins[p.m_th.m_th_id]->undo();
                 break;
-            default:
-                UNREACHABLE();
-                break;
             }                    
         }        
         SASSERT(m_updates.size() == sz);

--- a/src/ast/euf/euf_justification.cpp
+++ b/src/ast/euf/euf_justification.cpp
@@ -43,10 +43,6 @@ namespace euf {
         }
         case kind_t::equality_t: 
             return out << "equality #" << m_n1->get_id() << " == #" << m_n2->get_id();
-            
-        default:
-            UNREACHABLE();
-            return out;
         }
         return out;
     }

--- a/src/ast/for_each_ast.h
+++ b/src/ast/for_each_ast.h
@@ -239,10 +239,6 @@ public:
                 }
                 break;
             }
-                
-            default:
-                UNREACHABLE();
-                break;
             }
         }        
         
@@ -268,5 +264,3 @@ private:
         }
     }        
 };
-
-

--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -2689,7 +2689,6 @@ void fpa2bv_converter::mk_to_fp_real(func_decl * f, sort * s, expr * rm, expr * 
         case BV_RM_TO_NEGATIVE: mrm = MPF_ROUND_TOWARD_NEGATIVE; break;
         case BV_RM_TO_POSITIVE: mrm = MPF_ROUND_TOWARD_POSITIVE; break;
         case BV_RM_TO_ZERO: mrm = MPF_ROUND_TOWARD_ZERO; break;
-        default: UNREACHABLE();
         }
 
         rational q;
@@ -3726,8 +3725,6 @@ void fpa2bv_converter::mk_is_rm(expr * rme, BV_RM_VAL rm, expr_ref & result) {
     case BV_RM_TO_POSITIVE:
     case BV_RM_TO_ZERO:
         return m_simp.mk_eq(rme, rm_num, result);
-    default:
-        UNREACHABLE();
     }
 }
 

--- a/src/ast/fpa_decl_plugin.cpp
+++ b/src/ast/fpa_decl_plugin.cpp
@@ -1057,8 +1057,6 @@ bool fpa_util::contains_floats(ast * a) {
         }
         break;
     }
-    default:
-        UNREACHABLE();
     }
 
     return false;

--- a/src/ast/func_decl_dependencies.cpp
+++ b/src/ast/func_decl_dependencies.cpp
@@ -168,8 +168,6 @@ class func_decl_dependencies::top_sort {
                     return true;
                 }
                 break;
-            default:
-                UNREACHABLE();
             }
         }
         return false;

--- a/src/ast/rewriter/bv_bounds.cpp
+++ b/src/ast/rewriter/bv_bounds.cpp
@@ -268,7 +268,6 @@ br_status bv_bounds::rewrite(unsigned limit, func_decl * f, unsigned num, expr *
                             nis_head = nis.size();
                             break;
                         }
-            default: UNREACHABLE();
         }
     }
     if (!m_okay || !is_sat()) {

--- a/src/ast/rewriter/pb2bv_rewriter.cpp
+++ b/src/ast/rewriter/pb2bv_rewriter.cpp
@@ -259,9 +259,6 @@ struct pb2bv_rewriter::imp {
                     fmls.push_back(m.mk_eq(bound, es.back()));
                 }
                 return ::mk_and(fmls);
-            default:
-                UNREACHABLE();
-                return expr_ref(m.mk_true(), m);
             }
         }
 

--- a/src/ast/rewriter/quant_hoist.cpp
+++ b/src/ast/rewriter/quant_hoist.cpp
@@ -187,8 +187,6 @@ private:
         case Q_exists_neg: return is_forall;
         case Q_none_pos: return true;
         case Q_none_neg: return true;
-        default:
-            UNREACHABLE();
         }
         return false;
     }

--- a/src/ast/rewriter/rewriter_types.h
+++ b/src/ast/rewriter/rewriter_types.h
@@ -41,7 +41,6 @@ inline std::ostream& operator<<(std::ostream& out, br_status st) {
     case BR_REWRITE_FULL: return out << "rewrite_full";
     case BR_DONE: return out << "done";
     case BR_FAILED: return out << "failed";
-    default: return out << "unknown";
     }
 }
 

--- a/src/ast/rewriter/seq_monadic.cpp
+++ b/src/ast/rewriter/seq_monadic.cpp
@@ -67,8 +67,6 @@ namespace {
             return "brzozowski";
         case seq::transition_mode::light_antimirov_tm:
             return "light-antimirov";
-        default:
-            return "unknown";
         }
     }
 

--- a/src/ast/rewriter/seq_monadic.cpp
+++ b/src/ast/rewriter/seq_monadic.cpp
@@ -68,6 +68,7 @@ namespace {
         case seq::transition_mode::light_antimirov_tm:
             return "light-antimirov";
         }
+        return "unknown";
     }
 
     char const* bail_name(unsigned i) {

--- a/src/ast/sls/sls_arith_base.cpp
+++ b/src/ast/sls/sls_arith_base.cpp
@@ -137,9 +137,6 @@ namespace sls {
             if (args + ineq.m_coeff < 0)
                 return num_t(0);
             return args + ineq.m_coeff + 1;
-        default:
-            UNREACHABLE();
-            return num_t(0);
         }
     }
 
@@ -395,9 +392,6 @@ namespace sls {
                 add_update(v, num_t(- 1));
                 break;
             }
-            default:
-                UNREACHABLE();
-                break;
             }
         }
         else {
@@ -419,9 +413,6 @@ namespace sls {
                 
                 break;
             }
-            default:
-                UNREACHABLE();
-                break;
             }
         }
     }

--- a/src/ast/sls/sls_arith_base.cpp
+++ b/src/ast/sls/sls_arith_base.cpp
@@ -138,6 +138,8 @@ namespace sls {
                 return num_t(0);
             return args + ineq.m_coeff + 1;
         }
+        UNREACHABLE();
+        return num_t(0);
     }
 
     //

--- a/src/ast/sls/sls_array_plugin.cpp
+++ b/src/ast/sls/sls_array_plugin.cpp
@@ -75,9 +75,6 @@ namespace sls {
                 case const_axiom:
                     add_eq_axiom(sto, sel);
                     break;
-                default:
-                    UNREACHABLE();
-                    break;
                 }
             }
         }

--- a/src/ast/sls/sls_bv_engine.cpp
+++ b/src/ast/sls/sls_bv_engine.cpp
@@ -264,8 +264,6 @@ void sls_engine::mk_random_move(ptr_vector<func_decl> & unsat_constants)
         case MV_INV:
             mk_inv(m_bv_util.get_bv_size(fd->get_range()), m_tracker.get_value(fd), new_value);
             break;
-        default:
-            NOT_IMPLEMENTED_YET();
         }
 
         TRACE(sls, tout << "Randomization candidates: ";

--- a/src/ast/sls/sls_bv_lookahead.cpp
+++ b/src/ast/sls/sls_bv_lookahead.cpp
@@ -646,6 +646,7 @@ namespace sls {
         case bv_lookahead::move_type::move_t:   return out << "move";
         case bv_lookahead::move_type::reset_t:  return out << "reset";
         }
+        return out;
     }
 
     bool bv_lookahead::apply_update(expr* p, expr* t, bvect const& new_value, move_type mt) {

--- a/src/ast/sls/sls_bv_lookahead.cpp
+++ b/src/ast/sls/sls_bv_lookahead.cpp
@@ -645,8 +645,6 @@ namespace sls {
         case bv_lookahead::move_type::random_t: return out << "random";
         case bv_lookahead::move_type::move_t:   return out << "move";
         case bv_lookahead::move_type::reset_t:  return out << "reset";
-        default:
-            return out;
         }
     }
 

--- a/src/math/dd/dd_bdd.cpp
+++ b/src/math/dd/dd_bdd.cpp
@@ -285,9 +285,6 @@ namespace dd {
             return cnf_size(m_cost_bdd);
         case dnf_cost:
             return dnf_size(m_cost_bdd);
-        default:
-            UNREACHABLE();
-            return 0;
         }
     }
 

--- a/src/math/dd/dd_bdd.cpp
+++ b/src/math/dd/dd_bdd.cpp
@@ -286,6 +286,8 @@ namespace dd {
         case dnf_cost:
             return dnf_size(m_cost_bdd);
         }
+        UNREACHABLE();
+        return 0;
     }
 
     bool bdd_manager::is_bad_cost(double current_cost, double best_cost) const {

--- a/src/math/lp/core_solver_pretty_printer_def.h
+++ b/src/math/lp/core_solver_pretty_printer_def.h
@@ -136,9 +136,6 @@ template <typename T, typename X> void core_solver_pretty_printer<T, X>::adjust_
         break;
     case column_type::free_column:
         break;
-    default:
-        UNREACHABLE();
-        break;
     }
 }
 

--- a/src/math/lp/lar_core_solver.h
+++ b/src/math/lp/lar_core_solver.h
@@ -169,8 +169,6 @@ public:
         case column_type::boxed:
         case column_type::fixed:
             return true;
-        default:
-            UNREACHABLE();
         }
         return false;
     }
@@ -184,8 +182,6 @@ public:
         case column_type::boxed:
         case column_type::fixed:
             return true;
-        default:
-            UNREACHABLE();
         }
         return false;
     }

--- a/src/math/lp/lar_solver.cpp
+++ b/src/math/lp/lar_solver.cpp
@@ -800,8 +800,6 @@ namespace lp {
                 return true;
             }
             return false;
-        default:
-            SASSERT(false);
         }
         return false;
     }

--- a/src/math/lp/lia_move.h
+++ b/src/math/lp/lia_move.h
@@ -46,8 +46,6 @@ namespace lp {
             return "undef";
         case lia_move::cancelled:
             return "cancelled";
-        default:
-            UNREACHABLE();
         };
         return "strange";
     }

--- a/src/math/lp/lp_core_solver_base.h
+++ b/src/math/lp/lp_core_solver_base.h
@@ -467,8 +467,6 @@ public:
         case column_type::free_column:
             out << "[-oo, oo]";
             break;
-        default:
-            UNREACHABLE();
         }
         if (print_nl)
             out << "\n";

--- a/src/math/lp/lp_core_solver_base_def.h
+++ b/src/math/lp/lp_core_solver_base_def.h
@@ -147,8 +147,6 @@ column_is_dual_feasible(unsigned j) const {
         break;
     case column_type::free_column:
         return numeric_traits<X>::is_zero(m_d[j]);
-    default:
-        UNREACHABLE();
     }
     UNREACHABLE();
     return false;
@@ -191,8 +189,6 @@ template <typename T, typename X> bool lp_core_solver_base<T, X>::column_is_feas
     case column_type::free_column:
         return true;
         break;
-    default:
-        UNREACHABLE();
     }
     return false; // it is unreachable
 }

--- a/src/math/lp/lp_primal_core_solver.h
+++ b/src/math/lp/lp_primal_core_solver.h
@@ -104,8 +104,6 @@ namespace lp {
                 if (is_pos(rc.coeff())) 
                     return this->x_above_lower_bound(j);
                 return this->x_below_upper_bound(j);
-            default:
-                return false;
             }
             UNREACHABLE(); // unreachable
             return false;
@@ -131,8 +129,6 @@ namespace lp {
                 if (is_neg(rc.coeff())) 
                     return this->x_above_lower_bound(j);
                 return this->x_below_upper_bound(j);
-            default:
-                return false;
             }
             UNREACHABLE(); // unreachable
             return false;
@@ -585,8 +581,6 @@ namespace lp {
                 }
 
                 break;
-            default:
-                UNREACHABLE();
         }
         if (!unlimited && theta < zero_of_type<X>()) {
             theta = zero_of_type<X>();

--- a/src/math/lp/lp_primal_core_solver_def.h
+++ b/src/math/lp/lp_primal_core_solver_def.h
@@ -63,9 +63,6 @@ bool lp_primal_core_solver<T, X>::correctly_moved_to_bounds(unsigned j) const {
         return this->m_x[j] == this->m_upper_bounds[j];
     case column_type::free_column:
         return true;
-    default:
-        UNREACHABLE();
-        return false;
     }
 }
 
@@ -91,9 +88,6 @@ bool lp_primal_core_solver<T, X>::column_is_benefitial_for_entering_basis(unsign
             return true;
         if (dj < zero_of_type<T>() && this->m_x[j] == this->m_upper_bounds[j])
             return true;
-        break;
-    default:
-        UNREACHABLE();
         break;
     }
     return false;

--- a/src/math/lp/lp_settings_def.h
+++ b/src/math/lp/lp_settings_def.h
@@ -31,7 +31,6 @@ std::string column_type_to_string(column_type t) {
     case column_type::lower_bound:   return "lower_bound";
     case column_type::upper_bound: return "upper_bound";
     case column_type::free_column: return "free_column";
-    default:  UNREACHABLE();
     }
     return "unknown"; // it is unreachable
 }

--- a/src/math/lp/nla_common.h
+++ b/src/math/lp/nla_common.h
@@ -27,7 +27,6 @@ inline llc negate(llc cmp) {
     case llc::GT: return llc::LE;
     case llc::EQ: return llc::NE;
     case llc::NE: return llc::EQ;
-    default: SASSERT(false);
     };
     return cmp; // not reachable
 }
@@ -40,7 +39,6 @@ inline llc swap_side(llc cmp) {
     case llc::GT: return llc::LT;
     case llc::EQ: return llc::EQ;
     case llc::NE: return llc::NE;
-    default: SASSERT(false);
     };
     return cmp; // not reachable
 }

--- a/src/math/lp/nla_core.cpp
+++ b/src/math/lp/nla_core.cpp
@@ -65,7 +65,6 @@ bool core::compare_holds(const rational& ls, llc cmp, const rational& rs) const 
     case llc::GT: return ls > rs;
     case llc::EQ: return ls == rs;
     case llc::NE: return ls != rs;
-    default: SASSERT(false);
     };
         
     return false;
@@ -284,9 +283,6 @@ bool core::explain_ineq(lemma_builder& lemma, const lp::lar_term& t, llc cmp, co
         // TBD - NB: does this work for Reals?
         r = explain_lower_bound(t, rs + rational(1), exp) || explain_upper_bound(t, rs - rational(1), exp);           
         break;
-    default:
-        UNREACHABLE();
-        return false;
     }
     if (r) {
         lemma &= exp;
@@ -1499,9 +1495,6 @@ unsigned core::get_var_weight(lpvar j) const {
         break;
     case lp::column_type::free_column:
         k = 9;
-        break;
-    default:
-        UNREACHABLE();
         break;
     }
     if (is_monic_var(j)) {

--- a/src/math/polynomial/upolynomial.cpp
+++ b/src/math/polynomial/upolynomial.cpp
@@ -1888,9 +1888,6 @@ namespace upolynomial {
             case MPBQ:
                 sign = eval_sign_at(psz, p, b);
                 break;
-            default:
-                UNREACHABLE();
-                break;
             }
             if (sign == 0)
                 continue;

--- a/src/math/realclosure/realclosure.cpp
+++ b/src/math/realclosure/realclosure.cpp
@@ -1087,9 +1087,6 @@ namespace realclosure {
             case extension::TRANSCENDENTAL: return false;
             case extension::INFINITESIMAL:  return true;
             case extension::ALGEBRAIC:      return to_algebraic(ext)->depends_on_infinitesimals();
-            default:
-                UNREACHABLE();
-                return false;
             }
         }
 
@@ -2489,9 +2486,6 @@ namespace realclosure {
                 case extension::TRANSCENDENTAL: return false;
                 case extension::INFINITESIMAL:  return false;
                 case extension::ALGEBRAIC: return is_algebraic_int(a);
-                default:
-                    UNREACHABLE();
-                    return false;
                 }
             }
         }
@@ -4122,10 +4116,6 @@ namespace realclosure {
                 case MPBQ:
                     sign = eval_sign_at(psz, p, b);
                     break;
-                default:
-                    UNREACHABLE();
-                    sign = 0;
-                    break;
                 }
                 if (sign == 0)
                     continue;
@@ -4966,9 +4956,6 @@ namespace realclosure {
             case extension::TRANSCENDENTAL: determine_transcendental_sign(v); r = true; break; // it is never zero
             case extension::INFINITESIMAL:  determine_infinitesimal_sign(v);  r = true; break; // it is never zero
             case extension::ALGEBRAIC:      r = determine_algebraic_sign(v); break;
-            default:
-                UNREACHABLE();
-                r = false;
             }
             TRACE(rcf_determine_sign_bug,
                   tout << "result: " << r << "\n";

--- a/src/math/realclosure/realclosure.cpp
+++ b/src/math/realclosure/realclosure.cpp
@@ -1088,6 +1088,8 @@ namespace realclosure {
             case extension::INFINITESIMAL:  return true;
             case extension::ALGEBRAIC:      return to_algebraic(ext)->depends_on_infinitesimals();
             }
+            UNREACHABLE();
+            return false;
         }
 
         /**
@@ -2487,6 +2489,8 @@ namespace realclosure {
                 case extension::INFINITESIMAL:  return false;
                 case extension::ALGEBRAIC: return is_algebraic_int(a);
                 }
+                UNREACHABLE();
+                return false;
             }
         }
 

--- a/src/muz/base/dl_context.cpp
+++ b/src/muz/base/dl_context.cpp
@@ -324,8 +324,6 @@ namespace datalog {
         case SK_UINT64:
             dom = alloc(uint64_sort_domain, *this, s);
             break;
-        default:
-            UNREACHABLE();
         }
         m_sorts.insert(s, dom);
     }
@@ -615,7 +613,6 @@ namespace datalog {
             m_rule_properties.check_background_free();
             break;
         case LAST_ENGINE:
-        default:
             UNREACHABLE();
             break;
         }

--- a/src/muz/rel/dl_bound_relation.cpp
+++ b/src/muz/rel/dl_bound_relation.cpp
@@ -363,9 +363,6 @@ namespace datalog {
             case LE_VAR:
                 r.mk_le(m_vars[0], m_vars[1]);
                 break;
-            default:
-                UNREACHABLE();
-                break;
             }    
             TRACE(dl, t.display(tout << "result\n"););   
         }

--- a/src/muz/tab/tab_context.cpp
+++ b/src/muz/tab/tab_context.cpp
@@ -776,6 +776,7 @@ namespace tb {
             case VAR_USE_SELECT:
                 return andrei_select(g);
             }
+            return weight_select(g);
         }
 
         void reset() {

--- a/src/muz/tab/tab_context.cpp
+++ b/src/muz/tab/tab_context.cpp
@@ -775,9 +775,6 @@ namespace tb {
                 return trivial_select(g);
             case VAR_USE_SELECT:
                 return andrei_select(g);
-            default:
-                return weight_select(g);
-
             }
         }
 

--- a/src/nlsat/nlsat_justification.h
+++ b/src/nlsat/nlsat_justification.h
@@ -86,7 +86,6 @@ namespace nlsat {
         case justification::DECISION: return out << "decision";
         case justification::CLAUSE: return out << "clause";
         case justification::LAZY: return out << "lazy";
-        default: return out << "??";
         }
     }
     

--- a/src/nlsat/nlsat_solver.cpp
+++ b/src/nlsat/nlsat_solver.cpp
@@ -3313,6 +3313,8 @@ namespace nlsat {
             case atom::ROOT_LE: return l.sign();
             case atom::ROOT_GE: return l.sign();
             }
+            UNREACHABLE();
+            return false;
         }
 
         bool is_full_dimensional(clause const & c) const {

--- a/src/nlsat/nlsat_solver.cpp
+++ b/src/nlsat/nlsat_solver.cpp
@@ -1375,8 +1375,6 @@ namespace nlsat {
                 case trail::UPDT_EQ:
                     undo_updt_eq(t.m_old_eq);
                     break;
-                default:
-                    break;
                 }
                 m_trail.pop_back();
             }
@@ -3314,9 +3312,6 @@ namespace nlsat {
             case atom::ROOT_GT: return !l.sign();
             case atom::ROOT_LE: return l.sign();
             case atom::ROOT_GE: return l.sign();
-            default:
-                UNREACHABLE();
-                return false;
             }
         }
 

--- a/src/nlsat/nlsat_types.h
+++ b/src/nlsat/nlsat_types.h
@@ -124,7 +124,6 @@ namespace nlsat {
         case atom::ROOT_LE: return out << "<= root";
         case atom::ROOT_GT: return out << "> root";
         case atom::ROOT_GE: return out << ">= root";
-        default: return out << (int)k;
         }
         return out;
     }

--- a/src/opt/maxcore.cpp
+++ b/src/opt/maxcore.cpp
@@ -171,9 +171,6 @@ public:
         case s_primal_binary_rc2:
             m_trace_id = "rc2bin";
             break;
-        default:
-            UNREACHABLE();
-            break;
         }
     }
 
@@ -267,8 +264,6 @@ public:
                 break;
             case l_undef:
                 return l_undef;
-            default:
-                break;
             }
         }
         found_optimum();
@@ -309,8 +304,6 @@ public:
                 break;
             case l_undef:
                 return l_undef;
-            default:
-                break;
             }
         }
         m_lower = m_upper;

--- a/src/opt/opt_context.cpp
+++ b/src/opt/opt_context.cpp
@@ -548,6 +548,8 @@ namespace opt {
         case O_MINIMIZE: return execute_min_max(obj.m_index, committed, scoped, false);
         case O_MAXSMT: return execute_maxsat(obj.m_id, committed, scoped);
         }
+        UNREACHABLE();
+        return l_undef;
     }
     
     /**
@@ -1272,7 +1274,7 @@ namespace opt {
         for (unsigned i = 0; i < sz; ++i) {
             domain.push_back(args[i]->get_sort());
         }
-        char const* name;
+        char const* name = "";
         switch(ty) {
         case O_MAXIMIZE: name = "maximize"; break;
         case O_MINIMIZE: name = "minimize"; break;
@@ -1650,6 +1652,8 @@ namespace opt {
         case O_MAXIMIZE: 
             return obj.m_adjust_value(m_optsmt.get_lower(obj.m_index));
         }        
+        UNREACHABLE();
+        return inf_eps();
     }
 
     inf_eps context::get_upper_as_num(unsigned idx) {
@@ -1665,6 +1669,8 @@ namespace opt {
         case O_MAXIMIZE: 
             return obj.m_adjust_value(m_optsmt.get_upper(obj.m_index));
         }
+        UNREACHABLE();
+        return inf_eps();
     }
 
     expr_ref context::get_lower(unsigned idx) {

--- a/src/opt/opt_context.cpp
+++ b/src/opt/opt_context.cpp
@@ -547,7 +547,6 @@ namespace opt {
         case O_MAXIMIZE: return execute_min_max(obj.m_index, committed, scoped, true);
         case O_MINIMIZE: return execute_min_max(obj.m_index, committed, scoped, false);
         case O_MAXSMT: return execute_maxsat(obj.m_id, committed, scoped);
-        default: UNREACHABLE(); return l_undef;
         }
     }
     
@@ -1278,7 +1277,6 @@ namespace opt {
         case O_MAXIMIZE: name = "maximize"; break;
         case O_MINIMIZE: name = "minimize"; break;
         case O_MAXSMT: name = "maxsat"; break;
-        default: name = ""; break;
         }
         func_decl* f = m.mk_fresh_func_decl(name,"", domain.size(), domain.data(), m.mk_bool_sort());
         m_objective_fns.insert(f, index);
@@ -1651,9 +1649,6 @@ namespace opt {
             return obj.m_adjust_value(m_optsmt.get_upper(obj.m_index));
         case O_MAXIMIZE: 
             return obj.m_adjust_value(m_optsmt.get_lower(obj.m_index));
-        default:
-            UNREACHABLE();
-            return inf_eps();
         }        
     }
 
@@ -1669,9 +1664,6 @@ namespace opt {
             return obj.m_adjust_value(m_optsmt.get_lower(obj.m_index));
         case O_MAXIMIZE: 
             return obj.m_adjust_value(m_optsmt.get_upper(obj.m_index));
-        default:
-            UNREACHABLE();
-            return inf_eps();
         }
     }
 
@@ -1841,9 +1833,6 @@ namespace opt {
             case O_MAXSMT: 
                 visitor.collect(obj.m_terms);
                 break;
-            default: 
-                UNREACHABLE();
-                break;
             }
         }
 
@@ -1885,9 +1874,6 @@ namespace opt {
                     }
                     out << ")\n";
                 }
-                break;
-            default: 
-                UNREACHABLE();
                 break;
             }
         }        

--- a/src/parsers/smt2/smt2parser.cpp
+++ b/src/parsers/smt2/smt2parser.cpp
@@ -2203,8 +2203,6 @@ namespace smt2 {
             case EF_PATTERN:
                 pop_pattern_frame(static_cast<pattern_frame*>(fr));
                 break;
-            default:
-                UNREACHABLE();
             }
             SASSERT(curr_is_rparen());
             next(); // consume ')'
@@ -2258,9 +2256,6 @@ namespace smt2 {
                         break;
                     case PES_CONTINUE:
                         // do nothing
-                        break;
-                    default:
-                        UNREACHABLE();
                         break;
                     }
                 }

--- a/src/sat/sat_cleaner.cpp
+++ b/src/sat/sat_cleaner.cpp
@@ -71,9 +71,6 @@ namespace sat {
                     *it_prev = *it2;
                     ++it_prev;
                     break;
-                default:
-                    UNREACHABLE();
-                    break;
                 }
             }
             wlist.set_end(it_prev);

--- a/src/sat/sat_gc.cpp
+++ b/src/sat/sat_gc.cpp
@@ -64,9 +64,6 @@ namespace sat {
                 return;
             gc_dyn_psm();
             break;
-        default:
-            UNREACHABLE();
-            break;
         }
         if (m_ext) m_ext->gc();
         if (gc > 0 && should_defrag()) {

--- a/src/sat/sat_lookahead.cpp
+++ b/src/sat/sat_lookahead.cpp
@@ -1857,6 +1857,8 @@ namespace sat {
         case march_cu_reward: return 1024 * (1024 * l * r + l + r);
         case unit_literal_reward: return l * r;
         }
+        UNREACHABLE();
+        return l * r;
     }
 
     void lookahead::reset_lookahead_reward(literal l) {

--- a/src/sat/sat_lookahead.cpp
+++ b/src/sat/sat_lookahead.cpp
@@ -1856,7 +1856,6 @@ namespace sat {
         case heule_unit_reward: return l * r;
         case march_cu_reward: return 1024 * (1024 * l * r + l + r);
         case unit_literal_reward: return l * r;
-        default: UNREACHABLE(); return l * r;
         }
     }
 

--- a/src/sat/sat_lookahead.h
+++ b/src/sat/sat_lookahead.h
@@ -57,7 +57,6 @@ namespace sat {
         case lookahead_mode::searching:  return out << "searching";
         case lookahead_mode::lookahead1: return out << "lookahead1";
         case lookahead_mode::lookahead2: return out << "lookahead2";
-        default: break;
         }
         return out;
     }

--- a/src/sat/sat_mus.cpp
+++ b/src/sat/sat_mus.cpp
@@ -161,8 +161,6 @@ namespace sat {
             case l_true:
                 update_model();
                 break;
-            default:
-                break;
             }
         }
         if (assignment.size() == 1) {

--- a/src/sat/sat_solver.cpp
+++ b/src/sat/sat_solver.cpp
@@ -1736,6 +1736,8 @@ namespace sat {
         case PS_RANDOM:
             return (m_rand() % 2) == 0;
         }
+        UNREACHABLE();
+        return false;
     }
 
     void solver::get_backbone_candidates(literal_vector& lits, unsigned max_num) {

--- a/src/sat/sat_solver.cpp
+++ b/src/sat/sat_solver.cpp
@@ -1186,9 +1186,6 @@ namespace sat {
                     it2++;
                 }
                 break;
-            default:
-                UNREACHABLE();
-                break;
             }
         }
         wlist.set_end(it2);
@@ -1738,9 +1735,6 @@ namespace sat {
             return m_best_phase[next];
         case PS_RANDOM:
             return (m_rand() % 2) == 0;
-        default:
-            UNREACHABLE();
-            return false;
         }
     }
 
@@ -2454,9 +2448,6 @@ namespace sat {
             break;
         case RS_STATIC:
             break;
-        default:
-            UNREACHABLE();
-            break;
         }
         CASSERT("sat_restart", check_invariant());
     }
@@ -2595,9 +2586,6 @@ namespace sat {
                     process_antecedent(l, num_marks);                
                 break;
             }
-            default:
-                UNREACHABLE();
-                break;
             }
             
             bool_var c_var;
@@ -2765,9 +2753,6 @@ namespace sat {
             }
             break;
         }
-        default:
-            UNREACHABLE();
-            break;
         }
     }
 
@@ -2888,9 +2873,6 @@ namespace sat {
             for (literal l : m_ext_antecedents) 
                 level = update_max_level(l, level, unique_max);
             break;
-        default:
-            UNREACHABLE();
-            break;
         }
         TRACE(sat, tout << "max-level " << level << " " << unique_max << "\n");
         return level;
@@ -2928,8 +2910,6 @@ namespace sat {
                 break;
             case BH_CHB:
                 m_last_conflict[var] = m_stats.m_conflicts;
-                break;
-            default:
                 break;
             }
             if (var_lvl == m_conflict_lvl)
@@ -3073,9 +3053,6 @@ namespace sat {
                     set_phase(i, m_best_phase[i]);
             }
 
-            break;
-        default:
-            UNREACHABLE();
             break;
         }
         m_rephase_inc += m_config.m_rephase_base;
@@ -3286,9 +3263,6 @@ namespace sat {
                 }
                 break;
             }
-            default:
-                UNREACHABLE();
-                break;
             }
             TRACE(sat_conflict, 
                   display_justification(tout << var << " ",js) << "\n";);
@@ -4023,8 +3997,6 @@ namespace sat {
             if (m_ext) 
                 m_ext->display_justification(out << "ext ", js.get_ext_justification_idx());            
             break;
-        default:
-            break;
         }
         return out;
     }
@@ -4687,9 +4659,6 @@ namespace sat {
             }
             break;
         }
-        default:
-            UNREACHABLE();
-            break;
         }
         TRACE(sat, display_index_set(tout << lit << ": " , s) << "\n";);
         return all_found;

--- a/src/sat/sat_watched.cpp
+++ b/src/sat/sat_watched.cpp
@@ -103,8 +103,6 @@ namespace sat {
                     out << "ext: " << w.get_ext_constraint_idx();
                 }
                 break;
-            default: 
-                UNREACHABLE();
             }
         }
         return out;

--- a/src/sat/smt/arith_diagnostics.cpp
+++ b/src/sat/smt/arith_diagnostics.cpp
@@ -209,9 +209,6 @@ namespace arith {
         case hint_type::nla_h:
             name = "nla";
             break;
-        default:
-            name = "unknown-arithmetic";
-            break;
         }
 
         auto push_eq = [&](bool is_eq, enode* x, enode* y) {

--- a/src/sat/smt/arith_solver.cpp
+++ b/src/sat/smt/arith_solver.cpp
@@ -851,8 +851,6 @@ namespace arith {
         case lp_api::upper_t:
             k = lp::LE;
             break;
-        default:
-            break;
         }
         auto vi = register_theory_var_in_lar_solver(b->get_var());
         if (vi == lp::null_lpvar) {
@@ -1018,8 +1016,6 @@ namespace arith {
                 return sat::check_result::CR_CONTINUE;
             case l_true:
                 break;
-            default:
-                UNREACHABLE();
             }
         }
 
@@ -1484,7 +1480,6 @@ namespace arith {
         case lp::GT: is_lower = false; sign = true;  break;
         case lp::EQ: is_eq = true;     sign = false; break;
         case lp::NE: is_eq = true;     sign = true;  break;
-        default: UNREACHABLE();
         }
         // TBD utility: lp::lar_term term = mk_term(ineq.m_poly);
         // then term is used instead of ineq.m_term

--- a/src/sat/smt/array_axioms.cpp
+++ b/src/sat/smt/array_axioms.cpp
@@ -70,9 +70,6 @@ namespace array {
             return assert_congruent_axiom(r.n->get_expr(), r.select->get_expr());
         case axiom_record::kind_t::is_choice:
             return assert_choice_axiom(r.n->get_app());
-        default:
-            UNREACHABLE();
-            break;
         }
         return false;
     }

--- a/src/sat/smt/array_diagnostics.cpp
+++ b/src/sat/smt/array_diagnostics.cpp
@@ -57,8 +57,6 @@ namespace array {
             return out << "congruence " << ctx.bpp(r.n) << " " << ctx.bpp(r.select);
         case axiom_record::kind_t::is_choice:
             return out << "choice " << ctx.bpp(r.n);
-        default:
-            UNREACHABLE();
         }
         return out;
     }

--- a/src/sat/smt/bv_solver.cpp
+++ b/src/sat/smt/bv_solver.cpp
@@ -765,9 +765,6 @@ namespace bv {
             return out << "bv <- " << m_bits[v1] << " != " << m_bits[v2] << " @" << cidx;
         case bv_justification::kind_t::bv2int:
             return out << "bv <- v" << v1 << " == v" << v2 << " <== " << ctx.bpp(c.a) << " == " << ctx.bpp(c.b) << " == " << ctx.bpp(c.c);
-        default:
-            UNREACHABLE();
-            break;
         }
         return out;
     }

--- a/src/sat/smt/euf_relevancy.cpp
+++ b/src/sat/smt/euf_relevancy.cpp
@@ -60,9 +60,6 @@ namespace euf {
             case update::set_qhead:
                 m_qhead = idx;
                 break;
-            default:
-                UNREACHABLE();
-                break;
             }
         }
         m_trail.shrink(sz);

--- a/src/sat/smt/euf_solver.cpp
+++ b/src/sat/smt/euf_solver.cpp
@@ -418,9 +418,6 @@ namespace euf {
             }
             break;
         }
-        default:
-            IF_VERBOSE(0, verbose_stream() << (unsigned)j.kind() << "\n");
-            UNREACHABLE();
         }
     }
 
@@ -1090,9 +1087,6 @@ namespace euf {
                 euf::enode* n = c.node();
                 return out << "euf literal propagation " << (sat::literal(n->bool_var(), n->value() == l_false)) << " " << m_egraph.bpp(n);
             } 
-            default:
-                UNREACHABLE();
-                return out;
             }                
         }
         else 

--- a/src/sat/smt/pb_solver.cpp
+++ b/src/sat/smt/pb_solver.cpp
@@ -744,15 +744,9 @@ namespace pb {
                     for (literal l : m_lemma) process_antecedent(~l, offset);
                     break;
                 }
-                default:
-                    UNREACHABLE();
-                    break;
                 }
                 break;
             }
-            default:
-                UNREACHABLE();
-                break;
             }
             
             SASSERT(validate_lemma());            
@@ -1079,9 +1073,6 @@ namespace pb {
                 }
                 break;
             }
-            default:
-                UNREACHABLE();
-                break;
             }            
 
             SASSERT(validate_lemma());
@@ -1701,7 +1692,6 @@ namespace pb {
         switch (c.tag()) {
         case pb::tag_t::card_t: get_antecedents(l, c.to_card(), r); break;
         case pb::tag_t::pb_t: get_antecedents(l, c.to_pb(), r); break;
-        default: UNREACHABLE(); break;            
         }
         if (get_config().m_drat && m_solver && !probing) {
             literal_vector lits;
@@ -1876,8 +1866,6 @@ namespace pb {
             for (auto [w, l] : c.to_pb()) {                
                 if (s().m_phase[l.var()] == !l.sign()) ++r;
             }
-            break;
-        default:
             break;
         }
         c.set_psm(r);
@@ -2255,8 +2243,6 @@ namespace pb {
         case pb::tag_t::pb_t:
             recompile(c.to_pb());
             break;
-        default:
-            UNREACHABLE();
         }                
     }
 
@@ -2889,8 +2875,6 @@ namespace pb {
             case pb::tag_t::pb_t:
                 sub = subsumes(p1, c->to_pb()); 
                 break;
-            default: 
-                break;
             }
             if (sub) {
                 ++m_stats.m_num_pb_subsumes;                
@@ -3119,8 +3103,6 @@ namespace pb {
                 result->add_pb_ge(p.lit(), wlits, p.k(), p.learned());
                 break;
             }
-            default:
-                UNREACHABLE();
             }                
         }
     }
@@ -3355,9 +3337,6 @@ namespace pb {
             return active2card();
         case sat::PB_LEMMA_PB:
             return active2constraint();
-        default:
-            UNREACHABLE();
-            return nullptr;
         }
     }
 
@@ -3480,9 +3459,6 @@ namespace pb {
             if (p.lit() != sat::null_literal) ineq.push(~p.lit(), offset * p.k());
             break;
         }
-        default:
-            UNREACHABLE();
-            break;
         }
     }
 

--- a/src/sat/smt/pb_solver.cpp
+++ b/src/sat/smt/pb_solver.cpp
@@ -3338,6 +3338,8 @@ namespace pb {
         case sat::PB_LEMMA_PB:
             return active2constraint();
         }
+        UNREACHABLE();
+        return nullptr;
     }
 
     constraint* solver::active2constraint() {
@@ -3772,5 +3774,4 @@ namespace pb {
     }
     
 }
-
 

--- a/src/smt/diff_logic.h
+++ b/src/smt/diff_logic.h
@@ -1632,8 +1632,6 @@ private:
                     TRACE(diff_logic, tout << delta << " ?> " << state.m_delta[target] << "\n";);
                     SASSERT(delta >= state.m_delta[target]);
                     break;
-                default:
-                    UNREACHABLE();
                 }
             }
         }        

--- a/src/smt/smt_clause_proof.cpp
+++ b/src/smt/smt_clause_proof.cpp
@@ -54,6 +54,8 @@ namespace smt {
         case CLS_TH_LEMMA:
             return status::th_lemma;
         }
+        UNREACHABLE();
+        return status::lemma;
     }
 
     proof_ref clause_proof::justification2proof(status st, justification* j) {
@@ -282,8 +284,8 @@ namespace smt {
         case clause_proof::status::deleted:
             return out << "del";
         }
+        return out << "unkn";
     }
 
 }
-
 

--- a/src/smt/smt_clause_proof.cpp
+++ b/src/smt/smt_clause_proof.cpp
@@ -53,9 +53,6 @@ namespace smt {
             return status::lemma;
         case CLS_TH_LEMMA:
             return status::th_lemma;
-        default:
-            UNREACHABLE();
-            return status::lemma;
         }
     }
 
@@ -218,8 +215,6 @@ namespace smt {
             case clause_proof::status::deleted:
                 display_literals(out << "(del", v) << ")\n";
                 break;
-            default:
-                UNREACHABLE();
             }
             out.flush();
         }
@@ -286,8 +281,6 @@ namespace smt {
             return out << "th_lem";
         case clause_proof::status::deleted:
             return out << "del";
-        default:
-            return out << "unkn";
         }
     }
 

--- a/src/smt/smt_conflict_resolution.cpp
+++ b/src/smt/smt_conflict_resolution.cpp
@@ -112,7 +112,6 @@ namespace smt {
                   break;
               case eq_justification::JUSTIFICATION: tout << " justification\n";  break;
               case eq_justification::CONGRUENCE: tout << " congruence\n"; break;
-              default:  break;
               });
 
         switch(js.get_kind()) {
@@ -140,8 +139,6 @@ namespace smt {
             }
             break;
         }
-        default:
-            UNREACHABLE();
         }
     }
 
@@ -303,8 +300,6 @@ namespace smt {
         case b_justification::JUSTIFICATION:
             r = std::max(r, get_justification_max_lvl(js.get_justification()));
             break;
-        default:
-            UNREACHABLE();
         }
         return r;
     }
@@ -554,8 +549,6 @@ namespace smt {
             case b_justification::JUSTIFICATION:
                 process_justification(consequent, js.get_justification(), num_marks);
                 break;
-            default:
-                UNREACHABLE();
             }
 
             while (true) {
@@ -914,9 +907,6 @@ namespace smt {
                 m_new_proofs.push_back(pr);
                 return pr;
             }
-        default:
-            UNREACHABLE();
-            return nullptr;
         }
     }
 
@@ -1181,8 +1171,6 @@ namespace smt {
                 }
                 break;
             }
-            default:
-                UNREACHABLE();
             }
             lhs = lhs->m_trans.m_target;
         }
@@ -1322,8 +1310,6 @@ namespace smt {
                 }
                 break;
             }
-            default:
-                UNREACHABLE();
             }
         }
 
@@ -1445,8 +1431,6 @@ namespace smt {
             case b_justification::JUSTIFICATION:
                 process_justification_for_unsat_core(js.get_justification());
                 break;
-            default:
-                UNREACHABLE();
             }
 
             if (m_ctx.is_assumption(consequent.var())) {

--- a/src/smt/smt_conflict_resolution.cpp
+++ b/src/smt/smt_conflict_resolution.cpp
@@ -908,6 +908,8 @@ namespace smt {
                 return pr;
             }
         }
+        UNREACHABLE();
+        return nullptr;
     }
 
     /**

--- a/src/smt/smt_context.cpp
+++ b/src/smt/smt_context.cpp
@@ -1950,6 +1950,8 @@ namespace smt {
             return m_lit_occs[l.index()] > m_lit_occs[(~l).index()];
         }
         }
+        UNREACHABLE();
+        return false;
     }
 
     /**

--- a/src/smt/smt_context.cpp
+++ b/src/smt/smt_context.cpp
@@ -1949,9 +1949,6 @@ namespace smt {
         case PS_OCCURRENCE: {
             return m_lit_occs[l.index()] > m_lit_occs[(~l).index()];
         }
-        default:
-            UNREACHABLE();
-            return false;
         }
     }
 
@@ -3960,8 +3957,6 @@ namespace smt {
                 break;
             case RS_ARITHMETIC:
                 m_restart_threshold = static_cast<unsigned>(m_restart_threshold + m_fparams.m_restart_factor);
-                break;
-            default:
                 break;
             }
         }

--- a/src/smt/smt_context_pp.cpp
+++ b/src/smt/smt_context_pp.cpp
@@ -644,9 +644,6 @@ namespace smt {
             display_literals_smt2(out, lits);
             break;
         }
-        default:
-            UNREACHABLE();
-            break;
         }
         return out << "\n";
     }
@@ -672,9 +669,6 @@ namespace smt {
             out << lits;
             break;
         }
-        default:
-            UNREACHABLE();
-            break;
         }
         return out << "\n";
     }

--- a/src/smt/smt_internalizer.cpp
+++ b/src/smt/smt_internalizer.cpp
@@ -1495,8 +1495,6 @@ namespace smt {
             dump_lemma(num_lits, lits);
             add_scores(num_lits, lits);
             break;
-        default:
-            break;
         }
         TRACE(mk_clause, display_literals_verbose(tout << "after simplification: " << literal_vector(num_lits, lits) << "\n", num_lits, lits) << "\n";);
 

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -709,8 +709,6 @@ namespace smt {
                 }
                 break;
             }
-            default:
-                UNREACHABLE();
             }
         }
 
@@ -1810,9 +1808,6 @@ namespace smt {
             throw default_exception(m_exception_msg.c_str());
         case state::is_exception_code:
             throw z3_error(m_exception_code);
-        default:
-            UNREACHABLE();
-            return l_undef;
         }
     }
 

--- a/src/smt/smt_parallel.cpp
+++ b/src/smt/smt_parallel.cpp
@@ -1809,6 +1809,8 @@ namespace smt {
         case state::is_exception_code:
             throw z3_error(m_exception_code);
         }
+        UNREACHABLE();
+        return l_undef;
     }
 
     bool parallel::batch_manager::get_cube(ast_translation &g2l, unsigned id, expr_ref_vector &cube, bool is_first_run, node_lease &lease) {

--- a/src/smt/smt_quantifier.cpp
+++ b/src/smt/smt_quantifier.cpp
@@ -123,9 +123,6 @@ namespace smt {
                 out << "[eq-expl] #" << en->get_owner_id() << " unknown ; #" << target->get_owner_id() << "\n";
             }
             break;
-        default:
-            out << "[eq-expl] #" << en->get_owner_id() << " unknown ; #" << target->get_owner_id() << "\n";
-            break;
         }
     }
 

--- a/src/smt/smt_relevancy.cpp
+++ b/src/smt/smt_relevancy.cpp
@@ -320,7 +320,6 @@ namespace smt {
                 case eh_trail::kind::POS_WATCH: ehs = get_watches(n, true); SASSERT(ehs); set_watches(n, true, ehs->tail()); break;
                 case eh_trail::kind::NEG_WATCH: ehs = get_watches(n, false); SASSERT(ehs); set_watches(n, false, ehs->tail()); break;
                 case eh_trail::kind::HANDLER:   ehs = get_handlers(n); SASSERT(ehs); set_handlers(n, ehs->tail()); break;
-                default: UNREACHABLE(); break;
                 }
                 m.dec_ref(n);
             }

--- a/src/smt/smt_setup.cpp
+++ b/src/smt/smt_setup.cpp
@@ -41,6 +41,7 @@ Revision History:
 #include "smt/theory_fpa.h"
 #include "smt/theory_polymorphism.h"
 #include "smt/theory_finite_set.h"
+#include "util/manage_warnings.h"
 
 namespace smt {
 
@@ -683,9 +684,11 @@ namespace smt {
         case arith_solver_id::AS_NEW_ARITH:
             setup_lra_arith();
             break;
+        START_DISABLE_COVERED_SWITCH_DEFAULT
         default:
             m_context.register_plugin(alloc(smt::theory_mi_arith, m_context));
             break;
+        END_DISABLE_WARNING_STMT
         }
     }
 
@@ -942,5 +945,4 @@ namespace smt {
     }
 
 }
-
 

--- a/src/smt/theory_arith_core.h
+++ b/src/smt/theory_arith_core.h
@@ -2206,8 +2206,6 @@ namespace smt {
             return get_value(v) >= k ? l_true : l_false;
         case B_UPPER:
             return get_value(v) <= k ? l_true : l_false;
-        default:
-            return l_undef;
         }
     }
 

--- a/src/smt/theory_arith_core.h
+++ b/src/smt/theory_arith_core.h
@@ -2207,6 +2207,7 @@ namespace smt {
         case B_UPPER:
             return get_value(v) <= k ? l_true : l_false;
         }
+        return l_undef;
     }
 
     /**
@@ -3571,4 +3572,3 @@ namespace smt {
 
 
 }
-

--- a/src/smt/theory_diff_logic_def.h
+++ b/src/smt/theory_diff_logic_def.h
@@ -545,9 +545,6 @@ void theory_diff_logic<Ext>::propagate() {
             }
             break;
         }
-        default:
-            SASSERT(false);
-            propagate_core();
         }
     }
     else {

--- a/src/smt/theory_lra.cpp
+++ b/src/smt/theory_lra.cpp
@@ -1037,8 +1037,6 @@ public:
         case lp_api::upper_t:
             k = lp::LE;
             break;
-        default:
-            break;
         }         
         auto vi = register_theory_var_in_lar_solver(b->get_var());
         if (vi == lp::null_lpvar) {
@@ -1669,8 +1667,6 @@ public:
             return FC_CONTINUE;
         case l_undef:
             return FC_GIVEUP;
-        default:
-            break;
         }
         return FC_GIVEUP;
     }
@@ -1813,9 +1809,6 @@ public:
         case l_undef:
             TRACE(arith, tout << "check feasible is undef\n";);
             return m.inc() ? FC_CONTINUE : FC_GIVEUP;
-        default:
-            UNREACHABLE();
-            break;
         }
         TRACE(arith, tout << "default giveup\n";);
         return FC_GIVEUP;
@@ -2123,8 +2116,6 @@ public:
             is_eq = true;
             pos = true;
             break;
-        default:
-            UNREACHABLE();
         }
         expr_ref atom(m);
         // TBD utility: lp::lar_term term = mk_term(ineq.m_poly);
@@ -4460,9 +4451,6 @@ public:
             case null_source:                    
                 out << idx << " null";
                 break;
-            default:
-                UNREACHABLE();
-                break; 
             }
         }
         for (lp::explanation::cimpq ev : evidence) 

--- a/src/smt/theory_pb.cpp
+++ b/src/smt/theory_pb.cpp
@@ -1644,8 +1644,6 @@ namespace smt {
             }            
             break;
         }
-        default:
-            break;
         }
         return result;
     }
@@ -1941,8 +1939,6 @@ namespace smt {
                 
                 break;
             }
-            default:
-                UNREACHABLE();
             }            
             m_bound += offset * bound;
 

--- a/src/solver/combined_solver.cpp
+++ b/src/solver/combined_solver.cpp
@@ -108,9 +108,6 @@ private:
         case IUB_RETURN_UNDEF: return false;
         case IUB_USE_TACTIC_IF_QF: return !has_quantifiers();
         case IUB_USE_TACTIC: return true;
-        default:
-            UNREACHABLE();
-            return false;
         }
     }
 

--- a/src/solver/combined_solver.cpp
+++ b/src/solver/combined_solver.cpp
@@ -109,6 +109,8 @@ private:
         case IUB_USE_TACTIC_IF_QF: return !has_quantifiers();
         case IUB_USE_TACTIC: return true;
         }
+        UNREACHABLE();
+        return false;
     }
 
 public:

--- a/src/solver/parallel_tactical.cpp
+++ b/src/solver/parallel_tactical.cpp
@@ -968,9 +968,6 @@ class parallel_solver {
                 throw default_exception(m_exception_msg.c_str());
             case state::is_exception_code:
                 throw z3_error(m_exception_code);
-            default:
-                UNREACHABLE();
-                return l_undef;
             }
         }
 
@@ -1838,8 +1835,6 @@ class parallel_solver {
                     }
                     break;
                 }
-                default:
-                    UNREACHABLE();
                 }
             }
 

--- a/src/solver/parallel_tactical.cpp
+++ b/src/solver/parallel_tactical.cpp
@@ -969,6 +969,8 @@ class parallel_solver {
             case state::is_exception_code:
                 throw z3_error(m_exception_code);
             }
+            UNREACHABLE();
+            return l_undef;
         }
 
         std::string const& get_reason_unknown() const { return m_reason_unknown; }

--- a/src/util/ext_numeral.h
+++ b/src/util/ext_numeral.h
@@ -21,6 +21,7 @@ Revision History:
 
 #include<ostream>
 #include "util/debug.h"
+#include "util/manage_warnings.h"
     
 enum ext_numeral_kind { EN_MINUS_INFINITY, EN_NUMERAL, EN_PLUS_INFINITY };
 
@@ -280,14 +281,18 @@ bool lt(numeral_manager & m,
             return m.lt(a, b);
         case EN_PLUS_INFINITY:
             return true;
+
+            // The default case below is not necessary: the cases above cover all the
+            // elements of the ext_numeral_kind enum.  But gcc complains with a warning
+            // if this default case is absent.  So we leave it in, but disable Clang's
+            // (correct) warning that the default is unnecessary.
+            START_DISABLE_COVERED_SWITCH_DEFAULT;
         default:
             UNREACHABLE();
+            END_DISABLE_WARNING_STMT;
             return false;
         }
     case EN_PLUS_INFINITY:
-        return false;
-    default:
-        UNREACHABLE();
         return false;
     }
 }
@@ -342,4 +347,3 @@ void display_pp(std::ostream & out,
     case EN_PLUS_INFINITY: out << "+&infin;"; break;
     }
 }
-

--- a/src/util/ext_numeral.h
+++ b/src/util/ext_numeral.h
@@ -295,6 +295,8 @@ bool lt(numeral_manager & m,
     case EN_PLUS_INFINITY:
         return false;
     }
+    UNREACHABLE();
+    return false;
 }
 
 template<typename numeral_manager>

--- a/src/util/manage_warnings.h
+++ b/src/util/manage_warnings.h
@@ -42,19 +42,26 @@ Revision History:
   DO_PRAGMA(clang diagnostic ignored #s)
 
 
+// This version should be used in decl contexts.
 #define END_DISABLE_WARNING			\
   _Pragma("clang diagnostic pop")		\
   DUMMY_DECL
 
+// This version should be used in statement contexts.
+#define END_DISABLE_WARNING_STMT		\
+  _Pragma("clang diagnostic pop")
+
 #define START_DISABLE_EXTRA_SEMI_WARNING START_DISABLE_WARNING(-Wextra-semi)
+#define START_DISABLE_COVERED_SWITCH_DEFAULT START_DISABLE_WARNING(-Wcovered-switch-default)
 
 #else
 
 #define START_DISABLE_EXTRA_SEMI_WARNING
+#define START_DISABLE_COVERED_SWITCH_DEFAULT
 #define END_DISABLE_WARNING
+#define END_DISABLE_WARNING_STMT
 
 #endif
-
 
 
 

--- a/src/util/mpf.cpp
+++ b/src/util/mpf.cpp
@@ -1147,7 +1147,6 @@ void mpf_manager::round_to_integral(mpf_rounding_mode rm, mpf const & x, mpf & o
                 m_mpz_manager.inc(div);
             break;
         case MPF_ROUND_TOWARD_ZERO:
-        default:
             /* nothing */;
         }
 
@@ -1210,7 +1209,6 @@ void mpf_manager::to_sbv_mpq(mpf_rounding_mode rm, const mpf & x, scoped_mpq & o
         case MPF_ROUND_TOWARD_POSITIVE: inc = (!x.sign && (round || sticky)); break;
         case MPF_ROUND_TOWARD_NEGATIVE: inc = (x.sign && (round || sticky)); break;
         case MPF_ROUND_TOWARD_ZERO: inc = false; break;
-        default: UNREACHABLE();
         }
         if (inc) m_mpz_manager.inc(z);
         TRACE(mpf_dbg_sbv,
@@ -2047,7 +2045,6 @@ void mpf_manager::round(mpf_rounding_mode rm, mpf & o) {
     case MPF_ROUND_TOWARD_POSITIVE: inc = (!o.sign && (round || sticky)); break;
     case MPF_ROUND_TOWARD_NEGATIVE: inc = (o.sign && (round || sticky)); break;
     case MPF_ROUND_TOWARD_ZERO: inc = false; break;
-    default: UNREACHABLE();
     }
 
     TRACE(mpf_dbg, tout << "Rounding increment -> significand +" << (int)inc << std::endl;);
@@ -2115,7 +2112,6 @@ void mpf_manager::round_sqrt(mpf_rounding_mode rm, mpf & o) {
     case MPF_ROUND_TOWARD_NEGATIVE: break;
     case MPF_ROUND_TOWARD_ZERO: break;
     case MPF_ROUND_TOWARD_POSITIVE: inc = round || sticky; break;
-    default: UNREACHABLE();
     }
 
     TRACE(mpf_dbg, tout << "last=" << last << " round=" << round << " sticky=" << sticky << " --> inc=" << inc << std::endl;);

--- a/src/util/sexpr.cpp
+++ b/src/util/sexpr.cpp
@@ -179,8 +179,6 @@ void sexpr::display_atom(std::ostream & out) const {
     case sexpr::kind_t::KEYWORD:
         out << static_cast<sexpr_symbol const *>(this)->m_val;
         break;
-    default:
-        UNREACHABLE();
     }
 }
 
@@ -254,8 +252,6 @@ void sexpr_manager::del(sexpr * n) {
             static_cast<sexpr_symbol*>(n)->~sexpr_symbol();
             m_allocator.deallocate(sizeof(sexpr_symbol), n);
             break;
-        default:
-            UNREACHABLE();
         }
     }
 }

--- a/src/util/sorting_network.h
+++ b/src/util/sorting_network.h
@@ -259,6 +259,8 @@ Notes:
                 case sorting_network_encoding::circuit_at_most:
                     return circuit_ge(full, k, n, xs); 
                 }
+                UNREACHABLE();
+                return xs[0];
             }
         }
         
@@ -285,6 +287,8 @@ Notes:
                 case sorting_network_encoding::ordered_at_most:
                     return mk_ordered_atmost_1(full, n, xs);
                 }
+                UNREACHABLE();
+                return xs[0];
             }
             else {
                 switch (m_cfg.m_encoding) {
@@ -302,6 +306,8 @@ Notes:
                 case sorting_network_encoding::circuit_at_most:
                     return circuit_le(full, k, n, xs); 
                 }
+                UNREACHABLE();
+                return xs[0];
             }
         }
 
@@ -340,6 +346,8 @@ Notes:
                 case sorting_network_encoding::circuit_at_most:
                     return circuit_eq(k, n, xs);        
                 }
+                UNREACHABLE();
+                return xs[0];
             }
         }
 
@@ -479,6 +487,8 @@ Notes:
             case EQ:
                 return mk_and(mk_not(carry[k]), carry[k-1]);
             }
+            UNREACHABLE();
+            return xs[0];
         }
 
         literal unate_ge(bool full, unsigned k, unsigned n, literal const* xs) {
@@ -569,6 +579,8 @@ Notes:
                 return mk_and(eqs);
             }                
             }            
+            UNREACHABLE();
+            return xs[0];
         }
 
         literal mk_ge(literal_vector const& x, literal_vector const& y) {

--- a/src/util/sorting_network.h
+++ b/src/util/sorting_network.h
@@ -258,9 +258,6 @@ Notes:
                     return unate_ge(full, k, n, xs);
                 case sorting_network_encoding::circuit_at_most:
                     return circuit_ge(full, k, n, xs); 
-                default:
-                    UNREACHABLE();
-                    return xs[0];
                 }
             }
         }
@@ -287,10 +284,6 @@ Notes:
                     return mk_at_most_1_bimander(full, n, xs, ors);
                 case sorting_network_encoding::ordered_at_most:
                     return mk_ordered_atmost_1(full, n, xs);
-                    
-                default:
-                    UNREACHABLE();
-                    return xs[0];
                 }
             }
             else {
@@ -308,9 +301,6 @@ Notes:
                     return unate_le(full, k, n, xs); 
                 case sorting_network_encoding::circuit_at_most:
                     return circuit_le(full, k, n, xs); 
-                default:                    
-                    UNREACHABLE();
-                    return xs[0];
                 }
             }
         }
@@ -349,9 +339,6 @@ Notes:
                     return unate_eq(k, n, xs);              
                 case sorting_network_encoding::circuit_at_most:
                     return circuit_eq(k, n, xs);        
-                default:                    
-                    UNREACHABLE();
-                    return xs[0];
                 }
             }
         }
@@ -491,9 +478,6 @@ Notes:
                 return carry[k-1];
             case EQ:
                 return mk_and(mk_not(carry[k]), carry[k-1]);
-            default:
-                UNREACHABLE();
-                return xs[0];
             }
         }
 
@@ -584,9 +568,6 @@ Notes:
                 eqs.push_back(mk_not(ovfl));
                 return mk_and(eqs);
             }                
-            default:
-                UNREACHABLE();
-                return xs[0];
             }            
         }
 
@@ -709,9 +690,6 @@ Notes:
                 break;
             case sorting_network_encoding::ordered_at_most:
                 return mk_ordered_exactly_1(full, n, xs);
-            default:
-                UNREACHABLE();
-                return mk_ordered_exactly_1(full, n, xs);                
             }
 
             if (full) {


### PR DESCRIPTION
Imports the `davedets:master` covered-switch-default cleanup into `Detlefs`.

- **Warning cleanup**
  - Removes redundant `default` cases across exhaustive enum switches.
  - Enables Clang’s `-Wcovered-switch-default`.

- **Portability**
  - Adds the non-Clang no-op for statement-context warning suppression.
  - Retains the arithmetic solver fallback for unrecognized solver IDs.

```cpp
START_DISABLE_COVERED_SWITCH_DEFAULT
default:
    m_context.register_plugin(alloc(smt::theory_mi_arith, m_context));
    break;
END_DISABLE_WARNING_STMT
```

---------