### PR TITLE
nla: run the bound squeeze before the nonlinear engines and back off satisfiable nlsat probes

### DIFF
--- a/src/math/lp/horner.cpp
+++ b/src/math/lp/horner.cpp
@@ -104,9 +104,6 @@ bool horner::horner_lemmas() {
         TRACE(nla_solver, tout << "not generating horner lemmas\n";);
         return false;
     }
-    // core::check already ran optimize_nl_bounds() before scheduling the
-    // nonlinear engines and returned when it left nothing to refine; the guard
-    // stays for safety.
     if (c().to_refine().empty()) {
         c().set_nla_satisfied();
         return false;

--- a/src/math/lp/horner.cpp
+++ b/src/math/lp/horner.cpp
@@ -104,15 +104,9 @@ bool horner::horner_lemmas() {
         TRACE(nla_solver, tout << "not generating horner lemmas\n";);
         return false;
     }
-    // Tighten the bounds of nonlinear variables over the LP tableau before the
-    // cross-nested/horner interval evaluation, so the tighter implied bounds can
-    // exclude zero and expose conflicts. Done here (instead of core::propagate)
-    // so the LP maximization only runs when horner is actually scheduled.
-    // optimize_nl_bounds() checks arith.nl.optimize_bounds internally.
-    c().m_monomial_bounds.optimize_nl_bounds();
-    // optimize_nl_bounds re-calibrated m_to_refine against the model it produced.
-    // If nothing remains to refine, every monomial is consistent under a feasible
-    // LP model: the nonlinear goal is satisfied. Declare it and stop.
+    // core::check already ran optimize_nl_bounds() before scheduling the
+    // nonlinear engines and returned when it left nothing to refine; the guard
+    // stays for safety.
     if (c().to_refine().empty()) {
         c().set_nla_satisfied();
         return false;

--- a/src/math/lp/nla_core.cpp
+++ b/src/math/lp/nla_core.cpp
@@ -1303,10 +1303,6 @@ lbool core::check(unsigned level) {
     patch_monomials();
     set_use_nra_model(false);
     if (m_to_refine.empty()) {
-        // A check that needs no nonlinear work is a sign of a healthy search:
-        // wind the eager-squeeze breaker down (see below). Decay rather than
-        // reset, so occasional healthy checks inside a squeeze-driven divergence
-        // do not keep re-arming eager mode.
         m_squeezes_without_progress /= 2;
         return l_true;
     }
@@ -1326,21 +1322,8 @@ lbool core::check(unsigned level) {
     if (no_effect() && refine_pseudo_linear())
         return l_false;
 
-    // Squeeze the bounds of monomial variables over the tableau (the analog of
-    // theory_arith's max_min_nl_vars) before any nonlinear engine runs. The
-    // implied bounds, each carrying an LP explanation, propagate back to the
-    // search; the squeeze also pins monomial variables at bounds or pivots them
-    // into the basis, so the engines see a tighter tableau. If it proves every
-    // monomial consistent the round ends before Grobner saturates or nlsat runs.
-    // Squeezing every call pays off only while the squeeze keeps finding better
-    // bounds; after a streak of fruitless calls fall back to the horner cadence,
-    // where a productive squeeze re-arms the eager mode.
-    // A long run of squeezes with no check ever finding its monomials already
-    // consistent is the signature of a lemma loop (squeezed bounds feed
-    // Grobner/Horner lemmas whose bounds are popped and re-derived forever):
-    // m_squeezes_without_progress then shuts the squeeze off entirely as a
-    // circuit breaker. The counter halves on every check that needs no
-    // nonlinear work, so a healthy search re-arms it.
+    // Squeeze monomial bounds eagerly while it helps, otherwise on the horner
+    // cadence; disable after too many fruitless calls.
     bool squeeze_enabled = m_squeezes_without_progress < 50;
     bool eager_squeeze = m_squeeze_fail_streak < 3;
     bool squeeze_cadence = lp_settings().stats().m_nla_calls % params().arith_nl_horner_frequency() == 0;
@@ -1461,13 +1444,7 @@ lbool core::bounded_nlsat() {
     p.set_uint("max_conflicts", lp_settings().m_max_conflicts);            
     m_nra.updt_params(p);
     lp_settings().stats().m_nra_calls++;
-    // A probe pays off only when it finds a conflict: re-engage eagerly then.
-    // Both other outcomes - l_true (an expensive confirmation that the current
-    // nonlinear state is satisfiable) and l_undef (the probe budget ran out) -
-    // back off exponentially, so a search whose quiet rounds keep getting the
-    // same answer stops paying ~100K rlimit for it every few rounds. The final
-    // full nra check (level >= 2) is not delayed, so completeness on satisfiable
-    // goals is unaffected.
+    // On a conflict re-engage, otherwise back off.
     if (ret == l_false)
         m_nlsat_delay_bound /= 2;
     else if (m_nlsat_delay_bound < (1u << 20))

--- a/src/math/lp/nla_core.cpp
+++ b/src/math/lp/nla_core.cpp
@@ -1301,9 +1301,9 @@ lbool core::check(unsigned level) {
 
     init_to_refine();
     patch_monomials();
-    set_use_nra_model(false);    
+    set_use_nra_model(false);
     if (m_to_refine.empty())
-        return l_true;    
+        return l_true;
     init_search();
     m_nla_satisfied = false;
 
@@ -1319,8 +1319,27 @@ lbool core::check(unsigned level) {
 
     if (no_effect() && refine_pseudo_linear())
         return l_false;
-       
-    
+
+    // Squeeze the bounds of monomial variables over the tableau (the analog of
+    // theory_arith's max_min_nl_vars) before any nonlinear engine runs. The
+    // implied bounds, each carrying an LP explanation, propagate back to the
+    // search; the squeeze also pins monomial variables at bounds or pivots them
+    // into the basis, so the engines see a tighter tableau. If it proves every
+    // monomial consistent the round ends before Grobner saturates or nlsat runs.
+    // Squeezing every call pays off only while the squeeze keeps finding better
+    // bounds; after a streak of fruitless calls fall back to the horner cadence,
+    // where a productive squeeze re-arms the eager mode.
+    bool eager_squeeze = m_squeeze_fail_streak < 3;
+    bool squeeze_cadence = lp_settings().stats().m_nla_calls % params().arith_nl_horner_frequency() == 0;
+    if (no_effect() && (run_horner || run_grobner) && (eager_squeeze || squeeze_cadence)) {
+        if (m_monomial_bounds.optimize_nl_bounds())
+            m_squeeze_fail_streak = 0;
+        else
+            ++m_squeeze_fail_streak;
+        if (m_to_refine.empty())
+            return l_true;
+    }
+
     {
         std::function<void(void)> check1 = [&]() { if (no_effect() && run_horner) m_horner.horner_lemmas(); };
         std::function<void(void)> check2 = [&]() { if (no_effect() && run_grobner) m_grobner(); };
@@ -1426,11 +1445,18 @@ lbool core::bounded_nlsat() {
     p.set_uint("max_conflicts", lp_settings().m_max_conflicts);            
     m_nra.updt_params(p);
     lp_settings().stats().m_nra_calls++;
-    if (ret == l_undef) 
-        ++m_nlsat_delay_bound;
-    else if (m_nlsat_delay_bound > 0)
-        m_nlsat_delay_bound /= 2;        
-    
+    // A probe pays off only when it finds a conflict: re-engage eagerly then.
+    // Both other outcomes - l_true (an expensive confirmation that the current
+    // nonlinear state is satisfiable) and l_undef (the probe budget ran out) -
+    // back off exponentially, so a search whose quiet rounds keep getting the
+    // same answer stops paying ~100K rlimit for it every few rounds. The final
+    // full nra check (level >= 2) is not delayed, so completeness on satisfiable
+    // goals is unaffected.
+    if (ret == l_false)
+        m_nlsat_delay_bound /= 2;
+    else if (m_nlsat_delay_bound < (1u << 20))
+        m_nlsat_delay_bound = std::max(2 * m_nlsat_delay_bound, 1u);
+
     m_nlsat_delay = m_nlsat_delay_bound;
 
     if (ret == l_true) 

--- a/src/math/lp/nla_core.cpp
+++ b/src/math/lp/nla_core.cpp
@@ -1302,8 +1302,14 @@ lbool core::check(unsigned level) {
     init_to_refine();
     patch_monomials();
     set_use_nra_model(false);
-    if (m_to_refine.empty())
+    if (m_to_refine.empty()) {
+        // A check that needs no nonlinear work is a sign of a healthy search:
+        // wind the eager-squeeze breaker down (see below). Decay rather than
+        // reset, so occasional healthy checks inside a squeeze-driven divergence
+        // do not keep re-arming eager mode.
+        m_squeezes_without_progress /= 2;
         return l_true;
+    }
     init_search();
     m_nla_satisfied = false;
 
@@ -1329,15 +1335,25 @@ lbool core::check(unsigned level) {
     // Squeezing every call pays off only while the squeeze keeps finding better
     // bounds; after a streak of fruitless calls fall back to the horner cadence,
     // where a productive squeeze re-arms the eager mode.
+    // A long run of squeezes with no check ever finding its monomials already
+    // consistent is the signature of a lemma loop (squeezed bounds feed
+    // Grobner/Horner lemmas whose bounds are popped and re-derived forever):
+    // m_squeezes_without_progress then shuts the squeeze off entirely as a
+    // circuit breaker. The counter halves on every check that needs no
+    // nonlinear work, so a healthy search re-arms it.
+    bool squeeze_enabled = m_squeezes_without_progress < 50;
     bool eager_squeeze = m_squeeze_fail_streak < 3;
     bool squeeze_cadence = lp_settings().stats().m_nla_calls % params().arith_nl_horner_frequency() == 0;
-    if (no_effect() && (run_horner || run_grobner) && (eager_squeeze || squeeze_cadence)) {
+    if (no_effect() && squeeze_enabled && (run_horner || run_grobner) && (eager_squeeze || squeeze_cadence)) {
+        ++m_squeezes_without_progress;
         if (m_monomial_bounds.optimize_nl_bounds())
             m_squeeze_fail_streak = 0;
         else
             ++m_squeeze_fail_streak;
-        if (m_to_refine.empty())
+        if (m_to_refine.empty()) {
+            m_squeezes_without_progress /= 2;
             return l_true;
+        }
     }
 
     {

--- a/src/math/lp/nla_core.h
+++ b/src/math/lp/nla_core.h
@@ -97,6 +97,9 @@ class core {
     // squeezes on every call, afterwards only on the horner cadence until a
     // productive squeeze resets the streak.
     unsigned                 m_squeeze_fail_streak = 0;
+    // bound-squeeze calls since a check last found every monomial consistent;
+    // when it grows large the eager squeeze is disabled (lemma-loop breaker).
+    unsigned                 m_squeezes_without_progress = 0;
     horner                   m_horner;
     grobner                  m_grobner;
     emonics                  m_emons;

--- a/src/math/lp/nla_core.h
+++ b/src/math/lp/nla_core.h
@@ -93,6 +93,10 @@ class core {
     // set when bound optimization re-calibrates m_to_refine to empty: every
     // monomial is consistent under the optimized model, so the goal is satisfied.
     bool                     m_nla_satisfied = false;
+    // consecutive bound-squeeze calls that improved nothing; while short, check()
+    // squeezes on every call, afterwards only on the horner cadence until a
+    // productive squeeze resets the streak.
+    unsigned                 m_squeeze_fail_streak = 0;
     horner                   m_horner;
     grobner                  m_grobner;
     emonics                  m_emons;

--- a/src/math/lp/nla_core.h
+++ b/src/math/lp/nla_core.h
@@ -93,12 +93,9 @@ class core {
     // set when bound optimization re-calibrates m_to_refine to empty: every
     // monomial is consistent under the optimized model, so the goal is satisfied.
     bool                     m_nla_satisfied = false;
-    // consecutive bound-squeeze calls that improved nothing; while short, check()
-    // squeezes on every call, afterwards only on the horner cadence until a
-    // productive squeeze resets the streak.
+    // consecutive fruitless optimize_nl_bounds() calls
     unsigned                 m_squeeze_fail_streak = 0;
-    // bound-squeeze calls since a check last found every monomial consistent;
-    // when it grows large the eager squeeze is disabled (lemma-loop breaker).
+    // optimize_nl_bounds() calls since check() last returned l_true
     unsigned                 m_squeezes_without_progress = 0;
     horner                   m_horner;
     grobner                  m_grobner;


### PR DESCRIPTION
Two scheduling changes in the nla core, motivated by closing the gap between `smt.arith.solver=6` and `smt.arith.solver=2` on F*-generated benchmarks, validated on the full SMT-LIB QF_NIA division.

## Changes

1. **Run the LP bound squeeze before the nonlinear engines** (`optimize_nl_bounds`, the analog of theory_arith's `max_min_nl_vars`). It used to run only inside `horner_lemmas()` — every `horner_frequency`'th call, in random order against Grobner — so Grobner regularly saturated large clusters and nlsat ran on the unsqueezed tableau. It now runs in `core::check` ahead of the weighted horner/grobner block: on every call while it keeps improving bounds, falling back to the horner cadence after a streak of fruitless calls. A circuit breaker (`m_squeezes_without_progress`) shuts the squeeze off when a long run of squeezes never yields a check with all monomials consistent — the signature of a lemma loop where squeezed bounds feed lemmas that are popped and re-derived forever.

2. **Exponential backoff of non-conflicting `bounded_nlsat` probes.** Each probe costs up to 100K rlimit. The delay adaptation treated `l_true` like `l_false` (halving the delay bound), so a search whose quiet rounds keep re-certifying a satisfiable nonlinear state paid for a probe every few rounds. Now only `l_false` (a found conflict) re-engages; `l_true` and `l_undef` double the delay bound (capped). The full `m_nra.check()` at `level >= 2` stays undelayed, so completeness on satisfiable goals is unaffected.

## Headline results

* `FStar.UInt128-1.smt2`: 0.20s → 0.06s with solver=6, reaching parity with solver=2 (0.02–0.05s). Grobner calls drop 44 → 4, the bounded nlsat call disappears, allocations drop 178M → 15.6M.
* `FStar.Matrix-2.smt2`: **unknown → unsat**. The file runs its query under `(set-option :rlimit 2500000)`; master needs 10.8M rlimit (canceled), this branch needs 1.5M. The nlsat probes were 68% of master's cost on this file, mostly re-certifying satisfiable states.

## Robustness: 50-seed sweep over F* benchmarks

19 F* files (`FStar.UInt128`, `FStar.Matrix`, Pulse, Euclid families), 50 random seeds each (`smt.random_seed=0..49`), `-T:60`, wall seconds.

**A *flip* is a seed whose result is strictly weaker than the same configuration's best result on that file with another seed** — it loses at least one query (returns `unknown` where another seed proves `unsat`) or times out. Files that are equally unsolved on every seed (e.g. the Euclid unknowns) are not flips; slow-but-correct runs are not flips. It measures how often the random seed changes *what you get* rather than how long you wait.

| file | solver=2 avg / max | master s6 avg / max | this PR s6 avg / max |
|---|---|---|---|
| Algebra.Monoid-1 | 0.02 / 0.03 | 0.02 / 0.02 | 0.02 / 0.03 |
| HashTable.Spec-1 | 0.02 / 0.02 | 1.28 / 59.81 (1 flip) | 0.10 / 0.34 |
| Math.Euclid-1 | 0.01 / 0.01 | 0.04 / 1.28 (1 flip) | 0.06 / 1.31 (2 flips) |
| Math.Euclid-2 (unk) | 1.31 / 1.35 | 1.28 / 1.33 | 1.29 / 1.35 |
| Math.Euclid-3 (unk) | 1.22 / 1.25 | 1.32 / 1.36 | 1.32 / 1.36 |
| Matrix-1 | 0.10 / 0.10 | 0.08 / 0.08 | 0.09 / 0.09 |
| **Matrix-2** | 0.03 / 0.03 | 1.70 / 1.73 (**unknown**, all seeds) | 0.52 / 0.54 (**unsat**, all seeds) |
| NikhilHo | 0.19 / 0.19 (1 query unk) | 0.03 / 0.04 | 0.05 / 0.05 |
| Pulse.ForEvery-1 | 0.07 / 0.08 | 0.29 / 0.30 | 0.38 / 0.38 |
| PulseCore.Heap-1 | 0.01 / 0.01 | 0.01 / 0.01 | 0.01 / 0.01 |
| PulseCore.IndTheorySep-1 | 0.02 / 0.04 | 0.02 / 0.02 | 0.02 / 0.02 |
| Tactics.V2.Derived-1/2 | 0.00 / 0.00 | 0.00 / 0.00 | 0.00 / 0.00 |
| UInt128-1 | 0.03 / 0.06 | 0.36 / 2.55 | 0.37 / 11.32 |
| UInt128-1-reduced-core | 0.04 / 0.07 | 0.09 / 0.26 | 0.04 / 0.22 |
| UInt128-10 (47 queries) | 0.74 / 3.48 (7 flips) | 1.61 / 23.60 (9 flips) | 2.51 / 59.78 (4 flips) |
| UInt128-axiom | 0.09 / 0.29 (6 flips) | 0.48 / 2.51 | 0.09 / 0.64 |
| UInt128-divergence | 0.00 / 0.00 | 0.00 / 0.01 | 0.00 / 0.00 |
| UInt128-nla-escalation | 0.01 / 0.01 | 0.01 / 0.01 | 0.01 / 0.01 |
| **TOTAL (sum of avgs / flips)** | **3.92s / 13** | **8.63s / 11** | **6.87s / 6** |

The PR beats master solver=6 on every axis (total average 8.63s → 6.87s, flips 11 → 6, Matrix-2 unknown → unsat on all 50 seeds, HashTable's 60s tail gone) and is more seed-robust than solver=2 (6 flips vs 13 — solver=2 fails UInt128-axiom outright on 6 of 50 seeds and drops a UInt128-10 query on 7).

## Full SMT-LIB QF_NIA (25,452 benchmarks)

Run via the benchmark workflow on the same dedicated runner as the master baseline, `-T:200 model_validate=true`:

| | master (1e5f8b276, 2026-08-12) | this PR (0bb250246) | delta |
|---|---|---|---|
| sat | 13,005 | 13,109 | **+104** |
| unsat | 6,623 | 6,632 | **+9** |
| **solved** | **19,628** | **19,741** | **+113** |
| timeout | 5,824 | 5,711 | −113 |
| unknown / errors | 0 / 0 | 0 / 0 | — |
| total wall | 375.4 h | 368.3 h | −7.0 h |

No sat/unsat disagreements between the two runs on any of the 25,452 files (430 gained vs 317 lost, all against timeouts; all sat models validated).

## Other validation

* fstar-ulib corpus (50 multi-query files): 0 unknowns on both, total time at parity.
* `z3test/regressions/fstar`: `FStar.Matrix-2` flips to solved; all other results match master.
* The known cost: `queries-FStar.UInt128-10` keeps rare slow seeds (1 of 50 near the 60s limit; master has a 23.6s seed and 9 flips on the same file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
