### PR TITLE
Remove obsolete maximize shared flag

### DIFF
--- a/src/opt/opt_solver.cpp
+++ b/src/opt/opt_solver.cpp
@@ -288,19 +288,14 @@ namespace opt {
        Return a predicate that blocks the current maximal value.
        
        The result of 'maximize' is post-processed. 
-       When maximization involves shared symbols the model produced
-       by local optimization does not necessarily satisfy combination 
-       constraints (it may not be a real model).
-       In this case, the model is post-processed (update_model 
-       causes an additional call to final_check to propagate theory equalities
-       when 'has_shared' is true).
+       The model produced by local optimization does not necessarily satisfy
+       combination constraints, so it is post-processed by update_model.
 
        Precondition: the state of the solver is satisfiable and such that a current model can be extracted.
        
     */
     bool opt_solver::maximize_objective(unsigned i, expr_ref& blocker) {
         smt::theory_var v = m_objective_vars[i];
-        bool has_shared = false;
         m_model = nullptr;
         blocker = nullptr;
         //
@@ -309,13 +304,12 @@ namespace opt {
         // Generally, the hint is not necessarily valid and has to be checked
         // relative to other theories.
         // 
-        inf_eps val = get_optimizer().maximize(v, blocker, has_shared);
+        inf_eps val = get_optimizer().maximize(v, blocker);
         m_last_hint = val;
         m_last_hint_status = l_undef;
         m_context.get_model(m_model);
         inf_eps val2;
-        has_shared = true;
-        TRACE(opt, tout << (has_shared?"has shared":"non-shared") << " " << val << " " << blocker << "\n";
+        TRACE(opt, tout << val << " " << blocker << "\n";
               if (m_model) tout << *m_model << "\n";);
         if (!m_objective_models[i]) 
             m_objective_models.set(i, m_model.get());
@@ -362,7 +356,6 @@ namespace opt {
         // check that "val" obtained from optimization hint is a valid bound.
         // 
         auto check_bound = [&]() {
-            SASSERT(has_shared);
             lbool r = bound_value(i, val);
             if (r == l_true) 
                 r = m_context.check(0, nullptr);
@@ -373,13 +366,13 @@ namespace opt {
         if (!val.is_finite()) {
             // skip model updates
         }
-        else if (m_context.get_context().update_model(has_shared)) {
+        else if (m_context.get_context().update_model(true)) {
             TRACE(opt, tout << "updated\n";);
             m_model = nullptr;
             m_context.get_model(m_model);
             if (!m_model)
                 return false;
-            else if (!has_shared || val == current_objective_value(i))
+            else if (val == current_objective_value(i))
                 m_objective_models.set(i, m_model.get());
             else if (!check_bound())
                 return false;

--- a/src/smt/theory_arith.h
+++ b/src/smt/theory_arith.h
@@ -1096,7 +1096,7 @@ namespace smt {
         //
         // -----------------------------------
         expr_ref mk_ge(generic_model_converter& fm, theory_var v, inf_numeral const& val);
-        inf_eps_rational<inf_rational> maximize(theory_var v, expr_ref& blocker, bool& has_shared) override;
+        inf_eps_rational<inf_rational> maximize(theory_var v, expr_ref& blocker) override;
         inf_eps_rational<inf_rational> value(theory_var v) override;
         theory_var add_objective(app* term) override;
         void enable_record_conflict(expr* bound);
@@ -1278,5 +1278,4 @@ namespace smt {
 
     
 }
-
 

--- a/src/smt/theory_arith_aux.h
+++ b/src/smt/theory_arith_aux.h
@@ -1054,19 +1054,17 @@ namespace smt {
     }
 
     template<typename Ext>
-    inf_eps_rational<inf_rational> theory_arith<Ext>::maximize(theory_var v, expr_ref& blocker, bool& has_shared) {
+    inf_eps_rational<inf_rational> theory_arith<Ext>::maximize(theory_var v, expr_ref& blocker) {
         TRACE(bound_bug, display_var(tout, v); display(tout););
         if (ctx.get_fparams().m_threads > 1)
             throw default_exception("multi-threaded optimization is not supported");
-        has_shared = false;
         if (!m_nl_monomials.empty()) {
-            has_shared = true;
             blocker = mk_gt(v);
             return inf_eps_rational<inf_rational>(get_value(v));            
         }
-        max_min_t r = max_min(v, true, true, has_shared); 
+        bool ignored_shared = false;
+        max_min_t r = max_min(v, true, true, ignored_shared);
         if (r == UNBOUNDED) {
-            has_shared = false;
             blocker = get_manager().mk_false();
             return inf_eps_rational<inf_rational>::infinity();
         }
@@ -2296,5 +2294,3 @@ namespace smt {
 #endif
 
 }
-
-

--- a/src/smt/theory_dense_diff_logic.h
+++ b/src/smt/theory_dense_diff_logic.h
@@ -263,7 +263,7 @@ namespace smt {
         //
         // -----------------------------------
 
-        inf_eps_rational<inf_rational> maximize(theory_var v, expr_ref& blocker, bool& has_shared) override;
+        inf_eps_rational<inf_rational> maximize(theory_var v, expr_ref& blocker) override;
         inf_eps_rational<inf_rational> value(theory_var v) override;
         theory_var add_objective(app* term) override;
         virtual expr_ref mk_gt(theory_var v, inf_eps const& val);
@@ -293,5 +293,4 @@ namespace smt {
     typedef theory_dense_diff_logic<smi_ext> theory_dense_smi;
     typedef theory_dense_diff_logic<si_ext>  theory_dense_si;
 }
-
 

--- a/src/smt/theory_dense_diff_logic_def.h
+++ b/src/smt/theory_dense_diff_logic_def.h
@@ -909,11 +909,10 @@ namespace smt {
     }
 
     template<typename Ext>
-    inf_eps_rational<inf_rational> theory_dense_diff_logic<Ext>::maximize(theory_var v, expr_ref& blocker, bool& has_shared) {
+    inf_eps_rational<inf_rational> theory_dense_diff_logic<Ext>::maximize(theory_var v, expr_ref& blocker) {
         typedef simplex::simplex<simplex::mpq_ext> Simplex;
         Simplex S(m.limit());
         objective_term const& objective = m_objectives[v];
-        has_shared = false;
         
         IF_VERBOSE(4,
                    for (auto const& o : objective) {
@@ -1124,5 +1123,4 @@ namespace smt {
     }
 
 }
-
 

--- a/src/smt/theory_diff_logic.h
+++ b/src/smt/theory_diff_logic.h
@@ -306,7 +306,7 @@ namespace smt {
         // -----------------------------------
 
         expr_ref mk_ge(generic_model_converter& fm, theory_var v, inf_eps const& val);
-        inf_eps maximize(theory_var v, expr_ref& blocker, bool& has_shared) override;
+        inf_eps maximize(theory_var v, expr_ref& blocker) override;
         inf_eps value(theory_var v) override;
         theory_var add_objective(app* term) override;
 
@@ -408,7 +408,6 @@ namespace smt {
     typedef theory_diff_logic<rdl_ext> theory_rdl;
     typedef theory_diff_logic<srdl_ext> theory_frdl;
 }
-
 
 
 

--- a/src/smt/theory_diff_logic_def.h
+++ b/src/smt/theory_diff_logic_def.h
@@ -1223,10 +1223,9 @@ typename theory_diff_logic<Ext>::inf_eps theory_diff_logic<Ext>::value(theory_va
 
 template<typename Ext>
 typename theory_diff_logic<Ext>::inf_eps 
-theory_diff_logic<Ext>::maximize(theory_var v, expr_ref& blocker, bool& has_shared) {
+theory_diff_logic<Ext>::maximize(theory_var v, expr_ref& blocker) {
     SASSERT(is_consistent());
 
-    has_shared = false;
     Simplex& S = m_S;
 
     CTRACE(arith,!m_graph.is_feasible_dbg(), m_graph.display(tout););
@@ -1454,5 +1453,4 @@ void theory_diff_logic<Ext>::init_zero() {
     SASSERT(!is_attached_to_var(e));
     m_rzero = mk_var(e);   
 }
-
 

--- a/src/smt/theory_lra.cpp
+++ b/src/smt/theory_lra.cpp
@@ -4192,7 +4192,7 @@ public:
         return false;
     }
 
-    theory_lra::inf_eps max_result(theory_var v, lpvar vi, lp::impq const& term_max, lp::lp_status st, expr_ref& blocker, bool& has_shared) {
+    theory_lra::inf_eps max_result(theory_var v, lpvar vi, lp::impq const& term_max, lp::lp_status st, expr_ref& blocker) {
         switch (st) {
         case lp::lp_status::OPTIMAL:
             init_variable_values();
@@ -4206,13 +4206,12 @@ public:
         default:
             SASSERT(st == lp::lp_status::UNBOUNDED);
             TRACE(arith, display(tout << st << " v" << v << " vi: " << vi << "\n"););
-            has_shared = false;
             blocker = m.mk_false();
             return inf_eps(rational::one(), inf_rational());
         }
     }
 
-    theory_lra::inf_eps maximize(theory_var v, expr_ref& blocker, bool& has_shared) {
+    theory_lra::inf_eps maximize(theory_var v, expr_ref& blocker) {
         unsigned level = 2;
         lp::impq term_max;
         lp::lp_status st;
@@ -4233,7 +4232,7 @@ public:
             if (max_with_nl(v, st, level, blocker, nl_result))
                 return nl_result;
         }
-        return max_result(v, vi, term_max, st, blocker, has_shared);
+        return max_result(v, vi, term_max, st, blocker);
     }
 
     expr_ref mk_gt(theory_var v) {
@@ -4662,8 +4661,8 @@ void theory_lra::collect_statistics(::statistics & st) const {
 theory_lra::inf_eps theory_lra::value(theory_var v) {
     return m_imp->value(v);
 }
-theory_lra::inf_eps theory_lra::maximize(theory_var v, expr_ref& blocker, bool& has_shared) {
-    return m_imp->maximize(v, blocker, has_shared);
+theory_lra::inf_eps theory_lra::maximize(theory_var v, expr_ref& blocker) {
+    return m_imp->maximize(v, blocker);
 }
 theory_var theory_lra::add_objective(app* term) {
     return m_imp->add_objective(term);

--- a/src/smt/theory_lra.h
+++ b/src/smt/theory_lra.h
@@ -116,7 +116,7 @@ namespace smt {
         // optimization
         expr_ref mk_ge(generic_model_converter& fm, theory_var v, inf_rational const& val);
         inf_eps value(theory_var) override;
-        inf_eps maximize(theory_var v, expr_ref& blocker, bool& has_shared) override;
+        inf_eps maximize(theory_var v, expr_ref& blocker) override;
         theory_var add_objective(app* term) override;
     };
 

--- a/src/smt/theory_opt.h
+++ b/src/smt/theory_opt.h
@@ -31,10 +31,9 @@ namespace smt {
         typedef inf_eps_rational<inf_rational> inf_eps;
         virtual ~theory_opt() = default;
         virtual inf_eps value(theory_var) = 0;
-        virtual inf_eps maximize(theory_var v, expr_ref& blocker, bool& has_shared) = 0; 
+        virtual inf_eps maximize(theory_var v, expr_ref& blocker) = 0;
         virtual theory_var add_objective(app* term) = 0;
         bool is_linear(ast_manager& m, expr* term);
         bool is_numeral(arith_util& a, expr* term);
     };
 }
-


### PR DESCRIPTION
## Summary
- remove the unused `has_shared` output parameter from `theory_opt::maximize`
- update LRA, legacy arithmetic, and both difference-logic implementations
- simplify `opt_solver` around unconditional model post-processing and bound validation

`opt_solver::maximize_objective` has unconditionally set `has_shared = true` since arithmetic optimization hints began requiring validation against theory combination. The values computed by theory implementations were therefore never observed.

The internal shared-variable tracking in legacy arithmetic `max_min` remains intact because it is also used to gate implied-bound propagation outside the optimizer interface.

## Testing
- `ninja -C build test-z3 shell`
- `build\test-z3.exe api`
- mixed integer/real optimization smoke test