### PR TITLE
[code-simplifier] Code Simplification - 2026-08-09

### DIFF
--- a/src/ast/rewriter/seq_monadic.cpp
+++ b/src/ast/rewriter/seq_monadic.cpp
@@ -85,7 +85,11 @@ namespace {
     }
 
     char const* result_name(lbool r) {
-        return r == l_true ? "sat" : r == l_false ? "unsat" : "unknown";
+        switch (r) {
+        case l_true:  return "sat";
+        case l_false: return "unsat";
+        default:      return "unknown";
+        }
     }
 }
 
@@ -117,8 +121,11 @@ lbool seq_monadic::nullable(expr* r) {
     if (i != l_undef)
         return i;
     char v = 0;
-    if (m_nullable_cache.find(r, v))
-        return v == 1 ? l_true : v == 0 ? l_false : l_undef;
+    if (m_nullable_cache.find(r, v)) {
+        if (v == 1) return l_true;
+        if (v == 0) return l_false;
+        return l_undef;
+    }
     expr_ref nb = m_rw.is_nullable(r);
     lbool res = m.is_true(nb) ? l_true : m.is_false(nb) ? l_false : l_undef;
     m_pin.push_back(r);

--- a/src/ast/rewriter/seq_regex_live.cpp
+++ b/src/ast/rewriter/seq_regex_live.cpp
@@ -89,7 +89,9 @@ namespace seq {
                 expr_ref f = m_rw.is_nullable(r);
                 n = m.is_true(f) ? l_true : m.is_false(f) ? l_false : l_undef;
             }
-            m_nullable[id] = n == l_true ? 1 : n == l_false ? 0 : 3;
+            if (n == l_true) m_nullable[id] = 1;
+            else if (n == l_false) m_nullable[id] = 0;
+            else m_nullable[id] = 3;
             return m_nullable[id];
         }
 


### PR DESCRIPTION
Replace nested ternary expressions with more readable switch statements and if/else chains in the recently added seq_monadic.cpp and seq_regex_live.cpp files. All behavior is preserved.

- result_name(): nested ternary -> switch statement
- nullable() cache lookup: nested ternary -> if/else chain
- m_nullable assignment: nested ternary -> if/else chain