### PR TITLE
nla: make the bounded_nlsat probe backoff cost-aware

### DIFF
--- a/src/math/lp/nla_core.cpp
+++ b/src/math/lp/nla_core.cpp
@@ -1010,17 +1010,22 @@ lbool core::bounded_nlsat() {
     lbool ret;
     p.set_uint("max_conflicts", 100);
     m_nra.updt_params(p);
+    uint64_t probe_cost = m_nra_lim.count();
     {
         scoped_limits sl(m_reslim);
         sl.push_child(&m_nra_lim);
         scoped_rlimit sr(m_nra_lim, 100000);
         ret = m_nra.check();
     }
-    p.set_uint("max_conflicts", lp_settings().m_max_conflicts);            
+    probe_cost = m_nra_lim.count() - probe_cost;
+    p.set_uint("max_conflicts", lp_settings().m_max_conflicts);
     m_nra.updt_params(p);
     lp_settings().stats().m_nra_calls++;
-    // On a conflict re-engage, otherwise back off.
-    m_nlsat_backoff.update(ret == l_false);
+    // A conflict, or a probe that cost almost nothing, re-engages; only an
+    // expensive inconclusive probe backs off. A search that needs a cheap
+    // satisfiability certificate every round to advance (e.g. between
+    // quantifier instantiation rounds) must not be starved of them.
+    m_nlsat_backoff.update(ret == l_false || probe_cost < 10000);
 
     if (ret == l_true)
         clear();

--- a/src/math/lp/nla_core.cpp
+++ b/src/math/lp/nla_core.cpp
@@ -946,7 +946,7 @@ lbool core::check(unsigned level) {
             ++m_check_assignment_fail_cnt;
     }
 
-    if (no_effect() && should_run_bounded_nlsat()) 
+    if (no_effect() && should_run_bounded_nlsat())
         ret = bounded_nlsat();
                 
     if (no_effect()) 
@@ -974,7 +974,7 @@ lbool core::check(unsigned level) {
         check_weighted(3, checks);
 
         unsigned num_calls = lp_settings().stats().m_nla_calls;
-        if (!conflict_found() && params().arith_nl_nra() && num_calls % 50 == 0 && num_calls > 500) 
+        if (!conflict_found() && params().arith_nl_nra() && num_calls % 50 == 0 && num_calls > 500)
             ret = bounded_nlsat();
     }
 
@@ -1005,27 +1005,45 @@ bool core::should_run_bounded_nlsat() {
     return params().arith_nl_nra() && m_nlsat_backoff.should_run();
 }
 
+// One budget-limited run of the nlsat solver on the full set of nonlinear
+// constraints. nlsat is complete for nonlinear real arithmetic but can be
+// arbitrarily expensive, so the run is capped by a conflict and an rlimit
+// budget. l_true: nlsat found a model, the state is satisfiable; l_false:
+// nlsat proved infeasibility and produced a lemma; l_undef: nlsat exhausted
+// its budget without an answer.
 lbool core::bounded_nlsat() {
+    const unsigned max_conflicts_budget = 100;
+    const unsigned rlimit_budget = 100000;
     params_ref p;
     lbool ret;
-    p.set_uint("max_conflicts", 100);
+    p.set_uint("max_conflicts", max_conflicts_budget);
     m_nra.updt_params(p);
-    uint64_t probe_cost = m_nra_lim.count();
+    uint64_t rlimit_consumed = 0;
     {
         scoped_limits sl(m_reslim);
-        sl.push_child(&m_nra_lim);
-        scoped_rlimit sr(m_nra_lim, 100000);
+        sl.push_child(&m_nra_lim); // zeroes m_nra_lim's counter
+        scoped_rlimit sr(m_nra_lim, rlimit_budget);
         ret = m_nra.check();
+        // must be read here: pop_child transfers the child's count to the
+        // parent and zeroes it, so outside this block the counter is 0 again
+        rlimit_consumed = m_nra_lim.count();
     }
-    probe_cost = m_nra_lim.count() - probe_cost;
     p.set_uint("max_conflicts", lp_settings().m_max_conflicts);
     m_nra.updt_params(p);
     lp_settings().stats().m_nra_calls++;
-    // A conflict, or a probe that cost almost nothing, re-engages; only an
-    // expensive inconclusive probe backs off. A search that needs a cheap
-    // satisfiability certificate every round to advance (e.g. between
-    // quantifier instantiation rounds) must not be starved of them.
-    m_nlsat_backoff.update(ret == l_false || probe_cost < 10000);
+
+    // A conflict, or a run that consumed almost none of its budget,
+    // re-engages the backoff scheduler; only an expensive run that gave up
+    // backs off. A search that needs a cheap satisfiability certificate
+    // every round to advance (e.g. between quantifier instantiation rounds)
+    // must not be starved of them.
+    bool cheap = rlimit_consumed < rlimit_budget / 10;
+    bool re_engage = ret == l_false || cheap;
+    m_nlsat_backoff.update(re_engage);
+
+    IF_VERBOSE(3, verbose_stream() << "(nla-bounded-nlsat :result " << ret
+               << " :rlimit-consumed " << rlimit_consumed
+               << " :re-engage " << (re_engage ? "true" : "false") << ")\n");
 
     if (ret == l_true)
         clear();

--- a/src/math/lp/nra_solver.cpp
+++ b/src/math/lp/nra_solver.cpp
@@ -36,6 +36,7 @@ struct solver::imp {
     scoped_ptr<scoped_anum_vector>   m_values; // values provided by LRA solver
     scoped_ptr<scoped_anum> m_tmp1, m_tmp2;
     nla::coi                  m_coi;
+    indexed_uint_set          m_skipped_constraints; // COI constraints kept out of the nlsat problem
     svector<lp::constraint_index> m_literal2constraint;
     struct eq {
         bool operator()(unsigned_vector const &a, unsigned_vector const &b) const {
@@ -62,6 +63,36 @@ struct solver::imp {
         m_nlsat = alloc(nlsat::solver, m_limit, m_params, false);
         m_values = alloc(scoped_anum_vector, am());
         m_lp2nl.reset();
+        m_skipped_constraints.reset();
+    }
+
+    // Power of two dividing the denominator of r (capped at 64).
+    static unsigned dyadic_valuation_of_denominator(rational const& r) {
+        rational den = denominator(r);
+        unsigned k = 0;
+        while (k < 64 && den.is_even()) {
+            den /= 2;
+            ++k;
+        }
+        return k;
+    }
+
+    // Bounds derived by the eager bound squeeze reach the constraint set as
+    // asserted atoms whose values are LP-vertex/delta-rational artifacts with a
+    // huge power-of-two denominator (e.g. 1367758954463/2^39). They are implied
+    // by the constraints they were derived from, yet after clearing denominators
+    // they inject outsized coefficients into the nlsat polynomials and blow up
+    // the resultant computations. Decimal constants from the input have
+    // denominators 10^k = 2^k*5^k with small k, so a large dyadic valuation
+    // singles out the derived bounds.
+    bool is_dyadic_artifact(lp::lar_base_constraint const& c) const {
+        unsigned const dyadic_artifact_threshold = 24;
+        if (dyadic_valuation_of_denominator(c.rhs()) >= dyadic_artifact_threshold)
+            return true;
+        for (auto const& [coeff, v] : c.coeffs())
+            if (dyadic_valuation_of_denominator(coeff) >= dyadic_artifact_threshold)
+                return true;
+        return false;
     }
 
     // Create polynomial definition for variable v used in setup_solver_poly.
@@ -122,6 +153,11 @@ struct solver::imp {
         // we rely on that all information encoded into the tableau is present as a constraint.
         for (auto ci : m_coi.constraints()) {
             auto &c = lra.constraints()[ci];
+            if (is_dyadic_artifact(c)) {
+                // implied bound artifact: keep it out of the nlsat problem
+                m_skipped_constraints.insert(ci);
+                continue;
+            }
             auto &pm = m_nlsat->pm();
             auto k = c.kind();
             auto rhs = c.rhs();
@@ -240,8 +276,10 @@ struct solver::imp {
             lra.init_model();
             for (lp::constraint_index ci : lra.constraints().indices()) {
                 if (check_constraint(ci)) continue;
-                // Non-COI constraint violations are benign; only COI violations indicate a bug.
-                if (m_coi.constraints().contains(ci)) {
+                // Non-COI constraint violations are benign, and constraints deliberately
+                // kept out of the nlsat problem may be violated by its model; only
+                // violations of COI constraints nlsat actually saw indicate a bug.
+                if (m_coi.constraints().contains(ci) && !m_skipped_constraints.contains(ci)) {
                     IF_VERBOSE(0, verbose_stream() << "constraint " << ci << " violated\n";
                                lra.constraints().display(verbose_stream()));
                     UNREACHABLE();


### PR DESCRIPTION
Fixes #10567.

The backoff introduced in #10521 doubled the `bounded_nlsat` delay on every non-conflict outcome (`l_true` and `l_undef` alike). That starves searches that need a cheap satisfiability certificate from the bounded nlsat run every round to advance. Both reproducers in #10567 bisect to #10521, and `iss-2603` (sat→timeout since 2026-07-25) has the same root cause.

## Changes

1. **Back off on cost, not outcome** (`nla_core.cpp`). A conflict, or a bounded nlsat run that consumed under 10% of its rlimit budget, re-engages; only an expensive inconclusive run backs off.
2. **Fix the cost measurement** (`nla_core.cpp`). The first version of this PR measured the run's cost as the difference of `m_nra_lim.count()` outside the scoped block; `push_child`/`pop_child` zero that counter on entry and drain it on exit, so the measured cost was always 0 and the backoff never engaged at all. The counter is now read inside the scope. **The validation numbers originally posted here were produced by that broken build** (effectively "never back off") and have been replaced by the table below.
3. **Keep dyadic implied-bound artifacts out of the nlsat problem** (`nra_solver.cpp`). Bounds derived by the eager bound squeeze come back from the SMT layer as constraints whose rationals have huge power-of-two denominators (e.g. `1367758954463/2^39`); after clearing denominators they inject ~2^42 coefficients into the nlsat polynomials and blow up resultant computations — this is what made the `l_undef` runs on iss-8099 burn their full budget. Constraints with a coefficient or rhs denominator divisible by 2^24 are now skipped when building the nlsat problem (decimal input constants, `10^k = 2^k·5^k`, pass untouched). Dropping constraints only weakens the problem, so `unsat` answers remain sound; a model violating a skipped constraint yields `l_undef`. Diagnostics: `-v:3` prints one line per bounded run, e.g. `(nla-bounded-nlsat :result l_false :rlimit-consumed 36557 :re-engage true)`.

## Validation (release build, all three commits)

| benchmark | nightly (with #10521) | this PR |
|---|---|---|
| iss-8099 bug-1 (`-T:20`) | timeout | `sat`, 1.8s (pre-#10521: 1.9s) |
| iss-8208 (`-T:20`) | timeout | `unsat`, 0.04s |
| iss-2603 | timeout | `sat`, 0.08s |
| queries-FStar.Matrix-2 (#10521 headline) | 15× `unsat`, 0.52s | 15× `unsat`, 0.49s |
| queries-FStar.UInt128-1 | 2× `unsat`, 0.06s | 2× `unsat`, 0.05s |
| queries-Pulse.Lib.HashTable.Spec-1 | 6 `unsat` / 4 `unknown`, 1.33s | same, 1.21s |
| queries-FStar.Math.Euclid-1 | `unsat`, 0.01s | `unsat`, 0.01s |

10-seed check: iss-8099 `sat` 10/10 (1.6–2.9s); iss-8208 `unsat` 8/10 — seeds 1 and 5 time out on every variant tested, including one with the backoff disabled entirely, so that fragility is unrelated to this change.

QF_NIA spot check (random subsets, 20s timeout): `QF_NIA_small` 59/78 solved on both sides with equal totals; `QF_NIA_SAT` 65/68 vs 66/68 — one borderline file (`zlib-crc32-BYFOUR`, 17s on nightly) crosses the timeout, while others improve (e.g. `Velroyen08` 6.9s → 1.7s).

## Residual

* The 45-file diverged nightly-gate sweep still needs a re-run on this build (the previously posted sweep used the broken measurement).
* The 2^24 threshold would also skip genuine binary-scaled constants (e.g. floating-point-derived inputs), costing completeness (`l_undef`) but never soundness there. It could be made a parameter if that bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
