### PR TITLE
Fix fp.rem significand truncation with a subnormal divisor

### DIFF
--- a/src/ast/fpa/fpa2bv_converter.cpp
+++ b/src/ast/fpa/fpa2bv_converter.cpp
@@ -1176,8 +1176,16 @@ void fpa2bv_converter::mk_rem(sort * s, expr_ref & x, expr_ref & y, expr_ref & r
     // way to go in the long run (using the lazy bit-blaster helps on simple instances).
     expr_ref lshift(m), rshift(m), shifted(m), huge_rem(m), huge_div(m), huge_div_is_even(m);
     expr_ref a_sig_ext_l = a_sig, b_sig_ext_l = b_sig;
+
+    // exp_diff is computed from the normalized exponents, so a subnormal
+    // divisor (b_exp at the minimum with a non-zero b_lz) drives it up to
+    // max_exp_diff + sbits - 1.
+    scoped_mpz max_sig_ext(m_mpz_manager);
+    m_mpz_manager.add(max_exp_diff, sbits, max_sig_ext);
+    m_mpz_manager.sub(max_sig_ext, 1, max_sig_ext);
+
     scoped_mpz remaining(m_mpz_manager);
-    m_mpz_manager.set(remaining, max_exp_diff);
+    m_mpz_manager.set(remaining, max_sig_ext);
     while (m_mpz_manager.gt(remaining, INT32_MAX)) {
         SASSERT(false); // zero-extend ast's expect int params which would overflow.
         a_sig_ext_l = m_bv_util.mk_zero_extend(INT32_MAX, a_sig_ext_l);
@@ -1193,10 +1201,14 @@ void fpa2bv_converter::mk_rem(sort * s, expr_ref & x, expr_ref & y, expr_ref & r
     a_sig_ext = m_bv_util.mk_concat(a_sig_ext_l, m_bv_util.mk_numeral(0, 3));
     b_sig_ext = m_bv_util.mk_concat(b_sig_ext_l, m_bv_util.mk_numeral(0, 3));
 
+    // Sizes lshift/rshift to match a_sig_ext, which bvshl and bvlshr
+    // require, so it grows with the significand extension above.
     scoped_mpz max_exp_diff_adj(m_mpz_manager);
     m_mpz_manager.add(max_exp_diff, sbits, max_exp_diff_adj);
     m_mpz_manager.sub(max_exp_diff_adj, ebits, max_exp_diff_adj);
     m_mpz_manager.add(max_exp_diff_adj, 1, max_exp_diff_adj);
+    m_mpz_manager.add(max_exp_diff_adj, sbits, max_exp_diff_adj);
+    m_mpz_manager.sub(max_exp_diff_adj, 1, max_exp_diff_adj);
     expr_ref edr_tmp = exp_diff, nedr_tmp = neg_exp_diff;
     m_mpz_manager.set(remaining, max_exp_diff_adj);
     if (m_mpz_manager.gt(remaining, INT32_MAX))

--- a/src/test/smt_context.cpp
+++ b/src/test/smt_context.cpp
@@ -170,4 +170,82 @@ void tst_smt_context()
         std::string reason_unknown;
         VERIFY(l_false == check_sat(*t, g, md, labels, pr, core, reason_unknown));
     }
+
+    {
+        // fp.rem with a subnormal divisor: exp_diff reaches 31, past the significand's headroom. rem(-2132.0, -1.2516975402832031e-06) is exactly 5/8388608; the truncated dividend makes it look like -0.
+        cmd_context cmd(false, &m);
+        std::istringstream is(
+            "(declare-const x (_ FloatingPoint 5 11))\n"
+            "(declare-const y (_ FloatingPoint 5 11))\n"
+            "(declare-const xb (_ BitVec 16))\n"
+            "(declare-const yb (_ BitVec 16))\n"
+            "(assert (= x ((_ to_fp 5 11) xb)))\n"
+            "(assert (= y ((_ to_fp 5 11) yb)))\n"
+            "(assert (= xb #b1110100000101010))\n"
+            "(assert (= yb #b1000000000010101))\n"
+            "(assert (not (= ((_ fp.to_ieee_bv 16) (fp.rem x y)) #x000a)))\n");
+        VERIFY(parse_smt2_commands(cmd, is));
+        goal_ref g = alloc(goal, m, false, true, false);
+        for (expr* a : cmd.assertions())
+            g->assert_expr(a);
+        tactic_ref t = and_then(mk_fpa2bv_tactic(m), mk_simplify_tactic(m), mk_bit_blaster_tactic(m), mk_smt_tactic(m));
+        model_ref md;
+        labels_vec labels;
+        proof_ref pr(m);
+        expr_dependency_ref core(m);
+        std::string reason_unknown;
+        VERIFY(l_false == check_sat(*t, g, md, labels, pr, core, reason_unknown));
+    }
+
+    {
+        // Same defect at exp_diff 32: rem(21632.0, 6.67572021484375e-06) is exactly 1/1048576, and the truncation doubles it.
+        cmd_context cmd(false, &m);
+        std::istringstream is(
+            "(declare-const x (_ FloatingPoint 5 11))\n"
+            "(declare-const y (_ FloatingPoint 5 11))\n"
+            "(declare-const xb (_ BitVec 16))\n"
+            "(declare-const yb (_ BitVec 16))\n"
+            "(assert (= x ((_ to_fp 5 11) xb)))\n"
+            "(assert (= y ((_ to_fp 5 11) yb)))\n"
+            "(assert (= xb #b0111010101001000))\n"
+            "(assert (= yb #b0000000001110000))\n"
+            "(assert (not (= ((_ fp.to_ieee_bv 16) (fp.rem x y)) #x0010)))\n");
+        VERIFY(parse_smt2_commands(cmd, is));
+        goal_ref g = alloc(goal, m, false, true, false);
+        for (expr* a : cmd.assertions())
+            g->assert_expr(a);
+        tactic_ref t = and_then(mk_fpa2bv_tactic(m), mk_simplify_tactic(m), mk_bit_blaster_tactic(m), mk_smt_tactic(m));
+        model_ref md;
+        labels_vec labels;
+        proof_ref pr(m);
+        expr_dependency_ref core(m);
+        std::string reason_unknown;
+        VERIFY(l_false == check_sat(*t, g, md, labels, pr, core, reason_unknown));
+    }
+
+    {
+        // The smallest overflow, exp_diff 30: rem(44096.0, 5.793571472167969e-05) lands 116 ulp out rather than collapsing to zero.
+        cmd_context cmd(false, &m);
+        std::istringstream is(
+            "(declare-const x (_ FloatingPoint 5 11))\n"
+            "(declare-const y (_ FloatingPoint 5 11))\n"
+            "(declare-const xb (_ BitVec 16))\n"
+            "(declare-const yb (_ BitVec 16))\n"
+            "(assert (= x ((_ to_fp 5 11) xb)))\n"
+            "(assert (= y ((_ to_fp 5 11) yb)))\n"
+            "(assert (= xb #b0111100101100010))\n"
+            "(assert (= yb #b0000001111001100))\n"
+            "(assert (not (= ((_ fp.to_ieee_bv 16) (fp.rem x y)) #x8148)))\n");
+        VERIFY(parse_smt2_commands(cmd, is));
+        goal_ref g = alloc(goal, m, false, true, false);
+        for (expr* a : cmd.assertions())
+            g->assert_expr(a);
+        tactic_ref t = and_then(mk_fpa2bv_tactic(m), mk_simplify_tactic(m), mk_bit_blaster_tactic(m), mk_smt_tactic(m));
+        model_ref md;
+        labels_vec labels;
+        proof_ref pr(m);
+        expr_dependency_ref core(m);
+        std::string reason_unknown;
+        VERIFY(l_false == check_sat(*t, g, md, labels, pr, core, reason_unknown));
+    }
 }


### PR DESCRIPTION
`fp.rem` in the fpa2bv converter could return a wrong remainder, often zero, when the divisor is subnormal. The dividend significand is extended by `max_exp_diff`, but the left shift applied to it is by `exp_diff`, which is computed from the normalized exponents and reaches `max_exp_diff + sbits - 1` once the divisor is subnormal. The shift then pushes the significand's high bits off the end and the remainder is computed from a truncated dividend.

This patch extends the significands by the largest shift they can receive:
  - Use `max_exp_diff + sbits - 1` rather than `max_exp_diff`.
  - Grow `max_exp_diff_adj` by the same amount, so `lshift`/`rshift` stay the width `bvshl` and `bvlshr` require.

Fixes #10609 