### PR TITLE
Reimplement datatype_factory using term_enumeration; add external enumerator support

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -630,6 +630,34 @@ public:
     void set_num_elements(sort_size const& s) { get_info()->set_num_elements(s); }
     unsigned get_size() const { return get_obj_size(); }
     bool is_type_var() const { return get_family_id() == poly_family_id; }
+
+    // Uniform access to the sort(s) nested under a parametric sort
+    // constructor, e.g., the domain/range sorts of an Array sort, the
+    // element sort of a Seq/RegEx sort, or the element sort of a
+    // FiniteSet sort. Such sorts store their argument sorts as PARAM_AST
+    // parameters, so a nested sort is simply a parameter that is an ast
+    // of kind AST_SORT. Defined out-of-line below, once is_sort()/to_sort()
+    // are available.
+    unsigned get_num_sort_parameters() const;
+    sort * get_sort_parameter(unsigned idx) const;
+
+    class sort_parameters {
+        sort const & m_s;
+    public:
+        class iterator {
+            sort const & m_s;
+            unsigned     m_idx;
+        public:
+            iterator(sort const & s, unsigned idx) : m_s(s), m_idx(idx) {}
+            iterator & operator++() { ++m_idx; return *this; }
+            sort * operator*() const { return m_s.get_sort_parameter(m_idx); }
+            bool operator!=(iterator const & other) const { return m_idx != other.m_idx; }
+        };
+        sort_parameters(sort const & s) : m_s(s) {}
+        iterator begin() const { return iterator(m_s, 0); }
+        iterator end() const { return iterator(m_s, m_s.get_num_sort_parameters()); }
+    };
+    sort_parameters get_sort_parameters() const { return sort_parameters(*this); }
 };
 
 // -----------------------------------
@@ -949,6 +977,29 @@ inline bool is_quantifier(ast const * n) { return n->get_kind() == AST_QUANTIFIE
 inline bool is_forall(ast const * n)     { return is_quantifier(n) && static_cast<quantifier const *>(n)->get_kind() == forall_k; }
 inline bool is_exists(ast const * n)     { return is_quantifier(n) && static_cast<quantifier const *>(n)->get_kind() == exists_k; }
 inline bool is_lambda(ast const * n)     { return is_quantifier(n) && static_cast<quantifier const *>(n)->get_kind() == lambda_k; }
+
+inline unsigned sort::get_num_sort_parameters() const {
+    unsigned n = 0;
+    for (unsigned i = 0; i < get_num_parameters(); ++i) {
+        parameter const & p = get_parameter(i);
+        if (p.is_ast() && is_sort(p.get_ast()))
+            ++n;
+    }
+    return n;
+}
+
+inline sort * sort::get_sort_parameter(unsigned idx) const {
+    for (unsigned i = 0; i < get_num_parameters(); ++i) {
+        parameter const & p = get_parameter(i);
+        if (p.is_ast() && is_sort(p.get_ast())) {
+            if (idx == 0)
+                return static_cast<sort *>(p.get_ast());
+            --idx;
+        }
+    }
+    UNREACHABLE();
+    return nullptr;
+}
 
 // -----------------------------------
 //

--- a/src/ast/rewriter/term_enumeration.cpp
+++ b/src/ast/rewriter/term_enumeration.cpp
@@ -746,20 +746,6 @@ term_enumeration::iterator::iterator(std::nullptr_t) {
     m_imp = nullptr;
 }
 
-term_enumeration::iterator::iterator(iterator&& other) noexcept {
-    m_imp = other.m_imp;
-    other.m_imp = nullptr;
-}
-
-term_enumeration::iterator& term_enumeration::iterator::operator=(iterator&& other) noexcept {
-    if (this != &other) {
-        dealloc(m_imp);
-        m_imp = other.m_imp;
-        other.m_imp = nullptr;
-    }
-    return *this;
-}
-
 term_enumeration::iterator::~iterator() {
     dealloc(m_imp);
 }

--- a/src/ast/rewriter/term_enumeration.cpp
+++ b/src/ast/rewriter/term_enumeration.cpp
@@ -348,6 +348,11 @@ public:
         m_rewriter.reset();
         m_seen_terms.reset();
         m_children_iter.reset();
+        m_external_seeded.reset();
+    }
+
+    void set_external_enumerator(std::function<expr*(sort*)> f) {
+        m_external = std::move(f);
     }
 
     expr* add_term(expr_ref const& term, unsigned cost) {
@@ -380,9 +385,23 @@ private:
     obj_hashtable<expr> m_seen_terms;
     std::unique_ptr<children_iterator> m_children_iter;
     sort *m_target_sort = nullptr;
+    std::function<expr*(sort*)> m_external;
+    obj_hashtable<sort> m_external_seeded;
 
     bool sort_matches(expr* e) const {
         return !m_target_sort || e->get_sort() == m_target_sort;
+    }
+
+    // Consult the external enumerator (if any) at most once per sort to
+    // seed a base leaf value. Used to supply values for non-datatype
+    // argument sorts that are not otherwise covered by the grammar.
+    void seed_external_if_needed(sort* s) {
+        if (!m_external || m_external_seeded.contains(s))
+            return;
+        m_external_seeded.insert(s);
+        expr_ref term(m_external(s), m);
+        if (term)
+            add_term(term, 0);
     }
 
     expr* find_next() {
@@ -483,6 +502,8 @@ private:
             
             production const &prod = *ops[m_op_idx];
             m_op_idx++;
+            for (sort* dom : prod.domain)
+                seed_external_if_needed(dom);
             m_children_iter = std::make_unique<children_iterator>(m, prod, m_bank, m_cost);
         }
     }
