### PR TITLE
Fix unsound arithmetic quantifier elimination

### DIFF
--- a/src/qe/qe_arith_plugin.cpp
+++ b/src/qe/qe_arith_plugin.cpp
@@ -2212,21 +2212,17 @@ public:
         // assert 
         //      path1 => x < t 
         // bounds:
-        //      path1 => x < t' => t < t'  when index(t') < index(t)
-        //      path1 => x < t' => t <= t' when index(t') >= index(t)
+        //      path1 => x < t' => t <= t'
         //      path1 => x <= s => t <= s
         // resolve:
         //      path1 => x >= u => t > u
         //      path1 => x > v  => t > v
-        // symmetry reduction:
-        //      
         // 
         //      path2 => x <= s
         // bounds:
         //      path2 => x < s => x < t => s <= t
         //      path2 => x = s => x < t => s < t
-        //      path2 => x <= s => x <= s' => s <  s' when index(s') < index(s)
-        //      path2 => x <= s => x <= s' => s <= s' when index(s') >= index(s)
+        //      path2 => x <= s => x <= s' => s <= s'
         // resolve:
         //      path2 => x < s => x >= u => s > u
         //      path2 => x = s => x >= u => s >= u
@@ -2325,16 +2321,13 @@ public:
                 }
            
                 //
-                // Break symmetries by using index:
-                // bounds before me are strictly larger.
                 // Cases:
                 // ax <= t & ax != t & bx < s => bt <= as
                 // ax <= t & ax = t  & bx < s => bt < as
-                //                     bx <= s => bt < as or bt <= as depending on symmetry
-                //     
-                bool result_is_strict = 
-                    (non_strict_real && is_eq_ctx && is_strict) ||
-                    (same_strict && i < index);
+                //                     bx <= s => bt <= as
+                // Substitutions must preserve the exact value of an atom because
+                // it may occur in both polarities.
+                bool result_is_strict = non_strict_real && is_eq_ctx && is_strict;
 
 
                 mk_bound(result_is_strict, is_lower, a, t, b, s, tmp);

--- a/src/test/qe_arith.cpp
+++ b/src/test/qe_arith.cpp
@@ -42,6 +42,22 @@ static expr_ref parse_fml(ast_manager& m, char const* str) {
     return result;
 }
 
+static void test_issue_6946() {
+    ast_manager m;
+    reg_decl_plugins(m);
+    expr_ref fml = parse_fml(m, "(forall ((v Real)) (= (= a v) (= v 0)))");
+    expr_ref expected = parse_fml(m, "(= a 0)");
+    expr_ref result(m);
+    smt_params params;
+    qe::expr_quant_elim qelim(m, params);
+    qelim(m.mk_true(), fml, result);
+    VERIFY(!has_quantifiers(result));
+
+    smt::context ctx(m, params);
+    ctx.assert_expr(m.mk_not(m.mk_iff(result, expected)));
+    VERIFY(l_false == ctx.check());
+}
+
 static char const* example1 = "(and (<= x 3.0) (<= (* 3.0 x) y) (<= z y))";
 static char const* example2 = "(and (<= z x) (<= x 3.0) (<= (* 3.0 x) y) (<= z y))";
 static char const* example3 = "(and (<= z x) (<= x 3.0) (< (* 3.0 x) y) (<= z y))";
@@ -593,6 +609,7 @@ static void test_project() {
 
 
 void tst_qe_arith() {
+    test_issue_6946();
     test_project();
     return;
     check_random_ineqs();


### PR DESCRIPTION
## Summary
- preserve exact arithmetic atom values during QE bound substitution
- remove index-based strictification that could collapse mixed-polarity formulas to an unsound result
- add a regression test for #6946 that checks the eliminated formula is quantifier-free and equivalent to `a = 0`

## Testing
- `test-z3 qe_arith`
- original #6946 reproducer with `(then qe smt)` returns `sat` with `a = 0`