### PR TITLE
opt: remove dead qsat path; answer unknown instead of throwing on unbounded objective under quantifiers

### DIFF
--- a/src/opt/opt_context.cpp
+++ b/src/opt/opt_context.cpp
@@ -517,14 +517,27 @@ namespace opt {
 
 
     lbool context::execute_min_max(unsigned index, bool committed, bool scoped, bool is_max) {
+        // Bounds before optimization come from the initial model, which the
+        // core checked against the quantified constraints (update_lower in
+        // optimize()). The theory-level push below does not instantiate
+        // quantifiers, so an "unbounded" verdict from it is not trustworthy.
+        inf_eps lower0 = m_optsmt.get_lower(index);
+        inf_eps upper0 = m_optsmt.get_upper(index);
         if (scoped) get_solver().push();            
         lbool result = m_optsmt.lex(index, is_max);
+        if (result == l_true && m_optsmt.is_unbounded(index, is_max) && contains_quantifiers()) {
+            // Give up on this objective: keep the initial model and its
+            // bounds and answer unknown, rather than throwing and leaving
+            // 'oo' behind for get-objectives to report.
+            if (scoped) get_solver().pop(1);
+            m_optsmt.update_lower(index, lower0);
+            m_optsmt.update_upper(index, upper0);
+            warning_msg("unbounded objectives on quantified constraints is not supported");
+            return l_undef;
+        }
         if (result == l_true) { m_optsmt.get_model(m_model, m_labels); SASSERT(m_model); }
         if (scoped) get_solver().pop(1);        
         if (result == l_true && committed) m_optsmt.commit_assignment(index);
-        if (result == l_true && m_optsmt.is_unbounded(index, is_max) && contains_quantifiers()) {
-            throw default_exception("unbounded objectives on quantified constraints is not supported");
-        }
         return result;
     }
     

--- a/src/opt/opt_context.cpp
+++ b/src/opt/opt_context.cpp
@@ -1752,8 +1752,6 @@ namespace opt {
             kv.m_value->collect_statistics(stats);
         get_memory_statistics(stats);
         get_rlimit_statistics(m.limit(), stats);
-        if (m_qmax) 
-            m_qmax->collect_statistics(stats);
     }
 
     void context::collect_param_descrs(param_descrs & r) {
@@ -1963,53 +1961,5 @@ namespace opt {
             }
             }       
         } 
-    }
-
-    bool context::is_qsat_opt() {
-        if (m_objectives.size() != 1) {
-            return false;
-        }
-        if (m_objectives[0].m_type != O_MAXIMIZE && 
-            m_objectives[0].m_type != O_MINIMIZE) {
-            return false;
-        }
-        if (!m_arith.is_real(m_objectives[0].m_term)) {
-            return false;
-        }
-        for (expr* fml : m_hard_constraints) {
-            if (has_quantifiers(fml)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    lbool context::run_qsat_opt() {
-        SASSERT(is_qsat_opt());
-        objective const& obj = m_objectives[0];
-        app_ref term(obj.m_term);
-        if (obj.m_type == O_MINIMIZE) {
-            term = m_arith.mk_uminus(term);
-        }
-        inf_eps value;
-        m_qmax = alloc(qe::qmax, m, m_params);
-        lbool result = (*m_qmax)(m_hard_constraints, term, value, m_model);
-        if (result != l_undef && obj.m_type == O_MINIMIZE) {
-            value.neg();
-        }
-        m_optsmt.setup(*m_opt_solver.get());
-        if (result == l_undef) {
-            if (obj.m_type == O_MINIMIZE) {
-                m_optsmt.update_upper(obj.m_index, value);
-            }
-            else {
-                m_optsmt.update_lower(obj.m_index, value);
-            }
-        }
-        else {
-            m_optsmt.update_lower(obj.m_index, value);
-            m_optsmt.update_upper(obj.m_index, value);
-        }
-        return result;
     }
 }

--- a/src/opt/opt_context.h
+++ b/src/opt/opt_context.h
@@ -23,7 +23,6 @@ Notes:
 #include "ast/converters/model_converter.h"
 #include "tactic/tactic.h"
 #include "solver/preferred_value_propagator.h"
-#include "qe/qsat.h"
 #include "opt/opt_solver.h"
 #include "opt/opt_pareto.h"
 #include "opt/optsmt.h"
@@ -178,7 +177,6 @@ namespace opt {
         ref<solver>         m_sat_solver;
         scoped_ptr<pareto_base>  m_pareto;
         bool                 m_pareto1;
-        scoped_ptr<qe::qmax> m_qmax;
         sref_vector<model>  m_box_models;
         unsigned            m_box_index;
         params_ref          m_params;
@@ -379,9 +377,6 @@ namespace opt {
         expr_ref mk_cmp(bool is_ge, model_ref& mdl, objective const& obj);
 
 
-        // quantifiers
-        bool is_qsat_opt();
-        lbool run_qsat_opt();
 
       
     };


### PR DESCRIPTION
Two small, independent `opt` fixes for objectives under quantified hard constraints.

### 1. Remove the dead quantified-optimization path (`090d5276b`)

`context::is_qsat_opt` / `run_qsat_opt` (the `qe::qmax` route) had no callers: the dispatch was `#if 0`-ed in 9c099d6b1 (2016, "fix mb maximization logic, so far not accessible") and the disabled block deleted in 48712b4f6. Re-enabling it on current master segfaults on the examples below, so this deletes the two functions, the `m_qmax` member (only read in `collect_statistics`) and the `qe/qsat.h` include. No behavior change.

`qe::qmax` / `qsat_maximize` in `src/qe/qsat.cpp` are now unreferenced; left in place here — happy to remove them in a follow-up if wanted.

### 2. Answer `unknown` instead of throwing, and stop reporting a bogus `oo` (`38261676a`)

```smt2
(declare-const x Real)
(assert (forall ((y Real)) (=> (>= y 0.0) (<= x (+ y 1.0)))))   ; optimum 1
(maximize x)
(check-sat)
(get-objectives)
```

Before:
```
(error "line 4 column 10: unbounded objectives on quantified constraints is not supported")
(objectives
 (x oo)
)
```

`optsmt` maximizes with the quantified constraints uninstantiated (the simplex push never reaches final check, so neither E-matching nor MBQI can add the bounding instance), so its "unbounded" verdict is not sound. `execute_min_max` detected this case but threw; the exception printed an error while leaving `lower = upper = oo` in `optsmt`, which a following `(get-objectives)` printed as a proven optimum.

Now `execute_min_max` restores the bounds derived from the initial model (which the core did check against the quantifiers), keeps that model, warns, and returns `l_undef`:
```
WARNING: unbounded objectives on quantified constraints is not supported
unknown
(objectives
 (x  (interval 0 oo))
)
```

API-visible change: `Z3_optimize_check` returns `Z3_L_UNDEF` here instead of raising an exception. A *finite* simplex value under quantified constraints is still accepted as before; proper quantified optimization is out of scope.

### Testing

- `z3test/regressions/opt_bug.smt2`: output byte-identical to master.
- A 43-instance OMT benchmark set (LRA/NRA/NIA/MaxSMT/BV/Pareto/quantified): only the two quantified instances change (error → `unknown` with a sound interval); all other answers identical.
- Lexicographic variant (quantified first objective, then a second one): `unknown`, `(interval 0 oo)` for the first, `(interval (- oo) oo)` for the second, genuine model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
