### PR TITLE
seq_monadic: inline unsat-core tracking, drop deletion-based minimization

### DIFF
--- a/src/ast/rewriter/seq_monadic.cpp
+++ b/src/ast/rewriter/seq_monadic.cpp
@@ -523,6 +523,7 @@ void seq_monadic::reset_search() {
     m_elem_sort = nullptr;
     m_atoms.reset();
     m_regexes.reset();
+    m_deps.reset();
     m_vars.reset();
     m_var_idx.reset();
     m_groups.reset();
@@ -552,6 +553,7 @@ bool seq_monadic::prepare(membership_vec const& memberships) {
         }
         m_regexes.push_back(regex);
         m_atoms.push_back(atoms);
+        m_deps.push_back(d);
         m_pin.push_back(regex);
     }
     // A variable's component group is complete once the search passes the variable's
@@ -610,6 +612,8 @@ lbool seq_monadic::leaf() {
         lbool ne = product_nonempty(m_groups[vi], &w);
         if (ne != l_true) {                       // groups were already shown non-empty;
             m_model.reset();                      // only reachable if the search was cut short
+            if (ne == l_false)                    // record the deps of the empty intersection
+                push_group_deps(vi);
             return ne;
         }
         m_pin.push_back(w);
@@ -619,12 +623,28 @@ lbool seq_monadic::leaf() {
 }
 
 lbool seq_monadic::dfs_membership(unsigned mi) {
+    unsigned mark = m_core_trail.size();
+    lbool r = dfs_membership_body(mi);
+    if (r != l_false)                             // not a refuted branch: drop its deps
+        m_core_trail.shrink(mark);
+    return r;
+}
+
+lbool seq_monadic::dfs_membership_body(unsigned mi) {
     if (mi == m_atoms.size())
         return leaf();
     return dfs_atoms(mi, 0, m_regexes.get(mi));
 }
 
 lbool seq_monadic::dfs_atoms(unsigned mi, unsigned i, expr* R) {
+    unsigned mark = m_core_trail.size();
+    lbool r = dfs_atoms_body(mi, i, R);
+    if (r != l_false)                             // not a refuted branch: drop its deps
+        m_core_trail.shrink(mark);
+    return r;
+}
+
+lbool seq_monadic::dfs_atoms_body(unsigned mi, unsigned i, expr* R) {
     if (m_giveup)
         return l_undef;                           // unwind the whole search, don't keep branching
     if (m_budget == 0) {
@@ -643,16 +663,20 @@ lbool seq_monadic::dfs_atoms(unsigned mi, unsigned i, expr* R) {
         lbool nb = nullable(R);
         if (nb == l_true)
             return dfs_membership(mi + 1);
-        if (nb == l_false)
+        if (nb == l_false) {                      // membership mi alone closes this branch
+            push_dep(m_deps[mi]);
             return l_false;
+        }
         m_stats.inc_bail(bail_reason::nullability);
         return l_undef;                           // undecidable nullability
     }
     atom const& a = atoms[i];
     if (!a.is_var) {                              // a constant element is consumed by a derivative
         expr_ref d = der_elem(R, a.elem.get());
-        if (re().is_empty(d))
+        if (re().is_empty(d)) {                   // membership mi alone closes this branch
+            push_dep(m_deps[mi]);
             return l_false;
+        }
         m_pin.push_back(d);
         return dfs_atoms(mi, i + 1, d);
     }
@@ -667,7 +691,7 @@ lbool seq_monadic::dfs_atoms(unsigned mi, unsigned i, expr* R) {
 
     // Explores one split target; the caller stops at the first l_true.
     auto explore = [&](expr* target) -> lbool {
-        m_groups[vi].push_back(component{ a.var.get(), R, target });
+        m_groups[vi].push_back(component{ a.var.get(), R, target, m_deps[mi] });
         // The group's emptiness test has to be run at some point anyway; running it as
         // soon as the group is complete (or as soon as it holds several components, where
         // an inconsistency can first arise) prunes the entire subtree below.
@@ -677,8 +701,12 @@ lbool seq_monadic::dfs_atoms(unsigned mi, unsigned i, expr* R) {
         else if (finalize || m_groups[vi].size() > 1)
             ne = group_nonempty(vi);
         lbool r;
-        if (ne == l_false)
+        if (ne == l_false) {
+            // The intersection of this variable's components is empty: the branch is
+            // closed by exactly the memberships that contributed those components.
+            push_group_deps(vi);
             r = l_false;
+        }
         else {
             if (ne == l_undef)
                 ++m_undef_vars;
@@ -729,6 +757,7 @@ lbool seq_monadic::decide(membership_vec const& memberships) {
     m_rw.get_derive().maybe_reset_cached_cofactors(1u << 16);
     m_budget = 200000;
     m_giveup = false;
+    m_core_trail.reset();                         // deps collected as branches close below
     lbool r = l_true;                             // empty conjunction is vacuously true
     if (!memberships.empty() && !prepare(memberships))
         r = l_undef;
@@ -741,10 +770,13 @@ lbool seq_monadic::decide(membership_vec const& memberships) {
 }
 
 lbool seq_monadic::solve(expr* term, expr* R) {
-    m_core.reset();
     membership_vec mv;
     mv.push_back({ expr_ref(term, m), expr_ref(R, m), nullptr });
     m_last_result = decide(mv);
+    if (m_last_result == l_false)
+        finalize_core();
+    else
+        m_core.reset();
     return m_last_result;
 }
 
@@ -815,39 +847,25 @@ void seq_monadic::add_len(expr* term, unsigned len, void* d) {
 }
 
 
-void seq_monadic::minimize_core(membership_vec const& memberships) {
+void seq_monadic::finalize_core() {
+    // The core is the set of dependencies that closed the refuted branches, left in
+    // m_core_trail by decide().  Deduplicate (by pointer identity) into m_core.
     m_core.reset();
-    if (!m_config.m_min_core) {
-        // No minimization: the core is simply every asserted membership's dependency.
-        for (auto const& [term, regex, d] : memberships)
-            if (d)
-                m_core.push_back(d);
-        return;
-    }
-    // Deletion-based minimization: start from the full unsat set and try to drop each
-    // membership; a membership is kept only if removing it makes the set no longer
-    // provably unsat.  The result is a minimal unsat subset (relevant constraints only).
-    membership_vec keep(memberships);
-    for (unsigned i = 0; i < keep.size(); ) {
-        membership_vec trial(keep);
-        trial.erase(trial.begin() + i);
-        if (decide(trial) == l_false)
-            keep.swap(trial);                     // membership i is not needed for unsat
-        else
-            ++i;                                  // membership i is needed; keep it
-    }
-    for (auto const& [term, regex, d] : keep)
-        if (d)
+    std::sort(m_core_trail.begin(), m_core_trail.end());
+    void* prev = nullptr;
+    for (void* d : m_core_trail) {
+        if (d && d != prev)
             m_core.push_back(d);
+        prev = d;
+    }
 }
 
 lbool seq_monadic::check() {
-    m_core.reset();
     lbool r = decide(m_memberships);
-    if (r == l_false) {
-        minimize_core(m_memberships);
-        m_model.reset();
-    }
+    if (r == l_false)
+        finalize_core();
+    else
+        m_core.reset();
     m_last_result = r;
     return m_last_result;
 }
@@ -863,7 +881,6 @@ std::ostream& seq_monadic::display(std::ostream& out) const {
     out << "(seq-monadic\n"
         << "  :mode " << mode_name(m_config.m_mode) << "\n"
         << "  :generate-model " << (m_config.m_model ? "true" : "false") << "\n"
-        << "  :minimize-core " << (m_config.m_min_core ? "true" : "false") << "\n"
         << "  :last-result " << result_name(m_last_result) << "\n"
         << "  :budget " << m_budget << "\n"
         << "  :giveup " << (m_giveup ? "true" : "false") << "\n"

--- a/src/ast/rewriter/seq_monadic.h
+++ b/src/ast/rewriter/seq_monadic.h
@@ -83,7 +83,6 @@ class seq_monadic {
     struct config {
         seq::transition_mode m_mode;
         bool m_model = true;  // whether solve()/check() extract a feasible model
-        bool m_min_core = true;   // whether check() minimizes the unsat core (else: all deps)
 
         config(seq::transition_mode mode) : m_mode(mode) {}
     };
@@ -134,7 +133,9 @@ class seq_monadic {
     using membership_vec = vector<std::tuple<expr_ref, expr_ref, void*>>;
     membership_vec m_memberships;           // asserted (term in regex, dep) for check()
     membership_vec m_last_search_memberships; // inputs used by the last internal decide()
-    ptr_vector<void> m_core;                // dependencies of an unsat subset, filled by check() on l_false
+    ptr_vector<void> m_core;                // dependencies of an unsat subset, filled by check()/solve() on l_false
+    ptr_vector<void> m_core_trail;          // deps collected inline as branches close during decide();
+                                            // shrunk on a satisfiable/undetermined branch, kept on a refuted one
     std::function<bool(expr *)> m_is_var;   // predicate for whether a term is a sequence variable
     lbool m_last_result = l_undef;           // result of the last public solve()/check()
     lbool m_last_search_result = l_undef;    // result of the last internal decide()
@@ -156,11 +157,14 @@ class seq_monadic {
     // the current state is derived from `state`; the component accepts when
     //   target ? (current == target)      -- reach component (w drives A from state to target)
     //           : nullable(current)        -- membership component (w in L(state))
-    struct component { expr* var; expr* state; expr* target; };
+    // `dep` is the dependency of the membership that produced this component; it is
+    // collected into the unsat core when the variable's component intersection is empty.
+    struct component { expr* var; expr* state; expr* target; void* dep; };
 
     // ---- depth-first search state; valid for the duration of one decide()/solve() ----
     vector<vector<atom>>   m_atoms;         // parsed atoms, one entry per membership
     expr_ref_vector        m_regexes;       // regex of each membership (parallel to m_atoms)
+    ptr_vector<void>       m_deps;          // dependency of each membership (parallel to m_atoms)
     ptr_vector<expr>       m_vars;          // variables occurring in the memberships
     obj_map<expr, unsigned> m_var_idx;      // variable -> index into m_vars / m_groups
     vector<svector<component>> m_groups;    // components accumulated on the current branch
@@ -221,8 +225,26 @@ class seq_monadic {
     // dfs_atoms(mi, i, R) continues membership `mi` at atom `i` with derivative state R.
     // l_true = a satisfying branch was found (m_model is filled when model generation is
     // enabled), l_false = every branch below is empty, l_undef = gave up.
+    //
+    // The public entry points are thin wrappers enforcing the core-collection discipline:
+    // each remembers the m_core_trail height on entry and, on a non-refuting result
+    // (l_true / l_undef), rewinds the trail to that height -- so only deps pushed on the
+    // committed refutation subtree survive.  The *_body methods hold the actual search.
     lbool dfs_membership(unsigned mi);
     lbool dfs_atoms(unsigned mi, unsigned i, expr* R);
+    lbool dfs_membership_body(unsigned mi);
+    lbool dfs_atoms_body(unsigned mi, unsigned i, expr* R);
+
+    // Push the dependency `d` (if non-null) onto the core trail.
+    void push_dep(void* d) { if (d) m_core_trail.push_back(d); }
+    // Push the dependencies of every component currently accumulated for variable `vi`;
+    // used when that variable's component intersection is found empty (a closed branch).
+    void push_group_deps(unsigned vi) {
+        for (auto const& c : m_groups[vi])
+            push_dep(c.dep);
+    }
+    // Deduplicate m_core_trail into m_core after a l_false decide().
+    void finalize_core();
 
     // Emptiness of the components accumulated for variable `vi` on the current branch,
     // memoized on their signature.  Duplicated components are collapsed before the
@@ -237,13 +259,9 @@ class seq_monadic {
     // explores the joint decomposition of all memberships depth-first.  A variable shared
     // by several memberships accumulates several components in the same branch, which are
     // intersected -- enforcing one consistent value across all memberships.  Does not
-    // touch m_memberships or m_core; fills m_model on l_true when model generation is
-    // enabled.
+    // touch m_memberships; fills m_model on l_true when model generation is enabled and,
+    // on l_false, leaves the dependencies that closed the search in m_core_trail.
     lbool decide(membership_vec const& memberships);
-
-    // Given an unsatisfiable membership set, extract a minimal unsatisfiable subset by
-    // deletion and collect the (non-null) dependencies of its members into m_core.
-    void minimize_core(membership_vec const& memberships);
 
     bool is_var(expr *term) const {
         return m_is_var ? m_is_var(term) : is_uninterp(term);        
@@ -279,10 +297,6 @@ public:
     // (possibly repeated / several distinct) and constant characters.
     //   l_true = sat, l_false = unsat, l_undef = unsupported shape / gave up.
     lbool solve(expr* term, expr* R);
-
-    // Enable/disable unsat-core minimization (default: enabled).  When disabled, core()
-    // returns the dependencies of all asserted memberships (no deletion-based shrinking).
-    void set_min_core(bool b) { m_config.m_min_core = b; }
 
     void set_is_var(std::function<bool(expr *)> const &is_var) {
         m_is_var = is_var;
@@ -322,10 +336,10 @@ public:
     // Per-variable extra constraints are expressed as extra memberships (v in R').
     // Leaves the asserted memberships unchanged.  l_true = sat (empty conjunction is sat),
     // l_false = unsat, l_undef = gave up.  On l_false, core() holds the dependencies
-    // of a minimal unsatisfiable subset.
+    // of an unsatisfiable subset (the union of the deps that closed the refuted branches).
     lbool check();
 
-    // Dependencies of a minimal unsatisfiable subset from the last check() that returned
+    // Dependencies of an unsatisfiable subset from the last check() that returned
     // l_false (nullptr dependencies are omitted).  Empty otherwise.
     ptr_vector<void> const& core() const { return m_core; }
 };

--- a/src/test/seq_monadic.cpp
+++ b/src/test/seq_monadic.cpp
@@ -230,44 +230,27 @@ class seq_monadic_test {
     }
 
     // Assert each membership with a distinct leaf dependency (id = its index) and expect
-    // the conjunction to be UNSAT.  With minimization ON, core() must be exactly
-    // `expected_core` (irrelevant constraints omitted); with minimization OFF, core()
-    // must be all membership dependencies.
+    // the conjunction to be UNSAT.  The core is now tracked inline as the search closes
+    // branches, so core() must be exactly `expected_core`: the union of the dependencies
+    // of the memberships that participated in the contradiction, with constraints
+    // irrelevant to the conflict omitted.
     void check_core(char const* name, vector<std::pair<expr*, expr*>> const& mems,
                     std::set<unsigned> const& expected_core) {
         m_mon.set_gen_model(false);
-        std::set<unsigned> all_ids, got_ids;
-        for (unsigned i = 0; i < mems.size(); ++i)
-            all_ids.insert(i);
-
-        // minimization disabled: the core is every asserted membership's dependency.
-        m_mon.set_min_core(false);
         m_trail.push_scope();
         for (unsigned i = 0; i < mems.size(); ++i)
             m_mon.add(mems[i].first, mems[i].second, m_dm.mk_leaf(i));
-        lbool got0 = m_mon.check();
+        lbool got = m_mon.check();
+        std::set<unsigned> got_ids;
         core_ids(got_ids);
-        bool ok0 = (got0 == l_false) && (got_ids == all_ids);
         m_trail.pop_scope(1);
 
-        // minimization enabled: the core drops constraints irrelevant to the conflict.
-        m_mon.set_min_core(true);
-        m_trail.push_scope();
-        for (unsigned i = 0; i < mems.size(); ++i)
-            m_mon.add(mems[i].first, mems[i].second, m_dm.mk_leaf(i));
-        lbool got1 = m_mon.check();
-        std::set<unsigned> min_ids;
-        core_ids(min_ids);
-        bool ok1 = (got1 == l_false) && (min_ids == expected_core);
-        m_trail.pop_scope(1);
-        m_mon.set_min_core(false);                // restore the harness default
-
-        bool ok = ok0 && ok1;
+        bool ok = (got == l_false) && (got_ids == expected_core);
         if (!ok) ++m_fail;
-        std::cout << (ok ? "  OK   " : "  FAIL ") << name << "  got=" << s(got1) << " core={";
+        std::cout << (ok ? "  OK   " : "  FAIL ") << name << "  got=" << s(got) << " core={";
         bool first = true;
-        for (unsigned id : min_ids) { std::cout << (first ? "" : ",") << id; first = false; }
-        std::cout << "} full=" << (ok0 ? "yes" : "no") << "\n";
+        for (unsigned id : got_ids) { std::cout << (first ? "" : ",") << id; first = false; }
+        std::cout << "}\n";
     }
 
     lbool smt_check(expr_ref_vector const& assertions, bool enable_monadic = true) {
@@ -293,7 +276,6 @@ public:
         m_reg(m), m_rw(m), m_mon(m_rw, m_trail, mode), u(m), m_str(m), m_re(m), m_mode(mode) {
         m_str = u.str.mk_string_sort();
         m_re  = re().mk_re(m_str);
-        m_mon.set_min_core(false);   // tests use unminimized cores by default
     }
 
     void run() {
@@ -494,7 +476,6 @@ public:
 
         m_trail.push_scope();
         unsigned display_dep1 = 1, display_dep2 = 2;
-        m_mon.set_min_core(true);
         m_mon.add(x, aaS, &display_dep1);
         m_mon.add(x, a_aaS, &display_dep2);
         lbool unsat_display_result = m_mon.check();
@@ -507,7 +488,6 @@ public:
             unsat_display_text.find(":model ()") != std::string::npos &&
             unsat_display_text.find(":last-internal-search") != std::string::npos;
         m_trail.pop_scope(1);
-        m_mon.set_min_core(false);
         if (!unsat_display_ok) ++m_fail;
         std::cout << (unsat_display_ok ? "  OK   " : "  FAIL ")
                   << "display distinguishes unsat result from core-search state\n";


### PR DESCRIPTION
## Summary

Replaces `seq_monadic`'s deletion-based unsat-core minimization with **inline core tracking** during the decision search.

Previously, after a `l_false` `decide()`, `minimize_core()` re-ran the entire decision procedure O(n) times (dropping one membership at a time) to shrink the core. Profiling the QF_S regex set (1476 benchmarks, 10s timeout) showed this cost **~15% of total `seq_monadic` time overall**, and **50–98% on the hard `split_membership` family**, where it turned solvable-in-budget instances into timeouts.

## Approach

Core tracking is now done in-line with solving:

- Each `component` carries the **dependency of the membership that produced it**.
- Whenever a branch is closed, the dependencies of the contradictory constraints are pushed onto a **core trail**:
  - a non-nullable leftover regex (membership `mi` alone),
  - an empty derivative on a constant element (membership `mi` alone),
  - an **empty intersection of a variable's component bucket** — the union of the deps of the memberships that contributed those components.
- The public `dfs_membership`/`dfs_atoms` entry points wrap the search bodies and **rewind the trail** on any non-refuting (`l_true`/`l_undef`) result, so only deps on the committed refutation subtree survive.
- The **union** of the surviving deps is the core.

Removed: `minimize_core`, `set_min_core`, `config::m_min_core`, and the `:minimize-core` display field.

## Validation

- `test-z3 seq_monadic` passes in both transition modes, producing the same tight cores as before (`{0,1}`, `{0,1}`, `{1,2}`) — now at **no extra search cost**.
- The core-tracking unit test is simplified to assert the inline core directly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
