### PR TITLE
Fix compiler warnings reported by CI builds

### DIFF
--- a/src/api/c++/z3++.h
+++ b/src/api/c++/z3++.h
@@ -4156,6 +4156,8 @@ namespace z3 {
         case RTN: return expr(*this, Z3_mk_fpa_rtn(m_ctx));
         case RTZ: return expr(*this, Z3_mk_fpa_rtz(m_ctx));
         }
+        assert(false);
+        return expr(*this, Z3_mk_fpa_rne(m_ctx));
     }
 
     inline expr context::bool_val(bool b) { return b ? expr(*this, Z3_mk_true(m_ctx)) : expr(*this, Z3_mk_false(m_ctx)); }

--- a/src/api/java/NativeStatic.txt
+++ b/src/api/java/NativeStatic.txt
@@ -251,7 +251,7 @@ struct JavaOnClauseInfo {
 static void java_on_clause_eh(void* _p, Z3_ast proof_hint, unsigned n, unsigned const* deps, Z3_ast_vector literals) {
   JavaOnClauseInfo *info = static_cast<JavaOnClauseInfo*>(_p);
   jintArray jdeps = info->jenv->NewIntArray((jsize)n);
-  info->jenv->SetIntArrayRegion(jdeps, 0, (jsize)n, (jint*)deps);
+  info->jenv->SetIntArrayRegion(jdeps, 0, (jsize)n, reinterpret_cast<jint const*>(deps));
   info->jenv->CallVoidMethod(info->jobj, info->on_clause, (jlong)proof_hint, jdeps, (jlong)literals);
   info->jenv->DeleteLocalRef(jdeps);
 }

--- a/src/api/z3_private.h
+++ b/src/api/z3_private.h
@@ -30,7 +30,6 @@ extern "C" {
     bool Z3_API Z3_get_numeral_rational(Z3_context c, Z3_ast a, rational& r);
 
 #ifdef __cplusplus
-};
+}
 #endif // __cplusplus
-
 

