### PR TITLE
nla_powers: drop infinitesimals before checking power terms

### DIFF
--- a/src/math/lp/nla_core.cpp
+++ b/src/math/lp/nla_core.cpp
@@ -846,6 +846,10 @@ void core::check_weighted(unsigned sz, std::pair<unsigned, std::function<void(vo
 
 lbool core::check_power(lpvar r, lpvar x, lpvar y) {
     clear();
+    // powers::check and lemma validation read only the rational parts of the
+    // column values; drop infinitesimals first, as init_to_refine does for check().
+    if (lra.is_feasible())
+        lra.get_rid_of_inf_eps();
     return m_powers.check(r, x, y, m_lemmas);
 }
 


### PR DESCRIPTION
theory_lra::eval_power calls core::check_power directly, bypassing core::check and thus init_to_refine's lra.get_rid_of_inf_eps(). The power solver was the only nla path that saw raw delta components, and since #10588 it returned l_undef whenever x, y or r carried one, turning inputs such as issue #6499 case 2 ((=> ass (= exp 1)), (not (= 2 (^ 2 exp))), (check-sat ass)) into 'unknown'.

Call get_rid_of_inf_eps() in core::check_power, as check() does, so powers::check reasons over a rational model and the existing lemmas apply. Fixes #6499.