### PR TITLE
Fix FMA results for small floating-point precisions

### DIFF
--- a/src/test/mpf.cpp
+++ b/src/test/mpf.cpp
@@ -111,9 +111,31 @@ static void test_to_sbv_mpq() {
     ENSURE(fm.mpq_manager().is_zero(r));
 }
 
+static void test_fma_small_precision() {
+    mpf_manager fm;
+    scoped_mpf x(fm), y(fm), z(fm), result(fm);
+
+    for (unsigned sbits = 2; sbits < 4; ++sbits) {
+        fm.set(x, 3, sbits, 1.0);
+        fm.set(y, 3, sbits, 1.0);
+        fm.mk_pzero(3, sbits, z);
+        fm.fma(MPF_ROUND_NEAREST_TEVEN, x, y, z, result);
+        ENSURE(fm.to_double(result) == 1.0);
+
+        fm.set(z, 3, sbits, 1.0);
+        fm.fma(MPF_ROUND_NEAREST_TEVEN, x, y, z, result);
+        ENSURE(fm.to_double(result) == 2.0);
+
+        fm.set(z, 3, sbits, -1.0);
+        fm.fma(MPF_ROUND_NEAREST_TEVEN, x, y, z, result);
+        ENSURE(fm.is_pzero(result));
+    }
+}
+
 void tst_mpf() {
     // enable_trace("mpf_mul_bug");
     bug_set_int();
     bug_set_double();
     test_to_sbv_mpq();
+    test_fma_small_precision();
 }

--- a/src/util/mpf.cpp
+++ b/src/util/mpf.cpp
@@ -915,14 +915,8 @@ void mpf_manager::fma(mpf_rounding_mode rm, mpf const & x, mpf const & y, mpf co
 
         set(o, x.ebits, x.sbits, res.sign(), res.exponent(), mpz(0));
 
-        if (x.sbits >= 4) {
-            m_mpz_manager.machine_div_rem(res.significand(), m_powers2(x.sbits - 4 + 3), o.significand, sticky_rem);
-            renorm_sticky |= !m_mpz_manager.is_zero(sticky_rem);
-        }
-        else {
-            m_mpz_manager.mul2k(res.significand(), 4 - x.sbits + 3, o.significand);
-            o.exponent -= 4 - x.sbits + 3;
-        }
+        m_mpz_manager.machine_div_rem(res.significand(), m_powers2(x.sbits - 1), o.significand, sticky_rem);
+        renorm_sticky |= !m_mpz_manager.is_zero(sticky_rem);
 
         if (renorm_sticky && m_mpz_manager.is_even(o.significand))
             m_mpz_manager.inc(o.significand);


### PR DESCRIPTION
## Summary

- fix `mpf_manager::fma` result extraction for formats with two- or three-bit significands
- remove the incorrect small-precision branch that scaled the significand in the wrong direction
- add unit coverage for exact multiply-add, addition, and cancellation at both affected precisions

For `(_ FloatingPoint 3 2)`, `fma(RNE, 1, 1, +0)` incorrectly folded to `2`; with a three-bit significand it folded to `4`. Both now produce `1`.

This fixes the constant-FMA sub-issue reported in #9319.

## Validation

- original `(_ FloatingPoint 3 2)` reproducer returns `unsat`
- exact FMA checks across significand widths 2 through 8
- `test-z3 /a`