--- a/src/ast/euf/euf_enode.h
+++ b/src/ast/euf/euf_enode.h
@@ -101,7 +101,7 @@ namespace euf {
 
         static enode* mk_tmp(region& r, unsigned num_args) {
             void* mem = r.allocate(get_enode_size(num_args));
-            enode* n = new (mem) enode(num_args);
+            enode* n = new (mem) enode(2);
             n->m_expr = nullptr;
             n->m_next = n;
             n->m_root = n;
@@ -114,7 +114,7 @@ namespace euf {
 
         static enode* mk_tmp(unsigned num_args) {
             void* mem = memory::allocate(get_enode_size(num_args));
-            enode* n = new (mem) enode(num_args);
+            enode* n = new (mem) enode(2);
             n->m_expr = nullptr;
             n->m_next = n;
             n->m_root = n;

--- a/src/ast/euf/euf_enode.h
+++ b/src/ast/euf/euf_enode.h
@@ -75,6 +75,8 @@ namespace euf {
         friend class etable;
         friend class egraph;
 
+        explicit enode(unsigned num_args): m_num_args(num_args) {}
+
         static unsigned get_enode_size(unsigned num_args) {
             return sizeof(enode) + num_args * sizeof(enode*);
         }
@@ -82,13 +84,12 @@ namespace euf {
         static enode* mk(region& r, expr* f, unsigned generation, unsigned num_args, enode* const* args) {
             SASSERT(num_args <= (is_app(f) ? to_app(f)->get_num_args() : 0));
             void* mem = r.allocate(get_enode_size(num_args));
-            enode* n = new (mem) enode();
+            enode* n = new (mem) enode(num_args);
             n->m_expr = f;
             n->m_next = n;
             n->m_root = n;
             n->m_generation = generation, 
             n->m_commutative = num_args == 2 && is_app(f) && to_app(f)->get_decl()->is_commutative();
-            n->m_num_args = num_args;
             n->m_cgc_enabled = true;
             for (unsigned i = 0; i < num_args; ++i) {
                 SASSERT(to_app(f)->get_arg(i) == args[i]->get_expr());
@@ -100,12 +101,11 @@ namespace euf {
 
         static enode* mk_tmp(region& r, unsigned num_args) {
             void* mem = r.allocate(get_enode_size(num_args));
-            enode* n = new (mem) enode();
+            enode* n = new (mem) enode(num_args);
             n->m_expr = nullptr;
             n->m_next = n;
             n->m_root = n;
             n->m_commutative = true;
-            n->m_num_args = 2;
             n->m_cgc_enabled = true;
             for (unsigned i = 0; i < num_args; ++i) 
                 n->m_args[i] = nullptr;            
@@ -114,12 +114,11 @@ namespace euf {
 
         static enode* mk_tmp(unsigned num_args) {
             void* mem = memory::allocate(get_enode_size(num_args));
-            enode* n = new (mem) enode();
+            enode* n = new (mem) enode(num_args);
             n->m_expr = nullptr;
             n->m_next = n;
             n->m_root = n;
             n->m_commutative = true;
-            n->m_num_args = 2;
             n->m_cgc_enabled = true;
             for (unsigned i = 0; i < num_args; ++i) 
                 n->m_args[i] = nullptr;            

--- a/src/ast/simplifiers/bv1_blaster.cpp
+++ b/src/ast/simplifiers/bv1_blaster.cpp
@@ -159,7 +159,7 @@ void bv1_blaster_simplifier::rw_cfg::reduce_extract(func_decl* f, expr* arg, exp
     bit_buffer bits;
     for (unsigned i = start; i <= end; ++i)
         bits.push_back(arg_bits[i]);
-    result = butil().mk_concat(bits.size(), bits.data());
+    result = butil().mk_concat(bits.size(), bits.empty() ? nullptr : bits.data());
 }
 
 void bv1_blaster_simplifier::rw_cfg::reduce_concat(unsigned num, expr* const* args, expr_ref& result) {
@@ -171,7 +171,7 @@ void bv1_blaster_simplifier::rw_cfg::reduce_concat(unsigned num, expr* const* ar
         get_bits(arg, arg_bits);
         bits.append(arg_bits.size(), arg_bits.data());
     }
-    result = butil().mk_concat(bits.size(), bits.data());
+    result = butil().mk_concat(bits.size(), bits.empty() ? nullptr : bits.data());
 }
 
 void bv1_blaster_simplifier::rw_cfg::reduce_bin_xor(expr* arg1, expr* arg2, expr_ref& result) {

--- a/src/math/lp/nla_explanations.cpp
+++ b/src/math/lp/nla_explanations.cpp
@@ -101,7 +101,7 @@ bool explanations::explain_ineq(lemma_builder& lemma, const lp::lar_term& t, llc
     if (t.is_empty() && rs.is_zero() &&
         (cmp == llc::LT || cmp == llc::GT || cmp == llc::NE)) return true;
     lp::explanation exp;
-    bool r;
+    bool r = false;
     switch (negate(cmp)) {
     case llc::LE:
         r = explain_upper_bound(t, rs, exp);

--- a/src/math/lp/nla_order_lemmas.cpp
+++ b/src/math/lp/nla_order_lemmas.cpp
@@ -235,7 +235,7 @@ void order::order_lemma_on_factorization(const monic& m, const factorization& ab
             lemma &= m;
         }
     }
-    for (unsigned j = 0, k = 1; j < 2; ++j, k--) {
+    for (unsigned j = 0; j < 2; ++j) {
         order_lemma_on_ac_explore(m, ab, j == 1);
     }
 }

--- a/src/math/realclosure/realclosure.cpp
+++ b/src/math/realclosure/realclosure.cpp
@@ -2423,7 +2423,7 @@ namespace realclosure {
             }
             SASSERT(i < n);
             SASSERT(!is_zero(p[i]));
-            ptr_buffer<value> nz_p;
+            ptr_vector<value> nz_p;
             for (; i < n; ++i)
                 nz_p.push_back(p[i].m_value);
             nz_isolate_roots(nz_p.size(), nz_p.data(), roots);
@@ -4100,7 +4100,7 @@ namespace realclosure {
             if (sz <= 1)
                 return 0;
             unsigned r = 0;
-            int sign, prev_sign;
+            int sign = 0, prev_sign;
             prev_sign = 0;
             unsigned i = 0;
             for (; i < sz; ++i) {
@@ -4955,7 +4955,7 @@ namespace realclosure {
         bool determine_sign(rational_function_value * v) {
             if (!contains_zero(v->interval()))
                 return true;
-            bool r;
+            bool r = false;
             switch (v->ext()->knd()) {
             case extension::TRANSCENDENTAL: determine_transcendental_sign(v); r = true; break; // it is never zero
             case extension::INFINITESIMAL:  determine_infinitesimal_sign(v);  r = true; break; // it is never zero

--- a/src/muz/spacer/spacer_util.cpp
+++ b/src/muz/spacer/spacer_util.cpp
@@ -798,12 +798,19 @@ struct adhoc_rewriter_rpp : public default_rewriter_cfg {
     }
 };
 
+static params_ref const& epp_params() {
+    static params_ref const p = [] {
+        params_ref result;
+        result.set_uint("min_alias_size", UINT_MAX);
+        result.set_uint("max_depth", UINT_MAX);
+        return result;
+    }();
+    return p;
+}
+
 mk_epp::mk_epp(ast *t, ast_manager &m, unsigned indent, unsigned num_vars,
                char const *var_prefix)
-    : mk_pp(t, m, m_epp_params, indent, num_vars, var_prefix), m_epp_expr(m) {
-    m_epp_params.set_uint("min_alias_size", UINT_MAX);
-    m_epp_params.set_uint("max_depth", UINT_MAX);
-
+    : mk_pp(t, m, epp_params(), indent, num_vars, var_prefix), m_epp_expr(m) {
     if (is_expr(m_ast)) {
         rw(to_expr(m_ast), m_epp_expr);
         m_ast = m_epp_expr;

--- a/src/muz/spacer/spacer_util.h
+++ b/src/muz/spacer/spacer_util.h
@@ -132,7 +132,6 @@ void find_decls(expr *fml, app_ref_vector &decls, std::string &prefix);
  * disables aliasing of common sub-expressions
  */
 struct mk_epp : public mk_pp {
-    params_ref m_epp_params;
     expr_ref m_epp_expr;
     mk_epp(ast *t, ast_manager &m, unsigned indent = 0, unsigned num_vars = 0,
            char const *var_prefix = nullptr);

--- a/src/qe/lite/qe_lite_tactic.cpp
+++ b/src/qe/lite/qe_lite_tactic.cpp
@@ -909,17 +909,17 @@ namespace fm {
         static unsigned get_obj_size(unsigned num_lits, unsigned num_vars) {
             return sizeof(constraint) + num_lits*sizeof(literal) + num_vars*(sizeof(var) + sizeof(rational));
         }
-        unsigned           m_id;
-        unsigned           m_num_lits:29;
-        unsigned           m_strict:1;
-        unsigned           m_dead:1;
-        unsigned           m_mark:1;
-        unsigned           m_num_vars;
-        literal *          m_lits;
-        var *              m_xs;
-        rational  *        m_as;
+        unsigned           m_id = 0;
+        unsigned           m_num_lits:29 = 0;
+        unsigned           m_strict:1 = 0;
+        unsigned           m_dead:1 = 0;
+        unsigned           m_mark:1 = 0;
+        unsigned           m_num_vars = 0;
+        literal *          m_lits = nullptr;
+        var *              m_xs = nullptr;
+        rational  *        m_as = nullptr;
         rational           m_c;
-        expr_dependency *  m_dep;
+        expr_dependency *  m_dep = nullptr;
         ~constraint() {
             rational * it  = m_as;
             rational * end = it + m_num_vars;

--- a/src/sat/smt/arith_diagnostics.cpp
+++ b/src/sat/smt/arith_diagnostics.cpp
@@ -190,7 +190,7 @@ namespace arith {
         family_id fid = m.get_family_id("arith");
         arith_util arith(m);
         solver& a = dynamic_cast<solver&>(*s.fid2solver(fid));
-        char const* name;
+        char const* name = nullptr;
         expr_ref_vector args(m);
 
         switch (m_ty) {
@@ -209,6 +209,8 @@ namespace arith {
         case hint_type::nla_h:
             name = "nla";
             break;
+        default:
+            UNREACHABLE();
         }
 
         auto push_eq = [&](bool is_eq, enode* x, enode* y) {

--- a/src/smt/mam.cpp
+++ b/src/smt/mam.cpp
@@ -3939,8 +3939,7 @@ namespace {
         void rematch(bool use_irrelevant) override {
             ptr_vector<code_tree>::iterator it  = m_trees.begin_code_trees();
             ptr_vector<code_tree>::iterator end = m_trees.end_code_trees();
-            unsigned lbl = 0;
-            for (; it != end; ++it, ++lbl) {
+            for (; it != end; ++it) {
                 code_tree * t = *it;
                 if (t) {
                     m_interpreter.init(t);
@@ -4059,4 +4058,3 @@ namespace smt {
         return alloc(mam_impl, ctx, true);
     }
 }
-

--- a/src/smt/theory_arith_core.h
+++ b/src/smt/theory_arith_core.h
@@ -922,8 +922,7 @@ namespace smt {
         theory_var base = r.m_base_var;
         typename vector<row_entry>::const_iterator it  = r.begin_entries();
         typename vector<row_entry>::const_iterator end = r.end_entries();
-        unsigned idx = 0;
-        for (; it != end; ++it, ++idx) {
+        for (; it != end; ++it) {
             if (!it->is_dead() && get_var_kind(it->m_var) == k && it->m_var != base) {
                 numeral c = it->m_coeff;
                 c.neg();
@@ -3028,7 +3027,6 @@ namespace smt {
     template<typename Ext>
     void theory_arith<Ext>::propagate_bounds() {
         TRACE(propagate_bounds_detail, display(tout););
-        unsigned count = 0;
         for (unsigned r_idx : m_to_check) {
             row & r = m_rows[r_idx];
             if (r.get_base_var() != null_theory_var) {
@@ -3038,14 +3036,14 @@ namespace smt {
                     is_row_useful_for_bound_prop(r, lower_idx, upper_idx);
 
                     if (lower_idx >= 0) 
-                        count += imply_bound_for_monomial(r, lower_idx, true);
+                        imply_bound_for_monomial(r, lower_idx, true);
                     else if (lower_idx == -1) 
-                        count += imply_bound_for_all_monomials(r, true);
+                        imply_bound_for_all_monomials(r, true);
                     
                     if (upper_idx >= 0) 
-                        count += imply_bound_for_monomial(r, upper_idx, false);
+                        imply_bound_for_monomial(r, upper_idx, false);
                     else if (upper_idx == -1) 
-                        count += imply_bound_for_all_monomials(r, false);
+                        imply_bound_for_all_monomials(r, false);
 
                     // sneaking cheap eq detection in this loop
                     propagate_cheap_eq(r_idx);

--- a/src/tactic/arith/fm_tactic.cpp
+++ b/src/tactic/arith/fm_tactic.cpp
@@ -335,17 +335,17 @@ class fm_tactic : public tactic {
         static unsigned get_obj_size(unsigned num_lits, unsigned num_vars) {
             return sizeof(constraint) + num_lits*sizeof(literal) + num_vars*(sizeof(var) + sizeof(rational));
         }
-        unsigned           m_id;
-        unsigned           m_num_lits:29;
-        unsigned           m_strict:1;
-        unsigned           m_dead:1;
-        unsigned           m_mark:1;
-        unsigned           m_num_vars;
-        literal *          m_lits;
-        var *              m_xs;
-        rational  *        m_as;
+        unsigned           m_id = 0;
+        unsigned           m_num_lits:29 = 0;
+        unsigned           m_strict:1 = 0;
+        unsigned           m_dead:1 = 0;
+        unsigned           m_mark:1 = 0;
+        unsigned           m_num_vars = 0;
+        literal *          m_lits = nullptr;
+        var *              m_xs = nullptr;
+        rational  *        m_as = nullptr;
         rational           m_c;
-        expr_dependency *  m_dep;
+        expr_dependency *  m_dep = nullptr;
         ~constraint() {
             rational * it  = m_as;
             rational * end = it + m_num_vars;

--- a/src/test/diff_logic.cpp
+++ b/src/test/diff_logic.cpp
@@ -39,7 +39,7 @@ struct tst_dl_functor {
     }
 };
 
-static void tst1() {
+[[maybe_unused]] static void tst1() {
     dlg g;
     smt::literal l;
     g.init_var(1);
@@ -55,7 +55,7 @@ static void tst1() {
     g.pop(1);
 }
 
-static void tst2() {
+[[maybe_unused]] static void tst2() {
     dlg g;
     rational w;
     smt::literal l1(1);
@@ -115,7 +115,7 @@ static int add_edge(dlg& g, dl_var src, dl_var dst, int weight, unsigned lit) {
     return id;
 }
 
-static void tst3() {
+[[maybe_unused]] static void tst3() {
     dlg g;
     for (unsigned i = 1; i <= 10; ++i) {
         g.init_var(i);

--- a/src/test/ext_numeral.cpp
+++ b/src/test/ext_numeral.cpp
@@ -34,8 +34,8 @@ static void tst_ ## NAME(int a, ext_numeral_kind ak, int expected_c, ext_numeral
     }                                                                   \
 }
 
-MK_TST_UNARY(neg);
-MK_TST_UNARY(inv);
+MK_TST_UNARY(neg)
+MK_TST_UNARY(inv)
 
 #define MK_TST_BIN_CORE(FUN_NAME, OP_NAME)                              \
 static void FUN_NAME(int a, ext_numeral_kind ak, int b, ext_numeral_kind bk, int expected_c, ext_numeral_kind expected_ck) { \
@@ -62,9 +62,9 @@ static void tst_ ## NAME(int a, ext_numeral_kind ak, int b, ext_numeral_kind bk,
     tst_ ## NAME ## _core(b, bk, a, ak, expected_c, expected_ck);       \
 }
 
-MK_TST_COMM_BIN(add);
-MK_TST_BIN(sub);
-MK_TST_COMM_BIN(mul);
+MK_TST_COMM_BIN(add)
+MK_TST_BIN(sub)
+MK_TST_COMM_BIN(mul)
 
 static void tst1() {
     tst_neg(0, EN_MINUS_INFINITY, 0, EN_PLUS_INFINITY);
@@ -170,12 +170,12 @@ static void tst_ ## NAME(int a, ext_numeral_kind ak, int b, ext_numeral_kind bk,
     tst_ ## NAME ## _core(b, bk, a, ak, expected);                      \
 }
 
-MK_TST_SYMM_REL(eq);
-MK_TST_SYMM_REL(neq);
-MK_TST_REL(lt);
-MK_TST_REL(gt);
-MK_TST_REL(le);
-MK_TST_REL(ge);
+MK_TST_SYMM_REL(eq)
+MK_TST_SYMM_REL(neq)
+MK_TST_REL(lt)
+MK_TST_REL(gt)
+MK_TST_REL(le)
+MK_TST_REL(ge)
 
 static void tst2() {
     tst_eq(0, EN_NUMERAL, 0, EN_NUMERAL, true);

--- a/src/test/interval.cpp
+++ b/src/test/interval.cpp
@@ -246,9 +246,9 @@ static void tst_ ## NAME(unsigned N, unsigned magnitude) {              \
     im.del(a); im.del(b); im.del(r);                                    \
 }
 
-MK_BINARY(mul, "(* a b)");
-MK_BINARY(add, "(+ a b)");
-MK_BINARY(sub, "(- a b)");
+MK_BINARY(mul, "(* a b)")
+MK_BINARY(add, "(+ a b)")
+MK_BINARY(sub, "(- a b)")
 
 static void tst_neg(unsigned N, unsigned magnitude) {
     reslimit rl;

--- a/src/test/karr.cpp
+++ b/src/test/karr.cpp
@@ -294,7 +294,7 @@ namespace karr {
 
     }
 
-};
+}
 
 void tst_karr() {
     karr::tst3();

--- a/src/test/mpff.cpp
+++ b/src/test/mpff.cpp
@@ -148,10 +148,10 @@ static void tst_ ## OP ## _core(int64_t n1, uint64_t d1, int64_t n2, uint64_t d2
     ENSURE(fm.le(fc2, fc1));                                           \
 }
 
-MK_BIN_OP(add);
-MK_BIN_OP(sub);
-MK_BIN_OP(mul);
-MK_BIN_OP(div);
+MK_BIN_OP(add)
+MK_BIN_OP(sub)
+MK_BIN_OP(mul)
+MK_BIN_OP(div)
 
 #define MK_BIN_RANDOM_TST(OP)                                           \
     static void tst_ ## OP(unsigned N, unsigned max, unsigned prec = 2, bool is_div = false) { \

--- a/src/test/sat_local_search.cpp
+++ b/src/test/sat_local_search.cpp
@@ -8,18 +8,14 @@
 
 static bool build_instance(char const * filename, sat::solver& s, sat::local_search& local_search)
 {
-    char  line[16383];
-    // for temporary storage
-
     std::ifstream infile(filename);
     if (!infile) {
         std::cout << "File not found " << filename << "\n";
         return false;
     }
-    infile.getline(line, 16383);
     int cur_term;
     int num_vars = 0, num_constraints = 0;
-    if (sscanf(line, "%d %d", &num_vars, &num_constraints) != 2) {
+    if (!(infile >> num_vars >> num_constraints)) {
         std::cout << "Failed to parse header (expected: num_vars num_constraints)\n";
         return false;
     }

--- a/src/util/debug.cpp
+++ b/src/util/debug.cpp
@@ -142,6 +142,7 @@ void set_default_exit_action(exit_action a) {
         }
         exit(code);
     }
+    abort();
 }
 
 atomic<debug_action> g_default_debug_action(debug_action::ask);

--- a/src/util/ref_buffer.h
+++ b/src/util/ref_buffer.h
@@ -43,6 +43,11 @@ protected:
             dec_ref(*it);
     }
 
+    void dec_all_ref() {
+        for (T* elem : m_buffer)
+            dec_ref(elem);
+    }
+
 public:
     typedef T * data_t;
 
@@ -51,7 +56,7 @@ public:
     }
 
     ~ref_buffer_core() {
-        dec_range_ref(m_buffer.begin(), m_buffer.end());
+        dec_all_ref();
     }
 
     void push_back(T * n) {
@@ -106,12 +111,12 @@ public:
     }
 
     void reset() {
-        dec_range_ref(m_buffer.begin(), m_buffer.end());
+        dec_all_ref();
         m_buffer.reset();
     }
 
     void finalize() {
-        dec_range_ref(m_buffer.begin(), m_buffer.end());
+        dec_all_ref();
         m_buffer.finalize();
     }        
 
@@ -186,4 +191,3 @@ template<typename T, unsigned INITIAL_SIZE=16>
 class sref_buffer : public ref_buffer_core<T, ref_unmanaged_wrapper<T>, INITIAL_SIZE> {
 public:
 };
-

--- a/src/util/sorting_network.h
+++ b/src/util/sorting_network.h
@@ -689,7 +689,7 @@ Notes:
         literal mk_exactly_1(bool full, unsigned n, literal const* xs) {
             TRACE(pb, tout << "exactly 1 with " << n << " arguments " << (full?"full":"not full") << "\n";);
             literal_vector ors;
-            literal r1;
+            literal r1 = ctx.mk_false();
             switch (m_cfg.m_encoding) {
             case sorting_network_encoding::grouped_at_most:
             case sorting_network_encoding::sorted_at_most:


### PR DESCRIPTION
## Summary
- initialize enum-switch results and placement-allocated fields flagged as potentially uninitialized
- fix a pretty-printer parameter lifetime bug and make inline-buffer ownership explicit
- remove C++98 compatibility, cast-qualifier, unused-code, and MSVC secure-CRT warnings in bindings and tests

## Build-log review
Reviewed 83 completed Z3 build/test workflow logs from the preceding 24 hours. Recurring source warnings were concentrated in GCC/MinGW maybe-uninitialized diagnostics, Clang portability/unused diagnostics, the generated Java callback cast, and one MSVC sscanf warning. Transient checkout, cache, and CMake environment warnings were not source defects.

## Validation
- CMake Debug build of test-z3
- test-z3 /a (96/96)