### PR TITLE
[code-simplifier] Refactor: extract toAppSlice helper in spacer.go to eliminate duplicated CGo boilerplate

### DIFF
--- a/src/api/go/spacer.go
+++ b/src/api/go/spacer.go
@@ -84,48 +84,40 @@ func (c *Context) QeLite(vars *ASTVector, body *Expr) *Expr {
 	return newExpr(c, C.Z3_qe_lite(c.ptr, vars.ptr, body.ptr))
 }
 
+// toAppSlice converts a slice of *Expr to a C array of Z3_app and returns a
+// pointer to the first element (or nil for an empty slice).
+func (c *Context) toAppSlice(exprs []*Expr) ([]C.Z3_app, *C.Z3_app) {
+	apps := make([]C.Z3_app, len(exprs))
+	for i, e := range exprs {
+		apps[i] = C.Z3_to_app(c.ptr, e.ptr)
+	}
+	if len(apps) == 0 {
+		return apps, nil
+	}
+	return apps, &apps[0]
+}
+
 // QeModelProject projects variables given a model.
 // bound is a slice of application expressions representing the variables to project.
 func (c *Context) QeModelProject(m *Model, bound []*Expr, body *Expr) *Expr {
-	n := len(bound)
-	cBound := make([]C.Z3_app, n)
-	for i, b := range bound {
-		cBound[i] = C.Z3_to_app(c.ptr, b.ptr)
-	}
-	var boundPtr *C.Z3_app
-	if n > 0 {
-		boundPtr = &cBound[0]
-	}
-	return newExpr(c, C.Z3_qe_model_project(c.ptr, m.ptr, C.uint(n), boundPtr, body.ptr))
+	apps, ptr := c.toAppSlice(bound)
+	_ = apps
+	return newExpr(c, C.Z3_qe_model_project(c.ptr, m.ptr, C.uint(len(bound)), ptr, body.ptr))
 }
 
 // QeModelProjectSkolem projects variables given a model, storing the skolem witnesses in map_.
 // bound is a slice of application expressions representing the variables to project.
 func (c *Context) QeModelProjectSkolem(m *Model, bound []*Expr, body *Expr, map_ *ASTMap) *Expr {
-	n := len(bound)
-	cBound := make([]C.Z3_app, n)
-	for i, b := range bound {
-		cBound[i] = C.Z3_to_app(c.ptr, b.ptr)
-	}
-	var boundPtr *C.Z3_app
-	if n > 0 {
-		boundPtr = &cBound[0]
-	}
-	return newExpr(c, C.Z3_qe_model_project_skolem(c.ptr, m.ptr, C.uint(n), boundPtr, body.ptr, map_.ptr))
+	apps, ptr := c.toAppSlice(bound)
+	_ = apps
+	return newExpr(c, C.Z3_qe_model_project_skolem(c.ptr, m.ptr, C.uint(len(bound)), ptr, body.ptr, map_.ptr))
 }
 
 // QeModelProjectWithWitness projects variables given a model and extracts witnesses.
 // The map_ is populated with bindings of projected variables to witness terms.
 // bound is a slice of application expressions representing the variables to project.
 func (c *Context) QeModelProjectWithWitness(m *Model, bound []*Expr, body *Expr, map_ *ASTMap) *Expr {
-	n := len(bound)
-	cBound := make([]C.Z3_app, n)
-	for i, b := range bound {
-		cBound[i] = C.Z3_to_app(c.ptr, b.ptr)
-	}
-	var boundPtr *C.Z3_app
-	if n > 0 {
-		boundPtr = &cBound[0]
-	}
-	return newExpr(c, C.Z3_qe_model_project_with_witness(c.ptr, m.ptr, C.uint(n), boundPtr, body.ptr, map_.ptr))
+	apps, ptr := c.toAppSlice(bound)
+	_ = apps
+	return newExpr(c, C.Z3_qe_model_project_with_witness(c.ptr, m.ptr, C.uint(len(bound)), ptr, body.ptr, map_.ptr))
 }


### PR DESCRIPTION
…ted CGo boilerplate

The three QeModelProject* functions each contained identical logic to convert a []*Expr slice into a C.Z3_app array with a nil-safe pointer. Extract that pattern into a Context.toAppSlice helper so the conversion is defined once and callers stay focused on their distinct C API calls.

No functional change; behavior is identical.