### PR TITLE
nla: move patching, bound explanations and engine backoff out of nla_core

### DIFF
--- a/src/math/lp/CMakeLists.txt
+++ b/src/math/lp/CMakeLists.txt
@@ -28,10 +28,12 @@ z3_add_component(lp
     nla_common.cpp
     nla_core.cpp
     nla_divisions.cpp
+    nla_explanations.cpp
     nla_grobner.cpp
     nla_intervals.cpp
     nla_monotone_lemmas.cpp
     nla_order_lemmas.cpp
+    nla_patcher.cpp
     nla_powers.cpp
     nla_pp.cpp
     nla_solver.cpp

--- a/src/math/lp/nla_backoff.h
+++ b/src/math/lp/nla_backoff.h
@@ -1,0 +1,61 @@
+/*++
+  Copyright (c) 2026 Microsoft Corporation
+
+  Module Name:
+
+  nla_backoff.h
+
+  Abstract:
+
+  Scheduling policies for expensive nonlinear engines.
+
+  Author:
+    Lev Nachmanson (levnach)
+
+  --*/
+#pragma once
+#include <algorithm>
+
+namespace nla {
+
+// Exponential backoff: on success re-engage, otherwise double the delay
+// until the next run.
+class backoff {
+    unsigned m_delay = 0;
+    unsigned m_delay_bound = 0;
+public:
+    void set_delay_bound(unsigned b) { m_delay_bound = b; }
+    // counts the delay down; the engine runs when it is exhausted
+    bool should_run() {
+        if (m_delay > 0)
+            --m_delay;
+        return m_delay < 2;
+    }
+    void update(bool success) {
+        if (success)
+            m_delay_bound /= 2;
+        else if (m_delay_bound < (1u << 20))
+            m_delay_bound = std::max(2 * m_delay_bound, 1u);
+        m_delay = m_delay_bound;
+    }
+};
+
+// Schedules the eager bound squeeze: eager while it improves bounds,
+// disabled after too many squeezes without check() finding nothing to refine.
+class squeeze_schedule {
+    unsigned m_fail_streak = 0;             // consecutive fruitless squeezes
+    unsigned m_squeezes_since_sat_check = 0; // squeezes since check() last found nothing to refine
+public:
+    bool enabled() const { return m_squeezes_since_sat_check < 50; }
+    bool eager() const { return m_fail_streak < 3; }
+    void on_squeeze(bool improved_bounds) {
+        ++m_squeezes_since_sat_check;
+        if (improved_bounds)
+            m_fail_streak = 0;
+        else
+            ++m_fail_streak;
+    }
+    void on_nothing_to_refine() { m_squeezes_since_sat_check /= 2; }
+};
+
+}

--- a/src/math/lp/nla_core.cpp
+++ b/src/math/lp/nla_core.cpp
@@ -35,6 +35,8 @@ core::core(lp::lar_solver& s, params_ref const& p, reslimit & lim) :
     m_divisions(*this),
     m_intervals(this, lim),
     m_monomial_bounds(this),
+    m_patcher(this),
+    m_explanations(this),
     m_horner(this),
     m_grobner(this),
     m_emons(m_evars),
@@ -42,7 +44,7 @@ core::core(lp::lar_solver& s, params_ref const& p, reslimit & lim) :
     m_nra(s, m_nra_lim, *this, p),
     m_throttle(lra.trail(), 
 	lra.settings().stats()) {
-     m_nlsat_delay_bound = lp_settings().nlsat_delay();
+     m_nlsat_backoff.set_delay_bound(lp_settings().nlsat_delay());
      lra.m_find_monics_with_changed_bounds_func = [&](const indexed_uint_set& columns_with_changed_bounds) {
         for (lpvar j : columns_with_changed_bounds) {
             if (is_monic_var(j))
@@ -176,158 +178,6 @@ bool core::check_monic(const monic& m) const {
 }
     
 
-bool core::explain_upper_bound(const lp::lar_term& t, const rational& rs, lp::explanation& e) const {
-    rational b(0); // the bound
-    for (lp::lar_term::ival p : t) {
-        rational pb;
-        if (explain_coeff_upper_bound(p, pb, e)) {
-            b += pb;
-        } else {
-            e.clear();
-            return false;
-        }
-    }
-    if (b > rs ) {
-        e.clear();
-        return false;
-    }
-    return true;
-}
-bool core::explain_lower_bound(const lp::lar_term& t, const rational& rs, lp::explanation& e) const {
-    rational b(0); // the bound
-    for (lp::lar_term::ival p : t) {
-        rational pb;
-        if (explain_coeff_lower_bound(p, pb, e)) {
-            b += pb;
-        } else {
-            e.clear();
-            return false;
-        }
-    }
-    if (b < rs ) {
-        e.clear();
-        return false;
-    }
-    return true;
-}
-
-bool core::explain_coeff_lower_bound(const lp::lar_term::ival& p, rational& bound, lp::explanation& e) const {
-    const rational& a = p.coeff();
-    SASSERT(!a.is_zero());
-    if (a.is_pos()) {
-        auto* dep = lra.get_column_lower_bound_witness(p.j());
-        if (!dep)
-            return false;
-        bound = a * lra.get_lower_bound(p.j()).x;
-        lra.push_explanation(dep, e);
-        return true;
-    }
-    // a.is_neg()
-    auto* dep = lra.get_column_upper_bound_witness(p.j());
-    if (!dep)
-        return false;
-    bound = a * lra.get_upper_bound(p.j()).x;
-    lra.push_explanation(dep, e);
-    return true;
-}
-
-bool core::explain_coeff_upper_bound(const lp::lar_term::ival& p, rational& bound, lp::explanation& e) const {
-    const rational& a = p.coeff();
-    lpvar j = p.j();
-    SASSERT(!a.is_zero());
-    if (a.is_neg()) {
-        auto *dep = lra.get_column_lower_bound_witness(j);
-        if (!dep)
-            return false;
-        bound = a * lra.get_lower_bound(j).x;
-        lra.push_explanation(dep, e);
-        return true;
-    }
-    // a.is_pos()
-    auto* dep = lra.get_column_upper_bound_witness(j);
-    if (!dep)
-        return false;
-    bound = a * lra.get_upper_bound(j).x;
-    lra.push_explanation(dep, e);
-    return true;
-}
-    
-// return true iff the negation of the ineq can be derived from the constraints
-bool core::explain_ineq(lemma_builder& lemma, const lp::lar_term& t, llc cmp, const rational& rs) {
-    // check that we have something like 0 < 0, which is always false and can be safely
-    // removed from the lemma
-        
-    if (t.is_empty() && rs.is_zero() &&
-        (cmp == llc::LT || cmp == llc::GT || cmp == llc::NE)) return true;
-    lp::explanation exp;
-    bool r;
-    switch (negate(cmp)) {
-    case llc::LE:
-        r = explain_upper_bound(t, rs, exp);
-        break;
-    case llc::LT:
-        r = explain_upper_bound(t, rs - rational(1), exp);
-        break;
-    case llc::GE: 
-        r = explain_lower_bound(t, rs, exp);
-        break;
-    case llc::GT:
-        r = explain_lower_bound(t, rs + rational(1), exp);
-        break;
-
-    case llc::EQ:
-        r = (explain_lower_bound(t, rs, exp) && explain_upper_bound(t, rs, exp)) ||
-            (rs.is_zero() && explain_by_equiv(t, exp));
-        break;
-    case llc::NE:
-        // TBD - NB: does this work for Reals?
-        r = explain_lower_bound(t, rs + rational(1), exp) || explain_upper_bound(t, rs - rational(1), exp);           
-        break;
-    }
-    if (r) {
-        lemma &= exp;
-        return true;
-    }
-        
-    return false;
-}
-
-/**
- * \brief
- if t is an octagon term -+x -+ y try to explain why the term always is
- equal zero
-*/
-bool core::explain_by_equiv(const lp::lar_term& t, lp::explanation& e) const {
-    lpvar i,j;
-    bool sign;
-    if (!is_octagon_term(t, sign, i, j))
-        return false;
-    if (m_evars.find(signed_var(i, false)) != m_evars.find(signed_var(j, sign)))
-        return false;
-            
-    m_evars.explain(signed_var(i, false), signed_var(j, sign), e);
-    TRACE(nla_solver, tout << "explained :"; lra.print_term_as_indices(t, tout););
-    return true;            
-}
-
-void core::mk_ineq_no_expl_check(lemma_builder& lemma, lp::lar_term& t, llc cmp, const rational& rs) {
-    TRACE(nla_solver_details, lra.print_term_as_indices(t, tout << "t = "););
-    lemma |= ineq(cmp, t, rs);
-    CTRACE(nla_solver, ineq_holds(ineq(cmp, t, rs)), print_ineq(ineq(cmp, t, rs), tout) << "\n";);
-    SASSERT(!ineq_holds(ineq(cmp, t, rs)));
-}
-
-llc apply_minus(llc cmp) {
-    switch(cmp) {
-    case llc::LE: return llc::GE;
-    case llc::LT: return llc::GT;
-    case llc::GE: return llc::LE;
-    case llc::GT: return llc::LT;
-    default: break;
-    }
-    return cmp;
-}   
-    
 // the monics should be equal by modulo sign but this is not so in the model
 void core::fill_explanation_and_lemma_sign(lemma_builder& lemma, const monic& a, const monic & b, rational const& sign) {
     SASSERT(sign == 1 || sign == -1);
@@ -510,94 +360,6 @@ const lp::lp_settings& core::lp_settings() const {
 unsigned core::random() { return lp_settings().random_next(); }
     
 
-// we look for octagon constraints here, with a left part  +-x +- y 
-void core::collect_equivs() {
-    const lp::lar_solver& s = lra;
-
-    for (const auto * t : s.terms()) {
-        if (!s.column_associated_with_row(t->j()))
-            continue;
-        lpvar j = t->j();
-        if (var_is_fixed_to_zero(j)) {
-            TRACE(nla_solver_mons, s.print_term_as_indices(*t, tout << "term = ") << "\n";);
-            add_equivalence_maybe(t, s.get_column_upper_bound_witness(j), s.get_column_lower_bound_witness(j));
-        }
-    }
-    m_emons.ensure_canonized();
-}
-
-
-// returns true iff the term is in a form +-x-+y.
-// the sign is true iff the term is x+y, -x-y.
-bool core::is_octagon_term(const lp::lar_term& t, bool & sign, lpvar& i, lpvar &j) const {
-    if (t.size() != 2)
-        return false;
-    bool seen_minus = false;
-    bool seen_plus = false;
-    i = null_lpvar;
-    j = null_lpvar;
-    for(lp::lar_term::ival p : t) {
-        const auto & c = p.coeff();
-        if (c == 1) {
-            seen_plus = true;
-        } else if (c == - 1) {
-            seen_minus = true;
-        } else {
-            return false;
-        }
-        if (i == null_lpvar)
-            i = p.j();
-        else
-            j = p.j();
-    }
-    SASSERT(j != null_lpvar);
-    sign = (seen_minus && seen_plus)? false : true;
-    return true;
-}
-    
-void core::add_equivalence_maybe(const lp::lar_term* t, u_dependency* c0, u_dependency* c1) {
-    bool sign;
-    lpvar i, j;
-    if (!is_octagon_term(*t, sign, i, j))
-        return;
-    if (sign)
-        m_evars.merge_minus(i, j, eq_justification({c0, c1}));
-    else 
-        m_evars.merge_plus(i, j, eq_justification({c0, c1}));
-}
-
-// x is equivalent to y if x = +- y
-void core::init_vars_equivalence() {
-    collect_equivs();
-    //    SASSERT(tables_are_ok());
-}
-
-bool core::vars_table_is_ok() const {
-    // return m_var_eqs.is_ok();
-    return true;
-}
-
-bool core::rm_table_is_ok() const {
-    // return m_emons.is_ok();
-    return true;
-}
-    
-bool core::tables_are_ok() const {
-    return vars_table_is_ok() && rm_table_is_ok();
-}
-    
-bool core::var_is_a_root(lpvar j) const { return m_evars.is_root(j); }
-
-template <typename T>
-bool core::vars_are_roots(const T& v) const {
-    for (lpvar j: v) {
-        if (!var_is_a_root(j))
-            return false;
-    }
-    return true;
-}
-
-
 void core::clear() {
     m_lemmas.clear();
     m_literals.clear();
@@ -611,7 +373,7 @@ void core::init_search() {
     TRACE(nla_solver_mons, tout << "init\n";);
     SASSERT(m_emons.invariant());
     clear();
-    init_vars_equivalence();
+    m_explanations.init_vars_equivalence();
     SASSERT(m_emons.invariant());
     SASSERT(elists_are_consistent(false));
 }
@@ -854,7 +616,7 @@ lemma_builder::lemma_builder(core& c, const char* name):name(name), c(c) {
 }
 
 lemma_builder& lemma_builder::operator|=(ineq const& ineq) {
-    if (!c.explain_ineq(*this, ineq.term(), ineq.cmp(), ineq.rs())) {
+    if (!c.m_explanations.explain_ineq(*this, ineq.term(), ineq.cmp(), ineq.rs())) {
         CTRACE(nla_solver, c.ineq_holds(ineq), c.print_ineq(ineq, tout) << "\n";);
         SASSERT(c.m_use_nra_model || !c.ineq_holds(ineq));
         current().push_back(ineq);
@@ -1029,54 +791,6 @@ bool core::elists_are_consistent(bool check_in_model) const {
     return true;
 }
 
-bool core::var_breaks_correct_monic_as_factor(lpvar j, const monic& m) const {
-    if (!val(var(m)).is_zero())
-        return true;
-    
-    if (!val(j).is_zero()) // j was not zero: the new value does not matter - m must have another zero factor
-        return false;
-    // do we have another zero in m?       
-    for (lpvar k : m) {
-        if (k != j && val(k).is_zero()) {
-            return false; // not breaking
-        }
-    }
-    // j was the only zero in m
-    return true;
-}
-
-bool core::var_breaks_correct_monic(lpvar j) const {
-    if (is_monic_var(j) && !m_to_refine.contains(j)) {
-        TRACE(nla_solver, tout << "j = " << j << ", m  = "; print_monic(emon(j), tout) << "\n";);
-        return true; // changing the value of a correct monic
-    }
-    
-    for (const monic & m : emons().get_use_list(j)) {
-        if (m_to_refine.contains(m.var()))
-            continue;
-        if (var_breaks_correct_monic_as_factor(j, m))
-            return true;
-    }            
-
-    return false;
-}
-
-void core::update_to_refine_of_var(lpvar j) {
-    for (const monic & m : emons().get_use_list(j)) {
-        if (var_val(m) == mul_val(m)) 
-            erase_from_to_refine(var(m));
-        else
-            insert_to_refine(var(m));
-    }
-    if (is_monic_var(j)) {
-        const monic& m = emon(j);
-        if (var_val(m) == mul_val(m))
-            erase_from_to_refine(j);
-        else
-            insert_to_refine(j);        
-    }
-}
-
 bool core::var_is_big(lpvar j) const {
     return !var_is_int(j) && val(j).is_big();
 }
@@ -1104,135 +818,6 @@ bool core::has_real(const monic& m) const {
         if (!var_is_int(j))
             return true;
     return false;
-}
-
-// returns true if the patching is blocking
-bool core::is_patch_blocked(lpvar u, const lp::impq& ival) const {
-    TRACE(nla_solver, tout << "u = " << u << '\n';);
-    if (m_cautious_patching &&
-        (!lra.inside_bounds(u, ival) || (var_is_int(u) && ival.is_int() == false))) {
-        TRACE(nla_solver, tout << "u = " << u << " blocked, for feas or integr\n";);
-        return true; // block
-    }
-
-    if (u == m_patched_var) {
-        TRACE(nla_solver, tout << "u == m_patched_var, no block\n";);
-        
-        return false; // do not block
-    }
-    // we can change only one variable in variables of m_patched_var
-    if (m_patched_monic->contains_var(u) || u == var(*m_patched_monic)) {
-        TRACE(nla_solver, tout << "u = " << u << " blocked as contained\n";);
-        return true; // block
-    }
-    
-    if (var_breaks_correct_monic(u)) {
-        TRACE(nla_solver, tout << "u = " << u << " blocked as used in a correct monomial\n";);
-        return true;
-    }
-    
-    TRACE(nla_solver, tout << "u = " << u << ", m_patched_m  = "; print_monic(*m_patched_monic, tout) <<
-          ", not blocked\n";);
-    
-    return false;
-}
-
-// it tries to patch m_patched_var
-bool core::try_to_patch(const rational& v) {
-    auto is_blocked = [this](lpvar u, const lp::impq& iv)  { return is_patch_blocked(u, iv); };
-    auto change_report = [this](lpvar u) { update_to_refine_of_var(u); };
-    return lra.try_to_patch(m_patched_var, v, is_blocked, change_report);
-}
-
-bool in_power(const svector<lpvar>& vs, unsigned l) {
-    unsigned k = vs[l];
-    return (l != 0 && vs[l - 1] == k) || (l + 1 < vs.size() && k == vs[l + 1]);
-}
-
-bool core::to_refine_is_correct() const {
-    for (unsigned j = 0; j < lra.number_of_vars(); ++j) {
-        if (!is_monic_var(j)) continue;
-        bool valid = check_monic(emon(j));
-        if (valid == m_to_refine.contains(j)) {
-            TRACE(nla_solver, tout << "inconstency in m_to_refine : ";
-                  print_monic(emon(j), tout) << "\n";
-                  if (valid) tout << "should NOT be in to_refine\n";
-                  else tout << "should be in to_refine\n";);
-            return false;
-        }
-    }
-    return true;
-}
-
-void core::patch_monomial(lpvar j) {    
-    m_patched_monic =& (emon(j));
-    m_patched_var = j;
-    TRACE(nla_solver, tout << "m = "; print_monic(*m_patched_monic, tout) << "\n";);
-    rational v = mul_val(*m_patched_monic);
-    if (val(j) == v) {
-        erase_from_to_refine(j);
-        return;
-    }
-    if (!var_breaks_correct_monic(j) && try_to_patch(v)) {
-        SASSERT(to_refine_is_correct());        
-        return;
-    }
-  
-    // We could not patch j, now we try patching the factor variables.
-    TRACE(nla_solver, tout << " trying squares\n";);
-    // handle perfect squares
-    if ((*m_patched_monic).vars().size() == 2 && (*m_patched_monic).vars()[0] == (*m_patched_monic).vars()[1]) {        
-        rational root;
-        if (v.is_perfect_square(root)) {
-            m_patched_var = (*m_patched_monic).vars()[0];
-            if (!var_breaks_correct_monic(m_patched_var) && (try_to_patch(root) || try_to_patch(-root))) { 
-                TRACE(nla_solver, tout << "patched square\n";);
-                return;
-            }
-        }
-        TRACE(nla_solver, tout << " cannot patch\n";);
-        return;
-    }
-
-    // We have v != abc, but we need to have v = abc.
-    // If we patch b then b should be equal to v/ac = v/(abc/b) = b(v/abc)
-    if (!v.is_zero()) {
-        rational r = val(j) / v;
-        SASSERT((*m_patched_monic).is_sorted());
-        TRACE(nla_solver, tout << "r = " << r << ", v = " << v << "\n";);
-        for (unsigned l = 0; l < (*m_patched_monic).size(); ++l) {
-            m_patched_var = (*m_patched_monic).vars()[l];
-            if (!in_power((*m_patched_monic).vars(), l) &&
-                !var_breaks_correct_monic(m_patched_var) &&
-                try_to_patch(r * val(m_patched_var))) { // r * val(k) gives the right value of k
-                TRACE(nla_solver, tout << "patched  " << m_patched_var << "\n";);
-                SASSERT(mul_val((*m_patched_monic)) == val(j));
-                erase_from_to_refine(j);
-                break;
-            }
-        }
-    }
-}
-
-void core::patch_monomials_on_to_refine() {
-    // the rest of the function might change m_to_refine, so have to copy
-    unsigned_vector to_refine;
-    for (unsigned j : m_to_refine) 
-        to_refine.push_back(j);
-    
-    unsigned sz = to_refine.size();
-
-    unsigned start = random();
-    for (unsigned i = 0; i < sz && !m_to_refine.empty(); ++i) 
-        patch_monomial(to_refine[(start + i) % sz]);
-
-    TRACE(nla_solver, tout << "sz = " << sz << ", m_to_refine = " << m_to_refine.size() <<
-          (sz > m_to_refine.size()? " less" : " same" ) << "\n";);
-}
-
-void core::patch_monomials() {
-    m_cautious_patching = true;
-    patch_monomials_on_to_refine();
 }
 
 /**
@@ -1300,10 +885,10 @@ lbool core::check(unsigned level) {
     }
 
     init_to_refine();
-    patch_monomials();
+    m_patcher.patch_monomials();
     set_use_nra_model(false);
     if (m_to_refine.empty()) {
-        m_squeezes_without_progress /= 2;
+        m_squeeze_schedule.on_nothing_to_refine();
         return l_true;
     }
     init_search();
@@ -1324,17 +909,11 @@ lbool core::check(unsigned level) {
 
     // Squeeze monomial bounds eagerly while it helps, otherwise on the horner
     // cadence; disable after too many fruitless calls.
-    bool squeeze_enabled = m_squeezes_without_progress < 50;
-    bool eager_squeeze = m_squeeze_fail_streak < 3;
     bool squeeze_cadence = lp_settings().stats().m_nla_calls % params().arith_nl_horner_frequency() == 0;
-    if (no_effect() && squeeze_enabled && (run_horner || run_grobner) && (eager_squeeze || squeeze_cadence)) {
-        ++m_squeezes_without_progress;
-        if (m_monomial_bounds.optimize_nl_bounds())
-            m_squeeze_fail_streak = 0;
-        else
-            ++m_squeeze_fail_streak;
+    if (no_effect() && m_squeeze_schedule.enabled() && (run_horner || run_grobner) && (m_squeeze_schedule.eager() || squeeze_cadence)) {
+        m_squeeze_schedule.on_squeeze(m_monomial_bounds.optimize_nl_bounds());
         if (m_to_refine.empty()) {
-            m_squeezes_without_progress /= 2;
+            m_squeeze_schedule.on_nothing_to_refine();
             return l_true;
         }
     }
@@ -1423,11 +1002,7 @@ lbool core::check(unsigned level) {
 }
 
 bool core::should_run_bounded_nlsat() {
-    if (!params().arith_nl_nra())
-        return false;
-    if (m_nlsat_delay > 0) 
-        --m_nlsat_delay;
-    return m_nlsat_delay < 2;
+    return params().arith_nl_nra() && m_nlsat_backoff.should_run();
 }
 
 lbool core::bounded_nlsat() {
@@ -1445,14 +1020,9 @@ lbool core::bounded_nlsat() {
     m_nra.updt_params(p);
     lp_settings().stats().m_nra_calls++;
     // On a conflict re-engage, otherwise back off.
-    if (ret == l_false)
-        m_nlsat_delay_bound /= 2;
-    else if (m_nlsat_delay_bound < (1u << 20))
-        m_nlsat_delay_bound = std::max(2 * m_nlsat_delay_bound, 1u);
+    m_nlsat_backoff.update(ret == l_false);
 
-    m_nlsat_delay = m_nlsat_delay_bound;
-
-    if (ret == l_true) 
+    if (ret == l_true)
         clear();
     return ret;
 }

--- a/src/math/lp/nla_core.h
+++ b/src/math/lp/nla_core.h
@@ -29,6 +29,9 @@
 #include "nlsat/nlsat_solver.h"
 #include "params/smt_params_helper.hpp"
 #include "math/lp/nla_throttle.h"
+#include "math/lp/nla_backoff.h"
+#include "math/lp/nla_patcher.h"
+#include "math/lp/nla_explanations.h"
 
 namespace nra {
     class solver;
@@ -60,9 +63,10 @@ class core {
     friend class monomial_bounds;
     friend class nra::solver;
     friend class divisions;
+    friend class patcher;
+    friend class explanations;
 
-    unsigned m_nlsat_delay = 0;
-    unsigned m_nlsat_delay_bound = 0;
+    backoff  m_nlsat_backoff;
     unsigned m_check_assignment_fail_cnt = 0;
 
     bool should_run_bounded_nlsat();
@@ -86,17 +90,16 @@ class core {
     monotone                 m_monotone;
     powers                   m_powers;
     divisions                m_divisions;
-    intervals                m_intervals; 
+    intervals                m_intervals;
     monomial_bounds          m_monomial_bounds;
+    patcher                  m_patcher;
+    explanations             m_explanations;
     unsigned                 m_conflicts;
     bool                     m_check_feasible = false;
     // set when bound optimization re-calibrates m_to_refine to empty: every
     // monomial is consistent under the optimized model, so the goal is satisfied.
     bool                     m_nla_satisfied = false;
-    // consecutive fruitless optimize_nl_bounds() calls
-    unsigned                 m_squeeze_fail_streak = 0;
-    // optimize_nl_bounds() calls since check() last returned l_true
-    unsigned                 m_squeezes_without_progress = 0;
+    squeeze_schedule         m_squeeze_schedule;
     horner                   m_horner;
     grobner                  m_grobner;
     emonics                  m_emons;
@@ -109,9 +112,6 @@ class core {
 
     bool                     m_use_nra_model = false;
     nra::solver              m_nra;
-    bool                     m_cautious_patching = true;
-    lpvar                    m_patched_var = 0;
-    monic const*             m_patched_monic = nullptr; 
 
     nla_throttle             m_throttle;
     bool                     m_throttle_enabled = true;
@@ -198,9 +198,7 @@ public:
 
     void set_active_vars_weights(nex_creator&);
     std::unordered_set<lpvar> get_vars_of_expr_with_opening_terms(const nex* e);
-    
-    void incremental_linearization(bool);
-    
+
     svector<lpvar> sorted_rvars(const factor& f) const;
     bool done() const;
 
@@ -215,13 +213,8 @@ public:
     // the value of the rooted monomias is equal to the value of the m.var() variable multiplied
     // by the canonize_sign
     bool canonize_sign(const monic& m) const;
-    
 
-    void deregister_monic_from_monicomials (const monic & m, unsigned i);
-
-    void deregister_monic_from_tables(const monic & m, unsigned i);
-
-    void add_monic(lpvar v, unsigned sz, lpvar const* vs);   
+    void add_monic(lpvar v, unsigned sz, lpvar const* vs);
     void add_idivision(lpvar q, lpvar x, lpvar y, lpvar r) { m_divisions.add_idivision(q, x, y, r); }
     void add_rdivision(lpvar q, lpvar x, lpvar y, lpvar r) { m_divisions.add_rdivision(q, x, y, r); }
     void add_bounded_division(lpvar q, lpvar x, lpvar y, lpvar r) { m_divisions.add_bounded_division(q, x, y, r); }
@@ -289,17 +282,13 @@ public:
                         const factor& b,
                         std::ostream& out);
 
-        
-    void mk_ineq_no_expl_check(lemma_builder& lemma, lp::lar_term& t, llc cmp, const rational& rs);
-    
+
     void maybe_add_a_factor(lpvar i,
                             const factor& c,
                             std::unordered_set<lpvar>& found_vars,
                             std::unordered_set<unsigned>& found_rm,
                             vector<factor> & r) const;
 
-    llc apply_minus(llc cmp);
-    
     void fill_explanation_and_lemma_sign(lemma_builder& lemma, const monic& a, const monic & b, rational const& sign);
 
     svector<lpvar> reduce_monic_to_rooted(const svector<lpvar> & vars, rational & sign) const;
@@ -345,13 +334,7 @@ public:
     
     bool var_is_separated_from_zero(lpvar j) const;
 
-    bool vars_are_equiv(lpvar a, lpvar b) const;    
-    bool explain_ineq(lemma_builder& lemma, const lp::lar_term& t, llc cmp, const rational& rs);
-    bool explain_upper_bound(const lp::lar_term& t, const rational& rs, lp::explanation& e) const;
-    bool explain_lower_bound(const lp::lar_term& t, const rational& rs, lp::explanation& e) const;
-    bool explain_coeff_lower_bound(const lp::lar_term::ival& p, rational& bound, lp::explanation& e) const;
-    bool explain_coeff_upper_bound(const lp::lar_term::ival& p, rational& bound, lp::explanation& e) const;
-    bool explain_by_equiv(const lp::lar_term& t, lp::explanation& e) const;
+    bool vars_are_equiv(lpvar a, lpvar b) const;
     bool has_zero_factor(const factorization& factorization) const;
 
     template <typename T>
@@ -359,30 +342,6 @@ public:
     lp::lp_settings& lp_settings();
     const lp::lp_settings& lp_settings() const;
     unsigned random();
-
-    // we look for octagon constraints here, with a left part  +-x +- y 
-    void collect_equivs();
-
-    bool is_octagon_term(const lp::lar_term& t, bool & sign, lpvar& i, lpvar &j) const;
-    
-    void add_equivalence_maybe(const lp::lar_term* t, u_dependency* c0, u_dependency* c1);
-
-    void init_vars_equivalence();
-
-    bool vars_table_is_ok() const;
-
-    bool rm_table_is_ok() const;
-    
-    bool tables_are_ok() const;
-    
-    bool var_is_a_root(lpvar j) const;
-
-    template <typename T>
-    bool vars_are_roots(const T& v) const;
-
-    void register_monic_in_tables(unsigned i_mon);
-
-    void register_monics_in_tables();
 
     void clear();
     
@@ -436,15 +395,6 @@ public:
     bool is_nl_var(lpvar) const;
     
     bool is_used_in_monic(lpvar) const;
-    void patch_monomials();
-    void patch_monomials_on_to_refine();
-    void patch_monomial(lpvar);
-    bool var_breaks_correct_monic(lpvar) const;
-    bool var_breaks_correct_monic_as_factor(lpvar, const monic&) const;
-    void update_to_refine_of_var(lpvar j);
-    bool try_to_patch(const rational&);
-    bool to_refine_is_correct() const;
-    bool is_patch_blocked(lpvar u, const lp::impq&) const;
     bool has_big_num(const monic&) const;
     bool var_is_big(lpvar) const;
     bool has_real(const factorization&) const;

--- a/src/math/lp/nla_explanations.cpp
+++ b/src/math/lp/nla_explanations.cpp
@@ -1,0 +1,215 @@
+/*++
+  Copyright (c) 2026 Microsoft Corporation
+
+  Module Name:
+
+  nla_explanations.cpp
+
+  Author:
+    Lev Nachmanson (levnach)
+
+  --*/
+#include "math/lp/nla_explanations.h"
+#include "math/lp/nla_core.h"
+
+namespace nla {
+
+bool explanations::explain_upper_bound(const lp::lar_term& t, const rational& rs, lp::explanation& e) const {
+    rational b(0); // the bound
+    for (lp::lar_term::ival p : t) {
+        rational pb;
+        if (explain_coeff_upper_bound(p, pb, e)) {
+            b += pb;
+        } else {
+            e.clear();
+            return false;
+        }
+    }
+    if (b > rs ) {
+        e.clear();
+        return false;
+    }
+    return true;
+}
+
+bool explanations::explain_lower_bound(const lp::lar_term& t, const rational& rs, lp::explanation& e) const {
+    rational b(0); // the bound
+    for (lp::lar_term::ival p : t) {
+        rational pb;
+        if (explain_coeff_lower_bound(p, pb, e)) {
+            b += pb;
+        } else {
+            e.clear();
+            return false;
+        }
+    }
+    if (b < rs ) {
+        e.clear();
+        return false;
+    }
+    return true;
+}
+
+bool explanations::explain_coeff_lower_bound(const lp::lar_term::ival& p, rational& bound, lp::explanation& e) const {
+    const rational& a = p.coeff();
+    auto& lra = c().lra;
+    SASSERT(!a.is_zero());
+    if (a.is_pos()) {
+        auto* dep = lra.get_column_lower_bound_witness(p.j());
+        if (!dep)
+            return false;
+        bound = a * lra.get_lower_bound(p.j()).x;
+        lra.push_explanation(dep, e);
+        return true;
+    }
+    // a.is_neg()
+    auto* dep = lra.get_column_upper_bound_witness(p.j());
+    if (!dep)
+        return false;
+    bound = a * lra.get_upper_bound(p.j()).x;
+    lra.push_explanation(dep, e);
+    return true;
+}
+
+bool explanations::explain_coeff_upper_bound(const lp::lar_term::ival& p, rational& bound, lp::explanation& e) const {
+    const rational& a = p.coeff();
+    auto& lra = c().lra;
+    lpvar j = p.j();
+    SASSERT(!a.is_zero());
+    if (a.is_neg()) {
+        auto *dep = lra.get_column_lower_bound_witness(j);
+        if (!dep)
+            return false;
+        bound = a * lra.get_lower_bound(j).x;
+        lra.push_explanation(dep, e);
+        return true;
+    }
+    // a.is_pos()
+    auto* dep = lra.get_column_upper_bound_witness(j);
+    if (!dep)
+        return false;
+    bound = a * lra.get_upper_bound(j).x;
+    lra.push_explanation(dep, e);
+    return true;
+}
+
+// return true iff the negation of the ineq can be derived from the constraints
+bool explanations::explain_ineq(lemma_builder& lemma, const lp::lar_term& t, llc cmp, const rational& rs) {
+    // check that we have something like 0 < 0, which is always false and can be safely
+    // removed from the lemma
+
+    if (t.is_empty() && rs.is_zero() &&
+        (cmp == llc::LT || cmp == llc::GT || cmp == llc::NE)) return true;
+    lp::explanation exp;
+    bool r;
+    switch (negate(cmp)) {
+    case llc::LE:
+        r = explain_upper_bound(t, rs, exp);
+        break;
+    case llc::LT:
+        r = explain_upper_bound(t, rs - rational(1), exp);
+        break;
+    case llc::GE:
+        r = explain_lower_bound(t, rs, exp);
+        break;
+    case llc::GT:
+        r = explain_lower_bound(t, rs + rational(1), exp);
+        break;
+
+    case llc::EQ:
+        r = (explain_lower_bound(t, rs, exp) && explain_upper_bound(t, rs, exp)) ||
+            (rs.is_zero() && explain_by_equiv(t, exp));
+        break;
+    case llc::NE:
+        // TBD - NB: does this work for Reals?
+        r = explain_lower_bound(t, rs + rational(1), exp) || explain_upper_bound(t, rs - rational(1), exp);
+        break;
+    }
+    if (r) {
+        lemma &= exp;
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * \brief
+ if t is an octagon term -+x -+ y try to explain why the term always is
+ equal zero
+*/
+bool explanations::explain_by_equiv(const lp::lar_term& t, lp::explanation& e) const {
+    lpvar i,j;
+    bool sign;
+    if (!is_octagon_term(t, sign, i, j))
+        return false;
+    auto& evars = c().m_evars;
+    if (evars.find(signed_var(i, false)) != evars.find(signed_var(j, sign)))
+        return false;
+
+    evars.explain(signed_var(i, false), signed_var(j, sign), e);
+    TRACE(nla_solver, tout << "explained :"; c().lra.print_term_as_indices(t, tout););
+    return true;
+}
+
+// we look for octagon constraints here, with a left part  +-x +- y
+void explanations::collect_equivs() {
+    const lp::lar_solver& s = c().lra;
+
+    for (const auto * t : s.terms()) {
+        if (!s.column_associated_with_row(t->j()))
+            continue;
+        lpvar j = t->j();
+        if (c().var_is_fixed_to_zero(j)) {
+            TRACE(nla_solver_mons, s.print_term_as_indices(*t, tout << "term = ") << "\n";);
+            add_equivalence_maybe(t, s.get_column_upper_bound_witness(j), s.get_column_lower_bound_witness(j));
+        }
+    }
+    c().m_emons.ensure_canonized();
+}
+
+// returns true iff the term is in a form +-x-+y.
+// the sign is true iff the term is x+y, -x-y.
+bool explanations::is_octagon_term(const lp::lar_term& t, bool & sign, lpvar& i, lpvar &j) const {
+    if (t.size() != 2)
+        return false;
+    bool seen_minus = false;
+    bool seen_plus = false;
+    i = null_lpvar;
+    j = null_lpvar;
+    for(lp::lar_term::ival p : t) {
+        const auto & c = p.coeff();
+        if (c == 1) {
+            seen_plus = true;
+        } else if (c == - 1) {
+            seen_minus = true;
+        } else {
+            return false;
+        }
+        if (i == null_lpvar)
+            i = p.j();
+        else
+            j = p.j();
+    }
+    SASSERT(j != null_lpvar);
+    sign = (seen_minus && seen_plus)? false : true;
+    return true;
+}
+
+void explanations::add_equivalence_maybe(const lp::lar_term* t, u_dependency* c0, u_dependency* c1) {
+    bool sign;
+    lpvar i, j;
+    if (!is_octagon_term(*t, sign, i, j))
+        return;
+    if (sign)
+        c().m_evars.merge_minus(i, j, eq_justification({c0, c1}));
+    else
+        c().m_evars.merge_plus(i, j, eq_justification({c0, c1}));
+}
+
+// x is equivalent to y if x = +- y
+void explanations::init_vars_equivalence() {
+    collect_equivs();
+}
+
+}

--- a/src/math/lp/nla_explanations.h
+++ b/src/math/lp/nla_explanations.h
@@ -1,0 +1,42 @@
+/*++
+  Copyright (c) 2026 Microsoft Corporation
+
+  Module Name:
+
+  nla_explanations.h
+
+  Abstract:
+
+  Explains inequalities by the bounds of the variables of their terms,
+  collects the equivalences x = +-y implied by octagon terms +-x +- y
+  fixed to zero, and explains by these equivalences.
+
+  Author:
+    Lev Nachmanson (levnach)
+
+  --*/
+#pragma once
+#include "math/lp/nla_common.h"
+
+namespace nla {
+    class core;
+    class lemma_builder;
+    class explanations : common {
+    public:
+        explanations(core* c): common(c) {}
+
+        // return true iff the negation of the ineq can be derived from the constraints
+        bool explain_ineq(lemma_builder& lemma, const lp::lar_term& t, llc cmp, const rational& rs);
+        bool explain_upper_bound(const lp::lar_term& t, const rational& rs, lp::explanation& e) const;
+        bool explain_lower_bound(const lp::lar_term& t, const rational& rs, lp::explanation& e) const;
+        bool explain_coeff_lower_bound(const lp::lar_term::ival& p, rational& bound, lp::explanation& e) const;
+        bool explain_coeff_upper_bound(const lp::lar_term::ival& p, rational& bound, lp::explanation& e) const;
+        bool explain_by_equiv(const lp::lar_term& t, lp::explanation& e) const;
+
+        // x is equivalent to y if x = +-y
+        void init_vars_equivalence();
+        void collect_equivs();
+        bool is_octagon_term(const lp::lar_term& t, bool& sign, lpvar& i, lpvar& j) const;
+        void add_equivalence_maybe(const lp::lar_term* t, u_dependency* c0, u_dependency* c1);
+    };
+}

--- a/src/math/lp/nla_intervals.cpp
+++ b/src/math/lp/nla_intervals.cpp
@@ -277,7 +277,7 @@ bool intervals::interval_from_term(const nex& e, scoped_dep_interval& i) {
     rational a, b;
     lp::lar_term norm_t = expression_to_normalized_term(&e.to_sum(), a, b);
     lp::explanation exp;
-    if (m_core->explain_by_equiv(norm_t, exp)) {
+    if (m_core->m_explanations.explain_by_equiv(norm_t, exp)) {
         m_dep_intervals.set_interval_for_scalar(i, b);
         if (wd == e_with_deps::with_deps) {
             for (auto p : exp) {

--- a/src/math/lp/nla_patcher.cpp
+++ b/src/math/lp/nla_patcher.cpp
@@ -1,0 +1,194 @@
+/*++
+  Copyright (c) 2026 Microsoft Corporation
+
+  Module Name:
+
+  nla_patcher.cpp
+
+  Author:
+    Lev Nachmanson (levnach)
+
+  --*/
+#include "math/lp/nla_patcher.h"
+#include "math/lp/nla_core.h"
+
+namespace nla {
+
+bool patcher::var_breaks_correct_monic_as_factor(lpvar j, const monic& m) const {
+    if (!val(var(m)).is_zero())
+        return true;
+
+    if (!val(j).is_zero()) // j was not zero: the new value does not matter - m must have another zero factor
+        return false;
+    // do we have another zero in m?
+    for (lpvar k : m) {
+        if (k != j && val(k).is_zero()) {
+            return false; // not breaking
+        }
+    }
+    // j was the only zero in m
+    return true;
+}
+
+bool patcher::var_breaks_correct_monic(lpvar j) const {
+    if (c().is_monic_var(j) && !c().to_refine().contains(j)) {
+        TRACE(nla_solver, tout << "j = " << j << ", m  = "; c().print_monic(c().emon(j), tout) << "\n";);
+        return true; // changing the value of a correct monic
+    }
+
+    for (const monic & m : c().emons().get_use_list(j)) {
+        if (c().to_refine().contains(m.var()))
+            continue;
+        if (var_breaks_correct_monic_as_factor(j, m))
+            return true;
+    }
+
+    return false;
+}
+
+void patcher::update_to_refine_of_var(lpvar j) {
+    for (const monic & m : c().emons().get_use_list(j)) {
+        if (var_val(m) == mul_val(m))
+            c().erase_from_to_refine(var(m));
+        else
+            c().insert_to_refine(var(m));
+    }
+    if (c().is_monic_var(j)) {
+        const monic& m = c().emon(j);
+        if (var_val(m) == mul_val(m))
+            c().erase_from_to_refine(j);
+        else
+            c().insert_to_refine(j);
+    }
+}
+
+// returns true if the patching is blocking
+bool patcher::is_patch_blocked(lpvar u, const lp::impq& ival) const {
+    TRACE(nla_solver, tout << "u = " << u << '\n';);
+    if (m_cautious_patching &&
+        (!c().lra.inside_bounds(u, ival) || (c().var_is_int(u) && ival.is_int() == false))) {
+        TRACE(nla_solver, tout << "u = " << u << " blocked, for feas or integr\n";);
+        return true; // block
+    }
+
+    if (u == m_patched_var) {
+        TRACE(nla_solver, tout << "u == m_patched_var, no block\n";);
+
+        return false; // do not block
+    }
+    // we can change only one variable in variables of m_patched_var
+    if (m_patched_monic->contains_var(u) || u == var(*m_patched_monic)) {
+        TRACE(nla_solver, tout << "u = " << u << " blocked as contained\n";);
+        return true; // block
+    }
+
+    if (var_breaks_correct_monic(u)) {
+        TRACE(nla_solver, tout << "u = " << u << " blocked as used in a correct monomial\n";);
+        return true;
+    }
+
+    TRACE(nla_solver, tout << "u = " << u << ", m_patched_m  = "; c().print_monic(*m_patched_monic, tout) <<
+          ", not blocked\n";);
+
+    return false;
+}
+
+// it tries to patch m_patched_var
+bool patcher::try_to_patch(const rational& v) {
+    auto is_blocked = [this](lpvar u, const lp::impq& iv)  { return is_patch_blocked(u, iv); };
+    auto change_report = [this](lpvar u) { update_to_refine_of_var(u); };
+    return c().lra.try_to_patch(m_patched_var, v, is_blocked, change_report);
+}
+
+static bool in_power(const svector<lpvar>& vs, unsigned l) {
+    unsigned k = vs[l];
+    return (l != 0 && vs[l - 1] == k) || (l + 1 < vs.size() && k == vs[l + 1]);
+}
+
+bool patcher::to_refine_is_correct() const {
+    for (unsigned j = 0; j < c().lra.number_of_vars(); ++j) {
+        if (!c().is_monic_var(j)) continue;
+        bool valid = check_monic(c().emon(j));
+        if (valid == c().to_refine().contains(j)) {
+            TRACE(nla_solver, tout << "inconstency in m_to_refine : ";
+                  c().print_monic(c().emon(j), tout) << "\n";
+                  if (valid) tout << "should NOT be in to_refine\n";
+                  else tout << "should be in to_refine\n";);
+            return false;
+        }
+    }
+    return true;
+}
+
+void patcher::patch_monomial(lpvar j) {
+    m_patched_monic =& (c().emon(j));
+    m_patched_var = j;
+    TRACE(nla_solver, tout << "m = "; c().print_monic(*m_patched_monic, tout) << "\n";);
+    rational v = mul_val(*m_patched_monic);
+    if (val(j) == v) {
+        c().erase_from_to_refine(j);
+        return;
+    }
+    if (!var_breaks_correct_monic(j) && try_to_patch(v)) {
+        SASSERT(to_refine_is_correct());
+        return;
+    }
+
+    // We could not patch j, now we try patching the factor variables.
+    TRACE(nla_solver, tout << " trying squares\n";);
+    // handle perfect squares
+    if ((*m_patched_monic).vars().size() == 2 && (*m_patched_monic).vars()[0] == (*m_patched_monic).vars()[1]) {
+        rational root;
+        if (v.is_perfect_square(root)) {
+            m_patched_var = (*m_patched_monic).vars()[0];
+            if (!var_breaks_correct_monic(m_patched_var) && (try_to_patch(root) || try_to_patch(-root))) {
+                TRACE(nla_solver, tout << "patched square\n";);
+                return;
+            }
+        }
+        TRACE(nla_solver, tout << " cannot patch\n";);
+        return;
+    }
+
+    // We have v != abc, but we need to have v = abc.
+    // If we patch b then b should be equal to v/ac = v/(abc/b) = b(v/abc)
+    if (!v.is_zero()) {
+        rational r = val(j) / v;
+        SASSERT((*m_patched_monic).is_sorted());
+        TRACE(nla_solver, tout << "r = " << r << ", v = " << v << "\n";);
+        for (unsigned l = 0; l < (*m_patched_monic).size(); ++l) {
+            m_patched_var = (*m_patched_monic).vars()[l];
+            if (!in_power((*m_patched_monic).vars(), l) &&
+                !var_breaks_correct_monic(m_patched_var) &&
+                try_to_patch(r * val(m_patched_var))) { // r * val(k) gives the right value of k
+                TRACE(nla_solver, tout << "patched  " << m_patched_var << "\n";);
+                SASSERT(mul_val((*m_patched_monic)) == val(j));
+                c().erase_from_to_refine(j);
+                break;
+            }
+        }
+    }
+}
+
+void patcher::patch_monomials_on_to_refine() {
+    // the rest of the function might change m_to_refine, so have to copy
+    unsigned_vector to_refine;
+    for (unsigned j : c().to_refine())
+        to_refine.push_back(j);
+
+    unsigned sz = to_refine.size();
+
+    unsigned start = random();
+    for (unsigned i = 0; i < sz && !c().to_refine().empty(); ++i)
+        patch_monomial(to_refine[(start + i) % sz]);
+
+    TRACE(nla_solver, tout << "sz = " << sz << ", m_to_refine = " << c().to_refine().size() <<
+          (sz > c().to_refine().size()? " less" : " same" ) << "\n";);
+}
+
+void patcher::patch_monomials() {
+    m_cautious_patching = true;
+    patch_monomials_on_to_refine();
+}
+
+}

--- a/src/math/lp/nla_patcher.h
+++ b/src/math/lp/nla_patcher.h
@@ -1,0 +1,39 @@
+/*++
+  Copyright (c) 2026 Microsoft Corporation
+
+  Module Name:
+
+  nla_patcher.h
+
+  Abstract:
+
+  Patches the values of monic variables to agree with the products of
+  their factor values, shrinking the set of monomials to refine.
+
+  Author:
+    Lev Nachmanson (levnach)
+
+  --*/
+#pragma once
+#include "math/lp/nla_common.h"
+
+namespace nla {
+    class core;
+    class patcher : common {
+        bool         m_cautious_patching = true;
+        lpvar        m_patched_var = 0;
+        monic const* m_patched_monic = nullptr;
+
+        bool var_breaks_correct_monic(lpvar j) const;
+        bool var_breaks_correct_monic_as_factor(lpvar j, monic const& m) const;
+        void update_to_refine_of_var(lpvar j);
+        bool try_to_patch(const rational& v);
+        bool is_patch_blocked(lpvar u, const lp::impq& ival) const;
+        bool to_refine_is_correct() const;
+        void patch_monomial(lpvar j);
+        void patch_monomials_on_to_refine();
+    public:
+        patcher(core* c): common(c) {}
+        void patch_monomials();
+    };
+}


### PR DESCRIPTION
Follow-up to #10521, addressing the review note about accumulation of bloat in `nla_core`.

Code motion only, no behavioral change:

- **`nla_backoff.h`**: two small policy classes replace four ad-hoc counters in `core`. `backoff` owns the nlsat delay (`bounded_nlsat()` now calls `m_nlsat_backoff.update(ret == l_false)`), and `squeeze_schedule` owns the eager-squeeze scheduling (`enabled()`/`eager()`/`on_squeeze()`/`on_nothing_to_refine()`), so `check()` reads as orchestration again.
- **`nla_patcher.{h,cpp}`**: the monomial patching cluster (`patch_monomial(s)`, `try_to_patch`, `is_patch_blocked`, `var_breaks_correct_monic*`, and the patching state) moves into a `patcher : common` component, following the `monomial_bounds` pattern.
- **`nla_explanations.{h,cpp}`**: the `explain_ineq`/`explain_upper_bound`/`explain_coeff_*`/`explain_by_equiv` family plus octagon-equivalence collection (`is_octagon_term`, `collect_equivs`, `init_vars_equivalence`) move into an `explanations` component.
- Deleted dead code: `mk_ineq_no_expl_check`, `apply_minus`, `tables_are_ok` and friends, `vars_are_roots`, and five declaration-only methods with no definitions.

Validation: release and debug builds are clean; `monomial_bounds` and `horner` unit tests pass; an assertion-enabled run on `FStar.UInt128-1` passes. A/B against current master over 40 F* benchmark files (`-T:20 smt.arith.solver=6`) gives identical unsat counts on every file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)