### PR TITLE
[CMake] Support co-installed static and shared packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,18 @@ endif()
 ################################################################################
 # Option to control what type of library we build
 ################################################################################
-option(Z3_BUILD_LIBZ3_SHARED "Build libz3 as a shared library if true, otherwise build a static library" ON)
+# Z3_BUILD_LIBZ3_SHARED is retained for existing build scripts.  Use CMake's
+# standard switch internally so packages can make the same choice.
+if (DEFINED Z3_BUILD_LIBZ3_SHARED)
+  set(BUILD_SHARED_LIBS "${Z3_BUILD_LIBZ3_SHARED}")
+endif()
+option(BUILD_SHARED_LIBS "Build libz3 as a shared library" ON)
+set(Z3_BUILD_LIBZ3_SHARED "${BUILD_SHARED_LIBS}")
+if (BUILD_SHARED_LIBS)
+  set(Z3_LIBZ3_VARIANT shared)
+else()
+  set(Z3_LIBZ3_VARIANT static)
+endif()
 option(Z3_BUILD_LIBZ3_MSVC_STATIC "Build libz3 as a statically-linked runtime library"                   OFF)
 
 
@@ -603,7 +614,7 @@ if (Z3_BUILD_LIBZ3_CORE)
 
   export(EXPORT Z3_EXPORTED_TARGETS
      NAMESPACE z3::
-     FILE "${PROJECT_BINARY_DIR}/Z3Targets.cmake"
+     FILE "${PROJECT_BINARY_DIR}/Z3-${Z3_LIBZ3_VARIANT}-targets.cmake"
   )
 else()
   # When not building libz3, we need to find it
@@ -670,6 +681,20 @@ write_basic_package_version_file("${PROJECT_BINARY_DIR}/Z3ConfigVersion.cmake"
   COMPATIBILITY SameMajorVersion
 )
 
+set(Z3_FIND_GMP_MODULE_DIR "${PROJECT_SOURCE_DIR}/cmake/modules")
+configure_file(
+  "${PROJECT_SOURCE_DIR}/cmake/Z3StaticDependencies.cmake.in"
+  "${PROJECT_BINARY_DIR}/Z3-static-dependencies.cmake"
+  @ONLY
+)
+set(Z3_FIND_GMP_MODULE_DIR "\${CMAKE_CURRENT_LIST_DIR}")
+configure_file(
+  "${PROJECT_SOURCE_DIR}/cmake/Z3StaticDependencies.cmake.in"
+  "${PROJECT_BINARY_DIR}/cmake/Z3-static-dependencies.cmake"
+  @ONLY
+)
+unset(Z3_FIND_GMP_MODULE_DIR)
+
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/z3.pc.cmake.in"
 	"${CMAKE_CURRENT_BINARY_DIR}/z3.pc" @ONLY)
 
@@ -681,10 +706,22 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/z3.pc.cmake.in"
 if (Z3_BUILD_LIBZ3_CORE)
   install(EXPORT
     Z3_EXPORTED_TARGETS
-    FILE "Z3Targets.cmake"
+    FILE "Z3-${Z3_LIBZ3_VARIANT}-targets.cmake"
     NAMESPACE z3::
     DESTINATION "${CMAKE_INSTALL_Z3_CMAKE_PACKAGE_DIR}"
   )
