### PR TITLE
Skip divisibility-closure registration for zero dividends in theory_lra (fixes #10579)

### DIFF
--- a/src/smt/theory_lra.cpp
+++ b/src/smt/theory_lra.cpp
@@ -486,8 +486,12 @@ class theory_lra::imp {
                         theory_var rv = mk_var(n);
                         m_nla->add_bounded_division(register_theory_var_in_lar_solver(q), register_theory_var_in_lar_solver(x), register_theory_var_in_lar_solver(y), register_theory_var_in_lar_solver(rv));
                     }
-                    if (!a.is_numeral(n2) && is_app(n1) && is_app(n2)) {
-                        // register mod(x, y) with variable divisor for divisibility reasoning
+                    if (!a.is_numeral(n2) && !a.is_zero(n1) && is_app(n1) && is_app(n2)) {
+                        // register mod(x, y) with variable divisor for divisibility reasoning;
+                        // skip a zero dividend: mk_idiv_mod_axioms already forces
+                        // y != 0 => mod(0, y) = 0 and div(0, y) = 0 by linear axioms, so
+                        // divisibility closure adds nothing and ensure_nla() here would
+                        // pull an otherwise linear problem into the nonlinear solver
                         ensure_nla();
                         if (m_nla) {
                             app_ref div(a.mk_idiv(n1, n2), m);


### PR DESCRIPTION
Fixes #10579.

## Problem

Commit 7b26fe1 (#10107) registers every variable-divisor `mod` term with the nla divisibility-closure engine. That regressed this 5-line optimization instance from instant `sat` to a >20s timeout:

```smt2
(declare-const a Real)
(declare-const b Real)
(assert (> b (to_real (mod 0 a))))
(maximize a)
(check-sat)
```

## Root cause

`mk_idiv_mod_axioms` has a dedicated **linear** path for a zero dividend: `y != 0 => mod(0, y) = 0` and `div(0, y) = 0`, precisely so that `mod 0 y` never pulls in nonlinear reasoning. The new registration block in `theory_lra.cpp` did not exempt this case: it called `ensure_nla()` and internalized a fresh `(div 0 y)` term, dragging the otherwise linear problem into the nonlinear/integer-branching machinery. Under `maximize` this turned unbounded-objective detection into endless branch-and-bound (~14k `arith-branch` before the timeout).

The closure lemmas themselves can never fire on zero-dividend entries anyway — `check_linear_divisibility` skips zero dividend values on both sides, and for `check_mod_congruence` the zero-dividend entry only reproduces the already-asserted Euclidean identity — so the registration carried pure cost and no reasoning power.

## Fix

Skip the divisibility registration when the dividend is the numeral 0, mirroring the zero-dividend special case in `mk_idiv_mod_axioms`.

## Validation

- iss10579 repro: `sat` in 0.01s again (was timeout); Int-divisor variant likewise; non-`maximize` variant unchanged.
- #7464 repro (the instance 7b26fe1 fixed): still `unsat` in 0.015s.
- z3test `regressions/issues`: all pass.
- 150 differential-fuzz mod/div formulas with variable divisors (including zero-dividend `mod`) vs 4.15.4: 0 mismatches.

Note: variable-divisor `mod` with a **nonzero** dividend under `maximize` (e.g. `(> b (to_real (mod 1 a)))`) still times out, but it also timed out before 7b26fe1 — pre-existing and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)