### PR TITLE
Fix theory_polymorphism infinite non-productive restart loop

### DIFF
--- a/src/smt/theory_polymorphism.h
+++ b/src/smt/theory_polymorphism.h
@@ -71,6 +71,14 @@ namespace smt {
                 vector<polymorphism::instantiation> instances;
                 m_inst.instantiate(instances);
                 if (!instances.empty()) {
+                    // There are still polymorphic axioms to instantiate. Force the
+                    // solver to fail under the theory assumption so that a new
+                    // research round (see should_research) can assert the new
+                    // instances. Assigning the negation of the (already true)
+                    // assumption creates a conflict, so we must return FC_CONTINUE
+                    // to let conflict resolution turn it into l_false; returning
+                    // FC_DONE here would report l_true while the context is
+                    // inconsistent, violating a core search invariant.
                     for (auto const& [orig, inst, sub] : instances)
                         ctx.add_asserted(inst);
                     ctx.internalize_assertions();

--- a/src/smt/theory_polymorphism.h
+++ b/src/smt/theory_polymorphism.h
@@ -67,17 +67,37 @@ namespace smt {
         }
 
         final_check_status final_check_eh(unsigned) override {
+            // m_inst.pending() indicates there is still queued work in the
+            // instantiation engine (e.g. add_instantiations() can enqueue new
+            // decls discovered mid-round, past the bound snapshotted at the
+            // start of the round in polymorphism::inst::instantiate). This
+            // work is not tied to *new* top-level assertions, so
+            // add_theory_assumptions() alone will not necessarily schedule
+            // another propagate() round for it. Drive it here directly: try
+            // to instantiate now, and only force a restart (FC_CONTINUE) if
+            // that produced actual new instances. If nothing new is produced
+            // even though m_inst still reports work queued (e.g. because a
+            // restart unwound scoped trail state before this point), treat it
+            // as no further progress being possible and let search continue
+            // normally (FC_DONE) rather than looping forever.
             if (m_inst.pending()) {
-                // There are still polymorphic axioms to instantiate. Force the
-                // solver to fail under the theory assumption so that a new
-                // research round (see should_research) can assert the new
-                // instances. Assigning the negation of the (already true)
-                // assumption creates a conflict, so we must return FC_CONTINUE
-                // to let conflict resolution turn it into l_false; returning
-                // FC_DONE here would report l_true while the context is
-                // inconsistent, violating a core search invariant.
-                ctx.assign(~mk_literal(m_assumption), nullptr);
-                return FC_CONTINUE;
+                vector<polymorphism::instantiation> instances;
+                m_inst.instantiate(instances);
+                if (!instances.empty()) {
+                    for (auto const& [orig, inst, sub] : instances)
+                        ctx.add_asserted(inst);
+                    ctx.internalize_assertions();
+                    // There are still polymorphic axioms to instantiate. Force the
+                    // solver to fail under the theory assumption so that a new
+                    // research round (see should_research) can assert the new
+                    // instances. Assigning the negation of the (already true)
+                    // assumption creates a conflict, so we must return FC_CONTINUE
+                    // to let conflict resolution turn it into l_false; returning
+                    // FC_DONE here would report l_true while the context is
+                    // inconsistent, violating a core search invariant.
+                    ctx.assign(~mk_literal(m_assumption), nullptr);
+                    return FC_CONTINUE;
+                }
             }
             return FC_DONE;
         }

--- a/src/smt/theory_polymorphism.h
+++ b/src/smt/theory_polymorphism.h
@@ -67,19 +67,6 @@ namespace smt {
         }
 
         final_check_status final_check_eh(unsigned) override {
-            // m_inst.pending() indicates there is still queued work in the
-            // instantiation engine (e.g. add_instantiations() can enqueue new
-            // decls discovered mid-round, past the bound snapshotted at the
-            // start of the round in polymorphism::inst::instantiate). This
-            // work is not tied to *new* top-level assertions, so
-            // add_theory_assumptions() alone will not necessarily schedule
-            // another propagate() round for it. Drive it here directly: try
-            // to instantiate now, and only force a restart (FC_CONTINUE) if
-            // that produced actual new instances. If nothing new is produced
-            // even though m_inst still reports work queued (e.g. because a
-            // restart unwound scoped trail state before this point), treat it
-            // as no further progress being possible and let search continue
-            // normally (FC_DONE) rather than looping forever.
             if (m_inst.pending()) {
                 vector<polymorphism::instantiation> instances;
                 m_inst.instantiate(instances);
@@ -87,14 +74,6 @@ namespace smt {
                     for (auto const& [orig, inst, sub] : instances)
                         ctx.add_asserted(inst);
                     ctx.internalize_assertions();
-                    // There are still polymorphic axioms to instantiate. Force the
-                    // solver to fail under the theory assumption so that a new
-                    // research round (see should_research) can assert the new
-                    // instances. Assigning the negation of the (already true)
-                    // assumption creates a conflict, so we must return FC_CONTINUE
-                    // to let conflict resolution turn it into l_false; returning
-                    // FC_DONE here would report l_true while the context is
-                    // inconsistent, violating a core search invariant.
                     ctx.assign(~mk_literal(m_assumption), nullptr);
                     return FC_CONTINUE;
                 }


### PR DESCRIPTION
## Problem

`theory_polymorphism::final_check_eh()` checks `polymorphism::inst::pending()` and forces a research restart (via a blocking-literal conflict) whenever it is true. However, the actual instantiation work only runs inside `propagate()`, which is gated by a separate `m_pending` flag. That flag is set **only** when new top-level assertions arrive via `add_theory_assumptions()`.

If the instantiation engine`s internal decl queue still has residual work queued from a previous round (`polymorphism::inst::add_instantiations()` can enqueue new decls past the bound snapshotted at the start of the current `instantiate()` call), but no new top-level assertions have been asserted, `m_pending` is never set again, so `propagate()` never runs. Yet `final_check_eh()` keeps observing `pending() == true` and forces an endless sequence of non-productive research restarts, with **zero search progress**, until the solver times out.

This was discovered via a TPTP TH1 (rank-1 polymorphic higher-order) benchmark problem that looped for its entire timeout budget without any conflicts/propagations happening, despite the polymorphic instantiation engine itself correctly identifying the needed instances in a single round.

## Fix

Drive instantiation directly from `final_check_eh()` whenever `pending()` is true, and only force a restart (`FC_CONTINUE`) if that call actually produced new instances. This makes the polymorphism theory self-contained (it no longer depends on an external "did new top-level assertions arrive" signal to make progress), so it can no longer starve.

## Testing

- Full unit test suite (`test-z3 /a`, 99 tests) passes on this branch built from a clean `master` checkout.
- Verified end-to-end: a previously-looping polymorphic TH1 problem now shows real search progress (growing conflict/propagation counts, MBQI activity) instead of looping with static stats, confirming the fix addresses the root cause rather than just changing symptoms.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>