### PR TITLE
[code-simplifier] Remove duplicate #include of ast_translation.h in bound_manager.cpp

### DIFF
--- a/src/ast/simplifiers/bound_manager.cpp
+++ b/src/ast/simplifiers/bound_manager.cpp
@@ -21,7 +21,6 @@ Notes:
 #include "ast/ast_pp.h"
 #include "ast/ast_translation.h"
 #include "ast/simplifiers/bound_manager.h"
-#include "ast/ast_translation.h"
 
 bound_manager::bound_manager(ast_manager & m):
     m_util(m),


### PR DESCRIPTION
The file already included ast/ast_translation.h before the bound_manager.h include. A duplicate include was inadvertently added after bound_manager.h when adding the translate() method in PR #10634.