### PR TITLE
theory_lra: index m_bool_var2bound by bool_var instead of hashing it

### DIFF
--- a/src/smt/theory_lra.cpp
+++ b/src/smt/theory_lra.cpp
@@ -159,7 +159,7 @@ class theory_lra::imp {
     vector<ptr_vector<api_bound> > m_use_list;        // bounds where variables are used.
 
     // attributes for incremental version:
-    u_map<api_bound*>      m_bool_var2bound;
+    ptr_vector<api_bound>  m_bool_var2bound;   // indexed by bool_var (dense); nullptr = absent
     vector<lp_bounds>      m_bounds;
     unsigned_vector        m_unassigned_bounds;
     unsigned_vector        m_bounds_trail;
@@ -952,7 +952,8 @@ public:
         lp_api::bound_kind k;
         theory_var v = null_theory_var;
         bool_var bv = ctx().mk_bool_var(atom);
-        m_bool_var2bound.erase(bv);
+        if (bv < m_bool_var2bound.size())
+            m_bool_var2bound[bv] = nullptr;
         ctx().set_var_theory(bv, get_id());
         if (a.is_le(atom, n1, n2) && a.is_extended_numeral(n2, r) && is_app(n1)) {
             v = internalize_def(to_app(n1));
@@ -992,7 +993,7 @@ public:
         m_bounds[v].push_back(b);
         updt_unassigned_bounds(v, +1);
         m_bounds_trail.push_back(v);
-        m_bool_var2bound.insert(bv, b);
+        m_bool_var2bound.setx(bv, b, nullptr);
         mk_bound_axioms(*b);
         TRACE(arith_internalize, tout << "Internalized " << bv << ": " << bpp(atom) << "\n";);
         return true;
@@ -1030,8 +1031,8 @@ public:
     }
 
     lbool get_phase(bool_var v) {
-        api_bound* b;
-        if (!m_bool_var2bound.find(v, b)) {
+        api_bound* b = m_bool_var2bound.get(v, nullptr);
+        if (!b) {
             return l_undef;
         }
         lp::lconstraint_kind k = lp::EQ;
@@ -2293,10 +2294,10 @@ public:
         while (m_asserted_qhead < m_asserted_atoms.size() && !ctx().inconsistent() && m.inc()) {
             auto [bv, is_true] = m_asserted_atoms[m_asserted_qhead];
                         
-            api_bound* b = nullptr;
+            api_bound* b = m_bool_var2bound.get(bv, nullptr);
             TRACE(arith, tout << "propagate: " << literal(bv, !is_true) << "\n";
-                  if (!m_bool_var2bound.contains(bv)) tout << "not found\n");
-            if (m_bool_var2bound.find(bv, b) && !assert_bound(bv, is_true, *b)) {
+                  if (!b) tout << "not found\n");
+            if (b && !assert_bound(bv, is_true, *b)) {
                 get_infeasibility_explanation_and_set_conflict();
                 return true;
             }
@@ -4400,7 +4401,8 @@ public:
         if (!ctx().b_internalized(b)) {
             fm.hide(b->get_decl());
             bool_var bv =  ctx().mk_bool_var(b);
-            m_bool_var2bound.erase(bv);
+            if (bv < m_bool_var2bound.size())
+                m_bool_var2bound[bv] = nullptr;
             ctx().set_var_theory(bv, get_id());
             // ctx().set_enode_flag(bv, true);
             lp_api::bound_kind bkind = lp_api::bound_kind::lower_t;
@@ -4411,7 +4413,7 @@ public:
             updt_unassigned_bounds(v, +1);
             m_bounds[v].push_back(a);
             m_bounds_trail.push_back(v);
-            m_bool_var2bound.insert(bv, a);
+            m_bool_var2bound.setx(bv, a, nullptr);
 
             TRACE(arith, tout << "internalized " << bv << ": " << mk_pp(b, m) << "\n";);
         }


### PR DESCRIPTION
Fixes the hotspot reported in Z3Prover/bench#3613.

## The bug

`theory_lra::m_bool_var2bound` is a `u_map<api_bound*>`. Three things combine into an algorithmic pathology:

1. **`u_hash` is the identity** (`src/util/map.h:280`), so key `k` always lands at slot `k & mask`.
2. **bool_vars are recycled.** Backtracking deletes them, the ids get reused, and the same atoms are internalized again and again. On `inputs/issues/iss-2178/bug-1.smt2` that means **147,668 inserts over only 8,699 distinct live keys**, max bool_var 9,954 — all packed into the contiguous prefix of a 16,384-slot table.
3. **`insert` only stops at a FREE slot.** A *deleted* slot is remembered as a reuse candidate but does not terminate the linear probe (`INSERT_LOOP_BODY`, `src/util/hashtable.h`). `internalize_atom` does `erase(bv)` immediately before `insert(bv, b)`, so that prefix becomes permanently used-or-deleted.

Result: inserting key `k` walks roughly `9955 - k` slots. The operation is **O(#distinct bool_vars), not O(1)** — internalization becomes quadratic.

Callgrind on `bug-1.smt2` at `rlimit=3000000`:

```
1,665,529,892 (18.77%)  core_hashtable<...bound<sat::literal>*...>::insert
  236,916,885 ( 2.67%)  mpz_manager<true>::del      <- next hotspot, 7x smaller
```

11,279 instructions per insert. Replaying the real key trace through the probing logic gives **207,448,738 probes, 1,404.8 per insert** — at ~8 Ir/probe that is 1.66e9 Ir, matching the measured 1,665,529,892 almost exactly. Doubling the inserts doubles the per-insert cost (5,765 Ir at `rlimit=1.5M` → 11,279 at `rlimit=3M`), confirming it is quadratic rather than a constant factor.

## The fix

bool_var ids are dense small unsigned integers, and smt already keeps several bool_var-indexed vectors (`m_assignment`, `m_bdata`, `m_activity`, `m_watches`, ...), so index a `ptr_vector` directly. `api_bound*` is never null when stored, which makes the `find`/`contains` → `get(bv, nullptr)` rewrite exact. One file, +12/−10.

## Measurements

On `bug-1.smt2`, same tree and flags, identical search (`conflicts`, `decisions`, `mk-bool-var`, `quant-instantiations`, `rlimit-count`, `memory` all unchanged):

| | base | patched | |
|---|---|---|---|
| instructions, `rlimit=3000000` | 8,872,944,804 | 7,202,192,073 | **−18.8%** |
| wall, `rlimit=3,000,000` | 1.55s | 1.40s | −10% |
| wall, `rlimit=20,000,000` | 17.48s | 12.84s | **−27%** |
| wall, `rlimit=60,000,000` | 71.41s | 43.44s | **−39%** |

No memory regression (max-memory 187.47 → 186.29 MB).

## What this is not

**Corpus-wide this is not a broad speedup, and the PR does not claim one.** A/B against master over SMT-LIB 2025 AUFLIRA, QF_ANIA, QF_S, QF_SLIA, QF_UFDTLIA, QF_UFLIA and QF_UFNIA — ~128k benchmark pairs at `-T:20` — puts per-logic medians within about ±2%, with p10/p90 spanning ±10–15%, i.e. inside shared-runner noise. QF_SLIA, the only logic with a large sample (4,525 benchmarks over 2s), sits at +1.5%.

A probe-waste screen over the corpus shows why: 363 of 634 sampled benchmarks do **zero** `theory_lra` bound inserts and cannot be affected at all. The win is confined to benchmarks that re-internalize arithmetic atoms often enough for the quadratic term to dominate. Measured serially on an idle machine, the six highest-waste benchmarks in the corpus gain 26.8% (`bug-1.smt2`), 9.2%, 5.2%, 4.2%, 2.8% and 0.8%.

The case for this change is *removing an O(#bool_vars)-per-insert pathology with no measured downside*, not a corpus-wide gain.

## Correctness

- **Zero sat/unsat disagreements across ~128k corpus benchmark pairs.** Every status difference in the A/B is a timeout / `signal-9` / wall-timeout category flip.
- A local differential run over 600 benchmarks from Z3Prover/bench at `rlimit=2000000`, comparing full stdout and stderr, shows **no differences**.
- **No regressions.** The per-benchmark losses visible in the A/B are runner noise. On the worst-looking pair (QF_UFNIA, where only 28 of 206 benchmarks complete) the CI outliers span −28% to +61%; re-measured serially on an idle machine every one falls within 3.4% of zero, **in both directions** — the CI "wins" evaporate exactly as the "losses" do. On those benchmarks the search is bit-identical and max-memory is slightly lower with the patch. The CI data also contains an impossibility — one benchmark flipping `base=unsat` to `patched=timeout` — which can only be runner timing swing, since the search is deterministic and the patch only ever removes work.

## Follow-up (not in this PR)

`src/sat/smt/arith_solver.h:217` has the identical `u_map<api_bound*> m_bool_var2bound` with the same erase-then-insert pattern (`arith_internalize.cpp:330`, `:396`) and the same latent blowup. Happy to fold it in here if preferred.

More generally, any `u_map` whose keys are recycled dense ids and which sees erase traffic can degrade this way, since the identity hash packs every key into a prefix and tombstones never terminate a probe. Giving `u_hash` a mixing function would fix the whole class, but it changes `u_map` iteration order globally and could perturb heuristics across z3 — the local vector change is the safer call.
