### PR TITLE
cmake: parallelise the GCC LTO link

### DIFF
--- a/cmake/compiler_lto.cmake
+++ b/cmake/compiler_lto.cmake
@@ -22,6 +22,15 @@ if (Z3_LINK_TIME_OPTIMIZATION)
       (CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
       set(_lto_compiler_flag "-flto")
       set(_lto_linker_flag "-flto")
+      if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        # A bare -flto leaves GCC's LTRANS phase serial, which then dominates
+        # the build. "auto" scales it to the machine, using the build system's
+        # jobserver when one is offered and the host CPU count otherwise, so it
+        # needs none of the per-machine tuning a fixed -flto=N would. Only the
+        # link flag needs this; leaving the compile flag bare keeps existing
+        # object files valid when this changes.
+        set(_lto_linker_flag "-flto=auto")
+      endif()
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(_lto_compiler_flag "/GL")
     set(_lto_linker_flag "/LTCG")


### PR DESCRIPTION
With `Z3_LINK_TIME_OPTIMIZATION=ON` the link line carries a bare `-flto`, which leaves GCC's LTRANS phase serial: linking `libz3.so` takes 543s with GCC 16.1.0 on a 24-core machine, against 45s with `-flto=auto`. This sets `-flto=auto` for GCC only, since Clang spells it `-flto=thin|full`; no version gate is needed because it predates the GCC 13 that Z3 already requires for `<format>`. Only the link flag changes — the compile flag stays a bare `-flto`, so existing object files stay valid. Note `auto` is a parallelism setting rather than a cap: under Ninja two concurrent link targets each use the full CPU count, as `-flto=N` also would — `-DCMAKE_JOB_POOLS=lto_link=1 -DCMAKE_JOB_POOL_LINK=lto_link` serialises them if that matters, and under the Makefiles generator the jobserver handles it.