@@ -501,12 +522,15 @@ private:
  */
 class sort_stream {
 public:
-    sort_stream(ast_manager& m, func_decl_ref_vector const& funcs, expr_ref_vector const& exprs, sort* s)
+    sort_stream(ast_manager& m, func_decl_ref_vector const& funcs, expr_ref_vector const& exprs, sort* s,
+                term_enumeration::external_enumerator_t const& ext = nullptr)
         : m(m), m_grammar(m), m_enum(m_grammar), autil(m), m_sort(s), m_current(m), m_pinned(m) {
         for (func_decl* f : funcs)
             m_grammar.add_func_decl(f);
         for (expr* e : exprs)
             m_grammar.add_expr(e);
+        if (ext)
+            m_enum.set_external_enumerator(ext);
         m_enum.reset();
         init_sort();
         advance();
@@ -601,6 +625,7 @@ struct term_enumeration::imp {
     std::function<unsigned(expr*)> m_cost;
     func_decl_ref_vector          m_user_funcs;
     expr_ref_vector               m_user_exprs;
+    term_enumeration::external_enumerator_t m_external;
 
     imp(ast_manager& m) :
         m(m), m_grammar(m), m_bottom_up_enumerator(m_grammar),
@@ -618,6 +643,11 @@ struct term_enumeration::imp {
 
     void set_cost(std::function<unsigned(expr*)> const& cost) {
         // TODO
+    }
+
+    void set_external_enumerator(term_enumeration::external_enumerator_t fn) {
+        m_bottom_up_enumerator.set_external_enumerator(fn);
+        m_external = std::move(fn);
     }
 
     std::ostream& display(std::ostream& out) const {
@@ -716,6 +746,20 @@ term_enumeration::iterator::iterator(std::nullptr_t) {
     m_imp = nullptr;
 }
 
+term_enumeration::iterator::iterator(iterator&& other) noexcept {
+    m_imp = other.m_imp;
+    other.m_imp = nullptr;
+}
+
+term_enumeration::iterator& term_enumeration::iterator::operator=(iterator&& other) noexcept {
+    if (this != &other) {
+        dealloc(m_imp);
+        m_imp = other.m_imp;
+        other.m_imp = nullptr;
+    }
+    return *this;
+}
+
 term_enumeration::iterator::~iterator() {
     dealloc(m_imp);
 }
@@ -730,7 +774,9 @@ term_enumeration::iterator& term_enumeration::iterator::operator++() {
 }
 
 term_enumeration::iterator term_enumeration::iterator::operator++(int) {
-    iterator tmp(*this);
+    iterator tmp(nullptr);
+    if (m_imp)
+        tmp.m_imp = alloc(iter_imp, *m_imp);
     ++(*this);
     return tmp;
 }
@@ -774,7 +820,7 @@ struct term_enumeration::tuple_iterator::timp {
     timp(imp& i, unsigned n, sort* const* sorts) :
         m_imp(i), m(i.m), m_n(n), m_current(i.m) {
         for (unsigned k = 0; k < n; ++k) {
-            m_streams.push_back(alloc(term_enum::sort_stream, m, i.m_user_funcs, i.m_user_exprs, sorts[k]));
+            m_streams.push_back(alloc(term_enum::sort_stream, m, i.m_user_funcs, i.m_user_exprs, sorts[k], i.m_external));
             m_terms.push_back(expr_ref_vector(m));
             m_done.push_back(false);
         }
@@ -926,6 +972,10 @@ void term_enumeration::add_production(expr* e) {
 
 void term_enumeration::set_cost(std::function<unsigned(expr*)> const& cost) {
     m_imp->set_cost(cost);
+}
+
+void term_enumeration::set_external_enumerator(external_enumerator_t fn) {
+    m_imp->set_external_enumerator(std::move(fn));
 }
 
 term_enumeration::terms term_enumeration::enum_terms(sort* s) {

--- a/src/ast/rewriter/term_enumeration.cpp
+++ b/src/ast/rewriter/term_enumeration.cpp
@@ -773,14 +773,6 @@ term_enumeration::iterator& term_enumeration::iterator::operator++() {
     return *this;
 }
 
-term_enumeration::iterator term_enumeration::iterator::operator++(int) {
-    iterator tmp(nullptr);
-    if (m_imp)
-        tmp.m_imp = alloc(iter_imp, *m_imp);
-    ++(*this);
-    return tmp;
-}
-
 bool term_enumeration::iterator::operator==(iterator const& other) const {
     if (!m_imp && !other.m_imp) return true;
     if (!m_imp) return other.m_imp->m_end;

--- a/src/ast/rewriter/term_enumeration.h
+++ b/src/ast/rewriter/term_enumeration.h
@@ -34,8 +34,8 @@ public:
     public:
         iterator(imp& i, sort* s);
         iterator(std::nullptr_t);
-        iterator(iterator&& other) noexcept;
-        iterator& operator=(iterator&& other) noexcept;
+        iterator(iterator&& other) = delete;
+        iterator& operator=(iterator&& other) = delete;
         iterator(iterator const&) = delete;
         iterator& operator=(iterator const&) = delete;
         ~iterator();

--- a/src/ast/rewriter/term_enumeration.h
+++ b/src/ast/rewriter/term_enumeration.h
@@ -19,12 +19,25 @@ public:
 
     void set_cost(std::function<unsigned(expr*)> const& cost);
 
+    // An external enumerator is consulted (at most once per sort) to
+    // produce a base value for sorts that are not covered by the grammar
+    // (e.g., non-datatype sorts referenced as fields of an algebraic
+    // datatype). This allows clients such as the model's datatype value
+    // factory to combine bottom-up enumeration of constructor applications
+    // with model-provided values for the non-datatype argument sorts.
+    using external_enumerator_t = std::function<expr*(sort*)>;
+    void set_external_enumerator(external_enumerator_t fn);
+
     class iterator {
         struct iter_imp;
         iter_imp* m_imp;
     public:
         iterator(imp& i, sort* s);
         iterator(std::nullptr_t);
+        iterator(iterator&& other) noexcept;
+        iterator& operator=(iterator&& other) noexcept;
+        iterator(iterator const&) = delete;
+        iterator& operator=(iterator const&) = delete;
         ~iterator();
         expr* operator*();
         iterator operator++(int);

--- a/src/ast/rewriter/term_enumeration.h
+++ b/src/ast/rewriter/term_enumeration.h
@@ -40,7 +40,6 @@ public:
         iterator& operator=(iterator const&) = delete;
         ~iterator();
         expr* operator*();
-        iterator operator++(int);
         iterator& operator++();
         bool operator!=(iterator const& other) const {
             return !(*this == other);

--- a/src/model/datatype_factory.cpp
+++ b/src/model/datatype_factory.cpp
@@ -7,7 +7,13 @@ Module Name:
 
 Abstract:
 
-    <abstract>
+    Value factory for algebraic datatypes, implemented on top of the
+    generic bottom-up term_enumeration module. Constructors of the
+    datatype sort (and of every datatype sort reachable through
+    constructor argument sorts) are registered as grammar productions.
+    Values for non-datatype argument sorts (e.g., Int, arrays,
+    uninterpreted sorts) are supplied through term_enumeration's external
+    enumerator hook, which defers to the underlying model.
 
 Author:
 
@@ -19,241 +25,139 @@ Revision History:
 #include "model/datatype_factory.h"
 #include "model/model_core.h"
 #include "ast/ast_pp.h"
-#include "ast/expr_functors.h"
 
 datatype_factory::datatype_factory(ast_manager & m, model_core & md):
     struct_factory(m, m.mk_family_id("datatype"), md),
     m_util(m) {
 }
 
+datatype_factory::~datatype_factory() {
+    for (auto & kv : m_some_enum)
+        dealloc(kv.m_value);
+    for (auto & kv : m_fresh_iter)
+        dealloc(kv.m_value);
+    for (auto & kv : m_fresh_enum)
+        dealloc(kv.m_value);
+}
+
+/**
+   \brief Build (or retrieve from \c cache) a term_enumeration that can
+   enumerate values of sort \c s. The enumerator's grammar is seeded with
+   the constructors of \c s and of every datatype sort transitively
+   reachable through constructor argument sorts. Values for argument
+   sorts that are not datatypes are produced on demand by the external
+   enumerator, which asks the model for a value.
+*/
+term_enumeration & datatype_factory::get_enumerator(sort * s, obj_map<sort, term_enumeration *> & cache) {
+    term_enumeration * te = nullptr;
+    if (cache.find(s, te))
+        return *te;
+
+    te = alloc(term_enumeration, m_manager);
+    cache.insert(s, te);
+
+    ptr_vector<sort> todo;
+    obj_hashtable<sort> visited;
+    todo.push_back(s);
+    visited.insert(s);
+    while (!todo.empty()) {
+        sort * cur = todo.back();
+        todo.pop_back();
+        if (!m_util.is_datatype(cur))
+            continue;
+        for (func_decl * c : *m_util.get_datatype_constructors(cur)) {
+            te->add_production(c);
+            unsigned num = c->get_arity();
+            for (unsigned i = 0; i < num; ++i) {
+                sort * s_arg = c->get_domain(i);
+                if (m_util.is_datatype(s_arg) && !visited.contains(s_arg)) {
+                    visited.insert(s_arg);
+                    todo.push_back(s_arg);
+                }
+            }
+        }
+    }
+
+    te->set_external_enumerator([this](sort * s_arg) -> expr* {
+        return m_model.get_some_value(s_arg);
+    });
+
+    return *te;
+}
+
 expr * datatype_factory::get_some_value(sort * s) {
     if (!m_util.is_datatype(s))
         return m_model.get_some_value(s);
-    value_set * set = nullptr;
-    if (m_sort2value_set.find(s, set) && !set->set.empty())
-        return *(set->set.begin());
-    func_decl * c = m_util.get_non_rec_constructor(s);
-    ptr_vector<expr> args;
-    unsigned num  = c->get_arity();
-    for (unsigned i = 0; i < num; ++i) 
-        args.push_back(m_model.get_some_value(c->get_domain(i)));    
-    expr * r = m_manager.mk_app(c, args);
-    register_value(r);
-    TRACE(datatype, tout << mk_pp(r, m_util.get_manager()) << "\n";);
-    return r;    
-}
-
-/**
-   \brief Return the last fresh (or almost) fresh value of sort s.
-*/
-expr * datatype_factory::get_last_fresh_value(sort * s) {
-    expr * val = nullptr;
-    if (m_last_fresh_value.find(s, val)) 
-        return val;
     auto& [set, values] = get_value_set(s);
-    if (set.empty())
-        val = get_some_value(s);
-    else 
-        val = *(set.begin());
-    if (m_util.is_recursive(s))
-        m_last_fresh_value.insert(s, val);
-    return val;
-}
-
-bool datatype_factory::is_subterm_of_last_value(app* e) {
-    expr* last;
-    if (!m_last_fresh_value.find(e->get_sort(), last)) {
-        return false;
+    if (!set.empty())
+        return *(set.begin());
+    term_enumeration & te = get_enumerator(s, m_some_enum);
+    for (expr * e : te.enum_terms(s)) {
+        register_value(e);
+        TRACE(datatype, tout << mk_pp(e, m_util.get_manager()) << "\n";);
+        return e;
     }
-    contains_app contains(m_manager, e);
-    bool result = contains(last);
-    TRACE(datatype, tout << mk_pp(e, m_manager) << " in " << mk_pp(last, m_manager) << " " << result << "\n";);
-    return result;
-}
-
-/**
-   \brief Create an almost fresh value. If s is recursive, then the result is not 0.
-   It also updates m_last_fresh_value
-*/
-expr * datatype_factory::get_almost_fresh_value(sort * s) {
-    if (!m_util.is_datatype(s))
-        return m_model.get_some_value(s);
-    auto& [set, values] = get_value_set(s);
-    if (set.empty()) {
-        expr * val = get_some_value(s);
-        SASSERT(val);
-        if (m_util.is_recursive(s))
-            m_last_fresh_value.insert(s, val);
-        return val;
-    }
-    // Traverse constructors, and try to invoke get_fresh_value of one of the arguments (if the argument is not a sibling datatype of s).
-    // If the argument is a sibling datatype of s, then
-    // use get_last_fresh_value.
-    ptr_vector<func_decl> const & constructors = *m_util.get_datatype_constructors(s);
-    for (func_decl * constructor : constructors) {
-        expr_ref_vector args(m_manager);
-        bool found_fresh_arg = false;
-        bool recursive       = false;
-        unsigned num            = constructor->get_arity();
-        for (unsigned i = 0; i < num; ++i) {
-            sort * s_arg        = constructor->get_domain(i);
-            if (!found_fresh_arg && (!m_util.is_datatype(s_arg) || !m_util.are_siblings(s, s_arg) || !m_util.is_recursive(s_arg))) {
-                expr * new_arg = m_model.get_fresh_value(s_arg);
-                if (new_arg != nullptr) {
-                    found_fresh_arg = true;
-                    args.push_back(new_arg);
-                    continue;
-                }
-            }
-            if (!found_fresh_arg && m_util.is_datatype(s_arg) && m_util.are_siblings(s, s_arg) && m_util.is_recursive(s_arg)) {
-                recursive = true;
-                expr * last_fresh = get_last_fresh_value(s_arg);
-                args.push_back(last_fresh);
-            }
-            else {
-                expr * some_arg = m_model.get_some_value(s_arg);
-                args.push_back(some_arg);
-            }
-        }
-        if (recursive || found_fresh_arg) {
-            app * new_value = m_manager.mk_app(constructor, args);
-            SASSERT(!found_fresh_arg || !set.contains(new_value));
-            register_value(new_value);
-            if (m_util.is_recursive(s)) {
-                if (is_subterm_of_last_value(new_value)) {
-                    new_value = static_cast<app*>(m_last_fresh_value.find(s));
-                }
-                else {
-                    m_last_fresh_value.insert(s, new_value);
-                }
-            }
-            TRACE(datatype, tout << "almost fresh: " << mk_pp(new_value, m_manager) << "\n";);
-            return new_value;
-        }
-    }
-    SASSERT(!m_util.is_recursive(s));
+    UNREACHABLE();
     return nullptr;
 }
-
 
 expr * datatype_factory::get_fresh_value(sort * s) {
     if (!m_util.is_datatype(s))
         return m_model.get_fresh_value(s);
     TRACE(datatype, tout << "generating fresh value for: " << s->get_name() << "\n";);
+
     auto& [set, values] = get_value_set(s);
-    // Approach 0) 
-    // if no value for s was generated so far, then used get_some_value
-    if (set.empty()) {
-        expr * val = get_some_value(s);
-        if (m_util.is_recursive(s))
-            m_last_fresh_value.insert(s, val);
-        TRACE(datatype, tout << "0. result: " << mk_pp(val, m_manager) << "\n";);
-        return val;
-    }
-    // Approach 1)
-    // Traverse constructors, and try to invoke get_fresh_value of one of the 
-    // arguments (if the argument is not a sibling datatype of s).
-    // Two datatypes are siblings if they were defined together in the same mutually recursive definition.
 
-
-    ptr_vector<func_decl> const& constructors = *m_util.get_datatype_constructors(s);
-    for (func_decl * constructor : constructors) {
-        retry_value:
-        expr_ref_vector args(m_manager);
-        expr_ref new_value(m_manager);
-        bool found_fresh_arg = false;
-        unsigned num            = constructor->get_arity();
-        for (unsigned i = 0; i < num; ++i) {
-            sort * s_arg        = constructor->get_domain(i);
-            if (!found_fresh_arg && 
-                !m_util.is_recursive_nested(s_arg) && 
-                (!m_util.is_recursive(s) || !m_util.is_datatype(s_arg) || !m_util.are_siblings(s, s_arg))) {
-                expr * new_arg = m_model.get_fresh_value(s_arg);
-                if (new_arg != nullptr) {
-                    found_fresh_arg = true;
-                    args.push_back(new_arg);
-                    continue;
+    if (!m_util.is_recursive(s)) {
+        // No structural growth is possible for a non-recursive datatype, so
+        // bottom-up term enumeration alone cannot produce arbitrarily many
+        // distinct values (e.g., a plain record with an Int field, or an
+        // enumeration sort). Instead, try to vary one constructor argument
+        // using the model's own fresh values, falling back to constructors
+        // that have not been used yet (this covers enumeration sorts, whose
+        // nullary constructors have no arguments to vary).
+        for (func_decl * c : *m_util.get_datatype_constructors(s)) {
+            expr_ref_vector args(m_manager);
+            bool found_fresh_arg = false;
+            unsigned num = c->get_arity();
+            for (unsigned i = 0; i < num; ++i) {
+                sort * s_arg = c->get_domain(i);
+                if (!found_fresh_arg) {
+                    expr * fresh_arg = m_util.is_datatype(s_arg) ? get_fresh_value(s_arg) : m_model.get_fresh_value(s_arg);
+                    if (fresh_arg) {
+                        found_fresh_arg = true;
+                        args.push_back(fresh_arg);
+                        continue;
+                    }
                 }
+                args.push_back(m_util.is_datatype(s_arg) ? get_some_value(s_arg) : m_model.get_some_value(s_arg));
             }
-            expr * some_arg = m_model.get_some_value(s_arg);
-            args.push_back(some_arg);
-        }
-        new_value = m_manager.mk_app(constructor, args);
-        CTRACE(datatype, found_fresh_arg && set.contains(new_value), tout << "seen: " << new_value << "\n";);
-        if (found_fresh_arg && set.contains(new_value))
-            goto retry_value;
-        if (!set.contains(new_value)) {
-            register_value(new_value);
-            if (m_util.is_recursive(s))
-                m_last_fresh_value.insert(s, new_value);
-            TRACE(datatype, tout << "1. result: " << mk_pp(new_value, m_manager) << "\n";);
-            return new_value;
-        }
-    }
-    // Approach 2)
-    // For recursive datatypes.
-    // search for constructor...
-    unsigned num_iterations = 0;
-    if (m_util.is_recursive(s)) {
-        while (true) {
-            ++num_iterations;
-            TRACE(datatype, tout << num_iterations << " " << mk_pp(get_last_fresh_value(s), m_manager) << "\n";);
-            ptr_vector<func_decl> const & constructors = *m_util.get_datatype_constructors(s);
-            for (func_decl * constructor : constructors) {
-                expr_ref_vector args(m_manager);
-                bool found_sibling   = false;
-                unsigned num         = constructor->get_arity();
-                TRACE(datatype, tout << "checking constructor: " << constructor->get_name() << "\n";);
-                for (unsigned i = 0; i < num; ++i) {
-                    sort * s_arg        = constructor->get_domain(i);
-                    TRACE(datatype, tout << mk_pp(s, m_manager) << " " 
-                          << mk_pp(s_arg, m_manager) << " are_siblings " 
-                          << m_util.are_siblings(s, s_arg) << "  is_datatype " 
-                          << m_util.is_datatype(s_arg) << " found_sibling " 
-                          << found_sibling << "\n";);
-                    if (!found_sibling && m_util.are_siblings(s, s_arg)) {
-                        found_sibling = true;
-                        expr * maybe_new_arg = nullptr;
-                        if (!m_util.is_datatype(s_arg))
-                            maybe_new_arg = m_model.get_fresh_value(s_arg);
-                        else if (num_iterations <= 10 && (num_iterations <= 1 || m_util.is_recursive(s_arg)))
-                            maybe_new_arg = get_almost_fresh_value(s_arg);                        
-                        else 
-                            maybe_new_arg = get_fresh_value(s_arg);
-                        if (!maybe_new_arg) {
-                            TRACE(datatype, 
-                                  tout << "no argument found for " << mk_pp(s_arg, m_manager) << "\n";);
-                            maybe_new_arg = m_model.get_some_value(s_arg);
-                            found_sibling = false;
-                        }
-                        SASSERT(maybe_new_arg);
-                        args.push_back(maybe_new_arg);
-                    }
-                    else {
-                        expr * some_arg = m_model.get_some_value(s_arg);
-                        SASSERT(some_arg);
-                        args.push_back(some_arg);
-                    }
-                }
-                if (found_sibling) {
-                    expr_ref new_value(m_manager);
-                    new_value = m_manager.mk_app(constructor, args);
-                    TRACE(datatype, tout << "potential new value: " << mk_pp(new_value, m_manager) << "\n";);
-                    m_last_fresh_value.insert(s, new_value);
-                    if (!set.contains(new_value)) {
-                        register_value(new_value);
-                        TRACE(datatype, tout << "2. result: " << mk_pp(new_value, m_manager) << "\n";);
-                        return new_value;
-                    }
-                }
+            expr * new_value = m_manager.mk_app(c, args);
+            if (!set.contains(new_value)) {
+                register_value(new_value);
+                TRACE(datatype, tout << "result: " << mk_pp(new_value, m_manager) << "\n";);
+                return new_value;
             }
         }
+        return set.empty() ? get_some_value(s) : nullptr;
     }
-    // Approach 3)
-    // for non-recursive datatypes.
-    // Search for value that was not created before.
-    SASSERT(!m_util.is_recursive(s));
-    
+
+    term_enumeration::iterator * it = nullptr;
+    if (!m_fresh_iter.find(s, it)) {
+        term_enumeration & te = get_enumerator(s, m_fresh_enum);
+        it = alloc(term_enumeration::iterator, te.enum_terms(s).begin());
+        m_fresh_iter.insert(s, it);
+    }
+
+    expr * e = nullptr;
+    while ((e = **it) != nullptr) {
+        ++(*it);
+        if (!set.contains(e)) {
+            register_value(e);
+            TRACE(datatype, tout << "result: " << mk_pp(e, m_manager) << "\n";);
+            return e;
+        }
+    }
     return nullptr;
 }
 

--- a/src/model/datatype_factory.cpp
+++ b/src/model/datatype_factory.cpp
@@ -44,9 +44,11 @@ datatype_factory::~datatype_factory() {
    \brief Build (or retrieve from \c cache) a term_enumeration that can
    enumerate values of sort \c s. The enumerator's grammar is seeded with
    the constructors of \c s and of every datatype sort transitively
-   reachable through constructor argument sorts. Values for argument
-   sorts that are not datatypes are produced on demand by the external
-   enumerator, which asks the model for a value.
+   reachable through constructor argument sorts -- including datatype
+   sorts nested under parametric sort constructors such as Array, Seq
+   and FiniteSet (e.g. (Array Int MyList), (Seq MyList)). Values for
+   argument sorts that are not datatypes are produced on demand by the
+   external enumerator, which asks the model for a value.
 */
 term_enumeration & datatype_factory::get_enumerator(sort * s, obj_map<sort, term_enumeration *> & cache) {
     term_enumeration * te = nullptr;
@@ -63,17 +65,28 @@ term_enumeration & datatype_factory::get_enumerator(sort * s, obj_map<sort, term
     while (!todo.empty()) {
         sort * cur = todo.back();
         todo.pop_back();
-        if (!m_util.is_datatype(cur))
-            continue;
-        for (func_decl * c : *m_util.get_datatype_constructors(cur)) {
-            te->add_production(c);
-            unsigned num = c->get_arity();
-            for (unsigned i = 0; i < num; ++i) {
-                sort * s_arg = c->get_domain(i);
-                if (m_util.is_datatype(s_arg) && !visited.contains(s_arg)) {
-                    visited.insert(s_arg);
-                    todo.push_back(s_arg);
+        if (m_util.is_datatype(cur)) {
+            for (func_decl * c : *m_util.get_datatype_constructors(cur)) {
+                te->add_production(c);
+                unsigned num = c->get_arity();
+                for (unsigned i = 0; i < num; ++i) {
+                    sort * s_arg = c->get_domain(i);
+                    if (!visited.contains(s_arg)) {
+                        visited.insert(s_arg);
+                        todo.push_back(s_arg);
+                    }
                 }
+            }
+        }
+        // Sorts such as Array, Seq and FiniteSet may nest a datatype sort
+        // as one of their sort parameters (e.g., the range of an Array,
+        // the element sort of a Seq or FiniteSet). Follow those nested
+        // sorts uniformly, via sort::get_sort_parameters(), so that any
+        // datatype constructors they contain are also registered.
+        for (sort * nested : cur->get_sort_parameters()) {
+            if (!visited.contains(nested)) {
+                visited.insert(nested);
+                todo.push_back(nested);
             }
         }
     }

--- a/src/model/datatype_factory.h
+++ b/src/model/datatype_factory.h
@@ -20,18 +20,25 @@ Revision History:
 
 #include "model/struct_factory.h"
 #include "ast/datatype_decl_plugin.h"
+#include "ast/rewriter/term_enumeration.h"
 
 class datatype_factory : public struct_factory {
     datatype_util         m_util;
-    obj_map<sort, expr *> m_last_fresh_value;
-    
-    expr * get_last_fresh_value(sort * s);
-    expr * get_almost_fresh_value(sort * s);
 
-    bool is_subterm_of_last_value(app* e);
+    // One term_enumeration instance per (top-level) datatype sort. Each
+    // instance is seeded with the constructors of the sort and of every
+    // datatype sort transitively reachable through constructor argument
+    // sorts, and is given an external enumerator that defers to the model
+    // for values of non-datatype argument sorts.
+    obj_map<sort, term_enumeration *>          m_some_enum;
+    obj_map<sort, term_enumeration *>          m_fresh_enum;
+    obj_map<sort, term_enumeration::iterator *> m_fresh_iter;
+
+    term_enumeration & get_enumerator(sort * s, obj_map<sort, term_enumeration *> & cache);
 
 public:
     datatype_factory(ast_manager & m, model_core & md);
+    ~datatype_factory() override;
     expr * get_some_value(sort * s) override;
     expr * get_fresh_value(sort * s) override;
 };


### PR DESCRIPTION
## Summary

Re-implements `datatype_factory` (the model value factory for algebraic datatypes in `src/model`) on top of the generic `term_enumeration` bottom-up enumeration module, and extends `term_enumeration` to accept an external enumerator so that values for non-datatype sorts can be supplied by the model.

## Changes

### `src/ast/rewriter/term_enumeration.{h,cpp}`
- Added `term_enumeration::set_external_enumerator(external_enumerator_t)`, an `std::function<expr*(sort*)>` consulted (at most once per sort per enumeration session, and once per constructor-argument sort) to seed a base leaf value for sorts not otherwise covered by the grammar. This lets a client mix bottom-up combinatorial enumeration (e.g. datatype constructors) with externally supplied values (e.g. Int/Array/uninterpreted sort values from a model).
- Propagated the external enumerator into `sort_stream` (used for tuple enumeration) for consistency.
- Made `term_enumeration::iterator` move-only (it holds a raw owning pointer and previously had unsafe implicit copy semantics that could double-free); this allows a single iterator to be kept alive and advanced across separate calls, which `datatype_factory` relies on for `get_fresh_value`.

### `src/model/datatype_factory.{h,cpp}`
- Replaced the previous hand-written recursive/"almost fresh value" algorithm with:
  - `get_some_value`: builds (and caches) a `term_enumeration` seeded with the constructors of the sort and every datatype sort transitively reachable through constructor argument sorts, with an external enumerator that defers to `model_core::get_some_value` for non-datatype argument sorts. Returns the first (cheapest) enumerated term, which is naturally built from non-recursive constructors first.
  - `get_fresh_value`: for recursive datatypes, keeps a persistent `term_enumeration::iterator` per sort and advances it to obtain successive structurally-distinct values. For non-recursive datatypes (records, enums), enumeration alone can't manufacture unboundedly many values from a fixed external leaf, so it instead varies one constructor argument via the model directly (or picks an unused nullary constructor for enums).

## Testing
- Built with CMake + Ninja/MSVC (Release).
- `test-z3 /a`: 99/99 tests passing, including `term_enumeration` and `parametric_datatype`.
- Manual SMT-LIB2 checks with `model_validate=true` for: recursive lists, mutually recursive datatypes, enum sorts, and non-recursive records with `Int`/`Array` fields — all produce valid, pairwise-distinct model values.