### PR TITLE
Support symbolic str.replace in theory_nseq

### DIFF
--- a/src/ast/euf/euf_sgraph.cpp
+++ b/src/ast/euf/euf_sgraph.cpp
@@ -140,13 +140,13 @@ namespace euf {
             n->m_level = 1;
             n->m_length = 1;
             n->m_is_classical = false;
-            // Defined seq operations (str.replace*, str.replace_all, str.replace_re*) are
-            // classified as s_var because they have no dedicated snode kind, but they are NOT
-            // free variables: their value is fixed by the recfun/axiom layer. Mark them rigid
-            // so the Nielsen modifiers never eliminate or split them (see snode::is_rigid).
+            // Recursive replacement operations are classified as s_var because they have no
+            // dedicated snode kind, but they are not free variables: their value is fixed by
+            // the recfun/axiom layer. str.replace is different: replace_axiom supplies a
+            // complete case split whose selected seq.eq constrains this proxy before search.
             {
                 expr* e = n->m_expr;
-                n->m_rigid = e && (m_seq.str.is_replace(e) || m_seq.str.is_replace_all(e) ||
+                n->m_rigid = e && (m_seq.str.is_replace_all(e) ||
                                    m_seq.str.is_replace_re(e) || m_seq.str.is_replace_re_all(e));
                 // re.of_pred also has no dedicated snode kind, but over a lambda in
                 // the recognized range fragment it is just the canonical multi-range

--- a/src/ast/euf/euf_snode.h
+++ b/src/ast/euf/euf_snode.h
@@ -70,7 +70,7 @@ namespace euf {
         bool m_ground = true;        // no uninterpreted string variables
         bool m_regex_free = true;    // no regex constructs
         bool m_is_classical = true;  // classical regular expression
-        bool m_rigid = false;        // defined seq op (replace/replace_all/replace_re*) — opaque to Nielsen, never substitute/split
+        bool m_rigid = false;        // recursive replacement op — opaque to Nielsen, never substitute/split
         unsigned m_level = 0;        // tree depth/level (0 for empty, 1 for singletons)
         unsigned m_length = 0;       // token count, number of leaf tokens in the tree
         unsigned m_regex_weight = 0; // estimated automaton size of this regex (saturating);
@@ -262,16 +262,11 @@ namespace euf {
         bool is_var() const {
             return m_kind == snode_kind::s_var;
         }
-        // A rigid snode is a defined sequence operation (str.replace, str.replace_all,
-        // str.replace_re, str.replace_re_all) whose semantics are supplied externally by
-        // the recfun/axiom layer. It is classified as s_var but must NOT be treated as a
-        // free, eliminable Nielsen variable: substituting/Nielsen-splitting it (e.g.
-        // unifying two distinct replace_all applications) silently discards its definition
-        // and yields invalid models. theory_nseq gives up (FC_GIVEUP) when a rigid snode
-        // participates in the constraints (see nielsen_node::references_rigid), deferring
-        // to the recfun/axiom layer instead of searching. Note: replace_all etc. on
-        // concrete arguments are folded away by seq_rewriter before reaching here, so this
-        // only affects genuinely symbolic occurrences.
+        // A rigid snode is a recursive replacement operation (str.replace_all or
+        // str.replace_re*) whose semantics are supplied externally by the recfun/axiom layer.
+        // It is classified as s_var but must not be treated as a free, eliminable Nielsen
+        // variable. Single-occurrence str.replace is not rigid because its finite axiom
+        // schema selects a defining seq.eq before Nielsen search.
         bool is_rigid() const {
             return m_rigid;
         }
@@ -431,4 +426,3 @@ struct spp {
 inline std::ostream &operator<<(std::ostream &out, spp const&p) {
     return out << mk_pp(p.n->get_expr(), p.m);
 }
-

--- a/src/ast/rewriter/seq_axioms.h
+++ b/src/ast/rewriter/seq_axioms.h
@@ -112,7 +112,7 @@ namespace seq {
         void str_from_code_axiom(expr* n);
         void unit_axiom(expr* n);
         void length_axiom(expr* n);
-        void unroll_not_contains(expr* e);
+        void unroll_not_contains(expr* e); // one-step expansion used by sequence solvers
         void not_contains_axiom(expr *e);
         void replace_re_axiom(expr* e);
         void replace_all_axiom(expr* e);
@@ -133,4 +133,3 @@ namespace seq {
     };
 
 }
-

--- a/src/ast/rewriter/seq_split.cpp
+++ b/src/ast/rewriter/seq_split.cpp
@@ -674,8 +674,8 @@ expr_ref seq_split::head_normalize(expr* t, split_mode mode, unsigned threshold,
         // how many splits the lazy enumeration may emit
         const unsigned cap = std::min(threshold, BOOL_CLOSURE_CAP);
         split_set sa, sb, tmp;
-        if (!materialize(a, mode, cap, oracle, sa) ||
-            !materialize(b, mode, cap, oracle, sb)) {
+        if (!materialize(a, mode, cap, oracle, sa, &deriv_memo) ||
+            !materialize(b, mode, cap, oracle, sb, &deriv_memo)) {
             ok = false;
             return expr_ref(m);
         }
@@ -699,7 +699,7 @@ expr_ref seq_split::head_normalize(expr* t, split_mode mode, unsigned threshold,
         // complement().
         const unsigned cap = std::min(threshold, BOOL_CLOSURE_CAP);
         split_set sa, res;
-        if (!materialize(a, mode, cap, split_oracle{}, sa)) {
+        if (!materialize(a, mode, cap, split_oracle{}, sa, &deriv_memo)) {
             ok = false;
             return expr_ref(m);
         }
@@ -723,9 +723,10 @@ expr_ref seq_split::head_normalize(expr* t, split_mode mode, unsigned threshold,
 }
 
 bool seq_split::materialize(expr* node, split_mode mode, unsigned threshold,
-                            split_oracle const& oracle, split_set& out) {
+                            split_oracle const& oracle, split_set& out,
+                            obj_hashtable<expr>* deriv_memo) {
     ++m_stats.m_materialize;
-    iterator it(*this, node, mode, threshold, oracle);
+    iterator it(*this, node, mode, threshold, oracle, deriv_memo);
     expr_ref d(m), n(m);
     while (it.next(d, n))
         out.push_back(split_pair(d, n, m));
@@ -750,9 +751,10 @@ expr_ref seq_split::make(expr* r) {
 // expansion work happens lazily, one split per next() call.
 
 seq_split::iterator::iterator(seq_split& engine, expr* node, split_mode mode,
-                              unsigned threshold, split_oracle oracle) :
+                              unsigned threshold, split_oracle oracle,
+                              obj_hashtable<expr>* deriv_memo) :
     m_engine(engine), m(engine.m), m_mode(mode), m_threshold(threshold),
-    m_oracle(std::move(oracle)), m_work(engine.m) {
+    m_oracle(std::move(oracle)), m_work(engine.m), m_deriv_memo(deriv_memo) {
     SASSERT(node);
     m_work.push_back(node);
 }
@@ -765,7 +767,8 @@ bool seq_split::iterator::next(expr_ref& out_d, expr_ref& out_n) {
         m_work.pop_back();
 
         bool ok = true;
-        expr_ref hn = m_engine.head_normalize(t, m_mode, m_threshold, m_oracle, ok, m_deriv_memo);
+        obj_hashtable<expr>& deriv_memo = m_deriv_memo ? *m_deriv_memo : m_local_deriv_memo;
+        expr_ref hn = m_engine.head_normalize(t, m_mode, m_threshold, m_oracle, ok, deriv_memo);
         if (!ok) {
             m_giveup = true;           // unsupported / weak Boolean / overrun
             ++m_engine.m_stats.m_giveups;

--- a/src/ast/rewriter/seq_split.h
+++ b/src/ast/rewriter/seq_split.h
@@ -175,7 +175,8 @@ class seq_split {
     // Fully drain a suspended split-set into `out` (used for inter/compl bodies).
     // Runs an `iterator` to exhaustion; returns false on a give-up.
     bool materialize(expr* node, split_mode mode, unsigned threshold,
-                     split_oracle const& oracle, split_set& out);
+                     split_oracle const& oracle, split_set& out,
+                     obj_hashtable<expr>* deriv_memo = nullptr);
 
     // Push <d, n> onto `out`, unless `oracle` rejects it.
     void push(split_set& out, split_oracle const& oracle, expr* d, expr* n) const;
@@ -245,11 +246,14 @@ public:
         bool            m_giveup = false;
         // Complement ~-regex states already expanded via the symbolic-derivative
         // rule; re-encountering one (a cycle) falls back to the De Morgan rule so
-        // the lazy unfolding terminates.  Per-iterator (iterators run concurrently).
-        obj_hashtable<expr> m_deriv_memo;
+        // the lazy unfolding terminates. Nested materializations share the top-level
+        // iterator's memo; independent iterators keep separate local memos.
+        obj_hashtable<expr>  m_local_deriv_memo;
+        obj_hashtable<expr>* m_deriv_memo;
     public:
         iterator(seq_split& engine, expr* node, split_mode mode,
-                 unsigned threshold, split_oracle oracle);
+                 unsigned threshold, split_oracle oracle,
+                 obj_hashtable<expr>* deriv_memo = nullptr);
         // Compute the next split.  On success returns true and sets <d, n>; on
         // exhaustion or give-up returns false (see gave_up()).  Calling next()
         // again after it has returned false keeps returning false.

--- a/src/smt/seq/seq_nielsen.h
+++ b/src/smt/seq/seq_nielsen.h
@@ -849,7 +849,7 @@ namespace seq {
         bool is_satisfied() const;
 
         // true if ANY equality/disequality/membership references a rigid (defined) op
-        // snode (str.replace, str.replace_all, str.replace_re*). Used to defer to the
+        // snode (str.replace_all or str.replace_re*). Used to defer to the
         // axiom layer (FC_GIVEUP) before searching: these terms are not free variables
         // but are pinned by the recfun/axiom layer, and the Nielsen modifiers would
         // substitute/unify them as if free, discarding their definition and producing

--- a/src/smt/seq/seq_nielsen_search.cpp
+++ b/src/smt/seq/seq_nielsen_search.cpp
@@ -219,7 +219,7 @@ namespace seq {
         ++m_stats.m_num_eager_calls;
         const ptr_vector<nielsen_edge> empty_path;
 
-        // Rigid defined ops (str.replace_all, …) must never be Nielsen-substituted;
+        // Rigid recursive replacement ops must never be Nielsen-substituted;
         // a rigid term is inherited down the whole chain, so a single check on the
         // leaf (which holds all current constraints) suffices — bail before any det
         // step (mirrors final_check's guard).

--- a/src/smt/theory_nseq.cpp
+++ b/src/smt/theory_nseq.cpp
@@ -178,15 +178,6 @@ namespace smt {
         // register in our private sgraph
         get_snode(term);
 
-        if (m_seq.str.is_replace(term)) {
-            ctx.push_trail(value_trail(m_num_replace_terms));
-            ++m_num_replace_terms;
-        }
-        if (m_seq.str.is_contains(term)) {
-            ctx.push_trail(value_trail(m_num_contains_terms));
-            ++m_num_contains_terms;
-        }
-
         if (m_seq.is_seq(term) && m_axioms.sk().is_skolem(term))
             ensure_length_var(term);
 
@@ -313,6 +304,72 @@ namespace smt {
     // Boolean assignment notification
     // -----------------------------------------------------------------------
 
+    expr* theory_nseq::find_string_constant(expr* e) const {
+        zstring value;
+        if (m_seq.str.is_string(e, value))
+            return e;
+        if (!ctx.e_internalized(e))
+            return nullptr;
+        enode* root = ctx.get_enode(e)->get_root();
+        enode* current = root;
+        do {
+            if (m_seq.str.is_string(current->get_expr(), value))
+                return current->get_expr();
+            current = current->get_next();
+        } while (current != root);
+        return nullptr;
+    }
+
+    bool theory_nseq::lower_contains_to_regex(expr* e, bool use_eqc) {
+        expr* source = nullptr, *pattern = nullptr;
+        VERIFY(m_seq.str.is_contains(e, source, pattern));
+        expr* constant = use_eqc ? find_string_constant(pattern) : pattern;
+        zstring value;
+        if (!constant || !m_seq.str.is_string(constant, value))
+            return false;
+
+        const bool syntactic = constant == pattern;
+        if (syntactic && m_lowered_contains.contains(e))
+            return true;
+
+        literal eq_lit = true_literal;
+        if (!syntactic) {
+            eq_lit = mk_literal(m.mk_eq(pattern, constant));
+            ctx.mark_as_relevant(eq_lit);
+        }
+
+        const literal contains_lit = mk_literal(e);
+        if (value.empty()) {
+            if (syntactic)
+                ctx.mk_th_axiom(get_id(), contains_lit);
+            else
+                ctx.mk_th_axiom(get_id(), ~eq_lit, contains_lit);
+        }
+        else {
+            sort* re_sort = m_seq.re.mk_re(source->get_sort());
+            expr* all = m_seq.re.mk_full_seq(re_sort);
+            const expr_ref regex(m_seq.re.mk_concat(
+                all, m_seq.re.mk_concat(m_seq.re.mk_to_re(constant), all)), m);
+            const expr_ref membership(m_seq.re.mk_in_re(source, regex), m);
+            ctx.internalize(membership, false);
+            const literal mem_lit = ctx.get_literal(membership);
+            if (syntactic) {
+                ctx.mk_th_axiom(get_id(), ~contains_lit, mem_lit);
+                ctx.mk_th_axiom(get_id(), contains_lit, ~mem_lit);
+            }
+            else {
+                ctx.mk_th_axiom(get_id(), ~eq_lit, ~contains_lit, mem_lit);
+                ctx.mk_th_axiom(get_id(), ~eq_lit, contains_lit, ~mem_lit);
+            }
+        }
+
+        if (syntactic) {
+            m_lowered_contains.insert(e);
+            ctx.push_trail(insert_obj_trail<expr>(m_lowered_contains, e));
+        }
+        return true;
+    }
+
     void theory_nseq::assign_eh(const bool_var v, const bool is_true) {
         try {
             expr* e = ctx.bool_var2expr(v);
@@ -385,31 +442,23 @@ namespace smt {
             }
             else if (m_seq.str.is_contains(e)) {
                 if (m_replace_contains.contains(e)) {
-                    if (is_true)
+                    if (lower_contains_to_regex(e, true))
+                        return;
+                    if (is_true) {
                         m_axioms.contains_true_axiom(e);
+                    }
                     else {
+                        if (!m_symbolic_replace_contains.contains(e)) {
+                            m_symbolic_replace_contains.insert(e);
+                            ctx.push_trail(insert_obj_trail<expr>(m_symbolic_replace_contains, e));
+                        }
                         flet<bool> tracking(m_tracking_replace_contains, true);
                         m_axioms.unroll_not_contains(e);
                     }
                     return;
                 }
-                zstring str;
-                if (m_seq.str.is_string(to_app(e)->get_arg(1), str)) {
-                    // contains(u, v) with v const => u \in \Sigma* v \Sigma^*
-                    sort* re_sort = m_seq.re.mk_re(to_app(e)->get_arg(0)->get_sort());
-                    expr* all = m_seq.re.mk_full_seq(re_sort);
-                    const expr_ref con(m_seq.re.mk_in_re(to_app(e)->get_arg(0), m_seq.re.mk_concat(
-                        all,
-                        m_seq.re.mk_concat(
-                            m_seq.re.mk_to_re(to_app(e)->get_arg(1)), all)
-                    )), m);
-                    ctx.internalize(con, false);
-                    literal l = ctx.get_literal(con);
-                    if (!is_true)
-                        l = ~l;
-                    ctx.mk_th_axiom(get_id(), ~lit, l);
+                if (lower_contains_to_regex(e, false))
                     return;
-                }
                 if (is_true)
                     m_axioms.contains_true_axiom(e);
                 else
@@ -937,7 +986,7 @@ namespace smt {
             // Incremental not-contains unrolling can otherwise build a deep
             // recursive expansion on contains-heavy replace benchmarks.
             constexpr unsigned max_replace_contains_terms = 12;
-            if (m_num_replace_terms && m_num_contains_terms >= max_replace_contains_terms) {
+            if (m_symbolic_replace_contains.size() >= max_replace_contains_terms) {
                 TRACE(seq, tout << "nseq final_check: replace/contains expansion limit reached\n");
                 return FC_GIVEUP;
             }

--- a/src/smt/theory_nseq.cpp
+++ b/src/smt/theory_nseq.cpp
@@ -188,6 +188,9 @@ namespace smt {
             m_relevant_lengths.push_back(term);
         }
 
+        if (!ctx.relevancy())
+            relevant_eh(term);
+
         return true;
     }
 
@@ -1044,16 +1047,10 @@ namespace smt {
 
             SASSERT(!m_nielsen.root()->is_currently_conflict());
 
-            // nseq cannot soundly reason about defined sequence operations (str.replace,
-            // str.replace_all, str.replace_re*) inside the Nielsen graph: they are not free
-            // variables but are pinned by the recfun/axiom layer.  The modifiers (and the
-            // regex pre-check) would treat them as free (e.g. unifying two distinct
-            // replace_all applications), silently discarding their definition and yielding
-            // invalid models.  When such a rigid term participates in the constraints, defer
-            // to the axiom layer and give up.  (Concrete replace_all etc. are folded to
-            // literals by seq_rewriter before reaching the sgraph, so only genuinely
-            // symbolic occurrences are affected.)  This check precedes the regex pre-check
-            // so a rigid term as a membership subject cannot yield a bogus SAT either.
+            // Recursive replacement operations cannot soundly participate in Nielsen search:
+            // treating them as free variables would discard their recfun definitions.
+            // Single-occurrence str.replace is handled by its complete finite axiom schema
+            // and is therefore not rigid.
             if (m_nielsen.root()->references_rigid()) {
                 IF_VERBOSE(1, verbose_stream() << "nseq final_check: rigid defined op present, FC_GIVEUP\n";);
                 TRACE(seq, tout << "nseq final_check: rigid defined op present, FC_GIVEUP\n");

--- a/src/smt/theory_nseq.cpp
+++ b/src/smt/theory_nseq.cpp
@@ -49,6 +49,15 @@ namespace smt {
             [&](expr_ref_vector const &clause) {
             literal_vector lits;
             for (auto const &e : clause) {
+                expr* atom = nullptr;
+                if (m_tracking_replace_contains) {
+                    if (!m.is_not(e, atom))
+                        atom = e;
+                    if (m_seq.str.is_contains(atom) && !m_replace_contains.contains(atom)) {
+                        m_replace_contains.insert(atom);
+                        ctx.push_trail(insert_obj_trail<expr>(m_replace_contains, atom));
+                    }
+                }
                 auto lit = mk_literal(e);
                 if (lit == false_literal)
                     continue;
@@ -168,6 +177,15 @@ namespace smt {
 
         // register in our private sgraph
         get_snode(term);
+
+        if (m_seq.str.is_replace(term)) {
+            ctx.push_trail(value_trail(m_num_replace_terms));
+            ++m_num_replace_terms;
+        }
+        if (m_seq.str.is_contains(term)) {
+            ctx.push_trail(value_trail(m_num_contains_terms));
+            ++m_num_contains_terms;
+        }
 
         if (m_seq.is_seq(term) && m_axioms.sk().is_skolem(term))
             ensure_length_var(term);
@@ -366,6 +384,15 @@ namespace smt {
                     m_axioms.suffix_axiom(e);
             }
             else if (m_seq.str.is_contains(e)) {
+                if (m_replace_contains.contains(e)) {
+                    if (is_true)
+                        m_axioms.contains_true_axiom(e);
+                    else {
+                        flet<bool> tracking(m_tracking_replace_contains, true);
+                        m_axioms.unroll_not_contains(e);
+                    }
+                    return;
+                }
                 zstring str;
                 if (m_seq.str.is_string(to_app(e)->get_arg(1), str)) {
                     // contains(u, v) with v const => u \in \Sigma* v \Sigma^*
@@ -584,8 +611,12 @@ namespace smt {
         if (r == seq::nielsen_graph::search_result::unsat) {
             IF_VERBOSE(1, verbose_stream() << "nseq eager: structural conflict\n";);
             TRACE(seq, tout << "nseq eager: structural conflict\n");
-            ++m_num_eager_conflicts;
-            explain_nielsen_conflict(); // reads conflict_sources() + root, then sets the conflict
+            if (explain_nielsen_conflict())
+                ++m_num_eager_conflicts;
+            else {
+                m_nielsen.eager_invalidate();
+                m_eager_processed = 0;
+            }
         }
         // Keep the chain for the next propagation (incremental).  It is discarded by
         // pop_scope_eh / final_check's reset, never here.
@@ -792,8 +823,10 @@ namespace smt {
             m_axioms.indexof_axiom(n);
         else if (m_seq.str.is_last_index(n))
             m_axioms.last_indexof_axiom(n);
-        else if (m_seq.str.is_replace(n))
+        else if (m_seq.str.is_replace(n)) {
+            flet<bool> tracking(m_tracking_replace_contains, true);
             m_axioms.replace_axiom(n);
+        }
         else if (m_seq.str.is_replace_all(n))
             m_axioms.replace_all_axiom(n);
         else if (m_seq.str.is_extract(n))
@@ -901,6 +934,14 @@ namespace smt {
 
     final_check_status theory_nseq::final_check_eh(unsigned /*final_check_round*/) {
         try {
+            // Incremental not-contains unrolling can otherwise build a deep
+            // recursive expansion on contains-heavy replace benchmarks.
+            constexpr unsigned max_replace_contains_terms = 12;
+            if (m_num_replace_terms && m_num_contains_terms >= max_replace_contains_terms) {
+                TRACE(seq, tout << "nseq final_check: replace/contains expansion limit reached\n");
+                return FC_GIVEUP;
+            }
+
             // Always assert non-negativity for all string theory vars,
             // even when there are no string equations/memberships.
             if (assert_nonneg_for_all_vars()) {
@@ -1102,7 +1143,8 @@ namespace smt {
             if (result == seq::nielsen_graph::search_result::unsat) {
                 IF_VERBOSE(1, verbose_stream() << "nseq final_check: solve UNSAT\n";);
                 TRACE(seq, tout << "nseq final_check: solve UNSAT\n");
-                explain_nielsen_conflict();
+                if (!explain_nielsen_conflict())
+                    m_can_hot_restart = false;
                 return FC_CONTINUE;
             }
 
@@ -1247,14 +1289,20 @@ namespace smt {
     // Conflict explanation
     // -----------------------------------------------------------------------
 
-    void theory_nseq::explain_nielsen_conflict() {
+    bool theory_nseq::explain_nielsen_conflict() {
         enode_pair_vector eqs;
         literal_vector lits;
         for (seq::dep_source const& d : m_nielsen.conflict_sources()) {
             if (std::holds_alternative<enode_pair>(d))
                 eqs.push_back(std::get<enode_pair>(d));
-            else if (std::holds_alternative<sat::literal>(d))
-                lits.push_back(std::get<sat::literal>(d));
+            else if (std::holds_alternative<sat::literal>(d)) {
+                const literal lit = std::get<sat::literal>(d);
+                if (lit == null_literal || lit.var() >= ctx.get_num_bool_vars()) {
+                    TRACE(seq, tout << "nseq conflict cites a deleted literal; rebuilding graph\n");
+                    return false;
+                }
+                lits.push_back(lit);
+            }
             else
                 UNREACHABLE();
         }
@@ -1389,6 +1437,7 @@ namespace smt {
         }
         std::flush(std::cout);
 #endif
+        return true;
     }
 
     void theory_nseq::set_conflict(enode_pair_vector const& eqs, literal_vector const& lits) {

--- a/src/smt/theory_nseq.h
+++ b/src/smt/theory_nseq.h
@@ -62,9 +62,9 @@ namespace smt {
         unsigned                m_prop_qhead = 0;
         obj_hashtable<expr>     m_axiom_set;   // dedup guard for axiom_item enqueues
         obj_hashtable<expr>     m_replace_contains; // all contains guards introduced by replace axioms
+        obj_hashtable<expr>     m_lowered_contains; // syntactic constant contains axiomatized as regex
+        obj_hashtable<expr>     m_symbolic_replace_contains; // replace guards requiring recursive unrolling
         bool                    m_tracking_replace_contains = false;
-        unsigned                m_num_replace_terms = 0;
-        unsigned                m_num_contains_terms = 0;
         obj_hashtable<expr>     m_no_diseq_set;     // track expressions that should not trigger new disequality axioms
         hashtable<literal, obj_hash<literal>, default_eq<literal>>    m_ignored_mem;     // track membership constraints that should not be passed to Nielsen
         expr_ref_vector         m_relevant_lengths;     // track variables whose lengths are relevant
@@ -188,6 +188,8 @@ namespace smt {
         void enqueue_axiom(expr* e);
         void dequeue_axiom(expr* e);
         void ensure_length_var(expr* e) const;
+        expr* find_string_constant(expr* e) const;
+        bool lower_contains_to_regex(expr* e, bool use_eqc);
 
         // higher-order term unfolding
         bool unfold_ho_terms();

--- a/src/smt/theory_nseq.h
+++ b/src/smt/theory_nseq.h
@@ -61,6 +61,10 @@ namespace smt {
         vector<prop_item>       m_prop_queue;
         unsigned                m_prop_qhead = 0;
         obj_hashtable<expr>     m_axiom_set;   // dedup guard for axiom_item enqueues
+        obj_hashtable<expr>     m_replace_contains; // all contains guards introduced by replace axioms
+        bool                    m_tracking_replace_contains = false;
+        unsigned                m_num_replace_terms = 0;
+        unsigned                m_num_contains_terms = 0;
         obj_hashtable<expr>     m_no_diseq_set;     // track expressions that should not trigger new disequality axioms
         hashtable<literal, obj_hash<literal>, default_eq<literal>>    m_ignored_mem;     // track membership constraints that should not be passed to Nielsen
         expr_ref_vector         m_relevant_lengths;     // track variables whose lengths are relevant
@@ -154,7 +158,7 @@ namespace smt {
         // private helpers
         void populate_nielsen_graph();
         void eager_structural_check();
-        void explain_nielsen_conflict();
+        bool explain_nielsen_conflict();
         // benchmark-harvest: block the current assignment of membership/equation
         // literals so the SAT solver tries a different one.  Returns false if there
         // is nothing to block (empty clause).  Intentionally unsound.

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -120,6 +120,7 @@ add_executable(test-z3
   prime_generator.cpp
   psmt.cpp
   seq_regex_bisim.cpp
+  seq_split.cpp
   seq_nielsen.cpp
   proof_checker.cpp
   qe_arith.cpp

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -202,6 +202,7 @@
     X(finite_set) \
     X(finite_set_rewriter) \
     X(seq_regex_bisim) \
+    X(seq_split) \
     X(seq_nielsen) \
     X(nseq_basic) \
     X(nseq_zipt) \

--- a/src/test/nseq_basic.cpp
+++ b/src/test/nseq_basic.cpp
@@ -283,6 +283,76 @@ static void test_setup_seq_str_dispatches_nseq() {
     std::cout << "  ok: setup_seq_str dispatched to setup_nseq for 'nseq'\n";
 }
 
+static void test_nseq_replace_rigidity_scope() {
+    std::cout << "test_nseq_replace_rigidity_scope\n";
+    ast_manager m;
+    reg_decl_plugins(m);
+    seq_util su(m);
+    euf::egraph eg(m);
+    euf::sgraph sg(m, eg);
+    sort* str_sort = su.str.mk_string_sort();
+    const expr_ref x(m.mk_const(symbol("replace_x"), str_sort), m);
+    const expr_ref empty(su.str.mk_string(zstring()), m);
+    const expr_ref a(su.str.mk_string(zstring("a")), m);
+    const expr_ref replace(su.str.mk_replace(empty, x, a), m);
+    expr* replace_all_args[3] = { empty, x, a };
+    const expr_ref replace_all(
+        m.mk_app(su.get_family_id(), OP_SEQ_REPLACE_ALL, 3, replace_all_args), m);
+
+    VERIFY(!sg.mk(replace)->is_rigid());
+    VERIFY(sg.mk(replace_all)->is_rigid());
+    std::cout << "  ok: str.replace uses finite axioms; recursive replacement stays rigid\n";
+}
+
+static void test_nseq_replace_symbolic_pattern() {
+    std::cout << "test_nseq_replace_symbolic_pattern\n";
+    ast_manager m;
+    reg_decl_plugins(m);
+    smt_params params;
+    params.m_string_solver = symbol("nseq");
+    smt::context ctx(m, params);
+    seq_util su(m);
+    sort* str_sort = su.str.mk_string_sort();
+    const expr_ref pattern(m.mk_const(symbol("replace_pattern"), str_sort), m);
+    const expr_ref empty(su.str.mk_string(zstring()), m);
+    const expr_ref a(su.str.mk_string(zstring("A")), m);
+    const expr_ref b(su.str.mk_string(zstring("B")), m);
+    const expr_ref replace(su.str.mk_replace(empty, pattern, a), m);
+
+    ctx.push();
+    ctx.assert_expr(expr_ref(m.mk_eq(replace, b), m));
+    VERIFY(ctx.check() == l_false);
+    ctx.pop(1);
+
+    ctx.push();
+    ctx.assert_expr(expr_ref(m.mk_eq(replace, a), m));
+    VERIFY(ctx.check() == l_true);
+    ctx.pop(1);
+    std::cout << "  ok: symbolic str.replace is unsat/sat according to replace_axiom\n";
+}
+
+static void test_nseq_replace_membership_without_relevancy() {
+    std::cout << "test_nseq_replace_membership_without_relevancy\n";
+    ast_manager m;
+    reg_decl_plugins(m);
+    smt_params params;
+    params.m_string_solver = symbol("nseq");
+    params.m_relevancy_lvl = 0;
+    smt::context ctx(m, params);
+    seq_util su(m);
+    sort* str_sort = su.str.mk_string_sort();
+    const expr_ref pattern(m.mk_const(symbol("replace_membership_pattern"), str_sort), m);
+    const expr_ref empty(su.str.mk_string(zstring()), m);
+    const expr_ref a(su.str.mk_string(zstring("A")), m);
+    const expr_ref b(su.str.mk_string(zstring("B")), m);
+    const expr_ref replace(su.str.mk_replace(empty, pattern, a), m);
+    const expr_ref b_regex(su.re.mk_to_re(b), m);
+
+    ctx.assert_expr(expr_ref(su.re.mk_in_re(replace, b_regex), m));
+    VERIFY(ctx.check() == l_false);
+    std::cout << "  ok: replace_axiom is active for direct membership at relevancy=0\n";
+}
+
 // -----------------------------------------------------------------------
 // Fine & Wilf end-to-end tests (full smt::context, real arithmetic).
 // The equation shape U^n·V = Y·W^m·Z with different-base powers used to
@@ -382,6 +452,9 @@ void tst_nseq_basic() {
     test_nseq_const_nielsen_solvable();
     test_nseq_length_mismatch();
     test_setup_seq_str_dispatches_nseq();
+    test_nseq_replace_rigidity_scope();
+    test_nseq_replace_symbolic_pattern();
+    test_nseq_replace_membership_without_relevancy();
     test_nseq_fine_wilf_e2e_unsat();
     test_nseq_fine_wilf_e2e_sat();
     test_nseq_fine_wilf_option_off();

--- a/src/test/nseq_basic.cpp
+++ b/src/test/nseq_basic.cpp
@@ -344,11 +344,63 @@ static void test_nseq_replace_constant_pattern() {
     const expr_ref a(su.str.mk_string(zstring("a")), m);
     const expr_ref x(su.str.mk_string(zstring("X")), m);
     const expr_ref replace(su.str.mk_replace(source, a, x), m);
+    const expr_ref same_replace(su.str.mk_replace(source, a, x), m);
+    const expr_ref contains(su.str.mk_contains(source, a), m);
 
-    ctx.assert_expr(expr_ref(su.str.mk_contains(source, a), m));
+    VERIFY(replace == same_replace);
+
+    ctx.push();
+    ctx.assert_expr(contains);
     ctx.assert_expr(expr_ref(m.mk_eq(replace, source), m));
     VERIFY(ctx.check() == l_false);
-    std::cout << "  ok: positive replace containment uses the finite witness axiom\n";
+    ctx.pop(1);
+
+    ctx.push();
+    ctx.assert_expr(expr_ref(m.mk_not(contains), m));
+    ctx.assert_expr(expr_ref(m.mk_eq(replace, source), m));
+    VERIFY(ctx.check() == l_true);
+    ctx.pop(1);
+
+    const expr_ref empty(su.str.mk_string(zstring()), m);
+    const expr_ref empty_replace(su.str.mk_replace(source, empty, x), m);
+    const expr_ref prepended(su.str.mk_concat(x, source), m);
+    ctx.push();
+    ctx.assert_expr(expr_ref(m.mk_not(m.mk_eq(empty_replace, prepended)), m));
+    VERIFY(ctx.check() == l_false);
+    ctx.pop(1);
+    std::cout << "  ok: constant replace guards lower to positive/negative regex membership\n";
+}
+
+static void test_nseq_replace_equivalent_constant_patterns() {
+    std::cout << "test_nseq_replace_equivalent_constant_patterns\n";
+    ast_manager m;
+    reg_decl_plugins(m);
+    smt_params params;
+    params.m_string_solver = symbol("nseq");
+    smt::context ctx(m, params);
+    seq_util su(m);
+    sort* str_sort = su.str.mk_string_sort();
+    const expr_ref a(su.str.mk_string(zstring("a")), m);
+    const expr_ref x(su.str.mk_string(zstring("X")), m);
+    expr_ref_vector pinned(m);
+
+    for (unsigned i = 0; i < 13; ++i) {
+        const std::string suffix = std::to_string(i);
+        const expr_ref source(m.mk_const(symbol(("replace_source_" + suffix).c_str()), str_sort), m);
+        const expr_ref pattern(m.mk_const(symbol(("replace_pattern_" + suffix).c_str()), str_sort), m);
+        const expr_ref contains(su.str.mk_contains(source, pattern), m);
+        const expr_ref replace(su.str.mk_replace(source, pattern, x), m);
+        pinned.push_back(source);
+        pinned.push_back(pattern);
+        pinned.push_back(contains);
+        pinned.push_back(replace);
+        ctx.assert_expr(expr_ref(m.mk_eq(pattern, a), m));
+        ctx.assert_expr(expr_ref(m.mk_not(contains), m));
+        ctx.assert_expr(expr_ref(m.mk_eq(replace, source), m));
+    }
+
+    VERIFY(ctx.check() == l_true);
+    std::cout << "  ok: equivalent constants bypass the symbolic replace expansion limit\n";
 }
 
 static void test_nseq_replace_membership_without_relevancy() {
@@ -475,6 +527,7 @@ void tst_nseq_basic() {
     test_nseq_replace_rigidity_scope();
     test_nseq_replace_symbolic_pattern();
     test_nseq_replace_constant_pattern();
+    test_nseq_replace_equivalent_constant_patterns();
     test_nseq_replace_membership_without_relevancy();
     test_nseq_fine_wilf_e2e_unsat();
     test_nseq_fine_wilf_e2e_sat();

--- a/src/test/nseq_basic.cpp
+++ b/src/test/nseq_basic.cpp
@@ -331,6 +331,26 @@ static void test_nseq_replace_symbolic_pattern() {
     std::cout << "  ok: symbolic str.replace is unsat/sat according to replace_axiom\n";
 }
 
+static void test_nseq_replace_constant_pattern() {
+    std::cout << "test_nseq_replace_constant_pattern\n";
+    ast_manager m;
+    reg_decl_plugins(m);
+    smt_params params;
+    params.m_string_solver = symbol("nseq");
+    smt::context ctx(m, params);
+    seq_util su(m);
+    sort* str_sort = su.str.mk_string_sort();
+    const expr_ref source(m.mk_const(symbol("replace_source"), str_sort), m);
+    const expr_ref a(su.str.mk_string(zstring("a")), m);
+    const expr_ref x(su.str.mk_string(zstring("X")), m);
+    const expr_ref replace(su.str.mk_replace(source, a, x), m);
+
+    ctx.assert_expr(expr_ref(su.str.mk_contains(source, a), m));
+    ctx.assert_expr(expr_ref(m.mk_eq(replace, source), m));
+    VERIFY(ctx.check() == l_false);
+    std::cout << "  ok: positive replace containment uses the finite witness axiom\n";
+}
+
 static void test_nseq_replace_membership_without_relevancy() {
     std::cout << "test_nseq_replace_membership_without_relevancy\n";
     ast_manager m;
@@ -454,6 +474,7 @@ void tst_nseq_basic() {
     test_setup_seq_str_dispatches_nseq();
     test_nseq_replace_rigidity_scope();
     test_nseq_replace_symbolic_pattern();
+    test_nseq_replace_constant_pattern();
     test_nseq_replace_membership_without_relevancy();
     test_nseq_fine_wilf_e2e_unsat();
     test_nseq_fine_wilf_e2e_sat();

--- a/src/test/seq_split.cpp
+++ b/src/test/seq_split.cpp
@@ -317,6 +317,17 @@ public:
         (void)check_agree(cc);
     }
 
+    void test_nested_materialization_cycle() {
+        // The derivative of ~(.*."A".*) can regenerate the same complement
+        // while its body is being materialized. The shared cycle memo must make
+        // this terminate through the De Morgan fallback.
+        expr_ref contains_a(
+            re().mk_concat(dotstar(), re().mk_concat(word("A"), dotstar())), m);
+        expr_ref excludes_a(re().mk_complement(contains_a), m);
+        split_set s;
+        (void)eager(excludes_a, s, 32, split_mode::strong);
+    }
+
     void test_determinism() {
         expr_ref r(re().mk_concat(rng('a', 'a'), re().mk_star(rng('b', 'b'))), m);
         split_set s1, s2;
@@ -444,6 +455,7 @@ public:
         test_nary_union();
         test_nary_concat();
         test_nested_complement();
+        test_nested_materialization_cycle();
         test_determinism();
         test_threshold_boundary();
         test_early_stop_after_two();


### PR DESCRIPTION
## Summary

`theory_nseq` previously marked every symbolic `str.replace` result rigid. When one reached the Nielsen graph, `final_check_eh` returned `FC_GIVEUP`, even though single-occurrence replacement already has a complete finite axiom schema shared with `theory_seq`. This affected 9,834 of the 9,847 `nseq` unknowns in the QF_SLIA report cohort.

This PR:

- keeps `str.replace_all` and regex replacement operations rigid;
- allows only `str.replace` to act as an opaque Nielsen proxy constrained by the existing `seq::axioms::replace_axiom` case split;
- mirrors `theory_seq` containment handling for symbolic replace-generated guards;
- lowers `contains(u, c)` for constant `c` to `u in Sigma* . to_re(c) . Sigma*`, so negative containment becomes membership in the regex complement;
- recognizes e-graph-equivalent string constants and guards the lowering with the equality dependency;
- handles the empty constant directly and caches syntactic constant lowerings;
- counts only guards that still require recursive symbolic-pattern containment handling toward the expansion limit;
- rebuilds the Nielsen graph instead of reusing conflicts whose SAT dependencies were deleted by backtracking;
- shares regex derivative-cycle state across nested split materializations, preventing the complement/intersection recursion exposed by constant lowering;
- mirrors `theory_seq` by invoking `relevant_eh` during internalization when relevancy is disabled.

## QF_SLIA differential benchmark

Exact options:

```
-T:5 smt.string_solver=nseq model_validate=true smt.nseq.parikh=false smt.nseq.eager=false smt.nseq.regex_factorization_eager=false smt.nseq.regex_factorization_threshold=100000 smt.nseq.regex_dynamic_decomposition=false
```

Full 9,834-case plain-`str.replace` cohort, Release CMake/Ninja builds, eight controlled workers:

| Result | `c3` | PR before constant lowering (`7601e152a`) | Final (`a52ebb453`) |
|---|---:|---:|---:|
| SAT | 0 | 15 | 38 |
| UNSAT | 0 | 120 | 207 |
| Unknown | 9,834 | 9,629 | 156 |
| Timeout | 0 | 70 | 9,433 |
| Crash | 0 | 0 | 0 |
| Definite disagreement | 0 | 0 | 0 |

The final implementation solves **245** formerly missed cases, all agreeing with the theory-seq/master oracle. Relative to `7601e152a`, it has **114 newly solved cases**, four regressions, and no changed definite answers, for a net gain of 110 solves. The four regressions are closely related `str-pred-small-rw_{546,547,549,550}` cases; they now reach the existing symbolic containment expansion guard after the constant lowering changes the SAT/Nielsen search path.

Final timing quantiles:

| Status | Median | P95 |
|---|---:|---:|
| SAT | 0.054 s | 0.275 s |
| UNSAT | 0.086 s | 1.896 s |
| Unknown | 0.397 s | 2.359 s |
| Timeout | 5.037 s | 5.116 s |

Balanced parsing with Z3's SMT-LIB parser classifies the cohort as follows:

- constant-only patterns: 36 SAT, 92 UNSAT, 9,371 timeout, 0 unknown;
- at least one symbolic pattern: 2 SAT, 115 UNSAT, 156 unknown, 62 timeout.

Thus all remaining `unknown` results contain a genuinely symbolic pattern; constant-only residuals run to the five-second timeout rather than hitting the symbolic expansion guard.

The initial constant-lowering run exposed five deterministic stack overflows. Debugger traces identified a cycle in nested regex split materialization: each nested iterator created a fresh derivative memo, allowing the same complemented state to re-enter indefinitely. Sharing the top-level memo across nested materializations converts all five crashes to sound timeouts and additionally recovers three UNSAT cases. The final full run has zero crashes.

## Validation

- Release CMake/Ninja build
- `test-z3 nseq_basic`
- registered `seq_split` regression suite, including the nested complement cycle
- `test-z3 /a` — 96 passed, 0 failed
- five constant-lowering stack-overflow reproducers — all cleanly time out
- full 9,834-case cohort with `model_validate=true` — zero crashes and zero disagreements
- CLI and CMake-built Python binding smoke tests
- 13 `replace_all`/regex replacement controls unchanged versus `7601e152a`

Commits: `a88a84bfe`, `7601e152a`, `a52ebb453`