### PR TITLE
Fix incorrect strict optimization objective reporting

### DIFF
--- a/src/math/lp/lp_api.h
+++ b/src/math/lp/lp_api.h
@@ -71,6 +71,8 @@ namespace lp_api {
 
         rational const& get_value() const { return m_value; }
 
+        bool has_infinitesimal() const { return !m_eps.is_zero(); }
+
         lp::constraint_index get_constraint(bool b) const { return m_constraints[b]; }
 
         inf_rational get_value(bool is_true) const {

--- a/src/smt/theory_lra.cpp
+++ b/src/smt/theory_lra.cpp
@@ -164,6 +164,7 @@ class theory_lra::imp {
     unsigned_vector        m_unassigned_bounds;
     unsigned_vector        m_bounds_trail;
     unsigned               m_asserted_qhead;
+    unsigned_vector        m_active_inf_eps_constraints;
 
     svector<unsigned>       m_bv_to_propagate;      // Boolean variables that can be propagated
     
@@ -2467,6 +2468,17 @@ public:
 #endif
     
     unsigned propagate_lp_solver_bound(const lp::implied_bound& be) {
+        // implied_bound stores only a rational threshold and a strict bit.
+        // Do not project a consequence whose explanation uses a delta-rational
+        // API bound, because this can strengthen x >= r - eps into x > r.
+        if (!m_active_inf_eps_constraints.empty()) {
+            for (lp::constraint_index ci : lp().flatten(be.explain_implied())) {
+                for (lp::constraint_index eps_ci : m_active_inf_eps_constraints)
+                    if (ci == eps_ci)
+                        return 0;
+            }
+        }
+
         lpvar vi = be.m_j;
         theory_var v = lp().local_to_external(vi);
 
@@ -3304,6 +3316,10 @@ public:
         TRACE(arith, tout << b << "\n";);
         lp::constraint_index ci = b.get_constraint(is_true);
         lp().activate(ci);
+        if (is_true && b.has_infinitesimal()) {
+            ctx().push_trail(push_back_vector(m_active_inf_eps_constraints));
+            m_active_inf_eps_constraints.push_back(ci);
+        }
         if (is_infeasible()) 
             return false;
         lp::lconstraint_kind k = bound2constraint_kind(b.is_int(), b.get_bound_kind(), is_true);

--- a/src/test/api.cpp
+++ b/src/test/api.cpp
@@ -300,6 +300,38 @@ void test_strict_real_maximize() {
     Z3_del_context(ctx);
 }
 
+void test_strict_real_maximize_disjunction() {
+    Z3_config cfg = Z3_mk_config();
+    Z3_context ctx = Z3_mk_context(cfg);
+    Z3_del_config(cfg);
+
+    Z3_sort real_sort = Z3_mk_real_sort(ctx);
+    auto mk_const = [&](char const* name) {
+        return Z3_mk_const(ctx, Z3_mk_string_symbol(ctx, name), real_sort);
+    };
+    Z3_ast v = mk_const("v");
+    Z3_ast j = mk_const("j");
+    Z3_ast x = mk_const("x");
+    Z3_ast zero = Z3_mk_real(ctx, 0, 1);
+    Z3_ast one = Z3_mk_real(ctx, 1, 1);
+
+    Z3_optimize opt = Z3_mk_optimize(ctx);
+    Z3_optimize_inc_ref(ctx, opt);
+    Z3_optimize_assert(ctx, opt, Z3_mk_lt(ctx, j, zero));
+    Z3_ast two_v_args[] = { v, v };
+    Z3_optimize_assert(ctx, opt, Z3_mk_gt(ctx, Z3_mk_add(ctx, 2, two_v_args), x));
+    Z3_ast cases[] = { Z3_mk_eq(ctx, zero, x), Z3_mk_eq(ctx, zero, v) };
+    Z3_optimize_assert(ctx, opt, Z3_mk_or(ctx, 2, cases));
+    Z3_ast objective_args[] = { one, x };
+    unsigned h = Z3_optimize_maximize(ctx, opt, Z3_mk_add(ctx, 2, objective_args));
+
+    ENSURE(Z3_optimize_check(ctx, opt, 0, nullptr) == Z3_L_TRUE);
+    ENSURE(std::string(Z3_ast_to_string(ctx, Z3_optimize_get_lower(ctx, opt, h))) == "1");
+
+    Z3_optimize_dec_ref(ctx, opt);
+    Z3_del_context(ctx);
+}
+
 static void test_qfnra_degree80_square_bound() {
     Z3_config cfg = Z3_mk_config();
     Z3_context ctx = Z3_mk_context(cfg);
@@ -361,6 +393,7 @@ void tst_api() {
     test_optimize_translate();
     test_optimize_arith_params();
     test_strict_real_maximize();
+    test_strict_real_maximize_disjunction();
     test_qfnra_degree80_square_bound();
 }
 


### PR DESCRIPTION
## Summary
- track active delta-rational optimization validation constraints
- suppress implied-bound projection only when its explanation depends on such a constraint
- add a regression for the disjunctive strict-real optimization case

Fixes #10356