+  if (NOT BUILD_SHARED_LIBS)
+    install(
+      FILES "${PROJECT_BINARY_DIR}/cmake/Z3-static-dependencies.cmake"
+      DESTINATION "${CMAKE_INSTALL_Z3_CMAKE_PACKAGE_DIR}"
+    )
+    if (Z3_USE_LIB_GMP)
+      install(
+        FILES "${PROJECT_SOURCE_DIR}/cmake/modules/FindGMP.cmake"
+        DESTINATION "${CMAKE_INSTALL_Z3_CMAKE_PACKAGE_DIR}"
+      )
+    endif()
+  endif()
 endif()
 set(Z3_INSTALL_TREE_CMAKE_CONFIG_FILE "${PROJECT_BINARY_DIR}/cmake/Z3Config.cmake")
 set(Z3_FIRST_PACKAGE_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/cmake/Z3Config.cmake.in
+++ b/cmake/Z3Config.cmake.in
@@ -11,24 +11,83 @@
 ################################################################################
 
 
-# Handle dependencies (necessary when compiling the static library)
-if(NOT @Z3_BUILD_LIBZ3_SHARED@)
-  include(CMakeFindDependencyMacro)
+@PACKAGE_INIT@
 
-  # Threads::Threads
-  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-  find_dependency(Threads)
+set(_Z3_known_components static shared)
+set(_Z3_find_static FALSE)
+set(_Z3_find_shared FALSE)
+foreach (_Z3_component IN LISTS ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
+  if (_Z3_component IN_LIST _Z3_known_components)
+    set(_Z3_find_${_Z3_component} TRUE)
+  else()
+    set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
+      "Z3 does not recognize component `${_Z3_component}`.")
+    set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+    return()
+  endif()
+endforeach()
 
-  # GMP::GMP
-  if(@Z3_USE_LIB_GMP@)
-    find_dependency(GMP)
+if (_Z3_find_static AND _Z3_find_shared)
+  set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
+    "Z3 components `static` and `shared` are mutually exclusive.")
+  set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+  return()
+endif()
+
+set(_Z3_static_targets "${CMAKE_CURRENT_LIST_DIR}/Z3-static-targets.cmake")
+set(_Z3_shared_targets "${CMAKE_CURRENT_LIST_DIR}/Z3-shared-targets.cmake")
+if (_Z3_find_static)
+  set(_Z3_variant static)
+elseif (_Z3_find_shared)
+  set(_Z3_variant shared)
+elseif (DEFINED Z3_SHARED_LIBS)
+  if (Z3_SHARED_LIBS)
+    set(_Z3_variant shared)
+  else()
+    set(_Z3_variant static)
+  endif()
+elseif (DEFINED BUILD_SHARED_LIBS AND NOT BUILD_SHARED_LIBS)
+  set(_Z3_variant static)
+elseif (EXISTS "${_Z3_shared_targets}")
+  set(_Z3_variant shared)
+else()
+  set(_Z3_variant static)
+endif()
+
+set(_Z3_targets "${_Z3_${_Z3_variant}_targets}")
+if (NOT EXISTS "${_Z3_targets}")
+  set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
+    "Z3 `${_Z3_variant}` libraries were requested but not found.")
+  set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+  return()
+endif()
+
+if (TARGET z3::libz3)
+  get_target_property(_Z3_loaded_type z3::libz3 TYPE)
+  if (_Z3_variant STREQUAL static)
+    set(_Z3_requested_type STATIC_LIBRARY)
+  else()
+    set(_Z3_requested_type SHARED_LIBRARY)
+  endif()
+  if (NOT _Z3_loaded_type STREQUAL _Z3_requested_type)
+    set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
+      "Z3 `${_Z3_variant}` libraries were requested, but z3::libz3 was already loaded as a ${_Z3_loaded_type} target.")
+    set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+    return()
   endif()
 endif()
 
-# Exported targets
-include("${CMAKE_CURRENT_LIST_DIR}/Z3Targets.cmake")
-
-@PACKAGE_INIT@
+if (_Z3_variant STREQUAL static)
+  include("${CMAKE_CURRENT_LIST_DIR}/Z3-static-dependencies.cmake")
+  if (DEFINED ${CMAKE_FIND_PACKAGE_NAME}_FOUND
+      AND NOT ${CMAKE_FIND_PACKAGE_NAME}_FOUND)
+    return()
+  endif()
+  set(Z3_SHARED_LIBS FALSE)
+else()
+  set(Z3_SHARED_LIBS TRUE)
+endif()
+include("${_Z3_targets}")
 
 # Version information
 set(Z3_VERSION_MAJOR @Z3_VERSION_MAJOR@)

