### PR TITLE
Translate persistent simplifier state

### DIFF
--- a/src/ast/ast_translation.cpp
+++ b/src/ast/ast_translation.cpp
@@ -32,7 +32,7 @@ ast_translation::~ast_translation() {
 void ast_translation::seed(expr* src, expr* dst) {
     // Seed mappings exposed by a solver translated without this translation
     // object. cache() deliberately retains only shared nodes.
-    vector<std::pair<expr*, expr*>> todo;
+    svector<std::pair<expr*, expr*>> todo;
     todo.push_back({ src, dst });
     while (!todo.empty()) {
         auto [s, d] = todo.back();
@@ -40,38 +40,23 @@ void ast_translation::seed(expr* src, expr* dst) {
         if (m_cache.contains(s))
             continue;
         SASSERT(s->get_kind() == d->get_kind());
-        SASSERT(is_app(s) == is_app(d));
-        SASSERT(is_quantifier(s) == is_quantifier(d));
-        if (is_app(s)) {
-            app* sa = to_app(s);
-            app* da = to_app(d);
-            SASSERT(sa->get_num_args() == da->get_num_args());
-            SASSERT(sa->get_decl()->get_family_id() == da->get_decl()->get_family_id());
-            SASSERT(sa->get_decl()->get_decl_kind() == da->get_decl()->get_decl_kind());
-        }
-        else if (is_quantifier(s)) {
-            SASSERT(to_quantifier(s)->get_num_decls() == to_quantifier(d)->get_num_decls());
-        }
-        else {
-            SASSERT(to_var(s)->get_idx() == to_var(d)->get_idx());
-        }
         cache(s, d);
         if (!m_cache.contains(s->get_sort()))
             cache(s->get_sort(), d->get_sort());
-        if (is_app(s) && is_app(d)) {
+        if (is_app(s)) {
+            SASSERT(is_app(d));
             app* sa = to_app(s);
             app* da = to_app(d);
+            SASSERT(sa->get_num_args() == da->get_num_args());
             if (!m_cache.contains(sa->get_decl()))
                 cache(sa->get_decl(), da->get_decl());
             for (unsigned i = 0; i < sa->get_num_args(); ++i)
                 todo.push_back({ sa->get_arg(i), da->get_arg(i) });
         }
-        else if (is_quantifier(s) && is_quantifier(d)) {
+        else if (is_quantifier(s)) {
+            SASSERT(is_quantifier(d));
             quantifier* sq = to_quantifier(s);
             quantifier* dq = to_quantifier(d);
-            for (unsigned i = 0; i < sq->get_num_decls(); ++i)
-                if (!m_cache.contains(sq->get_decl_sort(i)))
-                    cache(sq->get_decl_sort(i), dq->get_decl_sort(i));
             todo.push_back({ sq->get_expr(), dq->get_expr() });
         }
     }

--- a/src/ast/ast_translation.cpp
+++ b/src/ast/ast_translation.cpp
@@ -37,24 +37,25 @@ void ast_translation::seed(expr* src, expr* dst) {
     while (!todo.empty()) {
         auto [s, d] = todo.back();
         todo.pop_back();
-        if (s->get_kind() != d->get_kind())
+        if (m_cache.contains(s))
             continue;
-        if (is_app(s) != is_app(d) || is_quantifier(s) != is_quantifier(d))
-            continue;
+        SASSERT(s->get_kind() == d->get_kind());
+        SASSERT(is_app(s) == is_app(d));
+        SASSERT(is_quantifier(s) == is_quantifier(d));
         if (is_app(s)) {
             app* sa = to_app(s);
             app* da = to_app(d);
-            if (sa->get_num_args() != da->get_num_args() ||
-                sa->get_decl()->get_family_id() != da->get_decl()->get_family_id() ||
-                sa->get_decl()->get_decl_kind() != da->get_decl()->get_decl_kind())
-                continue;
+            SASSERT(sa->get_num_args() == da->get_num_args());
+            SASSERT(sa->get_decl()->get_family_id() == da->get_decl()->get_family_id());
+            SASSERT(sa->get_decl()->get_decl_kind() == da->get_decl()->get_decl_kind());
         }
-        else if (is_quantifier(s) &&
-                 to_quantifier(s)->get_num_decls() != to_quantifier(d)->get_num_decls()) {
-            continue;
+        else if (is_quantifier(s)) {
+            SASSERT(to_quantifier(s)->get_num_decls() == to_quantifier(d)->get_num_decls());
         }
-        if (!m_cache.contains(s))
-            cache(s, d);
+        else {
+            SASSERT(to_var(s)->get_idx() == to_var(d)->get_idx());
+        }
+        cache(s, d);
         if (!m_cache.contains(s->get_sort()))
             cache(s->get_sort(), d->get_sort());
         if (is_app(s) && is_app(d)) {

--- a/src/ast/ast_translation.cpp
+++ b/src/ast/ast_translation.cpp
@@ -29,6 +29,53 @@ ast_translation::~ast_translation() {
     reset_cache();
 }
 
+void ast_translation::seed(expr* src, expr* dst) {
+    // Seed mappings exposed by a solver translated without this translation
+    // object. cache() deliberately retains only shared nodes.
+    vector<std::pair<expr*, expr*>> todo;
+    todo.push_back({ src, dst });
+    while (!todo.empty()) {
+        auto [s, d] = todo.back();
+        todo.pop_back();
+        if (s->get_kind() != d->get_kind())
+            continue;
+        if (is_app(s) != is_app(d) || is_quantifier(s) != is_quantifier(d))
+            continue;
+        if (is_app(s)) {
+            app* sa = to_app(s);
+            app* da = to_app(d);
+            if (sa->get_num_args() != da->get_num_args() ||
+                sa->get_decl()->get_family_id() != da->get_decl()->get_family_id() ||
+                sa->get_decl()->get_decl_kind() != da->get_decl()->get_decl_kind())
+                continue;
+        }
+        else if (is_quantifier(s) &&
+                 to_quantifier(s)->get_num_decls() != to_quantifier(d)->get_num_decls()) {
+            continue;
+        }
+        if (!m_cache.contains(s))
+            cache(s, d);
+        if (!m_cache.contains(s->get_sort()))
+            cache(s->get_sort(), d->get_sort());
+        if (is_app(s) && is_app(d)) {
+            app* sa = to_app(s);
+            app* da = to_app(d);
+            if (!m_cache.contains(sa->get_decl()))
+                cache(sa->get_decl(), da->get_decl());
+            for (unsigned i = 0; i < sa->get_num_args(); ++i)
+                todo.push_back({ sa->get_arg(i), da->get_arg(i) });
+        }
+        else if (is_quantifier(s) && is_quantifier(d)) {
+            quantifier* sq = to_quantifier(s);
+            quantifier* dq = to_quantifier(d);
+            for (unsigned i = 0; i < sq->get_num_decls(); ++i)
+                if (!m_cache.contains(sq->get_decl_sort(i)))
+                    cache(sq->get_decl_sort(i), dq->get_decl_sort(i));
+            todo.push_back({ sq->get_expr(), dq->get_expr() });
+        }
+    }
+}
+
 void ast_translation::cleanup() {
     reset_cache();
     m_cache.finalize();

--- a/src/ast/ast_translation.h
+++ b/src/ast/ast_translation.h
@@ -95,6 +95,7 @@ public:
 
     void reset_cache();
     void cleanup();
+    void seed(expr* src, expr* dst);
     
     unsigned loop_count() const { return m_loop_count; }
     unsigned hit_count() const { return m_hit_count; }
@@ -126,4 +127,3 @@ inline expr_dependency * translate(expr_dependency * d, ast_manager & from, ast_
     expr_dependency_translation td(t);
     return td(d);
 }
-

--- a/src/ast/normal_forms/defined_names.cpp
+++ b/src/ast/normal_forms/defined_names.cpp
@@ -18,6 +18,7 @@ Revision History:
 --*/
 #include "util/obj_hashtable.h"
 #include "ast/normal_forms/defined_names.h"
+#include "ast/ast_translation.h"
 #include "ast/used_vars.h"
 #include "ast/rewriter/var_subst.h"
 #include "ast/ast_smt2_pp.h"
@@ -69,6 +70,7 @@ struct defined_names::impl {
     void push_scope();
     void pop_scope(unsigned num_scopes);
     void reset();
+    void translate(impl& dst, ast_translation& tr) const;
 
     unsigned get_num_names() const { return m_names.size(); }
     func_decl * get_name_decl(unsigned i) const { return to_app(m_names.get(i))->get_decl(); }
@@ -80,6 +82,20 @@ struct defined_names::pos_impl : public defined_names::impl {
 
 };
 
+void defined_names::impl::translate(impl& dst, ast_translation& tr) const {
+    SASSERT(m_lims.empty());
+    SASSERT(dst.m_exprs.empty());
+    for (unsigned i = 0; i < m_exprs.size(); ++i) {
+        expr* e = tr(m_exprs.get(i));
+        app* n = to_app(tr(m_names.get(i)));
+        dst.cache_new_name(e, n);
+        if (m.proofs_enabled()) {
+            proof* p = to_app(tr(m_apply_proofs.get(i)));
+            dst.cache_new_name_intro_proof(e, p);
+        }
+    }
+}
+
 
 defined_names::impl::impl(ast_manager & m, char const * prefix):
     m(m),
@@ -88,6 +104,11 @@ defined_names::impl::impl(ast_manager & m, char const * prefix):
     m_apply_proofs(m) {
     if (prefix)
         m_z3name = prefix;
+}
+
+void defined_names::translate(defined_names& dst, ast_translation& tr) const {
+    m_impl->translate(*dst.m_impl, tr);
+    m_pos_impl->translate(*dst.m_pos_impl, tr);
 }
 
 /**
@@ -329,8 +350,4 @@ func_decl * defined_names::get_name_decl(unsigned i) const {
     unsigned n1 = m_impl->get_num_names();
     return i < n1 ? m_impl->get_name_decl(i) : m_pos_impl->get_name_decl(i - n1);
 }
-
-
-
-
 

--- a/src/ast/normal_forms/defined_names.cpp
+++ b/src/ast/normal_forms/defined_names.cpp
@@ -70,7 +70,7 @@ struct defined_names::impl {
     void push_scope();
     void pop_scope(unsigned num_scopes);
     void reset();
-    void translate(impl& dst, ast_translation& tr) const;
+    void translate(impl& src, ast_translation& tr);
 
     unsigned get_num_names() const { return m_names.size(); }
     func_decl * get_name_decl(unsigned i) const { return to_app(m_names.get(i))->get_decl(); }
@@ -82,16 +82,16 @@ struct defined_names::pos_impl : public defined_names::impl {
 
 };
 
-void defined_names::impl::translate(impl& dst, ast_translation& tr) const {
-    SASSERT(m_lims.empty());
-    SASSERT(dst.m_exprs.empty());
-    for (unsigned i = 0; i < m_exprs.size(); ++i) {
-        expr* e = tr(m_exprs.get(i));
-        app* n = to_app(tr(m_names.get(i)));
-        dst.cache_new_name(e, n);
-        if (m.proofs_enabled()) {
-            proof* p = to_app(tr(m_apply_proofs.get(i)));
-            dst.cache_new_name_intro_proof(e, p);
+void defined_names::impl::translate(impl& src, ast_translation& tr) {
+    SASSERT(src.m_lims.empty());
+    SASSERT(m_exprs.empty());
+    for (unsigned i = 0; i < src.m_exprs.size(); ++i) {
+        expr* e = tr(src.m_exprs.get(i));
+        app* n = to_app(tr(src.m_names.get(i)));
+        cache_new_name(e, n);
+        if (src.m.proofs_enabled()) {
+            proof* p = to_app(tr(src.m_apply_proofs.get(i)));
+            cache_new_name_intro_proof(e, p);
         }
     }
 }
@@ -106,9 +106,9 @@ defined_names::impl::impl(ast_manager & m, char const * prefix):
         m_z3name = prefix;
 }
 
-void defined_names::translate(defined_names& dst, ast_translation& tr) const {
-    m_impl->translate(*dst.m_impl, tr);
-    m_pos_impl->translate(*dst.m_pos_impl, tr);
+void defined_names::translate(defined_names& src, ast_translation& tr) {
+    m_impl->translate(*src.m_impl, tr);
+    m_pos_impl->translate(*src.m_pos_impl, tr);
 }
 
 /**
@@ -350,4 +350,3 @@ func_decl * defined_names::get_name_decl(unsigned i) const {
     unsigned n1 = m_impl->get_num_names();
     return i < n1 ? m_impl->get_name_decl(i) : m_pos_impl->get_name_decl(i - n1);
 }
-

--- a/src/ast/normal_forms/defined_names.cpp
+++ b/src/ast/normal_forms/defined_names.cpp
@@ -70,7 +70,7 @@ struct defined_names::impl {
     void push_scope();
     void pop_scope(unsigned num_scopes);
     void reset();
-    void translate(impl& src, ast_translation& tr);
+    void translate(impl const& src, ast_translation& tr);
 
     unsigned get_num_names() const { return m_names.size(); }
     func_decl * get_name_decl(unsigned i) const { return to_app(m_names.get(i))->get_decl(); }
@@ -82,7 +82,7 @@ struct defined_names::pos_impl : public defined_names::impl {
 
 };
 
-void defined_names::impl::translate(impl& src, ast_translation& tr) {
+void defined_names::impl::translate(impl const& src, ast_translation& tr) {
     SASSERT(src.m_lims.empty());
     SASSERT(m_exprs.empty());
     for (unsigned i = 0; i < src.m_exprs.size(); ++i) {
@@ -106,7 +106,7 @@ defined_names::impl::impl(ast_manager & m, char const * prefix):
         m_z3name = prefix;
 }
 
-void defined_names::translate(defined_names& src, ast_translation& tr) {
+void defined_names::translate(defined_names const& src, ast_translation& tr) {
     m_impl->translate(*src.m_impl, tr);
     m_pos_impl->translate(*src.m_pos_impl, tr);
 }

--- a/src/ast/normal_forms/defined_names.h
+++ b/src/ast/normal_forms/defined_names.h
@@ -84,7 +84,7 @@ public:
     void push();
     void pop(unsigned num_scopes);
     void reset();
-    void translate(defined_names& dst, ast_translation& tr) const;
+    void translate(defined_names& src, ast_translation& tr);
 
     unsigned get_num_names() const;
     func_decl * get_name_decl(unsigned i) const;

--- a/src/ast/normal_forms/defined_names.h
+++ b/src/ast/normal_forms/defined_names.h
@@ -84,9 +84,8 @@ public:
     void push();
     void pop(unsigned num_scopes);
     void reset();
+    void translate(defined_names& dst, ast_translation& tr) const;
 
     unsigned get_num_names() const;
     func_decl * get_name_decl(unsigned i) const;
 };
-
-

--- a/src/ast/normal_forms/defined_names.h
+++ b/src/ast/normal_forms/defined_names.h
@@ -84,7 +84,7 @@ public:
     void push();
     void pop(unsigned num_scopes);
     void reset();
-    void translate(defined_names& src, ast_translation& tr);
+    void translate(defined_names const& src, ast_translation& tr);
 
     unsigned get_num_names() const;
     func_decl * get_name_decl(unsigned i) const;

--- a/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.cpp
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.cpp
@@ -788,7 +788,7 @@ void bit_blaster_rewriter::get_translation(obj_map<func_decl, expr*>& const2bits
     m_imp->get_translation(const2bits, newbits);
 }
 
-void bit_blaster_rewriter::translate(bit_blaster_rewriter& src, ast_translation& tr) const {
+void bit_blaster_rewriter::translate(bit_blaster_rewriter const& src, ast_translation& tr) const {
     SASSERT(src.get_num_scopes() == 0);
     obj_map<func_decl, expr*> source;
     ptr_vector<func_decl> source_bits;

--- a/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.cpp
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.cpp
@@ -17,6 +17,7 @@ Notes:
 
 --*/
 #include "ast/rewriter/bit_blaster/bit_blaster_rewriter.h"
+#include "ast/ast_translation.h"
 #include "ast/bv_decl_plugin.h"
 #include "ast/rewriter/bit_blaster/bit_blaster_tpl_def.h"
 #include "ast/rewriter/rewriter_def.h"
@@ -207,6 +208,18 @@ struct blaster_rewriter_cfg : public default_rewriter_cfg {
             const2bits.insert(m_keys.get(i), m_values.get(i));
         for (func_decl* f : m_newbits) 
             newbits.push_back(f);        
+    }
+
+    void set_translation(obj_map<func_decl, expr*> const& const2bits, ptr_vector<func_decl> const& newbits) {
+        SASSERT(m_keys.empty());
+        SASSERT(m_newbits.empty());
+        for (auto const& [f, bits] : const2bits) {
+            m_const2bits.insert(f, bits);
+            m_keys.push_back(f);
+            m_values.push_back(bits);
+        }
+        for (func_decl* f : newbits)
+            m_newbits.push_back(f);
     }
 
     template<typename V>
@@ -714,6 +727,7 @@ struct bit_blaster_rewriter::imp : public rewriter_tpl<blaster_rewriter_cfg> {
     void start_rewrite() { m_cfg.start_rewrite(); }
     void end_rewrite(obj_map<func_decl, expr*>& const2bits, ptr_vector<func_decl> & newbits) { m_cfg.end_rewrite(const2bits, newbits); }
     void get_translation(obj_map<func_decl, expr*>& const2bits, ptr_vector<func_decl> & newbits) { m_cfg.get_translation(const2bits, newbits); }
+    void set_translation(obj_map<func_decl, expr*> const& const2bits, ptr_vector<func_decl> const& newbits) { m_cfg.set_translation(const2bits, newbits); }
     unsigned get_num_scopes() const { return m_cfg.get_num_scopes(); }
 };
 
@@ -772,4 +786,18 @@ void bit_blaster_rewriter::end_rewrite(obj_map<func_decl, expr*>& const2bits, pt
 
 void bit_blaster_rewriter::get_translation(obj_map<func_decl, expr*>& const2bits, ptr_vector<func_decl> & newbits) {
     m_imp->get_translation(const2bits, newbits);
+}
+
+void bit_blaster_rewriter::translate(bit_blaster_rewriter& dst, ast_translation& tr) const {
+    SASSERT(get_num_scopes() == 0);
+    obj_map<func_decl, expr*> source;
+    ptr_vector<func_decl> source_bits;
+    m_imp->get_translation(source, source_bits);
+    obj_map<func_decl, expr*> translated;
+    ptr_vector<func_decl> translated_bits;
+    for (auto const& [f, bits] : source)
+        translated.insert(tr(f), tr(bits));
+    for (func_decl* f : source_bits)
+        translated_bits.push_back(tr(f));
+    dst.m_imp->set_translation(translated, translated_bits);
 }

--- a/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.cpp
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.cpp
@@ -788,16 +788,16 @@ void bit_blaster_rewriter::get_translation(obj_map<func_decl, expr*>& const2bits
     m_imp->get_translation(const2bits, newbits);
 }
 
-void bit_blaster_rewriter::translate(bit_blaster_rewriter& dst, ast_translation& tr) const {
-    SASSERT(get_num_scopes() == 0);
+void bit_blaster_rewriter::translate(bit_blaster_rewriter& src, ast_translation& tr) const {
+    SASSERT(src.get_num_scopes() == 0);
     obj_map<func_decl, expr*> source;
     ptr_vector<func_decl> source_bits;
-    m_imp->get_translation(source, source_bits);
+    src.m_imp->get_translation(source, source_bits);
     obj_map<func_decl, expr*> translated;
     ptr_vector<func_decl> translated_bits;
     for (auto const& [f, bits] : source)
         translated.insert(tr(f), tr(bits));
     for (func_decl* f : source_bits)
         translated_bits.push_back(tr(f));
-    dst.m_imp->set_translation(translated, translated_bits);
+    m_imp->set_translation(translated, translated_bits);
 }

--- a/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.h
@@ -39,9 +39,8 @@ public:
     void push();
     void pop(unsigned num_scopes);
     unsigned get_num_scopes() const;
+    void translate(bit_blaster_rewriter& dst, ast_translation& tr) const;
 private:
     obj_map<func_decl, expr*> const& const2bits() const;     
 
 };
-
-

--- a/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.h
@@ -39,7 +39,7 @@ public:
     void push();
     void pop(unsigned num_scopes);
     unsigned get_num_scopes() const;
-    void translate(bit_blaster_rewriter& dst, ast_translation& tr) const;
+    void translate(bit_blaster_rewriter& src, ast_translation& tr) const;
 private:
     obj_map<func_decl, expr*> const& const2bits() const;     
 

--- a/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.h
+++ b/src/ast/rewriter/bit_blaster/bit_blaster_rewriter.h
@@ -39,7 +39,7 @@ public:
     void push();
     void pop(unsigned num_scopes);
     unsigned get_num_scopes() const;
-    void translate(bit_blaster_rewriter& src, ast_translation& tr) const;
+    void translate(bit_blaster_rewriter const& src, ast_translation& tr) const;
 private:
     obj_map<func_decl, expr*> const& const2bits() const;     
 

--- a/src/ast/rewriter/maximize_ac_sharing.cpp
+++ b/src/ast/rewriter/maximize_ac_sharing.cpp
@@ -124,7 +124,7 @@ maximize_ac_sharing::~maximize_ac_sharing() {
     restore_entries(0);
 }
 
-void maximize_ac_sharing::translate(maximize_ac_sharing& src, ast_translation& tr) {
+void maximize_ac_sharing::translate(maximize_ac_sharing const& src, ast_translation& tr) {
     SASSERT(src.m_scopes.empty());
     SASSERT(m_entries.empty());
     init();

--- a/src/ast/rewriter/maximize_ac_sharing.cpp
+++ b/src/ast/rewriter/maximize_ac_sharing.cpp
@@ -18,6 +18,7 @@ Revision History:
 --*/
 
 #include "ast/rewriter/maximize_ac_sharing.h"
+#include "ast/ast_translation.h"
 #include "ast/ast_pp.h"
 
 
@@ -121,6 +122,14 @@ maximize_ac_sharing::maximize_ac_sharing(ast_manager & m):
 
 maximize_ac_sharing::~maximize_ac_sharing() {
     restore_entries(0);
+}
+
+void maximize_ac_sharing::translate(maximize_ac_sharing& dst, ast_translation& tr) const {
+    SASSERT(m_scopes.empty());
+    SASSERT(dst.m_entries.empty());
+    dst.init();
+    for (entry* e : m_entries)
+        dst.insert(tr(e->m_decl), tr(e->m_arg1), tr(e->m_arg2));
 }
 
 

--- a/src/ast/rewriter/maximize_ac_sharing.cpp
+++ b/src/ast/rewriter/maximize_ac_sharing.cpp
@@ -124,12 +124,12 @@ maximize_ac_sharing::~maximize_ac_sharing() {
     restore_entries(0);
 }
 
-void maximize_ac_sharing::translate(maximize_ac_sharing& dst, ast_translation& tr) const {
-    SASSERT(m_scopes.empty());
-    SASSERT(dst.m_entries.empty());
-    dst.init();
-    for (entry* e : m_entries)
-        dst.insert(tr(e->m_decl), tr(e->m_arg1), tr(e->m_arg2));
+void maximize_ac_sharing::translate(maximize_ac_sharing& src, ast_translation& tr) {
+    SASSERT(src.m_scopes.empty());
+    SASSERT(m_entries.empty());
+    init();
+    for (entry* e : src.m_entries)
+        insert(tr(e->m_decl), tr(e->m_arg1), tr(e->m_arg2));
 }
 
 

--- a/src/ast/rewriter/maximize_ac_sharing.h
+++ b/src/ast/rewriter/maximize_ac_sharing.h
@@ -95,7 +95,7 @@ public:
     void push_scope();
     void pop_scope(unsigned num_scopes);
     void reset();
-    void translate(maximize_ac_sharing& src, ast_translation& tr);
+    void translate(maximize_ac_sharing const& src, ast_translation& tr);
     br_status reduce_app(func_decl* f, unsigned n, expr * const* args, expr_ref& result, proof_ref& result_pr);
 
 };
@@ -119,5 +119,5 @@ public:
     void push_scope() { m_cfg.push_scope(); }
     void pop_scope(unsigned n) { m_cfg.pop_scope(n); }
     void reset() { m_cfg.reset(); }
-    void translate(maximize_bv_sharing_rw& src, ast_translation& tr) { m_cfg.translate(src.m_cfg, tr); }
+    void translate(maximize_bv_sharing_rw const& src, ast_translation& tr) { m_cfg.translate(src.m_cfg, tr); }
 };

--- a/src/ast/rewriter/maximize_ac_sharing.h
+++ b/src/ast/rewriter/maximize_ac_sharing.h
@@ -95,6 +95,7 @@ public:
     void push_scope();
     void pop_scope(unsigned num_scopes);
     void reset();
+    void translate(maximize_ac_sharing& dst, ast_translation& tr) const;
     br_status reduce_app(func_decl* f, unsigned n, expr * const* args, expr_ref& result, proof_ref& result_pr);
 
 };
@@ -118,6 +119,5 @@ public:
     void push_scope() { m_cfg.push_scope(); }
     void pop_scope(unsigned n) { m_cfg.pop_scope(n); }
     void reset() { m_cfg.reset(); }
+    void translate(maximize_bv_sharing_rw& dst, ast_translation& tr) const { m_cfg.translate(dst.m_cfg, tr); }
 };
-
-

--- a/src/ast/rewriter/maximize_ac_sharing.h
+++ b/src/ast/rewriter/maximize_ac_sharing.h
@@ -95,7 +95,7 @@ public:
     void push_scope();
     void pop_scope(unsigned num_scopes);
     void reset();
-    void translate(maximize_ac_sharing& dst, ast_translation& tr) const;
+    void translate(maximize_ac_sharing& src, ast_translation& tr);
     br_status reduce_app(func_decl* f, unsigned n, expr * const* args, expr_ref& result, proof_ref& result_pr);
 
 };
@@ -119,5 +119,5 @@ public:
     void push_scope() { m_cfg.push_scope(); }
     void pop_scope(unsigned n) { m_cfg.pop_scope(n); }
     void reset() { m_cfg.reset(); }
-    void translate(maximize_bv_sharing_rw& dst, ast_translation& tr) const { m_cfg.translate(dst.m_cfg, tr); }
+    void translate(maximize_bv_sharing_rw& src, ast_translation& tr) { m_cfg.translate(src.m_cfg, tr); }
 };

--- a/src/ast/simplifiers/bit_blaster.cpp
+++ b/src/ast/simplifiers/bit_blaster.cpp
@@ -75,7 +75,7 @@ void bit_blaster_simplifier::pop(unsigned n) {
     m_rewriter.pop(n);
 }
 
-void bit_blaster_simplifier::translate(dependent_expr_simplifier& src) {
+void bit_blaster_simplifier::translate(dependent_expr_simplifier& src, ast_translation& tr) {
     auto& source = dynamic_cast<bit_blaster_simplifier&>(src);
-    source.m_rewriter.translate(m_rewriter, translation());
+    source.m_rewriter.translate(m_rewriter, tr);
 }

--- a/src/ast/simplifiers/bit_blaster.cpp
+++ b/src/ast/simplifiers/bit_blaster.cpp
@@ -77,5 +77,5 @@ void bit_blaster_simplifier::pop(unsigned n) {
 
 void bit_blaster_simplifier::translate(dependent_expr_simplifier& src, ast_translation& tr) {
     auto& source = dynamic_cast<bit_blaster_simplifier&>(src);
-    source.m_rewriter.translate(m_rewriter, tr);
+    m_rewriter.translate(source.m_rewriter, tr);
 }

--- a/src/ast/simplifiers/bit_blaster.cpp
+++ b/src/ast/simplifiers/bit_blaster.cpp
@@ -75,7 +75,7 @@ void bit_blaster_simplifier::pop(unsigned n) {
     m_rewriter.pop(n);
 }
 
-void bit_blaster_simplifier::translate(dependent_expr_simplifier& src, ast_translation& tr) {
-    auto& source = dynamic_cast<bit_blaster_simplifier&>(src);
+void bit_blaster_simplifier::translate(dependent_expr_simplifier const& src, ast_translation& tr) {
+    auto const& source = dynamic_cast<bit_blaster_simplifier const&>(src);
     m_rewriter.translate(source.m_rewriter, tr);
 }

--- a/src/ast/simplifiers/bit_blaster.cpp
+++ b/src/ast/simplifiers/bit_blaster.cpp
@@ -74,3 +74,8 @@ void bit_blaster_simplifier::pop(unsigned n) {
     dependent_expr_simplifier::pop(n);
     m_rewriter.pop(n);
 }
+
+void bit_blaster_simplifier::translate(dependent_expr_simplifier& src) {
+    auto& source = dynamic_cast<bit_blaster_simplifier&>(src);
+    source.m_rewriter.translate(m_rewriter, translation());
+}

--- a/src/ast/simplifiers/bit_blaster.h
+++ b/src/ast/simplifiers/bit_blaster.h
@@ -40,7 +40,7 @@ public:
     void collect_statistics(statistics& st) const override;
     void push() override;
     void pop(unsigned n) override;
-    void translate(dependent_expr_simplifier& src, ast_translation& tr) override;
+    void translate(dependent_expr_simplifier const& src, ast_translation& tr) override;
 
     /*
     * Expose the bit-blaster rewriter so that assumptions and implied bit-vectors can be reconstructed

--- a/src/ast/simplifiers/bit_blaster.h
+++ b/src/ast/simplifiers/bit_blaster.h
@@ -40,6 +40,7 @@ public:
     void collect_statistics(statistics& st) const override;
     void push() override;
     void pop(unsigned n) override;
+    void translate(dependent_expr_simplifier& src) override;
 
     /*
     * Expose the bit-blaster rewriter so that assumptions and implied bit-vectors can be reconstructed

--- a/src/ast/simplifiers/bit_blaster.h
+++ b/src/ast/simplifiers/bit_blaster.h
@@ -40,7 +40,7 @@ public:
     void collect_statistics(statistics& st) const override;
     void push() override;
     void pop(unsigned n) override;
-    void translate(dependent_expr_simplifier& src) override;
+    void translate(dependent_expr_simplifier& src, ast_translation& tr) override;
 
     /*
     * Expose the bit-blaster rewriter so that assumptions and implied bit-vectors can be reconstructed

--- a/src/ast/simplifiers/bv1_blaster.cpp
+++ b/src/ast/simplifiers/bv1_blaster.cpp
@@ -292,11 +292,10 @@ void bv1_blaster_simplifier::reduce() {
     }
 }
 
-void bv1_blaster_simplifier::translate(dependent_expr_simplifier& src) {
+void bv1_blaster_simplifier::translate(dependent_expr_simplifier& src, ast_translation& tr) {
     auto& source = dynamic_cast<bv1_blaster_simplifier&>(src);
     auto& src_cfg = source.m_rw.cfg();
     auto& dst_cfg = m_rw.cfg();
-    ast_translation& tr = translation();
     SASSERT(dst_cfg.m_const2bits.empty());
     for (auto const& [f, bits] : src_cfg.m_const2bits) {
         func_decl* new_f = tr(f);

--- a/src/ast/simplifiers/bv1_blaster.cpp
+++ b/src/ast/simplifiers/bv1_blaster.cpp
@@ -292,9 +292,9 @@ void bv1_blaster_simplifier::reduce() {
     }
 }
 
-void bv1_blaster_simplifier::translate(dependent_expr_simplifier& src, ast_translation& tr) {
-    auto& source = dynamic_cast<bv1_blaster_simplifier&>(src);
-    auto& src_cfg = source.m_rw.cfg();
+void bv1_blaster_simplifier::translate(dependent_expr_simplifier const& src, ast_translation& tr) {
+    auto const& source = dynamic_cast<bv1_blaster_simplifier const&>(src);
+    auto const& src_cfg = source.m_rw.cfg();
     auto& dst_cfg = m_rw.cfg();
     SASSERT(dst_cfg.m_const2bits.empty());
     for (auto const& [f, bits] : src_cfg.m_const2bits) {

--- a/src/ast/simplifiers/bv1_blaster.cpp
+++ b/src/ast/simplifiers/bv1_blaster.cpp
@@ -21,6 +21,7 @@ Author:
 
 --*/
 #include "ast/simplifiers/bv1_blaster.h"
+#include "ast/ast_translation.h"
 #include "ast/ast_util.h"
 #include "ast/rewriter/bv_rewriter.h"
 #include "ast/rewriter/rewriter_types.h"
@@ -288,5 +289,25 @@ void bv1_blaster_simplifier::reduce() {
         func_decl* first = to_app(to_app(v)->get_arg(0))->get_decl();
         if (new_bit_set.contains(first))
             m_fmls.model_trail().push(f, v, nullptr, {});
+    }
+}
+
+void bv1_blaster_simplifier::translate(dependent_expr_simplifier& src) {
+    auto& source = dynamic_cast<bv1_blaster_simplifier&>(src);
+    auto& src_cfg = source.m_rw.cfg();
+    auto& dst_cfg = m_rw.cfg();
+    ast_translation& tr = translation();
+    SASSERT(dst_cfg.m_const2bits.empty());
+    for (auto const& [f, bits] : src_cfg.m_const2bits) {
+        func_decl* new_f = tr(f);
+        expr* new_bits = tr(bits);
+        dst_cfg.m_const2bits.insert(new_f, new_bits);
+        dst_cfg.m_saved.push_back(new_f);
+        dst_cfg.m_saved.push_back(new_bits);
+    }
+    for (func_decl* f : src_cfg.m_newbits) {
+        func_decl* new_f = tr(f);
+        dst_cfg.m_newbits.push_back(new_f);
+        dst_cfg.m_saved.push_back(new_f);
     }
 }

--- a/src/ast/simplifiers/bv1_blaster.h
+++ b/src/ast/simplifiers/bv1_blaster.h
@@ -91,7 +91,7 @@ public:
     void updt_params(params_ref const& p) override { m_rw.cfg().updt_params(p); }
     void collect_param_descrs(param_descrs& r) override;
     void reduce() override;
-    void translate(dependent_expr_simplifier& src, ast_translation& tr) override;
+    void translate(dependent_expr_simplifier const& src, ast_translation& tr) override;
 };
 
 /*

--- a/src/ast/simplifiers/bv1_blaster.h
+++ b/src/ast/simplifiers/bv1_blaster.h
@@ -91,6 +91,7 @@ public:
     void updt_params(params_ref const& p) override { m_rw.cfg().updt_params(p); }
     void collect_param_descrs(param_descrs& r) override;
     void reduce() override;
+    void translate(dependent_expr_simplifier& src) override;
 };
 
 /*

--- a/src/ast/simplifiers/bv1_blaster.h
+++ b/src/ast/simplifiers/bv1_blaster.h
@@ -91,7 +91,7 @@ public:
     void updt_params(params_ref const& p) override { m_rw.cfg().updt_params(p); }
     void collect_param_descrs(param_descrs& r) override;
     void reduce() override;
-    void translate(dependent_expr_simplifier& src) override;
+    void translate(dependent_expr_simplifier& src, ast_translation& tr) override;
 };
 
 /*

--- a/src/ast/simplifiers/bv_slice.cpp
+++ b/src/ast/simplifiers/bv_slice.cpp
@@ -22,8 +22,8 @@ Author:
 
 namespace bv {
 
-    void slice::translate(dependent_expr_simplifier& src, ast_translation& tr) {
-        auto& source = dynamic_cast<slice&>(src);
+    void slice::translate(dependent_expr_simplifier const& src, ast_translation& tr) {
+        auto const& source = dynamic_cast<slice const&>(src);
         SASSERT(m_boundaries.empty());
         for (auto const& [e, boundaries] : source.m_boundaries)
             m_boundaries.insert(tr(e), boundaries);

--- a/src/ast/simplifiers/bv_slice.cpp
+++ b/src/ast/simplifiers/bv_slice.cpp
@@ -16,10 +16,19 @@ Author:
 --*/
 
 #include "ast/ast_pp.h"
+#include "ast/ast_translation.h"
 #include "ast/ast_ll_pp.h"
 #include "ast/simplifiers/bv_slice.h"
 
 namespace bv {
+
+    void slice::translate(dependent_expr_simplifier& src) {
+        auto& source = dynamic_cast<slice&>(src);
+        ast_translation& tr = translation();
+        SASSERT(m_boundaries.empty());
+        for (auto const& [e, boundaries] : source.m_boundaries)
+            m_boundaries.insert(tr(e), boundaries);
+    }
 
     void slice::reduce() {
         process_eqs();

--- a/src/ast/simplifiers/bv_slice.cpp
+++ b/src/ast/simplifiers/bv_slice.cpp
@@ -22,9 +22,8 @@ Author:
 
 namespace bv {
 
-    void slice::translate(dependent_expr_simplifier& src) {
+    void slice::translate(dependent_expr_simplifier& src, ast_translation& tr) {
         auto& source = dynamic_cast<slice&>(src);
-        ast_translation& tr = translation();
         SASSERT(m_boundaries.empty());
         for (auto const& [e, boundaries] : source.m_boundaries)
             m_boundaries.insert(tr(e), boundaries);

--- a/src/ast/simplifiers/bv_slice.h
+++ b/src/ast/simplifiers/bv_slice.h
@@ -50,7 +50,7 @@ namespace bv {
         char const* name() const override { return "bv-slice"; }
         void push() override { dependent_expr_simplifier::push(); }
         void pop(unsigned n) override { dependent_expr_simplifier::pop(n); }
-        void translate(dependent_expr_simplifier& src) override;
+        void translate(dependent_expr_simplifier& src, ast_translation& tr) override;
         void reduce() override;
     };
 }

--- a/src/ast/simplifiers/bv_slice.h
+++ b/src/ast/simplifiers/bv_slice.h
@@ -50,7 +50,7 @@ namespace bv {
         char const* name() const override { return "bv-slice"; }
         void push() override { dependent_expr_simplifier::push(); }
         void pop(unsigned n) override { dependent_expr_simplifier::pop(n); }
-        void translate(dependent_expr_simplifier& src, ast_translation& tr) override;
+        void translate(dependent_expr_simplifier const& src, ast_translation& tr) override;
         void reduce() override;
     };
 }

--- a/src/ast/simplifiers/bv_slice.h
+++ b/src/ast/simplifiers/bv_slice.h
@@ -50,6 +50,7 @@ namespace bv {
         char const* name() const override { return "bv-slice"; }
         void push() override { dependent_expr_simplifier::push(); }
         void pop(unsigned n) override { dependent_expr_simplifier::pop(n); }
+        void translate(dependent_expr_simplifier& src) override;
         void reduce() override;
     };
 }

--- a/src/ast/simplifiers/cnf_nnf.h
+++ b/src/ast/simplifiers/cnf_nnf.h
@@ -62,4 +62,9 @@ public:
     void push() override { dependent_expr_simplifier::push(); m_defined_names.push(); }
 
     void pop(unsigned n) override { dependent_expr_simplifier::pop(n); m_defined_names.pop(n); }
+
+    void translate(dependent_expr_simplifier& src) override {
+        auto& source = dynamic_cast<cnf_nnf_simplifier&>(src);
+        source.m_defined_names.translate(m_defined_names, translation());
+    }
 };

--- a/src/ast/simplifiers/cnf_nnf.h
+++ b/src/ast/simplifiers/cnf_nnf.h
@@ -65,6 +65,6 @@ public:
 
     void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
         auto& source = dynamic_cast<cnf_nnf_simplifier&>(src);
-        source.m_defined_names.translate(m_defined_names, tr);
+        m_defined_names.translate(source.m_defined_names, tr);
     }
 };

--- a/src/ast/simplifiers/cnf_nnf.h
+++ b/src/ast/simplifiers/cnf_nnf.h
@@ -63,8 +63,8 @@ public:
 
     void pop(unsigned n) override { dependent_expr_simplifier::pop(n); m_defined_names.pop(n); }
 
-    void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
-        auto& source = dynamic_cast<cnf_nnf_simplifier&>(src);
+    void translate(dependent_expr_simplifier const& src, ast_translation& tr) override {
+        auto const& source = dynamic_cast<cnf_nnf_simplifier const&>(src);
         m_defined_names.translate(source.m_defined_names, tr);
     }
 };

--- a/src/ast/simplifiers/cnf_nnf.h
+++ b/src/ast/simplifiers/cnf_nnf.h
@@ -63,8 +63,8 @@ public:
 
     void pop(unsigned n) override { dependent_expr_simplifier::pop(n); m_defined_names.pop(n); }
 
-    void translate(dependent_expr_simplifier& src) override {
+    void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
         auto& source = dynamic_cast<cnf_nnf_simplifier&>(src);
-        source.m_defined_names.translate(m_defined_names, translation());
+        source.m_defined_names.translate(m_defined_names, tr);
     }
 };

--- a/src/ast/simplifiers/dependent_expr_state.cpp
+++ b/src/ast/simplifiers/dependent_expr_state.cpp
@@ -132,17 +132,17 @@ bool dependent_expr_state::has_quantifiers() {
     m_has_quantifiers = found ? l_true : l_false;
     return m_has_quantifiers == l_true;
 }
-void dependent_expr_state::translate(dependent_expr_state& dst, ast_translation& tr) {
-    SASSERT(m_trail.get_num_scopes() == 0);
-    SASSERT(dst.m_qhead == 0);
-    dst.m_qhead = m_qhead;
-    dst.m_suffix_frozen = m_suffix_frozen;
-    dst.m_num_recfun = m_num_recfun;
-    dst.m_has_quantifiers = m_has_quantifiers;
-    for (func_decl* f : m_frozen_trail) {
+void dependent_expr_state::translate(dependent_expr_state& src, ast_translation& tr) {
+    SASSERT(src.m_trail.get_num_scopes() == 0);
+    SASSERT(m_qhead == 0);
+    m_qhead = src.m_qhead;
+    m_suffix_frozen = src.m_suffix_frozen;
+    m_num_recfun = src.m_num_recfun;
+    m_has_quantifiers = src.m_has_quantifiers;
+    for (func_decl* f : src.m_frozen_trail) {
         func_decl* new_f = tr(f);
-        dst.m_frozen.mark(new_f, true);
-        dst.m_frozen_trail.push_back(new_f);
+        m_frozen.mark(new_f, true);
+        m_frozen_trail.push_back(new_f);
     }
-    model_trail().translate(dst.model_trail(), tr);
+    model_trail().translate(src.model_trail(), tr);
 }

--- a/src/ast/simplifiers/dependent_expr_state.cpp
+++ b/src/ast/simplifiers/dependent_expr_state.cpp
@@ -132,7 +132,7 @@ bool dependent_expr_state::has_quantifiers() {
     m_has_quantifiers = found ? l_true : l_false;
     return m_has_quantifiers == l_true;
 }
-void dependent_expr_state::translate(dependent_expr_state& src, ast_translation& tr) {
+void dependent_expr_state::translate(dependent_expr_state const& src, ast_translation& tr) {
     SASSERT(src.m_trail.get_num_scopes() == 0);
     SASSERT(m_qhead == 0);
     m_qhead = src.m_qhead;

--- a/src/ast/simplifiers/dependent_expr_state.cpp
+++ b/src/ast/simplifiers/dependent_expr_state.cpp
@@ -12,6 +12,7 @@ Author:
 --*/
 
 #include "ast/simplifiers/dependent_expr_state.h"
+#include "ast/ast_translation.h"
 #include "ast/recfun_decl_plugin.h"
 #include "ast/for_each_ast.h"
 
@@ -130,4 +131,18 @@ bool dependent_expr_state::has_quantifiers() {
         found |= ::has_quantifiers((*this)[i].fml());
     m_has_quantifiers = found ? l_true : l_false;
     return m_has_quantifiers == l_true;
+}
+void dependent_expr_state::translate(dependent_expr_state& dst, ast_translation& tr) {
+    SASSERT(m_trail.get_num_scopes() == 0);
+    SASSERT(dst.m_qhead == 0);
+    dst.m_qhead = m_qhead;
+    dst.m_suffix_frozen = m_suffix_frozen;
+    dst.m_num_recfun = m_num_recfun;
+    dst.m_has_quantifiers = m_has_quantifiers;
+    for (func_decl* f : m_frozen_trail) {
+        func_decl* new_f = tr(f);
+        dst.m_frozen.mark(new_f, true);
+        dst.m_frozen_trail.push_back(new_f);
+    }
+    model_trail().translate(dst.model_trail(), tr);
 }

--- a/src/ast/simplifiers/dependent_expr_state.h
+++ b/src/ast/simplifiers/dependent_expr_state.h
@@ -73,6 +73,7 @@ public:
     virtual void add(dependent_expr const& j) = 0;
     virtual bool inconsistent() = 0;
     virtual model_reconstruction_trail& model_trail() = 0;
+    virtual model_reconstruction_trail const& model_trail() const = 0;
     virtual void flatten_suffix() {}
     virtual bool updated() = 0;
     virtual void reset_updated() = 0;
@@ -84,7 +85,7 @@ public:
         m_trail.push(thaw(*this));
     }
     void pop(unsigned n) { m_trail.pop_scope(n); }
-    void translate(dependent_expr_state& src, ast_translation& tr);
+    void translate(dependent_expr_state const& src, ast_translation& tr);
     
     void advance_qhead() { freeze_prefix(); m_suffix_frozen = false; m_has_quantifiers = l_undef;  m_qhead = qtail(); }
     unsigned num_exprs();
@@ -112,6 +113,7 @@ public:
     void add(dependent_expr const& j) override { throw default_exception("unexpected addition"); }
     bool inconsistent() override { return false; }
     model_reconstruction_trail& model_trail() override { throw default_exception("unexpected access to model reconstruction"); }
+    model_reconstruction_trail const& model_trail() const override { throw default_exception("unexpected access to model reconstruction"); }
     bool updated() override { return false; }
     void reset_updated() override {}
 };
@@ -137,6 +139,7 @@ struct base_dependent_expr_state : public dependent_expr_state {
     bool updated() override { return m_updated; }
     void reset_updated() override { m_updated = false; }
     model_reconstruction_trail& model_trail() override { return m_reconstruction_trail; }
+    model_reconstruction_trail const& model_trail() const override { return m_reconstruction_trail; }
     std::ostream& display(std::ostream& out) const override {
         unsigned i = 0;
         for (auto const& d : m_fmls) {
@@ -231,7 +234,7 @@ public:
     virtual char const* name() const = 0;
     virtual void push() { }
     virtual void pop(unsigned n) { }
-    virtual void translate(dependent_expr_simplifier& src, ast_translation& tr) {}
+    virtual void translate(dependent_expr_simplifier const& src, ast_translation& tr) {}
     virtual void reduce() = 0;
     virtual void collect_statistics(statistics& st) const {}
     virtual void reset_statistics() {}

--- a/src/ast/simplifiers/dependent_expr_state.h
+++ b/src/ast/simplifiers/dependent_expr_state.h
@@ -200,8 +200,6 @@ protected:
     ast_manager& m;
     dependent_expr_state& m_fmls;
     trail_stack& m_trail;
-    ast_translation* m_translation = nullptr;
-    ast_translation& translation() const { SASSERT(m_translation); return *m_translation; }
 
     unsigned num_scopes() const { return m_trail.get_num_scopes(); }
 
@@ -233,8 +231,7 @@ public:
     virtual char const* name() const = 0;
     virtual void push() { }
     virtual void pop(unsigned n) { }
-    virtual void set_ast_translation(ast_translation* tr) { m_translation = tr; }
-    virtual void translate(dependent_expr_simplifier& src) {}
+    virtual void translate(dependent_expr_simplifier& src, ast_translation& tr) {}
     virtual void reduce() = 0;
     virtual void collect_statistics(statistics& st) const {}
     virtual void reset_statistics() {}

--- a/src/ast/simplifiers/dependent_expr_state.h
+++ b/src/ast/simplifiers/dependent_expr_state.h
@@ -84,6 +84,7 @@ public:
         m_trail.push(thaw(*this));
     }
     void pop(unsigned n) { m_trail.pop_scope(n); }
+    void translate(dependent_expr_state& dst, ast_translation& tr);
     
     void advance_qhead() { freeze_prefix(); m_suffix_frozen = false; m_has_quantifiers = l_undef;  m_qhead = qtail(); }
     unsigned num_exprs();
@@ -199,6 +200,8 @@ protected:
     ast_manager& m;
     dependent_expr_state& m_fmls;
     trail_stack& m_trail;
+    ast_translation* m_translation = nullptr;
+    ast_translation& translation() const { SASSERT(m_translation); return *m_translation; }
 
     unsigned num_scopes() const { return m_trail.get_num_scopes(); }
 
@@ -230,6 +233,8 @@ public:
     virtual char const* name() const = 0;
     virtual void push() { }
     virtual void pop(unsigned n) { }
+    virtual void set_ast_translation(ast_translation* tr) { m_translation = tr; }
+    virtual void translate(dependent_expr_simplifier& src) {}
     virtual void reduce() = 0;
     virtual void collect_statistics(statistics& st) const {}
     virtual void reset_statistics() {}

--- a/src/ast/simplifiers/dependent_expr_state.h
+++ b/src/ast/simplifiers/dependent_expr_state.h
@@ -84,7 +84,7 @@ public:
         m_trail.push(thaw(*this));
     }
     void pop(unsigned n) { m_trail.pop_scope(n); }
-    void translate(dependent_expr_state& dst, ast_translation& tr);
+    void translate(dependent_expr_state& src, ast_translation& tr);
     
     void advance_qhead() { freeze_prefix(); m_suffix_frozen = false; m_has_quantifiers = l_undef;  m_qhead = qtail(); }
     unsigned num_exprs();

--- a/src/ast/simplifiers/elim_term_ite.h
+++ b/src/ast/simplifiers/elim_term_ite.h
@@ -53,6 +53,11 @@ public:
     void push() override { dependent_expr_simplifier::push(); m_df.push(); m_rewriter.push(); }
     
     void pop(unsigned n) override { m_rewriter.pop(n); m_df.pop(n); dependent_expr_simplifier::pop(n); }
+
+    void translate(dependent_expr_simplifier& src) override {
+        auto& source = dynamic_cast<elim_term_ite_simplifier&>(src);
+        source.m_df.translate(m_df, translation());
+    }
 };
 
 /*

--- a/src/ast/simplifiers/elim_term_ite.h
+++ b/src/ast/simplifiers/elim_term_ite.h
@@ -54,8 +54,8 @@ public:
     
     void pop(unsigned n) override { m_rewriter.pop(n); m_df.pop(n); dependent_expr_simplifier::pop(n); }
 
-    void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
-        auto& source = dynamic_cast<elim_term_ite_simplifier&>(src);
+    void translate(dependent_expr_simplifier const& src, ast_translation& tr) override {
+        auto const& source = dynamic_cast<elim_term_ite_simplifier const&>(src);
         m_df.translate(source.m_df, tr);
     }
 };

--- a/src/ast/simplifiers/elim_term_ite.h
+++ b/src/ast/simplifiers/elim_term_ite.h
@@ -54,9 +54,9 @@ public:
     
     void pop(unsigned n) override { m_rewriter.pop(n); m_df.pop(n); dependent_expr_simplifier::pop(n); }
 
-    void translate(dependent_expr_simplifier& src) override {
+    void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
         auto& source = dynamic_cast<elim_term_ite_simplifier&>(src);
-        source.m_df.translate(m_df, translation());
+        source.m_df.translate(m_df, tr);
     }
 };
 

--- a/src/ast/simplifiers/elim_term_ite.h
+++ b/src/ast/simplifiers/elim_term_ite.h
@@ -56,7 +56,7 @@ public:
 
     void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
         auto& source = dynamic_cast<elim_term_ite_simplifier&>(src);
-        source.m_df.translate(m_df, tr);
+        m_df.translate(source.m_df, tr);
     }
 };
 

--- a/src/ast/simplifiers/euf_completion.cpp
+++ b/src/ast/simplifiers/euf_completion.cpp
@@ -190,6 +190,14 @@ namespace euf {
             m_side_condition_solver->pop(n);
     }
 
+    void completion::translate(dependent_expr_simplifier& src) {
+        dynamic_cast<completion&>(src);
+        // The translated state still has qhead 0. Replaying its translated
+        // prefix rebuilds the e-graph, matcher, rules, and side solver using
+        // the destination declarations.
+        add_egraph();
+    }
+
     void completion::clear_propagation_queue() {
         for (auto r : m_propagation_queue)
             r->m_in_queue = false;

--- a/src/ast/simplifiers/euf_completion.cpp
+++ b/src/ast/simplifiers/euf_completion.cpp
@@ -190,12 +190,8 @@ namespace euf {
             m_side_condition_solver->pop(n);
     }
 
-    void completion::translate(dependent_expr_simplifier& src, ast_translation&) {
-        dynamic_cast<completion&>(src);
-        // The translated state still has qhead 0. Replaying its translated
-        // prefix rebuilds the e-graph, matcher, rules, and side solver using
-        // the destination declarations.
-        add_egraph();
+    void completion::translate(dependent_expr_simplifier&, ast_translation&) {
+        throw default_exception("euf_completion is not clonable");
     }
 
     void completion::clear_propagation_queue() {

--- a/src/ast/simplifiers/euf_completion.cpp
+++ b/src/ast/simplifiers/euf_completion.cpp
@@ -190,7 +190,7 @@ namespace euf {
             m_side_condition_solver->pop(n);
     }
 
-    void completion::translate(dependent_expr_simplifier&, ast_translation&) {
+    void completion::translate(dependent_expr_simplifier const&, ast_translation&) {
         throw default_exception("euf_completion is not clonable");
     }
 

--- a/src/ast/simplifiers/euf_completion.cpp
+++ b/src/ast/simplifiers/euf_completion.cpp
@@ -190,7 +190,7 @@ namespace euf {
             m_side_condition_solver->pop(n);
     }
 
-    void completion::translate(dependent_expr_simplifier& src) {
+    void completion::translate(dependent_expr_simplifier& src, ast_translation&) {
         dynamic_cast<completion&>(src);
         // The translated state still has qhead 0. Replaying its translated
         // prefix rebuilds the e-graph, matcher, rules, and side solver using

--- a/src/ast/simplifiers/euf_completion.h
+++ b/src/ast/simplifiers/euf_completion.h
@@ -229,7 +229,7 @@ namespace euf {
         char const* name() const override { return "euf-completion"; }
         void push() override;
         void pop(unsigned n) override;
-        void translate(dependent_expr_simplifier& src, ast_translation& tr) override;
+        void translate(dependent_expr_simplifier const& src, ast_translation& tr) override;
         void reduce() override;
         void collect_statistics(statistics& st) const override;
         void reset_statistics() override { m_stats.reset(); }

--- a/src/ast/simplifiers/euf_completion.h
+++ b/src/ast/simplifiers/euf_completion.h
@@ -229,7 +229,7 @@ namespace euf {
         char const* name() const override { return "euf-completion"; }
         void push() override;
         void pop(unsigned n) override;
-        void translate(dependent_expr_simplifier& src) override;
+        void translate(dependent_expr_simplifier& src, ast_translation& tr) override;
         void reduce() override;
         void collect_statistics(statistics& st) const override;
         void reset_statistics() override { m_stats.reset(); }

--- a/src/ast/simplifiers/euf_completion.h
+++ b/src/ast/simplifiers/euf_completion.h
@@ -229,6 +229,7 @@ namespace euf {
         char const* name() const override { return "euf-completion"; }
         void push() override;
         void pop(unsigned n) override;
+        void translate(dependent_expr_simplifier& src) override;
         void reduce() override;
         void collect_statistics(statistics& st) const override;
         void reset_statistics() override { m_stats.reset(); }

--- a/src/ast/simplifiers/fold_unfold.cpp
+++ b/src/ast/simplifiers/fold_unfold.cpp
@@ -55,6 +55,42 @@ namespace euf {
         reduce_alias(false);
     }
 
+    void fold_unfold::translate(dependent_expr_simplifier& src) {
+        auto& source = dynamic_cast<fold_unfold&>(src);
+        auto& tr = translation();
+        expr_dependency_translation dep_tr(tr);
+        SASSERT(num_scopes() == 0 && source.num_scopes() == 0);
+
+        for (enode* n : source.m_egraph.nodes())
+            mk_enode(tr(n->get_expr()));
+
+        for (enode* root : source.m_egraph.nodes()) {
+            if (!root->is_root())
+                continue;
+            enode* dst_root = m_egraph.find(tr(root->get_expr()));
+            for (enode* n : enode_class(root)) {
+                if (n == root)
+                    continue;
+                proof_ref pr(source.m);
+                if (source.m.proofs_enabled()) {
+                    expr_ref_vector prs(source.m);
+                    ptr_vector<size_t> just;
+                    source.m_egraph.begin_explain();
+                    source.m_egraph.explain_eq(just, nullptr, root, n);
+                    source.m_egraph.end_explain();
+                    for (size_t* j : just)
+                        prs.push_back(source.m_pr_dep[source.from_ptr(j)].first);
+                    prs.push_back(source.m.mk_eq(root->get_expr(), n->get_expr()));
+                    pr = source.m.mk_app(symbol("euf"), prs.size(), prs.data(), source.m.mk_proof_sort());
+                }
+                auto* dep = dep_tr(source.explain_eq(root, n));
+                auto* dst_n = m_egraph.find(tr(n->get_expr()));
+                m_egraph.merge(dst_root, dst_n, to_ptr(push_pr_dep(tr(pr.get()), dep)));
+            }
+        }
+        m_egraph.propagate();
+    }
+
     void fold_unfold::reduce_alias(bool fuf) {
         m_subst = nullptr;
         dep_eq_vector eqs;

--- a/src/ast/simplifiers/fold_unfold.cpp
+++ b/src/ast/simplifiers/fold_unfold.cpp
@@ -45,6 +45,19 @@ namespace euf {
         if (!m_config.m_enabled)
             return;
 
+        SASSERT(m_pr_dep.empty());
+        m_egraph.push();
+        auto reset_egraph = on_scope_exit([&]() {
+            m_find.reset();
+            m_args.reset();
+            m_todo.reset();
+            m_node2level.reset();
+            m_level2node.reset();
+            m_egraph.pop(1);
+            m_pr_dep.reset();
+            m_th_var = 0;
+        });
+
         m_fmls.freeze_suffix();
 
         for (extract_eq* ex : m_extract_plugins)
@@ -53,41 +66,6 @@ namespace euf {
         reduce_alias(true);
         reduce_linear();
         reduce_alias(false);
-    }
-
-    void fold_unfold::translate(dependent_expr_simplifier& src, ast_translation& tr) {
-        auto& source = dynamic_cast<fold_unfold&>(src);
-        expr_dependency_translation dep_tr(tr);
-        SASSERT(num_scopes() == 0 && source.num_scopes() == 0);
-
-        for (enode* n : source.m_egraph.nodes())
-            mk_enode(tr(n->get_expr()));
-
-        for (enode* root : source.m_egraph.nodes()) {
-            if (!root->is_root())
-                continue;
-            enode* dst_root = m_egraph.find(tr(root->get_expr()));
-            for (enode* n : enode_class(root)) {
-                if (n == root)
-                    continue;
-                proof_ref pr(source.m);
-                if (source.m.proofs_enabled()) {
-                    expr_ref_vector prs(source.m);
-                    ptr_vector<size_t> just;
-                    source.m_egraph.begin_explain();
-                    source.m_egraph.explain_eq(just, nullptr, root, n);
-                    source.m_egraph.end_explain();
-                    for (size_t* j : just)
-                        prs.push_back(source.m_pr_dep[source.from_ptr(j)].first);
-                    prs.push_back(source.m.mk_eq(root->get_expr(), n->get_expr()));
-                    pr = source.m.mk_app(symbol("euf"), prs.size(), prs.data(), source.m.mk_proof_sort());
-                }
-                auto* dep = dep_tr(source.explain_eq(root, n));
-                auto* dst_n = m_egraph.find(tr(n->get_expr()));
-                m_egraph.merge(dst_root, dst_n, to_ptr(push_pr_dep(tr(pr.get()), dep)));
-            }
-        }
-        m_egraph.propagate();
     }
 
     void fold_unfold::reduce_alias(bool fuf) {
@@ -208,7 +186,6 @@ namespace euf {
         unsigned sz = m_pr_dep.size();
         SASSERT(!m.proofs_enabled() || pr);
         m_pr_dep.push_back({proof_ref(pr, m), d});
-        m_trail.push(push_back_vector(m_pr_dep));
         return sz;
     }
 

--- a/src/ast/simplifiers/fold_unfold.cpp
+++ b/src/ast/simplifiers/fold_unfold.cpp
@@ -55,9 +55,8 @@ namespace euf {
         reduce_alias(false);
     }
 
-    void fold_unfold::translate(dependent_expr_simplifier& src) {
+    void fold_unfold::translate(dependent_expr_simplifier& src, ast_translation& tr) {
         auto& source = dynamic_cast<fold_unfold&>(src);
-        auto& tr = translation();
         expr_dependency_translation dep_tr(tr);
         SASSERT(num_scopes() == 0 && source.num_scopes() == 0);
 

--- a/src/ast/simplifiers/fold_unfold.h
+++ b/src/ast/simplifiers/fold_unfold.h
@@ -95,7 +95,7 @@ namespace euf {
 
         void reduce() override;
 
-        void translate(dependent_expr_simplifier& src) override;
+        void translate(dependent_expr_simplifier& src, ast_translation& tr) override;
 
         void updt_params(params_ref const &p) override;
 

--- a/src/ast/simplifiers/fold_unfold.h
+++ b/src/ast/simplifiers/fold_unfold.h
@@ -95,6 +95,8 @@ namespace euf {
 
         void reduce() override;
 
+        void translate(dependent_expr_simplifier& src) override;
+
         void updt_params(params_ref const &p) override;
 
         void collect_param_descrs(param_descrs &r) override;

--- a/src/ast/simplifiers/fold_unfold.h
+++ b/src/ast/simplifiers/fold_unfold.h
@@ -95,8 +95,6 @@ namespace euf {
 
         void reduce() override;
 
-        void translate(dependent_expr_simplifier& src, ast_translation& tr) override;
-
         void updt_params(params_ref const &p) override;
 
         void collect_param_descrs(param_descrs &r) override;

--- a/src/ast/simplifiers/injectivity_simplifier.h
+++ b/src/ast/simplifiers/injectivity_simplifier.h
@@ -27,6 +27,7 @@ Notes:
 #pragma once
 
 #include "ast/simplifiers/dependent_expr_state.h"
+#include "ast/ast_translation.h"
 #include "ast/rewriter/rewriter_def.h"
 
 class injectivity_simplifier : public dependent_expr_simplifier {
@@ -164,6 +165,15 @@ public:
         dependent_expr_simplifier(m, s), m_map(m), m_rw(m, m_map) {}
 
     char const* name() const override { return "injectivity"; }
+
+    void translate(dependent_expr_simplifier& src) override {
+        auto& source = dynamic_cast<injectivity_simplifier&>(src);
+        ast_translation& tr = translation();
+        SASSERT(m_map.empty());
+        for (auto const& [f, inverses] : source.m_map)
+            for (func_decl* g : *inverses)
+                m_map.insert(tr(f), tr(g));
+    }
 
     void reduce() override {
         // Phase 1: Scan for injectivity axioms

--- a/src/ast/simplifiers/injectivity_simplifier.h
+++ b/src/ast/simplifiers/injectivity_simplifier.h
@@ -166,8 +166,8 @@ public:
 
     char const* name() const override { return "injectivity"; }
 
-    void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
-        auto& source = dynamic_cast<injectivity_simplifier&>(src);
+    void translate(dependent_expr_simplifier const& src, ast_translation& tr) override {
+        auto const& source = dynamic_cast<injectivity_simplifier const&>(src);
         SASSERT(m_map.empty());
         for (auto const& [f, inverses] : source.m_map)
             for (func_decl* g : *inverses)

--- a/src/ast/simplifiers/injectivity_simplifier.h
+++ b/src/ast/simplifiers/injectivity_simplifier.h
@@ -166,9 +166,8 @@ public:
 
     char const* name() const override { return "injectivity"; }
 
-    void translate(dependent_expr_simplifier& src) override {
+    void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
         auto& source = dynamic_cast<injectivity_simplifier&>(src);
-        ast_translation& tr = translation();
         SASSERT(m_map.empty());
         for (auto const& [f, inverses] : source.m_map)
             for (func_decl* g : *inverses)

--- a/src/ast/simplifiers/max_bv_sharing.cpp
+++ b/src/ast/simplifiers/max_bv_sharing.cpp
@@ -62,8 +62,8 @@ public:
 
     void pop(unsigned n) override { dependent_expr_simplifier::pop(n); m_rewriter.pop_scope(n); }
 
-    void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
-        auto& source = dynamic_cast<max_bv_sharing&>(src);
+    void translate(dependent_expr_simplifier const& src, ast_translation& tr) override {
+        auto const& source = dynamic_cast<max_bv_sharing const&>(src);
         m_rewriter.translate(source.m_rewriter, tr);
     }
     

--- a/src/ast/simplifiers/max_bv_sharing.cpp
+++ b/src/ast/simplifiers/max_bv_sharing.cpp
@@ -61,10 +61,14 @@ public:
     void push() override { dependent_expr_simplifier::push(); m_rewriter.push_scope(); }
 
     void pop(unsigned n) override { dependent_expr_simplifier::pop(n); m_rewriter.pop_scope(n); }
+
+    void translate(dependent_expr_simplifier& src) override {
+        auto& source = dynamic_cast<max_bv_sharing&>(src);
+        source.m_rewriter.translate(m_rewriter, translation());
+    }
     
 };
 
 dependent_expr_simplifier * mk_max_bv_sharing(ast_manager & m, params_ref const & p, dependent_expr_state& fmls) {
     return alloc(max_bv_sharing, m, p, fmls);    
 }
-

--- a/src/ast/simplifiers/max_bv_sharing.cpp
+++ b/src/ast/simplifiers/max_bv_sharing.cpp
@@ -62,9 +62,9 @@ public:
 
     void pop(unsigned n) override { dependent_expr_simplifier::pop(n); m_rewriter.pop_scope(n); }
 
-    void translate(dependent_expr_simplifier& src) override {
+    void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
         auto& source = dynamic_cast<max_bv_sharing&>(src);
-        source.m_rewriter.translate(m_rewriter, translation());
+        source.m_rewriter.translate(m_rewriter, tr);
     }
     
 };

--- a/src/ast/simplifiers/max_bv_sharing.cpp
+++ b/src/ast/simplifiers/max_bv_sharing.cpp
@@ -64,7 +64,7 @@ public:
 
     void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
         auto& source = dynamic_cast<max_bv_sharing&>(src);
-        source.m_rewriter.translate(m_rewriter, tr);
+        m_rewriter.translate(source.m_rewriter, tr);
     }
     
 };

--- a/src/ast/simplifiers/model_reconstruction_trail.cpp
+++ b/src/ast/simplifiers/model_reconstruction_trail.cpp
@@ -18,6 +18,7 @@ Author:
 #include "ast/simplifiers/model_reconstruction_trail.h"
 #include "ast/simplifiers/dependent_expr_state.h"
 #include "ast/converters/generic_model_converter.h"
+#include "ast/ast_translation.h"
 
 
 void model_reconstruction_trail::add_vars(expr* e, ast_mark& free_vars) {
@@ -243,4 +244,38 @@ std::ostream& model_reconstruction_trail::display(std::ostream& out) const {
             out << "rm: " << d << "\n";
     }
     return out;
+}
+void model_reconstruction_trail::translate(model_reconstruction_trail& dst, ast_translation& tr) const {
+    SASSERT(dst.m_trail.empty());
+    expr_dependency_translation dep_tr(tr);
+    for (entry* e : m_trail) {
+        vector<dependent_expr> removed;
+        for (dependent_expr const& d : e->m_removed)
+            removed.push_back(dependent_expr(tr, d));
+        if (e->is_hide()) {
+            dst.hide(tr(e->m_decl.get()));
+        }
+        else if (e->is_def()) {
+            vector<std::tuple<func_decl_ref, expr_ref, expr_dependency_ref>> defs;
+            for (auto const& [f, def, dep] : e->m_defs)
+                defs.push_back({
+                    func_decl_ref(tr(f.get()), dst.m),
+                    expr_ref(tr(def.get()), dst.m),
+                    expr_dependency_ref(dep_tr(dep.get()), dst.m)
+                });
+            dst.push(defs, removed);
+        }
+        else {
+            auto* subst = alloc(expr_substitution, dst.m, e->m_subst->unsat_core_enabled(), e->m_subst->proofs_enabled());
+            for (auto const& [k, v] : e->m_subst->sub()) {
+                proof* pr = nullptr;
+                expr_dependency* dep = nullptr;
+                expr* value = nullptr;
+                VERIFY(e->m_subst->find(k, value, pr, dep));
+                subst->insert(tr(k), tr(value), tr(pr), dep_tr(dep));
+            }
+            dst.push(subst, removed, e->is_loose_constraint());
+        }
+        dst.m_trail.back()->m_active = e->m_active;
+    }
 }

--- a/src/ast/simplifiers/model_reconstruction_trail.cpp
+++ b/src/ast/simplifiers/model_reconstruction_trail.cpp
@@ -245,28 +245,28 @@ std::ostream& model_reconstruction_trail::display(std::ostream& out) const {
     }
     return out;
 }
-void model_reconstruction_trail::translate(model_reconstruction_trail& dst, ast_translation& tr) const {
-    SASSERT(dst.m_trail.empty());
+void model_reconstruction_trail::translate(model_reconstruction_trail const& src, ast_translation& tr) {
+    SASSERT(m_trail.empty());
     expr_dependency_translation dep_tr(tr);
-    for (entry* e : m_trail) {
+    for (entry* e : src.m_trail) {
         vector<dependent_expr> removed;
         for (dependent_expr const& d : e->m_removed)
             removed.push_back(dependent_expr(tr, d));
         if (e->is_hide()) {
-            dst.hide(tr(e->m_decl.get()));
+            hide(tr(e->m_decl.get()));
         }
         else if (e->is_def()) {
             vector<std::tuple<func_decl_ref, expr_ref, expr_dependency_ref>> defs;
             for (auto const& [f, def, dep] : e->m_defs)
                 defs.push_back({
-                    func_decl_ref(tr(f.get()), dst.m),
-                    expr_ref(tr(def.get()), dst.m),
-                    expr_dependency_ref(dep_tr(dep.get()), dst.m)
+                    func_decl_ref(tr(f.get()), m),
+                    expr_ref(tr(def.get()), m),
+                    expr_dependency_ref(dep_tr(dep.get()), m)
                 });
-            dst.push(defs, removed);
+            push(defs, removed);
         }
         else {
-            auto* subst = alloc(expr_substitution, dst.m, e->m_subst->unsat_core_enabled(), e->m_subst->proofs_enabled());
+            auto* subst = alloc(expr_substitution, m, e->m_subst->unsat_core_enabled(), e->m_subst->proofs_enabled());
             for (auto const& [k, v] : e->m_subst->sub()) {
                 proof* pr = nullptr;
                 expr_dependency* dep = nullptr;
@@ -274,8 +274,8 @@ void model_reconstruction_trail::translate(model_reconstruction_trail& dst, ast_
                 VERIFY(e->m_subst->find(k, value, pr, dep));
                 subst->insert(tr(k), tr(value), tr(pr), dep_tr(dep));
             }
-            dst.push(subst, removed, e->is_loose_constraint());
+            push(subst, removed, e->is_loose_constraint());
         }
-        dst.m_trail.back()->m_active = e->m_active;
+        m_trail.back()->m_active = e->m_active;
     }
 }

--- a/src/ast/simplifiers/model_reconstruction_trail.h
+++ b/src/ast/simplifiers/model_reconstruction_trail.h
@@ -145,6 +145,8 @@ public:
     model_reconstruction_trail(ast_manager& m, trail_stack& tr): 
         m(m), m_trail_stack(tr), m_model_vars_trail(m) {}
 
+    void translate(model_reconstruction_trail& dst, ast_translation& tr) const;
+
     /**
     * add a new substitution to the trail
     */
@@ -196,4 +198,3 @@ public:
 
     std::ostream& display(std::ostream& out) const;
 };
-

--- a/src/ast/simplifiers/model_reconstruction_trail.h
+++ b/src/ast/simplifiers/model_reconstruction_trail.h
@@ -145,7 +145,7 @@ public:
     model_reconstruction_trail(ast_manager& m, trail_stack& tr): 
         m(m), m_trail_stack(tr), m_model_vars_trail(m) {}
 
-    void translate(model_reconstruction_trail& dst, ast_translation& tr) const;
+    void translate(model_reconstruction_trail const& src, ast_translation& tr);
 
     /**
     * add a new substitution to the trail

--- a/src/ast/simplifiers/randomizer.h
+++ b/src/ast/simplifiers/randomizer.h
@@ -21,6 +21,7 @@ Author:
 #include "ast/ast.h"
 #include "ast/ast_pp.h"
 #include "ast/simplifiers/dependent_expr_state.h"
+#include "ast/ast_translation.h"
 #include "util/obj_hashtable.h"
 #include "params/tactic_params.hpp"
 #include <algorithm>
@@ -121,6 +122,35 @@ public:
         }
 
     char const* name() const override { return "randomizer"; }
+
+    void translate(dependent_expr_simplifier& src) override {
+        auto& source = dynamic_cast<randomizer_simplifier&>(src);
+        ast_translation& tr = translation();
+        m_rand = source.m_rand;
+        for (auto const& [f, r] : source.m_rename) {
+            func_decl* new_f = tr(f);
+            func_decl* new_r = tr(r);
+            m_rename.insert(new_f, new_r);
+            m_ast_trail.push_back(new_f);
+            m_ast_trail.push_back(new_r);
+            m_args.reset();
+            for (unsigned i = 0; i < new_f->get_arity(); ++i)
+                m_args.push_back(m.mk_var(i, new_f->get_domain(i)));
+        }
+        for (ast* a : source.m_ast_trail) {
+            if (!is_expr(a))
+                continue;
+            expr* e = to_expr(a);
+            expr* r = source.get_new_expr(e);
+            if (!r)
+                continue;
+            expr* new_e = tr(e);
+            expr* new_r = tr(r);
+            m_new_exprs.setx(new_e->get_id(), new_r);
+            m_ast_trail.push_back(new_e);
+            m_ast_trail.push_back(new_r);
+        }
+    }
 
     void reduce() override {
         for (unsigned idx : indices()) {

--- a/src/ast/simplifiers/randomizer.h
+++ b/src/ast/simplifiers/randomizer.h
@@ -67,7 +67,7 @@ class randomizer_simplifier : public dependent_expr_simplifier {
         m_todo.pop_back();
     }
 
-    expr* get_new_expr(expr* e) {
+    expr* get_new_expr(expr* e) const {
         return m_new_exprs.get(e->get_id(), nullptr);
     }
 
@@ -123,8 +123,8 @@ public:
 
     char const* name() const override { return "randomizer"; }
 
-    void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
-        auto& source = dynamic_cast<randomizer_simplifier&>(src);
+    void translate(dependent_expr_simplifier const& src, ast_translation& tr) override {
+        auto const& source = dynamic_cast<randomizer_simplifier const&>(src);
         m_rand = source.m_rand;
         for (auto const& [f, r] : source.m_rename) {
             func_decl* new_f = tr(f);

--- a/src/ast/simplifiers/randomizer.h
+++ b/src/ast/simplifiers/randomizer.h
@@ -123,9 +123,8 @@ public:
 
     char const* name() const override { return "randomizer"; }
 
-    void translate(dependent_expr_simplifier& src) override {
+    void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
         auto& source = dynamic_cast<randomizer_simplifier&>(src);
-        ast_translation& tr = translation();
         m_rand = source.m_rand;
         for (auto const& [f, r] : source.m_rename) {
             func_decl* new_f = tr(f);

--- a/src/ast/simplifiers/then_simplifier.h
+++ b/src/ast/simplifiers/then_simplifier.h
@@ -119,6 +119,20 @@ public:
         for (auto* s : m_simplifiers)
             s->pop(n);     
     }
+
+    void translate(dependent_expr_simplifier& src) override {
+        auto& source = dynamic_cast<then_simplifier&>(src);
+        if (m_simplifiers.size() != source.m_simplifiers.size())
+            throw default_exception("cannot translate mismatched simplifier pipelines");
+        for (unsigned i = 0; i < m_simplifiers.size(); ++i)
+            m_simplifiers[i]->translate(*source.m_simplifiers[i]);
+    }
+
+    void set_ast_translation(ast_translation* tr) override {
+        dependent_expr_simplifier::set_ast_translation(tr);
+        for (auto* s : m_simplifiers)
+            s->set_ast_translation(tr);
+    }
 };
 
 class if_change_simplifier : public then_simplifier {

--- a/src/ast/simplifiers/then_simplifier.h
+++ b/src/ast/simplifiers/then_simplifier.h
@@ -120,8 +120,8 @@ public:
             s->pop(n);     
     }
 
-    void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
-        auto& source = dynamic_cast<then_simplifier&>(src);
+    void translate(dependent_expr_simplifier const& src, ast_translation& tr) override {
+        auto const& source = dynamic_cast<then_simplifier const&>(src);
         if (m_simplifiers.size() != source.m_simplifiers.size())
             throw default_exception("cannot translate mismatched simplifier pipelines");
         for (unsigned i = 0; i < m_simplifiers.size(); ++i)

--- a/src/ast/simplifiers/then_simplifier.h
+++ b/src/ast/simplifiers/then_simplifier.h
@@ -120,18 +120,12 @@ public:
             s->pop(n);     
     }
 
-    void translate(dependent_expr_simplifier& src) override {
+    void translate(dependent_expr_simplifier& src, ast_translation& tr) override {
         auto& source = dynamic_cast<then_simplifier&>(src);
         if (m_simplifiers.size() != source.m_simplifiers.size())
             throw default_exception("cannot translate mismatched simplifier pipelines");
         for (unsigned i = 0; i < m_simplifiers.size(); ++i)
-            m_simplifiers[i]->translate(*source.m_simplifiers[i]);
-    }
-
-    void set_ast_translation(ast_translation* tr) override {
-        dependent_expr_simplifier::set_ast_translation(tr);
-        for (auto* s : m_simplifiers)
-            s->set_ast_translation(tr);
+            m_simplifiers[i]->translate(*source.m_simplifiers[i], tr);
     }
 };
 

--- a/src/solver/simplifier_solver.cpp
+++ b/src/solver/simplifier_solver.cpp
@@ -115,6 +115,7 @@ class simplifier_solver : public solver {
     then_simplifier             m_preprocess;
     expr_ref_vector             m_assumptions;
     model_converter_ref         m_mc;
+    simplifier_factory          m_factory;
     bool                        m_inconsistent = false;
     expr_safe_replace           m_core_replace;
 
@@ -186,8 +187,10 @@ public:
         m_core_replace(m),
         m_proof(m)
     {
-        if (fac) 
-            m_preprocess.add_simplifier((*fac)(m, s->get_params(), m_preprocess_state));
+        if (fac) {
+            m_factory = *fac;
+            m_preprocess.add_simplifier(m_factory(m, s->get_params(), m_preprocess_state));
+        }
         else 
             init_preprocess(m, s->get_params(), m_preprocess, m_preprocess_state);
     }
@@ -266,15 +269,23 @@ public:
     }
 
     solver* translate(ast_manager& m, params_ref const& p) override { 
-        solver* new_s = s->translate(m, p);
         ast_translation tr(get_manager(), m);
-        simplifier_solver* result = alloc(simplifier_solver, new_s, nullptr); // factory?
+        solver* new_s = s->translate(m, p);
+        SASSERT(s->get_num_assertions() == new_s->get_num_assertions());
+        for (unsigned i = 0; i < s->get_num_assertions(); ++i)
+            tr.seed(s->get_assertion(i), new_s->get_assertion(i));
+        simplifier_factory* factory = m_factory ? &m_factory : nullptr;
+        simplifier_solver* result = alloc(simplifier_solver, new_s, factory);
         for (dependent_expr const& f : m_fmls) 
             result->m_fmls.push_back(dependent_expr(tr, f));
+        result->m_preprocess.set_ast_translation(&tr);
+        auto reset_translation = on_scope_exit([&]() { result->m_preprocess.set_ast_translation(nullptr); });
+        result->m_preprocess.translate(m_preprocess);
+        m_preprocess_state.translate(result->m_preprocess_state, tr);
+        result->m_inconsistent = m_inconsistent;
         if (m_mc) 
             result->m_mc = m_mc->translate(tr);
 
-        // copy m_preprocess_state?
         return result;
     }    
 
@@ -403,4 +414,3 @@ public:
 solver* mk_simplifier_solver(solver* s, simplifier_factory* fac) {
     return alloc(simplifier_solver, s, fac);
 }
-

--- a/src/solver/simplifier_solver.cpp
+++ b/src/solver/simplifier_solver.cpp
@@ -278,9 +278,7 @@ public:
         simplifier_solver* result = alloc(simplifier_solver, new_s, factory);
         for (dependent_expr const& f : m_fmls) 
             result->m_fmls.push_back(dependent_expr(tr, f));
-        result->m_preprocess.set_ast_translation(&tr);
-        auto reset_translation = on_scope_exit([&]() { result->m_preprocess.set_ast_translation(nullptr); });
-        result->m_preprocess.translate(m_preprocess);
+        result->m_preprocess.translate(m_preprocess, tr);
         m_preprocess_state.translate(result->m_preprocess_state, tr);
         result->m_inconsistent = m_inconsistent;
         if (m_mc) 

--- a/src/solver/simplifier_solver.cpp
+++ b/src/solver/simplifier_solver.cpp
@@ -279,7 +279,7 @@ public:
         for (dependent_expr const& f : m_fmls) 
             result->m_fmls.push_back(dependent_expr(tr, f));
         result->m_preprocess.translate(m_preprocess, tr);
-        m_preprocess_state.translate(result->m_preprocess_state, tr);
+        result->m_preprocess_state.translate(m_preprocess_state, tr);
         result->m_inconsistent = m_inconsistent;
         if (m_mc) 
             result->m_mc = m_mc->translate(tr);

--- a/src/solver/simplifier_solver.cpp
+++ b/src/solver/simplifier_solver.cpp
@@ -51,6 +51,7 @@ class simplifier_solver : public solver {
         bool updated() override { return m_updated; }
         void reset_updated() override { m_updated = false; }
         model_reconstruction_trail& model_trail() override { return m_reconstruction_trail; }
+        model_reconstruction_trail const& model_trail() const override { return m_reconstruction_trail; }
         std::ostream& display(std::ostream& out) const override {
             unsigned i = 0;
             for (auto const& d : s.m_fmls) {

--- a/src/tactic/dependent_expr_state_tactic.h
+++ b/src/tactic/dependent_expr_state_tactic.h
@@ -97,6 +97,10 @@ public:
         return *m_model_trail;
     }
 
+    model_reconstruction_trail const& model_trail() const override {
+        return *m_model_trail;
+    }
+
     char const* name() const override { return m_simp ? m_simp->name() : "null"; }
 
     bool updated() override { return m_updated; }


### PR DESCRIPTION
Adds destination-oriented dependent_expr_simplifier::translate(dependent_expr_simplifier& src) hooks and preserves shared/model-reconstruction state across simplifier_solver translation. Stateful simplifiers copy or rebuild their persistent state at scope level zero. This change does not modify inc_sat_solver.