### PR TITLE
Complete binary API models from solver assertions

### DIFF
--- a/src/api/api_solver.cpp
+++ b/src/api/api_solver.cpp
@@ -32,6 +32,7 @@ Revision History:
 #include "api/api_model.h"
 #include "api/api_stats.h"
 #include "api/api_ast_vector.h"
+#include "ast/decl_collector.h"
 #include "model/model_params.hpp"
 #include "smt/smt_solver.h"
 #include "smt/smt_implied_equalities.h"
@@ -47,6 +48,47 @@ Revision History:
 #include "cmd_context/extra_cmds/proof_cmds.h"
 #include "solver/simplifier_solver.h"
 
+static void complete_model_from_assertions(solver& s, model& mdl) {
+    model_params mp(s.get_params());
+    if (!mp.completion())
+        return;
+
+    ast_manager& m = s.get_manager();
+    expr_ref_vector assertions(m);
+    s.get_assertions(assertions);
+    decl_collector decls(m);
+    for (expr* assertion : assertions)
+        decls.visit(assertion);
+
+    for (sort* srt : decls.get_sorts()) {
+        if (m.is_uninterp(srt) && !mdl.has_uninterpreted_sort(srt)) {
+            expr* value = m.get_some_value(srt);
+            mdl.register_usort(srt, 1, &value);
+        }
+    }
+
+    for (unsigned i = 0; i < mdl.get_num_functions(); ++i) {
+        func_decl* f = mdl.get_function(i);
+        func_interp* fi = mdl.get_func_interp(f);
+        if (fi->is_partial())
+            fi->set_else(m.get_some_value(f->get_range()));
+    }
+
+    for (func_decl* f : decls.get_func_decls()) {
+        if (f->get_family_id() != null_family_id || mdl.has_interpretation(f))
+            continue;
+        expr* value = mdl.get_some_value(f->get_range());
+        if (f->get_arity() == 0) {
+            mdl.register_decl(f, value);
+        }
+        else {
+            func_interp* fi = alloc(func_interp, m, f->get_arity());
+            fi->set_else(value);
+            mdl.register_decl(f, fi);
+        }
+    }
+    mdl.add_rec_funs();
+}
 
 extern "C" {
 
@@ -725,6 +767,7 @@ extern "C" {
             RETURN_Z3(nullptr);
         }
         if (_m) {
+            complete_model_from_assertions(*to_solver_ref(s), *_m);
             model_params mp(to_solver_ref(s)->get_params());
             if (mp.compact()) _m->compress();
         }

--- a/src/test/api.cpp
+++ b/src/test/api.cpp
@@ -13,6 +13,39 @@ Copyright (c) 2015 Microsoft Corporation
 #include <string>
 #include "util/trace.h"
 
+static void test_solver_model_completion() {
+    Z3_global_param_set("model.completion", "true");
+    Z3_config cfg = Z3_mk_config();
+    Z3_set_param_value(cfg, "MODEL", "true");
+    Z3_context ctx = Z3_mk_context(cfg);
+    Z3_del_config(cfg);
+
+    Z3_solver solver = Z3_mk_solver(ctx);
+    Z3_solver_inc_ref(ctx, solver);
+    Z3_sort s = Z3_mk_uninterpreted_sort(ctx, Z3_mk_string_symbol(ctx, "S"));
+    Z3_ast x = Z3_mk_const(ctx, Z3_mk_string_symbol(ctx, "x"), s);
+    Z3_func_decl f = Z3_mk_func_decl(ctx, Z3_mk_string_symbol(ctx, "f"), 1, &s, s);
+    Z3_ast fx = Z3_mk_app(ctx, f, 1, &x);
+    Z3_ast args[] = { Z3_mk_eq(ctx, x, x), Z3_mk_eq(ctx, fx, fx) };
+    Z3_solver_assert(ctx, solver, Z3_mk_and(ctx, 2, args));
+
+    ENSURE(Z3_solver_check(ctx, solver) == Z3_L_TRUE);
+    Z3_model mdl = Z3_solver_get_model(ctx, solver);
+    Z3_model_inc_ref(ctx, mdl);
+    ENSURE(Z3_model_get_const_interp(ctx, mdl, Z3_get_app_decl(ctx, Z3_to_app(ctx, x))));
+    ENSURE(Z3_model_get_func_interp(ctx, mdl, f));
+    ENSURE(Z3_model_get_num_sorts(ctx, mdl) == 1);
+    ENSURE(Z3_model_get_sort(ctx, mdl, 0) == s);
+    Z3_ast_vector universe = Z3_model_get_sort_universe(ctx, mdl, s);
+    ENSURE(universe);
+    ENSURE(Z3_ast_vector_size(ctx, universe) == 1);
+
+    Z3_model_dec_ref(ctx, mdl);
+    Z3_solver_dec_ref(ctx, solver);
+    Z3_del_context(ctx);
+    Z3_global_param_set("model.completion", "false");
+}
+
 void test_apps() {
     Z3_config cfg = Z3_mk_config();
     Z3_set_param_value(cfg,"MODEL","true");
@@ -362,6 +395,7 @@ void test_strict_real_maximize_disjunction() {
 // on machine load and on whatever ran earlier in the same process.
 
 void tst_api() {
+    test_solver_model_completion();
     test_apps();
     test_mk_app_polymorphic_arity();
     test_mk_quantifier_const_loose_bound_variables();


### PR DESCRIPTION
## Summary

- complete binary-API models from the solver's current assertions when `model.completion` is enabled
- retain uninterpreted constants and functions even when preprocessing simplifies away every occurrence
- register singleton universes for otherwise-eliminated uninterpreted sorts
- leave the default sparse-model behavior unchanged

`cmd_context` has its own declaration tables and uses them to complete models before printing. Binary API solvers do not have that declaration environment, but their current assertion set provides the appropriate scoped source of symbols. `Z3_solver_get_model` now collects declarations from those assertions only when completion is requested.

The Python reproducer from #7204 now produces:

```text
[x = mysort!val!0, f = [else -> mysort!val!0]]
[mysort]
[mysort!val!0]
```

Without `model.completion`, it still produces an empty model.

Fixes #7204.

## Validation

- C API regression covering an eliminated constant, function, sort, and universe
- original Python workflow with global and solver-local `model.completion`
- `test-z3 /a`