### PR TITLE
Use sequence length lower bounds in bounded models

### DIFF
--- a/src/smt/theory_seq.cpp
+++ b/src/smt/theory_seq.cpp
@@ -3507,8 +3507,12 @@ bool theory_seq::should_research(expr_ref_vector & unsat_core) {
     if (k_min < get_fparams().m_seq_max_unfolding) {
         m_max_unfolding_depth++;
         k_min *= 2;
-        if (m_util.is_seq(s_min))
+        if (m_util.is_seq(s_min)) {
             k_min = std::max(m_util.str.min_length(s_min), k_min);
+            rational lo;
+            if (lower_bound2(s_min, lo) && lo.is_unsigned())
+                k_min = std::max(lo.get_unsigned(), k_min);
+        }
         IF_VERBOSE(1, verbose_stream() << "(smt.seq :increase-length " << mk_bounded_pp(s_min, m, 3) << " " << k_min << ")\n");
         add_length_limit(s_min, k_min, false);
         return true;


### PR DESCRIPTION
## Summary
- incorporate asserted arithmetic lower bounds when increasing bounded sequence models
- skip iterative length limits that are already below a sequence variable's known minimum
- make the #8893 case jump directly to length 101

Fixes #8893