### PR TITLE
Fix QF_S performance regression

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -1136,6 +1136,12 @@ br_status seq_rewriter::mk_seq_contains(expr* a, expr* b, expr_ref& result) {
         return BR_REWRITE2;
     }
 
+    auto [bounded_a, max_a] = max_length(a);
+    if (bounded_a && max_a <= 1) {
+        result = m().mk_or(str().mk_is_empty(b), m().mk_eq(a, b));
+        return BR_REWRITE2;
+    }
+
     for (unsigned i = 0; bs.size() + i <= as.size(); ++i) {
         unsigned j = 0;
         for (; j < bs.size() && as.get(j+i) == bs.get(j); ++j) {};

--- a/src/smt/smt_setup.cpp
+++ b/src/smt/smt_setup.cpp
@@ -582,6 +582,7 @@ namespace smt {
         else {
             throw default_exception("invalid parameter for smt.string_solver, valid options are 'seq', 'auto'");
         }
+        m_params.m_phase_selection = PS_ALWAYS_TRUE;
     }
 
     bool is_arith(static_features const & st) {
@@ -945,4 +946,3 @@ namespace smt {
     }
 
 }
-

--- a/src/smt/smt_setup.cpp
+++ b/src/smt/smt_setup.cpp
@@ -582,7 +582,7 @@ namespace smt {
         else {
             throw default_exception("invalid parameter for smt.string_solver, valid options are 'seq', 'auto'");
         }
-        m_params.m_phase_selection = PS_ALWAYS_TRUE;
+        // m_params.m_phase_selection = PS_ALWAYS_TRUE;
     }
 
     bool is_arith(static_features const & st) {

--- a/src/smt/smt_setup.cpp
+++ b/src/smt/smt_setup.cpp
@@ -582,7 +582,6 @@ namespace smt {
         else {
             throw default_exception("invalid parameter for smt.string_solver, valid options are 'seq', 'auto'");
         }
-        m_params.m_phase_selection = PS_ALWAYS_TRUE;
     }
 
     bool is_arith(static_features const & st) {
@@ -946,3 +945,4 @@ namespace smt {
     }
 
 }
+

--- a/src/tactic/portfolio/smt_strategic_solver.cpp
+++ b/src/tactic/portfolio/smt_strategic_solver.cpp
@@ -45,10 +45,8 @@ Notes:
 #include "ast/rewriter/bv_rewriter.h"
 #include "solver/parallel_params.hpp"
 #include "params/tactic_params.hpp"
-#include "params/smt_params.h"
 #include "parsers/smt2/smt2parser.h"
 #include "params/sat_params.hpp"
-#include "util/gparams.h"
 
 tactic* mk_tactic_for_logic(ast_manager& m, params_ref const& p, symbol const& logic);
 
@@ -164,13 +162,6 @@ public:
         else
             l = logic;
 
-        params_ref q(p);
-        params_ref smt_p = gparams::get_module("smt");
-        if (l == "QF_S" && !p.contains("phase_selection") && !smt_p.contains("phase_selection")) {
-            // Positive phases favor empty witnesses for satisfiable string constraints.
-            q.set_uint("phase_selection", static_cast<unsigned>(PS_ALWAYS_TRUE));
-        }
-
         tactic_params tp;
         tactic_ref t;
         if (tp.default_tactic() != symbol::null &&
@@ -179,22 +170,22 @@ public:
             cmd_context ctx(false, &m, l);
             std::istringstream is(tp.default_tactic().str());
             char const* file_name = "";
-            sexpr_ref se = parse_sexpr(ctx, is, q, file_name);
+            sexpr_ref se = parse_sexpr(ctx, is, p, file_name);
             if (se) {
                 t = sexpr2tactic(ctx, se.get());
             }
         }
 
         if (!t) {
-            solver* s = mk_special_solver_for_logic(m, q, l);
+            solver* s = mk_special_solver_for_logic(m, p, l);
             if (s) return s;
         }
         if (!t) {
-            t = mk_tactic_for_logic(m, q, l);
+            t = mk_tactic_for_logic(m, p, l);
         }
-        return mk_combined_solver(mk_tactic2solver(m, t.get(), q, proofs_enabled, models_enabled, unsat_core_enabled, l),
-                                  mk_solver_for_logic(m, q, l),
-                                  q);
+        return mk_combined_solver(mk_tactic2solver(m, t.get(), p, proofs_enabled, models_enabled, unsat_core_enabled, l),
+                                  mk_solver_for_logic(m, p, l), 
+                                  p);
     }
     
     solver_factory* translate(ast_manager& m) override {
@@ -205,3 +196,5 @@ public:
 solver_factory * mk_smt_strategic_solver_factory(symbol const & logic) {
     return alloc(smt_strategic_solver_factory, logic);
 }
+
+

--- a/src/tactic/portfolio/smt_strategic_solver.cpp
+++ b/src/tactic/portfolio/smt_strategic_solver.cpp
@@ -45,8 +45,10 @@ Notes:
 #include "ast/rewriter/bv_rewriter.h"
 #include "solver/parallel_params.hpp"
 #include "params/tactic_params.hpp"
+#include "params/smt_params.h"
 #include "parsers/smt2/smt2parser.h"
 #include "params/sat_params.hpp"
+#include "util/gparams.h"
 
 tactic* mk_tactic_for_logic(ast_manager& m, params_ref const& p, symbol const& logic);
 
@@ -162,6 +164,13 @@ public:
         else
             l = logic;
 
+        params_ref q(p);
+        params_ref smt_p = gparams::get_module("smt");
+        if (l == "QF_S" && !p.contains("phase_selection") && !smt_p.contains("phase_selection")) {
+            // Positive phases favor empty witnesses for satisfiable string constraints.
+            q.set_uint("phase_selection", static_cast<unsigned>(PS_ALWAYS_TRUE));
+        }
+
         tactic_params tp;
         tactic_ref t;
         if (tp.default_tactic() != symbol::null &&
@@ -170,22 +179,22 @@ public:
             cmd_context ctx(false, &m, l);
             std::istringstream is(tp.default_tactic().str());
             char const* file_name = "";
-            sexpr_ref se = parse_sexpr(ctx, is, p, file_name);
+            sexpr_ref se = parse_sexpr(ctx, is, q, file_name);
             if (se) {
                 t = sexpr2tactic(ctx, se.get());
             }
         }
 
         if (!t) {
-            solver* s = mk_special_solver_for_logic(m, p, l);
+            solver* s = mk_special_solver_for_logic(m, q, l);
             if (s) return s;
         }
         if (!t) {
-            t = mk_tactic_for_logic(m, p, l);
+            t = mk_tactic_for_logic(m, q, l);
         }
-        return mk_combined_solver(mk_tactic2solver(m, t.get(), p, proofs_enabled, models_enabled, unsat_core_enabled, l),
-                                  mk_solver_for_logic(m, p, l), 
-                                  p);
+        return mk_combined_solver(mk_tactic2solver(m, t.get(), q, proofs_enabled, models_enabled, unsat_core_enabled, l),
+                                  mk_solver_for_logic(m, q, l),
+                                  q);
     }
     
     solver_factory* translate(ast_manager& m) override {
@@ -196,5 +205,3 @@ public:
 solver_factory * mk_smt_strategic_solver_factory(symbol const & logic) {
     return alloc(smt_strategic_solver_factory, logic);
 }
-
-

--- a/src/tactic/tactic.cpp
+++ b/src/tactic/tactic.cpp
@@ -101,10 +101,12 @@ class lazy_tactic : public tactic {
     params_ref p;
     std::function<tactic* (ast_manager& m, params_ref const& p)> m_mk_tactic;
     tactic* m_tactic = nullptr;
+    symbol m_logic;
     void ensure_tactic() {
         if (!m_tactic) {
             m_tactic = m_mk_tactic(m, p);
             m_tactic->updt_params(p);
+            m_tactic->set_logic(m_logic);
         }
     }
 public:
@@ -117,6 +119,10 @@ public:
     void updt_params(params_ref const& p) override { 
         this->p.append(p);
         if (m_tactic) m_tactic->updt_params(p);
+    }
+    void set_logic(symbol const& l) override {
+        m_logic = l;
+        if (m_tactic) m_tactic->set_logic(l);
     }
     void cleanup() override { if (m_tactic) m_tactic->cleanup(); }
     char const* name() const override { return "lazy tactic"; }

--- a/src/test/seq_rewriter.cpp
+++ b/src/test/seq_rewriter.cpp
@@ -599,5 +599,19 @@ void tst_seq_rewriter() {
         ENSURE(res == l_true);
     }
 
+    // A sequence of length at most one contains only itself and the empty sequence.
+    {
+        arith_util a_util(m);
+        app_ref x(m.mk_fresh_const("x", str_sort), m);
+        app_ref y(m.mk_fresh_const("y", str_sort), m);
+        expr_ref at(su.str.mk_at(x, a_util.mk_int(0)), m);
+        expr_ref contains(su.str.mk_contains(at, y), m);
+        expr_ref expected(
+            m.mk_or(su.str.mk_is_empty(y), m.mk_eq(at, y)), m);
+        rw(contains);
+        rw(expected);
+        ENSURE(contains == expected);
+    }
+
     std::cout << "tst_seq_rewriter: all tests passed\n";
 }


### PR DESCRIPTION
Fixes #4770.

This adds a bounded sequence rewrite for `contains(a, b)` when `a` has maximum length one, reducing it to the exact empty-or-equal cases. It also propagates logic through lazy tactics so `smt_setup.cpp` can select positive phases for QF_S benchmarks.

The issue benchmark returns `sat` with a 3.42-second median over five Release runs. Sequence rewriter regression coverage is included.