### PR TITLE
array_decl_plugin: correct diagnostic when select's first argument is not an array

### DIFF
--- a/src/ast/array_decl_plugin.cpp
+++ b/src/ast/array_decl_plugin.cpp
@@ -228,12 +228,17 @@ func_decl* array_decl_plugin::mk_select(unsigned arity, sort * const * domain) {
         return nullptr;
     }
     sort * s = domain[0];
+    if (!is_array_sort(s)) {
+        m_manager->raise_exception(std::format("select expects the first argument sort to be an array, but was provided a value of sort {}",
+                                                to_string(sort_ref(s, *m_manager))));
+        return nullptr;
+    }
     unsigned num_parameters = s->get_num_parameters();
     parameter const* parameters = s->get_parameters();
- 
+
     if (num_parameters != arity) {
-        m_manager->raise_exception(std::format("select requires {} arguments, but was provided with {} arguments", 
-                                                num_parameters, arity));
+        m_manager->raise_exception(std::format("select expects the first argument to be an array taking {}, instead it was passed {} arguments",
+                                                num_parameters - 1, arity - 1));
         return nullptr;
     }
     ptr_buffer<sort> new_domain; // we need this because of coercions.


### PR DESCRIPTION
Addresses the diagnostic half of #10570.

`array_decl_plugin::mk_select` read `get_num_parameters()` off the first argument's sort before checking that it is an array sort. Applying `select` to a non-array value — e.g. after an ambiguous user overload resolves to an `Int`-returning declaration — produced:

```
(error "select requires 0 arguments, but was provided with 2 arguments")
```

With this change:

```
(error "select expects the first argument sort to be an array, but was provided a value of sort Int")
```

and the genuine index-count mismatch case is phrased in terms of index counts, mirroring `mk_store`:

```
(error "select expects the first argument to be an array taking 2, instead it was passed 1 arguments")
```

The hash-order dependence of the overload resolution itself (the other half of #10570) is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
