### PR TITLE
[code-simplifier] Rename shadowing local variables in has_fresh_value

### DIFF
--- a/src/qe/lite/qe_lite_tactic.cpp
+++ b/src/qe/lite/qe_lite_tactic.cpp
@@ -2290,13 +2290,13 @@ private:
     static const unsigned EXPAND_BOUND_LIMIT = 10000;
 
     bool has_fresh_value(sort* s, unsigned num_forbidden) {
-        arith_util a_util(m);
-        if (a_util.is_int(s) || a_util.is_real(s))
+        arith_util arith(m);
+        if (arith.is_int(s) || arith.is_real(s))
             return true;
-        bv_util bv_util(m);
-        if (!bv_util.is_bv_sort(s))
+        bv_util bv(m);
+        if (!bv.is_bv_sort(s))
             return false;
-        unsigned width = bv_util.get_bv_size(s);
+        unsigned width = bv.get_bv_size(s);
         return width >= 32 || num_forbidden < (1u << width);
     }
 


### PR DESCRIPTION
Rename a_util -> arith and bv_util -> bv in has_fresh_value() to avoid using the same identifier for both the type name (bv_util) and the local variable, which shadows the class type name. Consistent with naming used elsewhere in the file (e.g., eq_der class uses a and bv as member names).