### PR TITLE
Fix FP overflow models with relevancy disabled

### DIFF
--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -2812,15 +2812,20 @@ void fpa2bv_converter::mk_to_fp_real(func_decl * f, sort * s, expr * rm, expr * 
         unsigned max_exp = m_mpz_manager.get_uint(max_exp_z);
         rational max_sig = m_mpf_manager.m_powers2.m1(sbits) / m_mpf_manager.m_powers2(sbits-1);
         max_real = max_sig * rational(m_mpf_manager.m_powers2(max_exp));
+        rational nearest_max_real = rational(m_mpf_manager.m_powers2(max_exp));
+        nearest_max_real /= rational(m_mpf_manager.m_powers2(sbits));
+        nearest_max_real += max_real;
         TRACE(fpa2bv_to_real, tout << "max exp: " << max_exp << " max real: " << max_real << std::endl;);
 
         expr_ref r_is_pinf(m), r_is_ninf(m);
         mk_is_pinf(result, r_is_pinf);
         mk_is_ninf(result, r_is_ninf);
 
-        expr_ref e_max_real(m), e_max_real_neg(m);
+        expr_ref e_max_real(m), e_max_real_neg(m), e_nearest_max_real(m), e_nearest_max_real_neg(m);
         e_max_real = m_arith_util.mk_numeral(max_real, false);
         e_max_real_neg = m_arith_util.mk_numeral(-max_real, false);
+        e_nearest_max_real = m_arith_util.mk_numeral(nearest_max_real, false);
+        e_nearest_max_real_neg = m_arith_util.mk_numeral(-nearest_max_real, false);
 
         expr_ref rm_nta(m), rm_nte(m), rm_tp(m), rm_tn(m), rm_tz(m);
         mk_is_rm(bv_rm, BV_RM_TIES_TO_AWAY, rm_nta);
@@ -2829,14 +2834,17 @@ void fpa2bv_converter::mk_to_fp_real(func_decl * f, sort * s, expr * rm, expr * 
         mk_is_rm(bv_rm, BV_RM_TO_NEGATIVE, rm_tn);
         mk_is_rm(bv_rm, BV_RM_TO_ZERO, rm_tz);
 
-        // IEEE 754: RNE/RNA carry all overflows to infinity with the sign of the result.
-        // RTP carries positive overflow to +inf, RTN carries negative overflow to -inf.
-        expr_ref rm_rounds_to_pinf(m), rm_rounds_to_ninf(m);
-        rm_rounds_to_pinf = m.mk_or(rm_tp, m.mk_or(rm_nte, rm_nta));
-        rm_rounds_to_ninf = m.mk_or(rm_tn, m.mk_or(rm_nte, rm_nta));
+        // Directed rounding overflows immediately beyond the largest finite value.
+        // Nearest rounding overflows at the midpoint to the next binade.
+        expr_ref rm_rounds_to_nearest(m);
+        rm_rounds_to_nearest = m.mk_or(rm_nte, rm_nta);
         expr_ref implies_gt_max_real(m), implies_lt_min_real(m);
-        implies_gt_max_real = m.mk_implies(r_is_pinf, m.mk_and(rm_rounds_to_pinf, m_arith_util.mk_gt(x, e_max_real)));
-        implies_lt_min_real = m.mk_implies(r_is_ninf, m.mk_and(rm_rounds_to_ninf, m_arith_util.mk_lt(x, e_max_real_neg)));
+        implies_gt_max_real = m.mk_implies(r_is_pinf,
+            m.mk_or(m.mk_and(rm_tp, m_arith_util.mk_gt(x, e_max_real)),
+                    m.mk_and(rm_rounds_to_nearest, m_arith_util.mk_ge(x, e_nearest_max_real))));
+        implies_lt_min_real = m.mk_implies(r_is_ninf,
+            m.mk_or(m.mk_and(rm_tn, m_arith_util.mk_lt(x, e_max_real_neg)),
+                    m.mk_and(rm_rounds_to_nearest, m_arith_util.mk_le(x, e_nearest_max_real_neg))));
 
         m_extra_assertions.push_back(implies_gt_max_real);
         m_extra_assertions.push_back(implies_lt_min_real);

--- a/src/smt/smt_setup.cpp
+++ b/src/smt/smt_setup.cpp
@@ -833,7 +833,7 @@ namespace smt {
             m_params.m_case_split_strategy == CS_RELEVANCY_GOAL)
             return;
 
-        if (st.m_has_bv && !st.m_has_fpa && st.m_num_quantifiers == 0)
+        if (st.m_has_bv && st.m_num_quantifiers == 0)
              m_params.m_relevancy_lvl = 0;           
     }
 
@@ -945,4 +945,3 @@ namespace smt {
     }
 
 }
-


### PR DESCRIPTION
## Summary

- enable `smt.relevancy=0` for quantifier-free FP/BV problems on the generic setup path
- correct symbolic Real-to-FP overflow bounds so nearest rounding reaches infinity only at the half-ULP midpoint above the largest finite value
- preserve the existing largest-finite threshold for directed rounding

The relevancy change exposed a latent model bug in `6553-2-simp.smt2`: the symbolic conversion encoding allowed RNE/RNA to produce infinity for any real above the largest finite float, while model evaluation correctly rounded such values back to the largest finite float.

Fixes #10605.

## Validation

- `Z3Prover/z3test/regressions/smt2/6553-2-simp.smt2`
- positive and negative Float32 overflow boundary checks for RNE, RNA, RTP, and RTN
- symbolic `(_ FloatingPoint 2 100)` overflow model validation
- `test-z3 /a`