### PR TITLE
Replace the flaky QF_NRA api test with a deterministic factoring regression

### DIFF
--- a/src/test/api.cpp
+++ b/src/test/api.cpp
@@ -332,58 +332,12 @@ void test_strict_real_maximize_disjunction() {
     Z3_del_context(ctx);
 }
 
-static void test_qfnra_degree80_square_bound() {
-    Z3_config cfg = Z3_mk_config();
-    Z3_context ctx = Z3_mk_context(cfg);
-    Z3_del_config(cfg);
+// The QF_NRA regression for #10505 lives in tst_upolynomial(). Driving it
+// through Z3_solver_check is not reproducible: the QF_NRA portfolio is a
+// sequence of try_for() tactics guarded by wall-clock timeouts and a probe on
+// process-global allocated memory, so the work reaching the factorizer depends
+// on machine load and on whatever ran earlier in the same process.
 
-    Z3_solver s = Z3_mk_solver(ctx);
-    Z3_solver_inc_ref(ctx, s);
-
-    // A deterministic resource limit instead of a wall-clock timeout: the fixed
-    // factoring path needs < 1M rlimit while the num_primes=1 blowup needs > 5M,
-    // so 2M separates them regardless of machine speed or debug/release build.
-    Z3_params p = Z3_mk_params(ctx);
-    Z3_params_inc_ref(ctx, p);
-    Z3_params_set_uint(ctx, p, Z3_mk_string_symbol(ctx, "rlimit"), 2000000);
-    Z3_solver_set_params(ctx, s, p);
-    Z3_params_dec_ref(ctx, p);
-
-    Z3_sort real_sort = Z3_mk_real_sort(ctx);
-    Z3_ast x = Z3_mk_const(ctx, Z3_mk_string_symbol(ctx, "x"), real_sort);
-    Z3_ast y = Z3_mk_const(ctx, Z3_mk_string_symbol(ctx, "y"), real_sort);
-
-    auto mk_real = [&](int num, int den = 1) { return Z3_mk_real(ctx, num, den); };
-    auto mk_mul = [&](Z3_ast a, Z3_ast b) { Z3_ast args[] = { a, b }; return Z3_mk_mul(ctx, 2, args); };
-    auto mk_pow = [&](Z3_ast base, unsigned power) {
-        Z3_ast result = mk_real(1);
-        Z3_ast factor = base;
-        while (power > 0) {
-            if (power & 1)
-                result = mk_mul(result, factor);
-            power >>= 1;
-            if (power > 0)
-                factor = mk_mul(factor, factor);
-        }
-        return result;
-    };
-
-    Z3_solver_assert(ctx, s, Z3_mk_ge(ctx, x, mk_real(1)));
-    Z3_solver_assert(ctx, s, Z3_mk_le(ctx, x, mk_real(100)));
-    Z3_solver_assert(ctx, s, Z3_mk_ge(ctx, y, mk_real(0)));
-    Z3_solver_assert(ctx, s, Z3_mk_eq(ctx, mk_pow(y, 80), x));
-    Z3_solver_assert(ctx, s, Z3_mk_lt(ctx, y, mk_real(1)));
-    Z3_lbool result = Z3_solver_check(ctx, s);
-    std::string unknown_reason;
-    if (result == Z3_L_UNDEF)
-        unknown_reason = Z3_solver_get_reason_unknown(ctx, s);
-
-    Z3_solver_dec_ref(ctx, s);
-    Z3_del_context(ctx);
-    if (result == Z3_L_UNDEF)
-        throw default_exception(("qfnra degree-80 regression returned unknown: " + unknown_reason).c_str());
-    ENSURE(result == Z3_L_FALSE);
-}
 void tst_api() {
     test_apps();
     test_mk_app_polymorphic_arity();
@@ -393,7 +347,6 @@ void tst_api() {
     test_optimize_arith_params();
     test_strict_real_maximize();
     test_strict_real_maximize_disjunction();
-    test_qfnra_degree80_square_bound();
 }
 
 void test_max_rev() {

--- a/src/test/upolynomial.cpp
+++ b/src/test/upolynomial.cpp
@@ -993,6 +993,57 @@ static void tst_fact() {
               5);
 }
 
+/**
+   \brief Regression for #10505.
+
+   nlsat reaches the degree-80 polynomial y^80 - 100 while refuting
+   1 <= x <= 100 /\ 0 <= y < 1 /\ y^80 = x. Factoring it with a single
+   finite-field trial leaves a combinatorial search costing ~7.5M resource units;
+   polynomial::default_factor_num_primes intersects the candidate degree sets of
+   several primes and brings that down to ~110K.
+
+   Factorization is a pure computation, so the resource count below is reproducible:
+   it does not depend on wall-clock time, on process memory, or on what else ran
+   before. Driving the same formula through Z3_solver_check is not reproducible,
+   because the QF_NRA portfolio picks its sub-solvers using try_for() deadlines and
+   a probe on globally allocated memory.
+*/
+static void tst_fact_default_num_primes() {
+    // Both ways of obtaining default parameters must agree with the shared
+    // constant; goal2nlsat reaches the factorizer through updt_params.
+    ENSURE(upolynomial::factor_params().m_p_trials == polynomial::default_factor_num_primes);
+    params_ref no_params;
+    upolynomial::factor_params fp;
+    fp.updt_params(no_params);
+    ENSURE(fp.m_p_trials == polynomial::default_factor_num_primes);
+
+    reslimit rl;
+    polynomial::numeral_manager nm;
+    polynomial::manager m(rl, nm);
+    polynomial_ref x0(m);
+    x0 = m.mk_polynomial(m.mk_var());
+    polynomial_ref p(m);
+    p = (x0^80) - 100;
+
+    upolynomial::manager um(rl, nm);
+    upolynomial::scoped_numeral_vector _p(um);
+    upolynomial::factors fs(um);
+    um.to_numeral_vector(p, _p);
+    try {
+        scoped_rlimit _limit(rl, 1000000);
+        um.factor(_p, fs, fp);
+    }
+    catch (z3_exception & ex) {
+        throw default_exception(std::string("degree-80 factorization failed (") + ex.what() +
+                                "); the default number of finite-field trials likely regressed (#10505)");
+    }
+    // y^80 - 100 = (y^40 - 10)*(y^40 + 10), both irreducible by Eisenstein at 2.
+    ENSURE(fs.distinct_factors() == 2);
+    upolynomial::scoped_numeral_vector _r(um);
+    fs.multiply(_r);
+    ENSURE(um.eq(_p, _r));
+}
+
 static void tst_rem(polynomial_ref const & p, polynomial_ref const & q, polynomial_ref const & expected) {
     ENSURE(is_univariate(p));
     ENSURE(is_univariate(q));
@@ -1069,6 +1120,7 @@ void tst_upolynomial() {
     tst_gcd();
     tst_lower_bound();
     tst_fact();
+    tst_fact_default_num_primes();
     tst_rem();
     tst_exact_div();
     tst_isolate_roots5();


### PR DESCRIPTION
Addresses https://github.com/Z3Prover/z3/pull/10552#issuecomment-5311396551 — the `api` unit test fails sporadically (`Ubuntu build - python make - MT`):

```
[95/96] api FAIL (exit code 134, 34.9s)
  what():  qfnra degree-80 regression returned unknown: max. resource limit exceeded
```

## Why it is not reproducible

`test_qfnra_degree80_square_bound` asserted that `Z3_solver_check` refutes `y^80 = x /\ 1 <= x <= 100 /\ 0 <= y < 1` within an rlimit of 2M, on the grounds that a resource count is machine independent. The count is, but the code path reaching it is not:

- `Z3_mk_solver` reaches `mk_qfnra_tactic`, and `mk_qfnra_mixed_solver` selects among five sub-solvers with `mk_memory_probe()` — `memory::get_allocation_size()`, a **process-global** counter — against a 30MB threshold. Anything allocated earlier in the same process moves that number, so adding an unrelated test to `tst_api()` can change which solver runs.
- Every candidate inside the chosen solver runs under a `try_for()` **wall-clock** deadline.

Measured on this branch's parent, one process, one test:

| build | `:max-memory` | wall time | rlimit |
|---|---|---|---|
| release | 0.4 MB | 0.18s | 819,428 |
| debug | **33.09 MB** | **6.2s** | 833,399 |

The debug run sits just past the 30MB threshold and spends 6.2 seconds working through `try_for` deadlines. On a loaded CI machine those deadlines expire after less work, so more candidates run, and the accumulated count crosses 2M and reports `unknown`.

The other hypothesis in the comment — global parameters interfering across threads — does not apply here: `run_test_child` runs each test in its own `popen` child process, so nothing leaks between tests.

This test was already removed once in f9c99afb3 ("Remove hanging QF_NRA API test") and came back through #10534, whose branch predated the removal.

## What replaces it

The fix being guarded (#10505, #10506) is a factoring default, so cover it where the measurement is deterministic. nlsat reaches the degree-80 univariate polynomial `y^80 - 100`, and factoring it costs:

| default `num_primes` | rlimit |
|---|---|
| 4 (`polynomial::default_factor_num_primes`) | 107,425 |
| 1 (the regression) | 7,455,518 |

A 1M limit sits 9x above the fixed path and 7x below the regression. Factoring is a pure computation with no wall-clock, memory-probe or global-parameter input, so the count is byte identical across runs and across debug and release. The new test also pins both default entry points, since `goal2nlsat` reaches the factorizer through `updt_params` rather than the constructor.

## Verification

- Reintroduced the regression by setting `default_factor_num_primes = 1`: the new test fails with `degree-80 factorization failed (canceled); the default number of finite-field trials likely regressed (#10505)`. Restored: passes.
- rlimit count identical across 3 runs and across Release and Debug builds.
- `test-z3 /a`: 96/96, Release (3x) and Debug.
- Debug `api` test: 6.38s -> 0.19s. New test costs 0.02s in release, 0.8s in debug.
