### PR TITLE
Extend bit-vector algebraic rewriting

### DIFF
--- a/src/ast/bv_decl_plugin.h
+++ b/src/ast/bv_decl_plugin.h
@@ -394,6 +394,7 @@ public:
     MATCH_UNARY(is_bv_not);
     MATCH_UNARY(is_redand);
     MATCH_UNARY(is_redor);
+    MATCH_UNARY(is_sign_ext);
 
     MATCH_BINARY(is_ext_rotate_left);
     MATCH_BINARY(is_ext_rotate_right);
@@ -634,5 +635,4 @@ public:
     }
 
 };
-
 

--- a/src/ast/rewriter/bv_bounds_base.h
+++ b/src/ast/rewriter/bv_bounds_base.h
@@ -226,11 +226,10 @@ namespace bv {
                 return true;
             }
 
-            if (m_bv.is_sign_ext(t)) {
-                expr* arg = to_app(t)->get_arg(0);
-                if (is_nonnegative(arg)) {
-                    unsigned n = m_bv.get_bv_size(t) - m_bv.get_bv_size(arg);
-                    result = m_bv.mk_zero_extend(n, arg);
+            if (m_bv.is_sign_ext(t, t1)) {
+                if (is_nonnegative(t1)) {
+                    unsigned n = m_bv.get_bv_size(t) - m_bv.get_bv_size(t1);
+                    result = m_bv.mk_zero_extend(n, t1);
                     return true;
                 }
             }

--- a/src/ast/rewriter/bv_bounds_base.h
+++ b/src/ast/rewriter/bv_bounds_base.h
@@ -209,6 +209,14 @@ namespace bv {
             return false;
         }
 
+        bool is_nonnegative(expr* t) const {
+            interval b;
+            unsigned sz = m_bv.get_bv_size(t);
+            return m_bound.find(t, b) &&
+                b.lo() <= b.hi() &&
+                b.hi() < rational::power_of_two(sz - 1);
+        }
+
         bool simplify_core(expr* t, expr_ref& result) {
             expr* t1;
             interval b;
@@ -216,6 +224,15 @@ namespace bv {
             if (m_bound.find(t, b) && b.is_singleton()) {
                 result = m_bv.mk_numeral(b.lo(), m_bv.get_bv_size(t));
                 return true;
+            }
+
+            if (m_bv.is_sign_ext(t)) {
+                expr* arg = to_app(t)->get_arg(0);
+                if (is_nonnegative(arg)) {
+                    unsigned n = m_bv.get_bv_size(t) - m_bv.get_bv_size(arg);
+                    result = m_bv.mk_zero_extend(n, arg);
+                    return true;
+                }
             }
 
             if (zero_patch(t, result))

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -1788,7 +1788,7 @@ br_status bv_rewriter::mk_concat(unsigned num_args, expr * const * args, expr_re
 
 bool bv_rewriter::is_zero_extended(expr* e, expr*& x) {
     expr* zero = nullptr;
-    return m_util.is_concat(zero, x) && is_zero(zero);
+    return m_util.is_concat(e, zero, x) && is_zero(zero);
 }
 
 bool bv_rewriter::is_sign_extended(expr* e, expr*& x) {

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -492,6 +492,15 @@ br_status bv_rewriter::mk_leq_core(bool is_signed, expr * a, expr * b, expr_ref 
         return BR_DONE;
     }
 
+    expr* x = nullptr, *y = nullptr;
+    if (is_signed &&
+        is_zero_extended(a, x) &&
+        is_zero_extended(b, y) &&
+        get_bv_size(x) == get_bv_size(y)) {
+        result = m_util.mk_ule(x, y);
+        return BR_REWRITE2;
+    }
+
     if (is_num1)
         r1 = m_util.norm(r1, sz, is_signed);
     if (is_num2)
@@ -840,6 +849,24 @@ br_status bv_rewriter::mk_extract(unsigned high, unsigned low, expr * arg, expr_
             }
         }
         UNREACHABLE();
+    }
+
+    if (low == 0 && is_app(arg)) {
+        expr* a = nullptr, *b = nullptr, *x = nullptr, *y = nullptr;
+        decl_kind k = to_app(arg)->get_decl_kind();
+        bool is_unsigned = k == OP_BUDIV_I || k == OP_BUREM_I;
+        bool is_signed = k == OP_BSDIV_I || k == OP_BSREM_I;
+        if ((is_unsigned || is_signed) && to_app(arg)->get_num_args() == 2) {
+            a = to_app(arg)->get_arg(0);
+            b = to_app(arg)->get_arg(1);
+            bool extended = is_unsigned
+                ? is_zero_extended(a, x) && is_zero_extended(b, y)
+                : is_sign_extended(a, x) && is_sign_extended(b, y);
+            if (extended && high + 1 == get_bv_size(x) && get_bv_size(x) == get_bv_size(y)) {
+                result = m.mk_app(get_fid(), k, x, y);
+                return BR_REWRITE1;
+            }
+        }
     }
 
     if (m_util.is_bv_not(arg) ||
@@ -1248,9 +1275,24 @@ br_status bv_rewriter::mk_bv_srem_core(expr * arg1, expr * arg2, bool hi_div0, e
             }
         }
 
-        if (r2.is_one()) {
+        if (r2.is_one() || r2.is_minus_one()) {
             result = mk_zero(bv_size);
             return BR_DONE;
+        }
+
+        expr* x = nullptr, *divisor = nullptr;
+        numeral divisor_value;
+        unsigned divisor_size = 0;
+        if (m_util.is_bv_sremi(arg1)) {
+            x = to_app(arg1)->get_arg(0);
+            divisor = to_app(arg1)->get_arg(1);
+        }
+        if (!r2.is_zero() && divisor && is_numeral(divisor, divisor_value, divisor_size)) {
+            divisor_value = m_util.norm(divisor_value, divisor_size, true);
+            if (!divisor_value.is_zero() && (divisor_value % r2).is_zero()) {
+                result = m.mk_app(get_fid(), OP_BSREM_I, x, arg2);
+                return BR_REWRITE1;
+            }
         }
 
         if (!r2.is_zero() && is_numeral(arg1, r1, bv_size)) {
@@ -1747,7 +1789,56 @@ br_status bv_rewriter::mk_concat(unsigned num_args, expr * const * args, expr_re
         return BR_DONE;
 }
 
+bool bv_rewriter::is_zero_extended(expr* e, expr*& x) {
+    if (!m_util.is_concat(e) || to_app(e)->get_num_args() != 2)
+        return false;
+    expr* zero = to_app(e)->get_arg(0);
+    if (!is_zero(zero))
+        return false;
+    x = to_app(e)->get_arg(1);
+    return true;
+}
 
+bool bv_rewriter::is_sign_extended(expr* e, expr*& x) {
+    if (is_app(e) && to_app(e)->get_decl_kind() == OP_SIGN_EXT) {
+        x = to_app(e)->get_arg(0);
+        return true;
+    }
+    if (!m_util.is_concat(e) || to_app(e)->get_num_args() < 2)
+        return false;
+    app* a = to_app(e);
+    x = a->get_arg(a->get_num_args() - 1);
+    unsigned sz = get_bv_size(x);
+    for (unsigned i = 0; i + 1 < a->get_num_args(); ++i) {
+        expr* sign = a->get_arg(i);
+        if (!m_util.is_extract(sign) ||
+            m_util.get_extract_high(sign) != sz - 1 ||
+            m_util.get_extract_low(sign) != sz - 1 ||
+            to_app(sign)->get_arg(0) != x)
+            return false;
+    }
+    return true;
+}
+
+bool bv_rewriter::factor_zero_extensions(
+    decl_kind k, unsigned num, expr* const* args, expr_ref& result) {
+    if (num < 2)
+        return false;
+    expr* x = nullptr;
+    if (!is_zero_extended(args[0], x))
+        return false;
+    unsigned inner_size = get_bv_size(x);
+    ptr_buffer<expr> inner_args;
+    inner_args.push_back(x);
+    for (unsigned i = 1; i < num; ++i) {
+        if (!is_zero_extended(args[i], x) || get_bv_size(x) != inner_size)
+            return false;
+        inner_args.push_back(x);
+    }
+    expr* inner = m.mk_app(get_fid(), k, inner_args.size(), inner_args.data());
+    result = m_util.mk_zero_extend(get_bv_size(args[0]) - inner_size, inner);
+    return true;
+}
 
 br_status bv_rewriter::mk_zero_extend(unsigned n, expr * arg, expr_ref & result) {
     if (n == 0) {
@@ -1808,6 +1899,8 @@ br_status bv_rewriter::mk_bv_or(unsigned num, expr * const * args, expr_ref & re
         result = args[0];
         return BR_DONE;
     }
+    if (factor_zero_extensions(OP_BOR, num, args, result))
+        return BR_REWRITE2;
     unsigned sz    = get_bv_size(args[0]);
     bool flattened = false;
     ptr_buffer<expr> flat_args;
@@ -2245,6 +2338,8 @@ br_status bv_rewriter::mk_bv_not(expr * arg, expr_ref & result) {
 }
 
 br_status bv_rewriter::mk_bv_and(unsigned num, expr * const * args, expr_ref & result) {
+    if (factor_zero_extensions(OP_BAND, num, args, result))
+        return BR_REWRITE2;
     ptr_buffer<expr> new_args;
     for (unsigned i = 0; i < num; ++i) {
         new_args.push_back(m_util.mk_bv_not(args[i]));
@@ -3093,6 +3188,16 @@ br_status bv_rewriter::mk_ite_core(expr * c, expr * t, expr * e, expr_ref & resu
     if (m.is_not(c)) {
         result = m.mk_ite(to_app(c)->get_arg(0), e, t);
         return BR_REWRITE1;
+    }
+
+    expr* x = nullptr, *y = nullptr;
+    if (is_zero_extended(t, x) && is_zero_extended(e, y) && get_bv_size(x) == get_bv_size(y)) {
+        result = m_util.mk_zero_extend(get_bv_size(t) - get_bv_size(x), m.mk_ite(c, x, y));
+        return BR_REWRITE2;
+    }
+    if (is_sign_extended(t, x) && is_sign_extended(e, y) && get_bv_size(x) == get_bv_size(y)) {
+        result = m_util.mk_sign_extend(get_bv_size(t) - get_bv_size(x), m.mk_ite(c, x, y));
+        return BR_REWRITE2;
     }
 
     // if x = 0 then 0 else 1

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -1787,13 +1787,8 @@ br_status bv_rewriter::mk_concat(unsigned num_args, expr * const * args, expr_re
 }
 
 bool bv_rewriter::is_zero_extended(expr* e, expr*& x) {
-    if (!m_util.is_concat(e) || to_app(e)->get_num_args() != 2)
-        return false;
-    expr* zero = to_app(e)->get_arg(0);
-    if (!is_zero(zero))
-        return false;
-    x = to_app(e)->get_arg(1);
-    return true;
+    expr* zero = nullptr;
+    return m_util.is_concat(zero, x) && is_zero(zero);
 }
 
 bool bv_rewriter::is_sign_extended(expr* e, expr*& x) {

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -1283,11 +1283,8 @@ br_status bv_rewriter::mk_bv_srem_core(expr * arg1, expr * arg2, bool hi_div0, e
         expr* x = nullptr, *divisor = nullptr;
         numeral divisor_value;
         unsigned divisor_size = 0;
-        if (m_util.is_bv_sremi(arg1)) {
-            x = to_app(arg1)->get_arg(0);
-            divisor = to_app(arg1)->get_arg(1);
-        }
-        if (!r2.is_zero() && divisor && is_numeral(divisor, divisor_value, divisor_size)) {
+        if (m_util.is_bv_sremi(arg1, x, divisor) && 
+            !r2.is_zero() && is_numeral(divisor, divisor_value, divisor_size)) {
             divisor_value = m_util.norm(divisor_value, divisor_size, true);
             if (!divisor_value.is_zero() && (divisor_value % r2).is_zero()) {
                 result = m.mk_app(get_fid(), OP_BSREM_I, x, arg2);

--- a/src/ast/rewriter/bv_rewriter.h
+++ b/src/ast/rewriter/bv_rewriter.h
@@ -112,6 +112,9 @@ class bv_rewriter : public poly_rewriter<bv_rewriter_core> {
     bool is_add_no_overflow(expr* e);
     bool is_mul_no_overflow(expr* e);
     unsigned num_leading_zero_bits(expr* e);
+    bool is_zero_extended(expr* e, expr*& x);
+    bool is_sign_extended(expr* e, expr*& x);
+    bool factor_zero_extensions(decl_kind k, unsigned num, expr* const* args, expr_ref& result);
 
     br_status mk_bv_sdiv_core(expr * arg1, expr * arg2, bool hi_div0, expr_ref & result);
     br_status mk_bv_udiv_core(expr * arg1, expr * arg2, bool hi_div0, expr_ref & result);
@@ -265,4 +268,3 @@ public:
 
 
 };
-

--- a/src/ast/simplifiers/bv_bounds_simplifier.cpp
+++ b/src/ast/simplifiers/bv_bounds_simplifier.cpp
@@ -15,21 +15,27 @@ Author:
 #include "ast/simplifiers/dominator_simplifier.h"
 #include "ast/rewriter/bv_bounds_base.h"
 #include "ast/rewriter/dom_simplifier.h"
+#include "ast/rewriter/th_rewriter.h"
 
 
 class dom_bv_bounds_simplifier : public dom_simplifier, public bv::bv_bounds_base {
     params_ref         m_params;
+    th_rewriter        m_rewriter;
     
 public:
-    dom_bv_bounds_simplifier(ast_manager& m, params_ref const& p) : bv_bounds_base(m), m_params(p) {
+    dom_bv_bounds_simplifier(ast_manager& m, params_ref const& p) :
+        bv_bounds_base(m), m_rewriter(m) {
         updt_params(p);
     }
     
     void updt_params(params_ref const & p) override {
+        m_params.append(p);
         m_propagate_eq = p.get_bool("propagate_eq", false);
+        m_rewriter.updt_params(m_params);
     }
     
     void collect_param_descrs(param_descrs& r) override {
+        th_rewriter::get_param_descrs(r);
         r.insert("propagate-eq", CPK_BOOL, "propagate equalities from inequalities", "false");
     }
     
@@ -39,9 +45,10 @@ public:
     
     void operator()(expr_ref& r) override {
         expr_ref result(m);
-        simplify_core(r, result);
-        if (result)
+        if (simplify_core(r, result)) {
+            m_rewriter(result);
             r = result;
+        }
     }       
     
     void pop(unsigned num_scopes) override {

--- a/src/test/simplifier.cpp
+++ b/src/test/simplifier.cpp
@@ -24,6 +24,40 @@ static void ev_const(Z3_context ctx, Z3_ast e) {
               Z3_OP_FALSE == Z3_get_decl_kind(ctx,Z3_get_app_decl(ctx, Z3_to_app(ctx, r))))));
 }
 
+static void expect_simplifies_to(Z3_context ctx, Z3_ast input, Z3_ast expected) {
+    Z3_ast actual = Z3_simplify(ctx, input);
+    expected = Z3_simplify(ctx, expected);
+    TRACE(simplifier,
+        tout << Z3_ast_to_string(ctx, input) << " -> "
+             << Z3_ast_to_string(ctx, actual) << "\n";);
+    ENSURE(Z3_is_eq_ast(ctx, actual, expected));
+}
+
+static void expect_context_simplifies_to(
+    Z3_context ctx, Z3_ast context, Z3_ast input, Z3_ast expected) {
+    Z3_goal goal = Z3_mk_goal(ctx, false, false, false);
+    Z3_goal_inc_ref(ctx, goal);
+    Z3_goal_assert(ctx, goal, context);
+    Z3_goal_assert(ctx, goal, input);
+
+    Z3_tactic tactic = Z3_mk_tactic(ctx, "propagate-bv-bounds2");
+    Z3_tactic_inc_ref(ctx, tactic);
+    Z3_apply_result result = Z3_tactic_apply(ctx, tactic, goal);
+    Z3_apply_result_inc_ref(ctx, result);
+    ENSURE(Z3_apply_result_get_num_subgoals(ctx, result) == 1);
+
+    expected = Z3_simplify(ctx, expected);
+    Z3_goal subgoal = Z3_apply_result_get_subgoal(ctx, result, 0);
+    bool found = false;
+    for (unsigned i = 0; i < Z3_goal_size(ctx, subgoal); ++i)
+        found |= Z3_is_eq_ast(ctx, Z3_goal_formula(ctx, subgoal, i), expected);
+    ENSURE(found);
+
+    Z3_apply_result_dec_ref(ctx, result);
+    Z3_tactic_dec_ref(ctx, tactic);
+    Z3_goal_dec_ref(ctx, goal);
+}
+
 static void test_bv() {
     Z3_config cfg = Z3_mk_config();
     Z3_context ctx = Z3_mk_context(cfg);
@@ -77,6 +111,67 @@ static void test_bv() {
 
     ev_const(ctx, Z3_mk_rotate_left(ctx,21,b13));
     ev_const(ctx, Z3_mk_rotate_right(ctx,21,b13));
+
+    Z3_sort bv8 = Z3_mk_bv_sort(ctx, 8);
+    Z3_sort bv16 = Z3_mk_bv_sort(ctx, 16);
+    Z3_ast x8 = Z3_mk_const(ctx, Z3_mk_string_symbol(ctx, "x8"), bv8);
+    Z3_ast y8 = Z3_mk_const(ctx, Z3_mk_string_symbol(ctx, "y8"), bv8);
+    Z3_ast x16 = Z3_mk_const(ctx, Z3_mk_string_symbol(ctx, "x16"), bv16);
+    Z3_ast cond = Z3_mk_const(ctx, Z3_mk_string_symbol(ctx, "cond"), Z3_mk_bool_sort(ctx));
+    Z3_ast zx = Z3_mk_zero_ext(ctx, 8, x8);
+    Z3_ast zy = Z3_mk_zero_ext(ctx, 8, y8);
+    Z3_ast sx = Z3_mk_sign_ext(ctx, 8, x8);
+    Z3_ast sy = Z3_mk_sign_ext(ctx, 8, y8);
+
+    expect_simplifies_to(ctx,
+        Z3_mk_extract(ctx, 7, 0, Z3_mk_bvudiv(ctx, zx, zy)),
+        Z3_mk_bvudiv(ctx, x8, y8));
+    expect_simplifies_to(ctx,
+        Z3_mk_extract(ctx, 7, 0, Z3_mk_bvurem(ctx, zx, zy)),
+        Z3_mk_bvurem(ctx, x8, y8));
+    expect_simplifies_to(ctx,
+        Z3_mk_extract(ctx, 7, 0, Z3_mk_bvsdiv(ctx, sx, sy)),
+        Z3_mk_bvsdiv(ctx, x8, y8));
+    expect_simplifies_to(ctx,
+        Z3_mk_extract(ctx, 7, 0, Z3_mk_bvsrem(ctx, sx, sy)),
+        Z3_mk_bvsrem(ctx, x8, y8));
+    expect_simplifies_to(ctx,
+        Z3_mk_bvsle(ctx, zx, zy),
+        Z3_mk_bvule(ctx, x8, y8));
+    expect_simplifies_to(ctx,
+        Z3_mk_bvand(ctx, zx, zy),
+        Z3_mk_zero_ext(ctx, 8, Z3_mk_bvand(ctx, x8, y8)));
+    expect_simplifies_to(ctx,
+        Z3_mk_bvor(ctx, zx, zy),
+        Z3_mk_zero_ext(ctx, 8, Z3_mk_bvor(ctx, x8, y8)));
+    expect_simplifies_to(ctx,
+        Z3_mk_ite(ctx, cond, zx, zy),
+        Z3_mk_zero_ext(ctx, 8, Z3_mk_ite(ctx, cond, x8, y8)));
+    expect_simplifies_to(ctx,
+        Z3_mk_ite(ctx, cond, sx, sy),
+        Z3_mk_sign_ext(ctx, 8, Z3_mk_ite(ctx, cond, x8, y8)));
+
+    Z3_ast bv12 = Z3_mk_numeral(ctx, "12", bv16);
+    Z3_ast bv4 = Z3_mk_numeral(ctx, "4", bv16);
+    expect_simplifies_to(ctx,
+        Z3_mk_bvsrem(ctx, Z3_mk_bvsrem(ctx, x16, bv12), bv4),
+        Z3_mk_bvsrem(ctx, x16, bv4));
+
+    Z3_ast y16 = Z3_mk_const(ctx, Z3_mk_string_symbol(ctx, "y16"), bv16);
+    Z3_ast bv255 = Z3_mk_numeral(ctx, "255", bv16);
+    expect_context_simplifies_to(ctx,
+        Z3_mk_bvule(ctx, y16, bv255),
+        Z3_mk_eq(ctx, zx, y16),
+        Z3_mk_eq(ctx, x8, Z3_mk_extract(ctx, 7, 0, y16)));
+
+    Z3_ast bv0 = Z3_mk_numeral(ctx, "0", bv8);
+    Z3_sort bv9 = Z3_mk_bv_sort(ctx, 9);
+    Z3_ast bv0_9 = Z3_mk_numeral(ctx, "0", bv9);
+    Z3_ast nonnegative_x = Z3_mk_concat(ctx, bv0_9, Z3_mk_extract(ctx, 6, 0, x8));
+    expect_context_simplifies_to(ctx,
+        Z3_mk_bvsle(ctx, bv0, x8),
+        Z3_mk_eq(ctx, x16, sx),
+        Z3_mk_eq(ctx, x16, nonnegative_x));
 
     Z3_del_config(cfg);
     Z3_del_context(ctx);


### PR DESCRIPTION
## Summary
- add width-aware bit-vector rewrites for extensions, division/remainder, comparisons, bitwise operations, and conditionals
- factor matching extensions and simplify divisible nested signed remainders
- use dominator-scoped BV bounds to discharge high-zero and non-negative side conditions
- add focused simplifier and contextual simplifier regression coverage

## Notes
Rules from the source gist that require unsafe or unsupported overflow assumptions are intentionally excluded. Division/remainder truncation is restricted to fixed SMT-LIB division-by-zero semantics.

## Testing
- `build\test-z3.exe simplifier`
- `build\test-z3.exe udoc_relation`
- `build\test-z3.exe /a` (99 tests)