### PR TITLE
remove dead re.of_pred materialization path in range_predicate_to_regex

### DIFF
--- a/src/ast/rewriter/seq_range_collapse.cpp
+++ b/src/ast/rewriter/seq_range_collapse.cpp
@@ -226,6 +226,11 @@ namespace seq {
         // Without this the merge algorithm produces incorrect unions
         // when it has to combine our materialized output with another
         // (id-sorted) regex set.
+        //
+        // An re.of_pred lambda would be more compact than a union of ranges,
+        // but it was measured to be no better on a regex benchmark corpus,
+        // and it is opaque to consumers that match on re.range / re.union
+        // structurally.
         expr_ref_vector ranges(m);
 
         for (unsigned i = 0; i < n; ++i) {
@@ -238,22 +243,6 @@ namespace seq {
         for (unsigned i = n - 1; i-- > 0;)
             acc = expr_ref(u.re.mk_union(ranges.get(i), acc), m);
         return acc;
-        #if 0
-        expr_ref bound(m.mk_var(0, char_sort), m);
-        symbol char_sym("ch");
-        auto &ch = u.get_char_plugin();
-        for (unsigned i = 0; i < n; ++i) {
-            auto [lo, hi] = p[i];
-            {
-                auto _seq251_0 = ch.mk_le(ch.mk_char(lo), bound);
-                auto _seq251_1 = ch.mk_le(bound, ch.mk_char(hi));
-                ranges.push_back(m.mk_and(_seq251_0, _seq251_1));
-            }
-        }
-        expr_ref body(m.mk_or(ranges), m);
-        auto lam = m.mk_lambda(1, &char_sort, &char_sym, body);
-        return expr_ref(u.re.mk_of_pred(lam), m);
-        #endif
     }
 
     expr_ref unfold_fold(seq_rewriter &rw, expr *r) {


### PR DESCRIPTION
`range_predicate_to_regex` materializes a multi-range character class as an id-sorted union of `re.range` leaves. An alternative that folds the class into a single `re.of_pred` lambda has sat unreachable behind `#if 0` since 436237bfb, which introduced the union path to replace an ill-sorted bare lambda (it returned the lambda directly, not wrapped in `re.of_pred`) and left the corrected `of_pred` form dormant rather than deleting it.

I re-enabled the `of_pred` path and measured it on a regex benchmark corpus (1476 files, 10s timeout, `model_validate=true`): it decided the same number of instances as the union form and was not faster. It is also opaque to consumers that match on `re.range` / `re.union` structurally.

This deletes the dead block and records why the union form is kept. The surrounding comment explaining the id-sort requirement for `seq_rewriter::merge_regex_sets` is unchanged.

Comment plus dead-code removal only; no behavioral change. Builds clean; unit tests unaffected.