### PR TITLE
Fix seq_rewriter::mk_seq_reverse on string literals and non-concrete elements

### DIFF
--- a/src/ast/rewriter/seq_monadic.cpp
+++ b/src/ast/rewriter/seq_monadic.cpp
@@ -718,8 +718,10 @@ lbool seq_monadic::leaf() {
             m_model.reset();                      // only reachable if the search was cut short
             return ne;
         }
-        if (m_reversed)                           // the search solved rev(term) in rev(R), so
-            w = m_rw.mk_seq_reverse(w);           // rev(x)'s witness is x's value backwards
+        if (m_reversed && !m_rw.mk_seq_reverse(w, w)) {  // the search solved rev(term) in
+            m_model.reset();                             // rev(R), so rev(x)'s witness is
+            return l_undef;                              // x's value backwards
+        }
         m_pin.push_back(w);
         m_model.insert(strip_rev_var(m_vars[vi]), w.get());
     }

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -468,27 +468,34 @@ br_status seq_rewriter::mk_seq_concat(expr* a, expr* b, expr_ref& result) {
     return BR_FAILED;
 }
 
-expr_ref seq_rewriter::mk_seq_reverse(expr* s) {
-    ptr_vector<expr> units;
-    ptr_vector<expr> todo;
+bool seq_rewriter::mk_seq_reverse(expr* s, expr_ref& result) {
+    ptr_vector<expr> elems, todo;
     todo.push_back(s);
     while (!todo.empty()) {
         expr* e = todo.back();
         todo.pop_back();
-        if (str().is_concat(e)) {
-            app* a = to_app(e);
-            for (unsigned i = a->get_num_args(); i-- > 0; )
-                todo.push_back(a->get_arg(i));
+        if (str().is_concat(e)) {             // str.++ is n-ary; pushing the arguments left
+            app* a = to_app(e);               // to right pops them right to left, which is
+            for (expr* arg : *a)              // the order the reversed sequence needs
+                todo.push_back(arg);
             continue;
         }
         if (str().is_empty(e))
             continue;
-        units.push_back(e);
+        elems.push_back(e);
     }
+    zstring zs;
     expr_ref_vector es(m());
-    for (unsigned i = units.size(); i-- > 0; )
-        es.push_back(units[i]);
-    return expr_ref(str().mk_concat(es.size(), es.data(), s->get_sort()), m());
+    for (expr* e : elems) {
+        if (str().is_unit(e))
+            es.push_back(e);                  // a one-element sequence is its own reverse
+        else if (str().is_string(e, zs))
+            es.push_back(str().mk_string(zs.reverse()));
+        else
+            return false;                     // there is no sequence-level reverse operator,
+    }                                         // so a non-concrete element has no reverse here
+    result = str().mk_concat(es, s->get_sort());
+    return true;
 }
 
 br_status seq_rewriter::mk_seq_length(expr* a, expr_ref& result) {

--- a/src/ast/rewriter/seq_rewriter.h
+++ b/src/ast/rewriter/seq_rewriter.h
@@ -356,7 +356,12 @@ public:
         return result;
     }
 
-    expr_ref mk_seq_reverse(expr* s);
+    /**
+     * Reverse a concrete sequence, i.e. a concatenation of str.unit terms and string
+     * literals. Returns false if some element is neither, because sequences have no
+     * reverse operator to fall back on and the reverse is then not expressible.
+     */
+    bool mk_seq_reverse(expr* s, expr_ref& result);
 
     /**
      * check if regular expression is of the form all ++ s ++ all ++ t + u ++ all, where, s, t, u are sequences

--- a/src/test/seq_rewriter.cpp
+++ b/src/test/seq_rewriter.cpp
@@ -20,11 +20,13 @@ Tests:
  23. (Σ*·S)* is flattened to () | Σ*·S
  24. Regex info tracks inferred maximal lengths
  25. Bag splitting ignores a whole-equation bag match
+ 26. mk_seq_reverse reverses concrete sequences and rejects non-concrete ones
 --*/
 
 #include "ast/arith_decl_plugin.h"
 #include "ast/ast_pp.h"
 #include "ast/reg_decl_plugins.h"
+#include "ast/rewriter/seq_rewriter.h"
 #include "ast/rewriter/th_rewriter.h"
 #include "ast/seq_decl_plugin.h"
 #include "smt/smt_context.h"
@@ -497,6 +499,62 @@ void tst_seq_rewriter() {
             ENSURE(!i_inner_star.length_is_empty() &&
                    n >= i_inner_star.min_length && n <= i_inner_star.max_length &&
                    (i_inner_star.residues & (1ull << (n % i_inner_star.period))));
+    }
+
+    // 26. seq_rewriter::mk_seq_reverse on concrete sequences.
+    {
+        seq_rewriter sr(m);
+        expr_ref result(m);
+        auto unit = [&](unsigned c) { return expr_ref(su.str.mk_unit(su.str.mk_char(c)), m); };
+        auto cat = [&](expr_ref_vector const& es) {
+            return expr_ref(su.str.mk_concat(es, str_sort), m);
+        };
+
+        // A string literal is a sequence of characters, not an opaque element: reversing
+        // it has to reverse its characters.
+        expr_ref abc_str(su.str.mk_string("abc"), m);
+        expr_ref cba_str(su.str.mk_string("cba"), m);
+        ENSURE(sr.mk_seq_reverse(abc_str, result));
+        ENSURE(result == cba_str);
+
+        // A concatenation of units comes back in the opposite order.
+        expr_ref_vector abc(m);
+        abc.push_back(unit('a')).push_back(unit('b')).push_back(unit('c'));
+        expr_ref_vector cba(m);
+        cba.push_back(unit('c')).push_back(unit('b')).push_back(unit('a'));
+        ENSURE(sr.mk_seq_reverse(cat(abc), result));
+        ENSURE(result == cat(cba));
+
+        // Literals and units mix, and each literal is reversed in place.
+        expr_ref_vector ab_c(m);
+        ab_c.push_back(expr_ref(su.str.mk_string("ab"), m)).push_back(unit('c'));
+        expr_ref_vector c_ba(m);
+        c_ba.push_back(unit('c')).push_back(expr_ref(su.str.mk_string("ba"), m));
+        ENSURE(sr.mk_seq_reverse(cat(ab_c), result));
+        ENSURE(result == cat(c_ba));
+
+        // Nesting on either side flattens to the same reversal.
+        expr_ref_vector ab(m), inner(m);
+        ab.push_back(unit('a')).push_back(unit('b'));
+        inner.push_back(cat(ab)).push_back(unit('c'));
+        ENSURE(sr.mk_seq_reverse(cat(inner), result));
+        ENSURE(result == cat(cba));
+
+        // The empty sequence and a single element are their own reverse.
+        expr_ref empty_seq(su.str.mk_empty(str_sort), m);
+        ENSURE(sr.mk_seq_reverse(empty_seq, result));
+        ENSURE(result == empty_seq);
+        ENSURE(sr.mk_seq_reverse(unit('a'), result));
+        ENSURE(result == unit('a'));
+
+        // Sequences have no reverse operator, so a non-concrete element has no reverse to
+        // return. Reporting failure is the only sound answer; returning the element
+        // unchanged would claim rev(x) = x.
+        expr_ref x(m.mk_const(symbol("x"), str_sort), m);
+        ENSURE(!sr.mk_seq_reverse(x, result));
+        expr_ref_vector ax(m);
+        ax.push_back(unit('a')).push_back(x);
+        ENSURE(!sr.mk_seq_reverse(cat(ax), result));
     }
 
     std::cout << "tst_seq_rewriter: all tests passed\n";


### PR DESCRIPTION
Follow-up to #10525, which moved `reverse_word` out of `seq_monadic` and made it the
public `seq_rewriter::mk_seq_reverse`.

The move was verbatim, so the function is still the one `seq_monadic` had: it collects the
elements of a `str.++` and reverses that list, treating anything that is not a concatenation
as a single element. That is correct for the one existing caller, whose witnesses are always
built as concatenations of `str.unit`, but not for a general sequence utility:

```
mk_seq_reverse("abc")  =  "abc"     // a literal is not str.++, so it is kept whole
mk_seq_reverse(x)      =  x         // for a sequence variable x, i.e. rev(x) = x
```

Sequences have no reverse operator -- there is only `re.reverse` on regular expressions --
so the reverse of a variable is not expressible, and the `expr_ref` return had no way to say
so. The signature therefore becomes `bool mk_seq_reverse(expr*, expr_ref&)`.

### Changes

- Reverse the characters of a string literal with `zstring::reverse`.
- Return `false` when an element is neither a unit nor a literal.
- `seq_monadic::leaf` propagates the failure by giving up on the witness rather than
  reporting a wrong model. It cannot currently observe this, since `reconstruct` builds
  witnesses with the plugin constructors and nothing coalesces them into literals, which is
  why the defect was invisible.

### Test

`tst_seq_rewriter` gains a case covering literals, units, the two mixed, nesting on either
side, the empty and singleton sequences, and rejection of a non-concrete element.

I checked that the test is a real regression test: against the previous implementation it
fails, and with the fix `test-z3 /a` is 96/96.
