### PR TITLE
Eliminate interval-constrained variables in qe-light

### DIFF
--- a/src/qe/lite/qe_lite_tactic.cpp
+++ b/src/qe/lite/qe_lite_tactic.cpp
@@ -2235,6 +2235,7 @@ class qe_lite::impl {
             }
             if (q->get_kind() != lambda_k) {
                 m_imp(indices, true, result);
+                m_imp.eliminate_diseq_vars(q, result);
             }
             // After eq_der + FM, try to expand remaining bounded
             // integer quantifiers into finite disjunctions.
@@ -2287,6 +2288,76 @@ private:
 
     bool m_use_array_der;
     static const unsigned EXPAND_BOUND_LIMIT = 10000;
+
+    bool has_fresh_value(sort* s, unsigned num_forbidden) {
+        arith_util a_util(m);
+        if (a_util.is_int(s) || a_util.is_real(s))
+            return true;
+        bv_util bv_util(m);
+        if (!bv_util.is_bv_sort(s))
+            return false;
+        unsigned width = bv_util.get_bv_size(s);
+        return width >= 32 || num_forbidden < (1u << width);
+    }
+
+    bool collect_negative_equalities(expr* e, unsigned index, bool positive, obj_hashtable<app>& equalities) {
+        if (is_ground(e))
+            return true;
+        if (is_var(e))
+            return to_var(e)->get_idx() != index;
+        if (is_quantifier(e)) {
+            quantifier* q = to_quantifier(e);
+            return !qel::occurs_var(index + q->get_num_decls(), q->get_expr());
+        }
+
+        SASSERT(is_app(e));
+        app* a = to_app(e);
+        expr* arg = nullptr;
+        if (m.is_not(a, arg))
+            return collect_negative_equalities(arg, index, !positive, equalities);
+        if (m.is_and(a) || m.is_or(a)) {
+            for (expr* arg : *a)
+                if (!collect_negative_equalities(arg, index, positive, equalities))
+                    return false;
+            return true;
+        }
+
+        expr* lhs = nullptr, *rhs = nullptr;
+        if (m.is_eq(a, lhs, rhs)) {
+            bool lhs_is_var = is_var(lhs) && to_var(lhs)->get_idx() == index;
+            bool rhs_is_var = is_var(rhs) && to_var(rhs)->get_idx() == index;
+            if (lhs_is_var != rhs_is_var) {
+                expr* value = lhs_is_var ? rhs : lhs;
+                if (!positive && !qel::occurs_var(index, value)) {
+                    equalities.insert(a);
+                    return true;
+                }
+            }
+        }
+        return !qel::occurs_var(index, e);
+    }
+
+    bool eliminate_diseq_vars(quantifier* q, expr_ref& body) {
+        expr_safe_replace replace(m);
+        bool changed = false;
+        for (unsigned i = 0; i < q->get_num_decls(); ++i) {
+            obj_hashtable<app> equalities;
+            if (collect_negative_equalities(body, i, true, equalities) &&
+                !equalities.empty() &&
+                has_fresh_value(q->get_decl_sort(q->get_num_decls() - i - 1), equalities.size())) {
+                for (app* eq : equalities)
+                    replace.insert(eq, m.mk_false());
+                changed = true;
+            }
+        }
+        if (!changed)
+            return false;
+        expr_ref result(m);
+        replace(body, result);
+        proof_ref pr(m);
+        m_rewriter(result, body, pr);
+        return true;
+    }
 
     bool has_unique_non_ground(expr_ref_vector const& fmls, unsigned& index) {
         index = fmls.size();

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -118,6 +118,7 @@ add_executable(test-z3
   seq_regex_bisim.cpp
   proof_checker.cpp
   qe_arith.cpp
+  qe_lite.cpp
   mbp_qel.cpp
   quant_elim.cpp
   quant_solve.cpp

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -174,6 +174,7 @@
     X(rcf) \
     X(polynorm) \
     X(qe_arith) \
+    X(qe_lite) \
     X(expr_substitution) \
     X(sorting_network) \
     X(theory_pb) \

--- a/src/test/qe_lite.cpp
+++ b/src/test/qe_lite.cpp
@@ -1,0 +1,123 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+--*/
+
+#include "ast/bv_decl_plugin.h"
+#include "ast/arith_decl_plugin.h"
+#include "ast/reg_decl_plugins.h"
+#include "ast/rewriter/bool_rewriter.h"
+#include "qe/lite/qe_lite_tactic.h"
+#include "smt/smt_context.h"
+
+static expr_ref apply_qe_lite(ast_manager& m, expr* fml) {
+    expr_ref result(fml, m);
+    proof_ref pr(m);
+    qe_lite qe(m, params_ref());
+    qe(result, pr);
+    return result;
+}
+
+static void test_disequality_elimination() {
+    ast_manager m;
+    reg_decl_plugins(m);
+    bv_util bv(m);
+    bool_rewriter rw(m);
+
+    sort* s = bv.mk_sort(3);
+    expr_ref x(m.mk_var(0, s), m);
+    app_ref p(m.mk_fresh_const("p", m.mk_bool_sort()), m);
+    expr_ref eq0(m.mk_eq(x, bv.mk_numeral(0, 3)), m);
+    expr_ref eq1(m.mk_eq(x, bv.mk_numeral(1, 3)), m);
+    expr_ref guarded(m);
+    rw.mk_and(eq1, m.mk_not(p), guarded);
+    expr* args[] = { p, m.mk_not(eq0), m.mk_not(guarded) };
+    expr_ref body(m);
+    rw.mk_and(3, args, body);
+    symbol name("x");
+    expr_ref fml(m.mk_exists(1, &s, &name, body), m);
+
+    fml = apply_qe_lite(m, fml);
+    VERIFY(!has_quantifiers(fml));
+
+    smt_params params;
+    smt::context ctx(m, params);
+    ctx.assert_expr(m.mk_not(m.mk_iff(fml, p)));
+    VERIFY(l_false == ctx.check());
+}
+
+static void test_fully_forbidden_bv() {
+    ast_manager m;
+    reg_decl_plugins(m);
+    bv_util bv(m);
+    bool_rewriter rw(m);
+
+    sort* s = bv.mk_sort(1);
+    expr_ref x(m.mk_var(0, s), m);
+    expr* args[] = {
+        m.mk_not(m.mk_eq(x, bv.mk_numeral(0, 1))),
+        m.mk_not(m.mk_eq(x, bv.mk_numeral(1, 1)))
+    };
+    expr_ref body(m);
+    rw.mk_and(2, args, body);
+    symbol name("x");
+    expr_ref fml(m.mk_exists(1, &s, &name, body), m);
+
+    fml = apply_qe_lite(m, fml);
+    smt_params params;
+    smt::context ctx(m, params);
+    ctx.assert_expr(fml);
+    VERIFY(l_false == ctx.check());
+}
+
+static void test_mixed_sort_declarations() {
+    ast_manager m;
+    reg_decl_plugins(m);
+    arith_util arith(m);
+    bv_util bv(m);
+    bool_rewriter rw(m);
+
+    sort* sorts[] = { arith.mk_int(), bv.mk_sort(1) };
+    symbol names[] = { symbol("x"), symbol("y") };
+    expr_ref x(m.mk_var(1, sorts[0]), m);
+    expr_ref y(m.mk_var(0, sorts[1]), m);
+    expr* args[] = {
+        arith.mk_gt(x, arith.mk_int(3)),
+        m.mk_not(m.mk_eq(y, bv.mk_numeral(0, 1))),
+        m.mk_not(m.mk_eq(y, bv.mk_numeral(1, 1)))
+    };
+    expr_ref body(m);
+    rw.mk_and(3, args, body);
+    expr_ref fml(m.mk_exists(2, sorts, names, body), m);
+
+    fml = apply_qe_lite(m, fml);
+    smt_params params;
+    smt::context ctx(m, params);
+    ctx.assert_expr(fml);
+    VERIFY(l_false == ctx.check());
+}
+
+static void test_lambda_unchanged() {
+    ast_manager m;
+    reg_decl_plugins(m);
+    arith_util arith(m);
+
+    sort* s = arith.mk_int();
+    symbol name("x");
+    expr_ref x(m.mk_var(0, s), m);
+    expr_ref body(m.mk_not(m.mk_eq(x, arith.mk_int(0))), m);
+    expr_ref fml(m.mk_lambda(1, &s, &name, body), m);
+    expr_ref result = apply_qe_lite(m, fml);
+
+    smt_params params;
+    smt::context ctx(m, params);
+    ctx.assert_expr(m.mk_not(m.mk_eq(fml, result)));
+    VERIFY(l_false == ctx.check());
+}
+
+void tst_qe_lite() {
+    test_disequality_elimination();
+    test_fully_forbidden_bv();
+    test_mixed_sort_declarations();
+    test_lambda_unchanged();
+}


### PR DESCRIPTION
## Summary
- add a `qe-light` pass for existential variables that occur only in negatively polarized equalities
- eliminate such variables when their domain has a value outside the finite forbidden set
- support unbounded integer/real domains and cardinality-checked bit-vector domains
- preserve lambdas and correctly map de Bruijn indices across mixed declaration sorts
- add regressions for #9315, fully forbidden finite domains, mixed sorts, and lambdas

## Testing
- `test-z3 qe_lite`
- `z3 9315.smt2 /v:2` eliminates both remaining bound variables