### PR TITLE
[CMake] Require only the GMP C interface

### DIFF
--- a/cmake/modules/FindGMP.cmake
+++ b/cmake/modules/FindGMP.cmake
@@ -2,48 +2,48 @@
 #
 # Once done this will define
 #  GMP_FOUND - BOOL: System has the GMP library installed
-#  GMP_INCLUDE_DIRS - LIST:The GMP include directories
-#  GMP_C_LIBRARIES - LIST:The libraries needed to use GMP via it's C interface
-#  GMP_CXX_LIBRARIES - LIST:The libraries needed to use GMP via it's C++ interface
+#  GMP_INCLUDE_DIR - PATH: The directory containing gmp.h
+#  GMP_LIBRARY - FILEPATH: The GMP C library
+#  GMP_INCLUDE_DIRS - LIST: The GMP include directories
+#  GMP_LIBRARIES - LIST: The libraries needed to use GMP
+#  GMP::GMP - TARGET: The GMP C library
 
 include(FindPackageHandleStandardArgs)
 
-# Try to find libraries
-find_library(GMP_C_LIBRARIES
-  NAMES gmp
-  DOC "GMP C libraries"
-)
-find_library(GMP_CXX_LIBRARIES
-  NAMES gmpxx
-  DOC "GMP C++ libraries"
-)
+# Honor the variables accepted by the previous version of this module.
+if (GMP_C_LIBRARIES AND NOT GMP_LIBRARY)
+  set(GMP_LIBRARY "${GMP_C_LIBRARIES}")
+endif()
+if (GMP_C_INCLUDES AND NOT GMP_INCLUDE_DIR)
+  set(GMP_INCLUDE_DIR "${GMP_C_INCLUDES}")
+endif()
 
-# Try to find headers
-find_path(GMP_C_INCLUDES
+find_library(GMP_LIBRARY
+  NAMES gmp
+  DOC "GMP C library"
+)
+find_path(GMP_INCLUDE_DIR
   NAMES gmp.h
   DOC "GMP C header"
 )
 
-find_path(GMP_CXX_INCLUDES
-  NAMES gmpxx.h
-  DOC "GMP C++ header"
-)
-
-# TODO: We should check we can link some simple code against libgmp and libgmpxx
-
 # Handle QUIET and REQUIRED and check the necessary variables were set and if so
 # set ``GMP_FOUND``
 find_package_handle_standard_args(GMP
-	REQUIRED_VARS GMP_C_LIBRARIES GMP_C_INCLUDES GMP_CXX_LIBRARIES GMP_CXX_INCLUDES)
+  REQUIRED_VARS GMP_LIBRARY GMP_INCLUDE_DIR)
 
 if (GMP_FOUND)
-  set(GMP_INCLUDE_DIRS "${GMP_C_INCLUDES}" "${GMP_CXX_INCLUDES}")
-  list(REMOVE_DUPLICATES GMP_INCLUDE_DIRS)
+  set(GMP_INCLUDE_DIRS "${GMP_INCLUDE_DIR}")
+  set(GMP_LIBRARIES "${GMP_LIBRARY}")
+  set(GMP_C_INCLUDES "${GMP_INCLUDE_DIR}")
+  set(GMP_C_LIBRARIES "${GMP_LIBRARY}")
 
   if (NOT TARGET GMP::GMP)
     add_library(GMP::GMP UNKNOWN IMPORTED)
     set_target_properties(GMP::GMP PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${GMP_C_INCLUDES}"
-      IMPORTED_LOCATION "${GMP_C_LIBRARIES}")
+      INTERFACE_INCLUDE_DIRECTORIES "${GMP_INCLUDE_DIR}"
+      IMPORTED_LOCATION "${GMP_LIBRARY}")
   endif()
 endif()
+
+mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARY)


### PR DESCRIPTION
The existing `FindGMP.cmake` module required the GMPXX C++ bindings to be found, but Z3 doesn't use or depend on them. This caused the build to reject installations of GMP that lacked the C++ bindings.

This PR corrects this problem and updates the Find module's cache variable names to mirror common CMake conventions. The old variables are still accepted for compatibility with existing downstream build scripts.