--- a/cmake/Z3StaticDependencies.cmake.in
+++ b/cmake/Z3StaticDependencies.cmake.in
@@ -1,0 +1,17 @@
+include(CMakeFindDependencyMacro)
+
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_dependency(Threads)
+
+if (@Z3_USE_LIB_GMP@)
+  set(_z3_saved_module_path "${CMAKE_MODULE_PATH}")
+  list(INSERT CMAKE_MODULE_PATH 0 "@Z3_FIND_GMP_MODULE_DIR@")
+  find_package(GMP MODULE QUIET)
+  set(CMAKE_MODULE_PATH "${_z3_saved_module_path}")
+  unset(_z3_saved_module_path)
+  if (NOT GMP_FOUND)
+    set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
+      "Z3's static library requires GMP, but GMP was not found.")
+    set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+  endif()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,7 @@ set (object_files "")
 foreach (component ${Z3_LIBZ3_COMPONENTS_LIST})
   list(APPEND object_files $<TARGET_OBJECTS:${component}>)
 endforeach()
-if (Z3_BUILD_LIBZ3_SHARED)
+if (BUILD_SHARED_LIBS)
   set(lib_type "SHARED")
 else()
   set(lib_type "STATIC")
@@ -148,6 +148,9 @@ if (NOT MSVC)
   # ``.ilk``, ``.pdb``, ``.lib`` and ``.exp`` files sharing the same
   # prefix.
   set_target_properties(libz3 PROPERTIES OUTPUT_NAME z3)
+elseif (WIN32 AND NOT BUILD_SHARED_LIBS)
+  # Do not overwrite the shared build's import library when co-installed.
+  set_target_properties(libz3 PROPERTIES OUTPUT_NAME libz3-static)
 endif()
 
 # The `PRIVATE` usage requirement is specified so that when building Z3 as a


### PR DESCRIPTION
Z3's CMake package has always assumed there's exactly one `libz3` to install: static or shared, whichever the build happened to produce. Both variants exported to the same `Z3Targets.cmake`, so if you ever installed both flavors to the same prefix (which package managers routinely need to do) the second install silently clobbered the first, and there was no way to ask `find_package(Z3)` for a specific one.

This PR fixes that by applying the pattern I wrote up in my blog post, ["Building a Dual Shared and Static Library with CMake"](https://alexreinking.com/blog/building-a-dual-shared-and-static-library-with-cmake.html) (2021), which I've since used to ship the same capability in Halide and tinyxml2. The core idea is that a library target is inescapably either `STATIC` or `SHARED` in CMake so instead of fighting that, the package treats "which variant" as a first-class configuration point, on both the build and install sides, and keeps that complexity in the library's own CMake files rather than pushing it onto consumers.

- Each variant now exports and installs to its own target file, Z3-static-targets.cmake and Z3-shared-targets.cmake, so a static and a shared install can coexist in the same prefix without clobbering each other.
- Consumers can be explicit at the call site: `find_package(Z3 COMPONENTS static)` or `shared`. Z3Config.cmake rejects nonsensical requests (both components at once, or one that isn't installed). When a consumer doesn't ask for a specific variant, the config falls back to a sensible default: an explicit `Z3_SHARED_LIBS` override if the consumer set one, then `BUILD_SHARED_LIBS`, then whatever's actually present on disk.
- The static variant's transitive dependencies (Threads, and GMP when enabled) are resolved lazily, only when the static component is actually loaded, via a new generated `Z3-static-dependencies.cmake`. This mirrors the shared build, which has no such dependencies to expose because they're already linked in.
- Internally, the build now drives off CMake's own `BUILD_SHARED_LIBS` instead of the Z3-specific `Z3_BUILD_LIBZ3_SHARED`, so the "which kind of library" decision is made the same way whether you're building Z3 itself or a project consuming it as a subdirectory. `Z3_BUILD_LIBZ3_SHARED` is kept as an alias so existing build scripts don't break.
- On Windows, the static build's output is renamed to libz3-static so its import library doesn't collide with the shared build's `.lib` file when both are installed together.