### PR TITLE
Fix SIGSEGV in seq_regex::model_len via safe expr_substitution::try_find

### DIFF
--- a/src/ast/expr_substitution.h
+++ b/src/ast/expr_substitution.h
@@ -47,6 +47,7 @@ public:
     void insert(expr* s, expr* def, expr_dependency* def_dep) { insert(s, def, nullptr, def_dep); }
     void erase(expr * s);
     expr* find(expr* s) { return m_subst[s]; }
+    expr* try_find(expr* s) { expr* v = nullptr; m_subst.find(s, v); return v; }
     expr_dependency* dep(expr* s) { return (*m_subst_dep)[s]; }
     bool find(expr * s, expr * & def, proof * & def_pr);
     bool find(expr * s, expr * & def, proof * & def_pr, expr_dependency * & def_dep);

--- a/src/smt/seq_regex.cpp
+++ b/src/smt/seq_regex.cpp
@@ -243,7 +243,7 @@ namespace smt {
                 len += s.length();
                 continue;
             }
-            expr* w = model.find(e);
+            expr* w = model.try_find(e);
             if (w && w != e) {                    // variable: replace by its witness
                 todo.push_back(w);
                 continue;


### PR DESCRIPTION
## Problem
Three benchmark inputs in the QF_SLIA regression suite (20240411-redos_attack_detection/sat/{658,667,2002}_attack.smt2, all using a large fixed regex loop (_ re.loop 5000 5000) ...) crashed with signal-11 (SIGSEGV).

## Root cause
xpr_substitution::find() delegates to obj_map::operator[], which asserts the key exists and unconditionally dereferences the hash table entry. In debug builds this shows up as an assertion violation:

`
File: src/util/obj_hashtable.h
Line: 180
...
smt::seq_regex::model_len (src/smt/seq_regex.cpp:246)
smt::seq_regex::model_satisfies_bound (src/smt/seq_regex.cpp:258)
`

smt::seq_regex::model_len() called ind() expecting a lookup that safely returns 
ullptr for a term not (yet) present in the monadic model substitution:
`cpp
expr* w = model.find(e);
if (w && w != e) { ... }   // assumes find() can return nullptr
`
In release builds (assertions disabled), the assert is skipped and the code dereferences a null hash table entry, producing the observed SIGSEGV.

## Fix
Add xpr_substitution::try_find(), which uses the safe obj_map::find(Key*, Value&) overload and returns 
ullptr when the key is absent. ind() is left unchanged, keeping its original contract that the expression is assumed to be in the domain of the substitution. seq_regex::model_len() now calls 	ry_find().

## Validation
- All three previously crashing inputs now run without crashing (sat or 	imeout under -T:5, matching the harness), instead of signal-11.
- Full unit test suite: 99 passed, 0 failed.