### PR TITLE
add seq::profile_abs, a standalone per-letter Parikh abstraction

### DIFF
--- a/src/ast/rewriter/CMakeLists.txt
+++ b/src/ast/rewriter/CMakeLists.txt
@@ -45,6 +45,7 @@ z3_add_component(rewriter
     seq_subset.cpp
     seq_derive.cpp
     seq_monadic.cpp
+    seq_profile_abs.cpp
     seq_range_collapse.cpp
     seq_range_predicate.cpp
     seq_rewriter.cpp

--- a/src/ast/rewriter/seq_profile_abs.cpp
+++ b/src/ast/rewriter/seq_profile_abs.cpp
@@ -1,0 +1,242 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+Module Name:
+
+    seq_profile_abs.cpp
+
+Abstract:
+
+    Per-letter Parikh abstraction refined by length.  See seq_profile_abs.h.
+
+--*/
+#include "ast/rewriter/seq_profile_abs.h"
+#include "util/zstring.h"
+
+namespace seq {
+    static const unsigned LCAP = 2;
+
+    static inline unsigned pbit(unsigned c, unsigned l) { return 1u << (c * 3 + l); }
+
+    void profile_abs::begin_pass(unsigned modulus, unsigned sigma) {
+        SASSERT(2 <= modulus && modulus <= max_modulus);
+        m_pk_mod = modulus;
+        m_pk_sigma = sigma;
+        m_pk_top = 0;
+        for (unsigned c = 0; c < modulus; ++c)
+            for (unsigned l = 0; l <= LCAP; ++l)
+                m_pk_top |= pbit(c, l);
+        m_pk_budget = 1 << 14;
+        m_pk_prof.reset();
+        m_pk_forced.reset();
+    }
+
+    unsigned profile_abs::prof_cat(unsigned a1, unsigned a2) const {
+        if (a1 == 0 || a2 == 0)
+            return 0;
+        unsigned r = 0;
+        for (unsigned c1 = 0; c1 < m_pk_mod; ++c1)
+            for (unsigned l1 = 0; l1 <= LCAP; ++l1) {
+                if (!(a1 & pbit(c1, l1)))
+                    continue;
+                for (unsigned c2 = 0; c2 < m_pk_mod; ++c2)
+                    for (unsigned l2 = 0; l2 <= LCAP; ++l2)
+                        if (a2 & pbit(c2, l2))
+                            r |= pbit((c1 + c2) % m_pk_mod, std::min(l1 + l2, LCAP));
+            }
+        return r;
+    }
+
+    // Binary exponentiation: the profile masks form a monoid under prof_cat
+    // with unit {(0,0)}, so A^n is exact and costs O(log n) products.
+    unsigned profile_abs::prof_pow(unsigned a1, unsigned n) const {
+        unsigned r = pbit(0, 0), base = a1;
+        while (n > 0) {
+            if (n & 1)
+                r = prof_cat(r, base);
+            n >>= 1;
+            if (n > 0)
+                base = prof_cat(base, base);
+        }
+        return r;
+    }
+
+    unsigned profile_abs::prof_star(unsigned a1) const {
+        unsigned r = pbit(0, 0);
+        while (true) {
+            const unsigned next = r | prof_cat(r, a1);
+            if (next == r)
+                return r;
+            r = next;
+        }
+    }
+
+    unsigned profile_abs::prof_loop(unsigned a1, unsigned lo, unsigned hi) const {
+        if (lo > hi)
+            return 0;
+        const unsigned base = prof_pow(a1, lo);
+        // A^lo..A^hi is contained in A^lo · A*, which is cheap and sound; take it
+        // whenever enumerating the exponents one by one would be the costlier of
+        // the two.  The lattice has only 3·m elements, so nothing is lost.
+        if (hi - lo > 3 * m_pk_mod)
+            return prof_cat(base, prof_star(a1));
+        unsigned r = 0, cur = base;
+        for (unsigned i = lo; i <= hi; ++i) {
+            r |= cur;
+            cur = prof_cat(cur, a1);
+        }
+        return r;
+    }
+
+    unsigned profile_abs::prof_chars(bool has_sigma, bool has_other) const {
+        unsigned r = 0;
+        if (has_sigma)
+            r |= pbit(1 % m_pk_mod, 1);
+        if (has_other)
+            r |= pbit(0, 1);
+        return r;
+    }
+
+    unsigned profile_abs::forced(expr* re) {
+        unsigned r = 0;
+        if (m_pk_forced.find(re, r))
+            return r;
+        if (m_pk_budget == 0)
+            return 0;               // sound: claim nothing is forced
+        --m_pk_budget;
+
+        expr* x = nullptr;
+        zstring s;
+        unsigned lo = 0, hi = 0;
+        if (seq.re.is_full_seq(re))
+            r = m_pk_top;
+        else if (seq.re.is_full_char(re)) {
+            // every one-character word belongs to allchar
+            for (unsigned c = 0; c < m_pk_mod; ++c)
+                r |= pbit(c, 1);
+        }
+        else if (seq.re.is_to_re(re, x) && seq.str.is_string(x, s)) {
+            if (s.length() == 0)
+                r = pbit(0, 0);                       // eps is the only word of profile (0,0)
+            else if (s.length() == 1 && s[0] == m_pk_sigma)
+                r = pbit(1 % m_pk_mod, 1);            // sigma is the only word of profile (1,1)
+        }
+        else if (seq.re.is_range(re, lo, hi)) {
+            if (lo <= m_pk_sigma && m_pk_sigma <= hi)
+                r = pbit(1 % m_pk_mod, 1);
+        }
+        else if (seq.re.is_union(re)) {
+            for (expr* arg : *to_app(re))
+                r |= forced(arg);
+        }
+        else if (seq.re.is_intersection(re)) {
+            r = m_pk_top;
+            for (expr* arg : *to_app(re))
+                r &= forced(arg);
+        }
+        else if (seq.re.is_complement(re, x))
+            r = m_pk_top & ~profiles(x);
+        else if (seq.re.is_star(re, x) || seq.re.is_opt(re, x))
+            r = forced(x) | pbit(0, 0);
+        m_pk_forced.insert(re, r);
+        return r;
+    }
+
+    unsigned profile_abs::profiles(expr* re) {
+        unsigned r = 0;
+        if (m_pk_prof.find(re, r))
+            return r;
+        if (m_pk_budget == 0)
+            return m_pk_top;        // sound: claim every profile is possible
+        --m_pk_budget;
+
+        expr* x = nullptr;
+        expr* y = nullptr;
+        zstring s;
+        unsigned lo = 0, hi = 0;
+        if (seq.re.is_empty(re))
+            r = 0;
+        else if (seq.re.is_full_seq(re))
+            r = m_pk_top;
+        else if (seq.re.is_full_char(re))
+            r = prof_chars(true, true);
+        else if (seq.re.is_to_re(re, x)) {
+            if (seq.str.is_string(x, s)) {
+                unsigned cnt = 0;
+                for (unsigned i = 0; i < s.length(); ++i)
+                    if (s[i] == m_pk_sigma)
+                        ++cnt;
+                r = pbit(cnt % m_pk_mod, std::min(s.length(), LCAP));
+            }
+            else
+                r = m_pk_top;
+        }
+        else if (seq.re.is_concat(re)) {
+            r = pbit(0, 0);
+            for (expr* arg : *to_app(re)) {
+                r = prof_cat(r, profiles(arg));
+                if (r == 0)
+                    break;
+            }
+        }
+        else if (seq.re.is_union(re)) {
+            for (expr* arg : *to_app(re))
+                r |= profiles(arg);
+        }
+        else if (seq.re.is_intersection(re)) {
+            r = m_pk_top;
+            for (expr* arg : *to_app(re))
+                r &= profiles(arg);
+        }
+        else if (seq.re.is_star(re, x))
+            r = prof_star(profiles(x));
+        else if (seq.re.is_plus(re, x)) {
+            const unsigned p = profiles(x);
+            r = prof_cat(p, prof_star(p));
+        }
+        else if (seq.re.is_opt(re, x))
+            r = profiles(x) | pbit(0, 0);
+        else if (seq.re.is_complement(re, x))
+            r = m_pk_top & ~forced(x);
+        else if (seq.re.is_diff(re, x, y))
+            r = profiles(x) & (m_pk_top & ~forced(y));
+        else if (seq.re.is_range(re, lo, hi)) {
+            if (lo > hi)
+                r = 0;              // SMT-LIB: an inverted range is the empty language
+            else {
+                const bool has_sigma = lo <= m_pk_sigma && m_pk_sigma <= hi;
+                r = prof_chars(has_sigma, hi > lo || !has_sigma);
+            }
+        }
+        else if (seq.re.is_loop(re, x, lo, hi))
+            r = prof_loop(profiles(x), lo, hi);
+        else if (seq.re.is_loop(re, x, lo)) {
+            const unsigned p = profiles(x);
+            r = prof_cat(prof_pow(p, lo), prof_star(p));
+        }
+        else
+            r = m_pk_top;           // of_pred, reverse, derivative, ...
+        m_pk_prof.insert(re, r);
+        return r;
+    }
+
+    unsigned profile_abs::residues_in_pass(expr* re) {
+        const unsigned mask = profiles(re);
+        unsigned res = 0;
+        for (unsigned c = 0; c < m_pk_mod; ++c)
+            for (unsigned l = 0; l <= LCAP; ++l)
+                if (mask & pbit(c, l)) {
+                    res |= 1u << c;
+                    break;
+                }
+        return res;
+    }
+
+    unsigned profile_abs::regex_residues(expr* re, unsigned modulus, unsigned sigma) {
+        if (modulus < 2 || modulus > max_modulus)
+            return UINT_MAX;
+        begin_pass(modulus, sigma);
+        return residues_in_pass(re);
+    }
+
+} // namespace seq

--- a/src/ast/rewriter/seq_profile_abs.h
+++ b/src/ast/rewriter/seq_profile_abs.h
@@ -1,0 +1,92 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+Module Name:
+
+    seq_profile_abs.h
+
+Abstract:
+
+    Per-letter Parikh abstraction of a regular expression, refined by length.
+
+    A word w is abstracted to the pair
+
+        (#sigma(w) mod modulus,  min(|w|, 2))
+
+    and a language to the SET of profiles of its words, held as a bitmask with
+    bit (c * 3 + l) set when profile (c, l) is possible.  The abstraction
+    over-approximates: w in L implies profile(w) is in the mask, so an empty
+    intersection with what an equation forces refutes.
+
+    The length component is what makes EXTENDED regexes usable.  A pure count
+    abstraction cannot see through complement -- comp(R) has to go to the full
+    set, since a word and its permutations share a count -- so the common idiom
+
+        (re.inter re.allchar (re.comp (str.to_re "a")))   "any char but a"
+
+    collapses to "anything at all".  Tracking length pins re.allchar to length
+    exactly 1, and the complement of a ONE-CHARACTER language can then be
+    excluded exactly at that length, recovering "one non-sigma character".
+
+    This module is deliberately free of any solver state: it maps an AST regex
+    to a bitmask and nothing else, so it can be driven by any string solver.
+    The consumer supplies the letters and the constraint rows.
+
+--*/
+#pragma once
+
+#include "ast/seq_decl_plugin.h"
+#include "util/obj_hashtable.h"
+
+namespace seq {
+
+    class profile_abs {
+        seq_util seq;
+
+        // state of the pass: a "pass" is one choice of (sigma, modulus), over
+        // which the caches below stay valid.
+        unsigned m_pk_mod    = 0;   // modulus of the abstraction being computed
+        unsigned m_pk_sigma  = 0;   // character being counted
+        unsigned m_pk_top    = 0;   // full profile mask for m_pk_mod
+        unsigned m_pk_budget = 0;   // remaining recursion steps, 0 = exhausted
+        obj_map<expr, unsigned> m_pk_prof;    // memo for profiles()
+        obj_map<expr, unsigned> m_pk_forced;  // memo for forced()
+
+        unsigned prof_cat(unsigned a, unsigned b) const;
+        unsigned prof_pow(unsigned a, unsigned n) const;
+        unsigned prof_star(unsigned a) const;
+        unsigned prof_loop(unsigned a, unsigned lo, unsigned hi) const;
+        unsigned prof_chars(bool has_sigma, bool has_other) const;
+
+    public:
+        explicit profile_abs(ast_manager& m) : seq(m) {}
+
+        // Largest modulus the profile bitmask can hold (3 length classes per
+        // residue must fit in an unsigned).
+        static const unsigned max_modulus = 10;
+
+        // Begin a pass for one (modulus, sigma) choice; resets the memos.
+        void begin_pass(unsigned modulus, unsigned sigma);
+
+        // Over-approximation of the profiles of L(re): w in L(re) implies
+        // profile(w) is in the result.  Degrades to the full mask when a
+        // construct is out of scope or the budget runs out -- always sound.
+        unsigned profiles(expr* re);
+
+        // Under-approximation of the profiles p for which EVERY word with
+        // profile p lies in L(re).  Makes complement precise: no word of
+        // comp(re) can have such a profile.  Degrades to the empty set.
+        unsigned forced(expr* re);
+
+        // Residues of #sigma, i.e. the profile mask projected on the count
+        // axis, as a bitmask over Z_modulus.  All bits set carries no
+        // information.  `modulus` must lie in [2, max_modulus].
+        unsigned regex_residues(expr* re, unsigned modulus, unsigned sigma);
+
+        // Same projection, but within a pass already begun by begin_pass.
+        // Lets a caller abstract several regexes under one (sigma, modulus)
+        // choice while sharing the memo tables.
+        unsigned residues_in_pass(expr* re);
+    };
+
+} // namespace seq

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -141,6 +141,7 @@ add_executable(test-z3
   seq_regex_witness.cpp
   seq_monadic.cpp
   seq_monadic_bench.cpp
+  seq_profile_abs.cpp
   simple_parser.cpp
   scanner_io.cpp
   simplex.cpp

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -123,6 +123,7 @@
     X(seq_regex_witness) \
     X(seq_monadic) \
     X(seq_monadic_bench) \
+    X(seq_profile_abs) \
     X(check_assumptions) \
     X(smt_context) \
     X(theory_dl) \

--- a/src/test/seq_profile_abs.cpp
+++ b/src/test/seq_profile_abs.cpp
@@ -1,0 +1,328 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+Module Name:
+
+    test/seq_profile_abs.cpp
+
+Abstract:
+
+    Unit tests for seq::profile_abs, the per-letter Parikh abstraction
+    refined by length.
+
+    The abstraction has two directions, and the tests check both against a
+    brute-force oracle rather than against hand-computed masks alone:
+
+      * profiles(R) OVER-approximates: w in L(R) implies profile(w) is in
+        the mask.  Verified by enumerating every word up to a small length
+        over a small alphabet and matching it against R with an independent
+        reference matcher.
+
+      * forced(R) UNDER-approximates: if profile p is in forced(R) then
+        EVERY word with profile p lies in L(R).  Verified by searching the
+        same word set for a counterexample.
+
+    Both properties are what the consumer relies on for refutation, so a
+    regression in either direction is a soundness bug, not a precision loss.
+
+Author:
+
+    Margus Veanes (veanes) 2026
+
+--*/
+#include "ast/rewriter/seq_profile_abs.h"
+#include "ast/reg_decl_plugins.h"
+#include "ast/ast_pp.h"
+#include "util/util.h"
+
+#include <iostream>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace {
+
+    using seq::profile_abs;
+
+    static unsigned const LCAP = 2;
+
+    static void check(bool ok, char const* what) {
+        if (!ok) {
+            std::cerr << "seq_profile_abs FAILED: " << what << "\n";
+            ENSURE(false);
+        }
+    }
+
+    static inline unsigned pbit(unsigned c, unsigned l) { return 1u << (c * 3 + l); }
+
+    // ---- reference matcher -------------------------------------------
+    //
+    // match_set(r, w, i) = { j : w[i..j) in L(r) }.  Computing the set of
+    // end positions rather than a yes/no answer makes concat, star and
+    // intersection straightforward and keeps complement exact.
+
+    class matcher {
+        seq_util& u;
+        std::string const& w;
+
+    public:
+        matcher(seq_util& u, std::string const& w) : u(u), w(w) {}
+
+        std::set<unsigned> ends(expr* r, unsigned i) {
+            std::set<unsigned> res;
+            unsigned const n = (unsigned)w.size();
+            expr *a = nullptr, *b = nullptr, *s = nullptr;
+            unsigned lo = 0, hi = 0;
+            zstring str;
+
+            if (u.re.is_empty(r))
+                return res;
+            if (u.re.is_full_seq(r)) {
+                for (unsigned j = i; j <= n; ++j)
+                    res.insert(j);
+                return res;
+            }
+            if (u.re.is_full_char(r)) {
+                if (i < n)
+                    res.insert(i + 1);
+                return res;
+            }
+            if (u.re.is_to_re(r, s) && u.str.is_string(s, str)) {
+                unsigned const L = str.length();
+                if (i + L <= n) {
+                    bool ok = true;
+                    for (unsigned k = 0; k < L && ok; ++k)
+                        ok = (unsigned)(unsigned char)w[i + k] == str[k];
+                    if (ok)
+                        res.insert(i + L);
+                }
+                return res;
+            }
+            if (u.re.is_range(r, lo, hi)) {
+                if (i < n) {
+                    unsigned c = (unsigned)(unsigned char)w[i];
+                    if (lo <= c && c <= hi)
+                        res.insert(i + 1);
+                }
+                return res;
+            }
+            if (u.re.is_concat(r, a, b)) {
+                for (unsigned mid : ends(a, i))
+                    for (unsigned j : ends(b, mid))
+                        res.insert(j);
+                return res;
+            }
+            if (u.re.is_union(r, a, b)) {
+                for (unsigned j : ends(a, i)) res.insert(j);
+                for (unsigned j : ends(b, i)) res.insert(j);
+                return res;
+            }
+            if (u.re.is_intersection(r, a, b)) {
+                std::set<unsigned> ra = ends(a, i), rb = ends(b, i);
+                for (unsigned j : ra)
+                    if (rb.count(j))
+                        res.insert(j);
+                return res;
+            }
+            if (u.re.is_diff(r, a, b)) {
+                std::set<unsigned> rb = ends(b, i);
+                for (unsigned j : ends(a, i))
+                    if (!rb.count(j))
+                        res.insert(j);
+                return res;
+            }
+            if (u.re.is_complement(r, a)) {
+                // w[i..j) not in L(a), for every j
+                std::set<unsigned> ra = ends(a, i);
+                for (unsigned j = i; j <= n; ++j)
+                    if (!ra.count(j))
+                        res.insert(j);
+                return res;
+            }
+            if (u.re.is_star(r, a)) {
+                res.insert(i);
+                bool grew = true;
+                while (grew) {
+                    grew = false;
+                    std::vector<unsigned> cur(res.begin(), res.end());
+                    for (unsigned p : cur)
+                        for (unsigned j : ends(a, p))
+                            if (j > p && res.insert(j).second)
+                                grew = true;
+                }
+                return res;
+            }
+            if (u.re.is_plus(r, a)) {
+                for (unsigned mid : ends(a, i)) {
+                    expr_ref st(u.re.mk_star(a), u.get_manager());
+                    for (unsigned j : ends(st, mid))
+                        res.insert(j);
+                }
+                return res;
+            }
+            if (u.re.is_opt(r, a)) {
+                res.insert(i);
+                for (unsigned j : ends(a, i)) res.insert(j);
+                return res;
+            }
+            std::cerr << "seq_profile_abs: reference matcher has no case for "
+                      << mk_pp(r, u.get_manager()) << "\n";
+            ENSURE(false);
+            return res;
+        }
+
+        bool matches(expr* r) {
+            return ends(r, 0).count((unsigned)w.size()) > 0;
+        }
+    };
+
+    // Every word of length <= max_len over `alphabet`.
+    static void all_words(std::string const& alphabet, unsigned max_len,
+                          std::vector<std::string>& out) {
+        out.push_back("");
+        size_t start = 0;
+        for (unsigned len = 1; len <= max_len; ++len) {
+            size_t end = out.size();
+            for (size_t k = start; k < end; ++k)
+                for (char c : alphabet)
+                    out.push_back(out[k] + c);
+            start = end;
+        }
+    }
+
+    static unsigned word_profile(std::string const& w, unsigned sigma, unsigned mod) {
+        unsigned cnt = 0;
+        for (char c : w)
+            if ((unsigned)(unsigned char)c == sigma)
+                ++cnt;
+        return pbit(cnt % mod, std::min((unsigned)w.size(), LCAP));
+    }
+
+    static expr_ref chr(seq_util& u, char c) {
+        return expr_ref(u.re.mk_to_re(u.str.mk_string(zstring((unsigned)(unsigned char)c))),
+                        u.get_manager());
+    }
+
+    static void run() {
+        ast_manager m;
+        reg_decl_plugins(m);
+        seq_util u(m);
+        profile_abs abs(m);
+
+        sort* str_sort = u.str.mk_string_sort();
+        sort* re_sort = u.re.mk_re(str_sort);
+
+        expr_ref a(chr(u, 'a')), b(chr(u, 'b'));
+        expr_ref dot(u.re.mk_full_char(re_sort), m);
+        expr_ref all(u.re.mk_full_seq(re_sort), m);
+
+        // The battery deliberately includes the extended idioms that the
+        // length refinement exists for.
+        expr_ref_vector battery(m);
+        battery.push_back(a);                                          // "a"
+        battery.push_back(u.re.mk_concat(a, a));                       // "aa"
+        battery.push_back(u.re.mk_union(a, b));                        // a | b
+        battery.push_back(u.re.mk_star(a));                            // a*
+        battery.push_back(u.re.mk_plus(a));                            // a+
+        battery.push_back(u.re.mk_opt(a));                             // a?
+        battery.push_back(u.re.mk_star(u.re.mk_concat(a, a)));         // (aa)*
+        battery.push_back(u.re.mk_union(u.re.mk_star(u.re.mk_concat(a, a)),
+                                        u.re.mk_star(u.re.mk_concat(a, u.re.mk_concat(a, a)))));
+        battery.push_back(u.re.mk_inter(dot, u.re.mk_complement(a)));  // . & ~a
+        battery.push_back(u.re.mk_complement(a));                      // ~a
+        battery.push_back(u.re.mk_complement(u.re.mk_star(a)));        // ~(a*)
+        battery.push_back(u.re.mk_diff(dot, a));                       // . \ a
+        battery.push_back(u.re.mk_concat(u.re.mk_star(a), b));         // a* b
+        battery.push_back(u.re.mk_inter(u.re.mk_star(a), u.re.mk_complement(u.re.mk_concat(a, a))));
+        battery.push_back(dot);
+        battery.push_back(all);
+        battery.push_back(u.re.mk_empty(re_sort));
+
+        std::vector<std::string> words;
+        all_words("abc", 4, words);
+
+        unsigned checked = 0;
+        for (unsigned mod = 2; mod <= 4; ++mod) {
+            for (char sig : std::string("ab")) {
+                unsigned sigma = (unsigned)(unsigned char)sig;
+                for (expr* r : battery) {
+                    abs.begin_pass(mod, sigma);
+                    unsigned const prof = abs.profiles(r);
+                    unsigned const forc = abs.forced(r);
+
+                    for (std::string const& w : words) {
+                        matcher mt(u, w);
+                        bool const in = mt.matches(r);
+                        unsigned const p = word_profile(w, sigma, mod);
+
+                        // over-approximation: membership implies the bit is set
+                        if (in && !(prof & p)) {
+                            std::cerr << "profiles() unsound for "
+                                      << mk_pp(r, m) << " on \"" << w << "\""
+                                      << " (mod " << mod << ", sigma " << sig << ")\n";
+                            check(false, "profiles over-approximation");
+                        }
+                        // under-approximation: a forced bit admits no non-member
+                        if (!in && (forc & p)) {
+                            std::cerr << "forced() unsound for "
+                                      << mk_pp(r, m) << " on \"" << w << "\""
+                                      << " (mod " << mod << ", sigma " << sig << ")\n";
+                            check(false, "forced under-approximation");
+                        }
+                        ++checked;
+                    }
+                }
+            }
+        }
+
+        // Note: forced() is NOT contained in profiles().  A profile that no
+        // word realizes -- e.g. length 1 with two occurrences of sigma -- is
+        // vacuously forced, since every word realizing it (there are none)
+        // lies in L(R), yet it is absent from profiles(R).  The two masks are
+        // deliberately independent approximations.
+
+        // ---- concrete residue expectations ----
+
+        // "aa" counting 'a' mod 2 -> only residue 0
+        {
+            unsigned res = abs.regex_residues(u.re.mk_concat(a, a), 2, 'a');
+            check(res == 0x1, "residues of \"aa\" mod 2 = {0}");
+        }
+        // "a" counting 'a' mod 2 -> only residue 1
+        {
+            unsigned res = abs.regex_residues(a, 2, 'a');
+            check(res == 0x2, "residues of \"a\" mod 2 = {1}");
+        }
+        // (aa)* counting 'a' mod 2 -> only residue 0
+        {
+            unsigned res = abs.regex_residues(u.re.mk_star(u.re.mk_concat(a, a)), 2, 'a');
+            check(res == 0x1, "residues of (aa)* mod 2 = {0}");
+        }
+        // . & ~a is exactly one non-'a' character: residue 0, and it must
+        // NOT degrade to "all residues" -- this is the case the length
+        // refinement exists for.
+        {
+            expr_ref e(u.re.mk_inter(dot, u.re.mk_complement(a)), m);
+            unsigned res = abs.regex_residues(e, 3, 'a');
+            check(res == 0x1, "residues of (. & ~a) mod 3 = {0}");
+        }
+        // re.all carries no information.
+        {
+            unsigned res = abs.regex_residues(all, 3, 'a');
+            check(res == 0x7, "residues of re.all mod 3 = all");
+        }
+        // out-of-range modulus is rejected
+        {
+            check(abs.regex_residues(a, 1, 'a') == UINT_MAX, "modulus 1 rejected");
+            check(abs.regex_residues(a, profile_abs::max_modulus + 1, 'a') == UINT_MAX,
+                  "modulus above max rejected");
+        }
+
+        std::cerr << "seq_profile_abs tests passed (" << checked
+                  << " word/regex soundness checks)\n";
+    }
+}
+
+void tst_seq_profile_abs() {
+    run();
+}


### PR DESCRIPTION
Adds `src/ast/rewriter/seq_profile_abs.{h,cpp}`: a small, solver-independent abstraction over regexes, plus an exhaustive unit test.

### What it computes

For a fixed letter `sigma` and modulus `m`, a *profile* of a word `w` is the pair

    (|w|_sigma mod m, min(|w|, 2))

`profile_abs` maps a regex to a bitmask over these profiles:

* `profiles(R)` **over**-approximates `{ profile(w) | w in L(R) }`
* `forced(R)` **under**-approximates `{ p | every w with profile(w) = p is in L(R) }`

Together these let a consumer refute a system of letter-count congruences over a conjunction of memberships. `regex_residues(R, m, sigma)` projects the result onto the count axis.

### Why length is tracked alongside the count

A pure count abstraction cannot see through complement: a word and its permutations share a count, so `re.comp` has to fall back to the full mask. Pinning `re.allchar` to length exactly 1 makes the common idiom

    (re.inter re.allchar (re.comp (str.to_re "a")))

work exactly — the complement of a one-character language is excluded precisely at length 1, recovering "one non-`a` character" rather than collapsing to top.

### Why it is a separate module

The class holds no solver state — only a `seq_util` and two memos that are valid for the duration of one `(sigma, modulus)` pass. It does not reference the SMT core, the E-graph, or any particular sequence theory, so any string solver can drive it. This is a step toward a more modular sequence solver: the abstraction was previously entangled with a specific solver's internals, and pulling it out makes it independently testable and reusable.

### Testing

`src/test/seq_profile_abs.cpp` checks **both** approximation directions against an *independent* reference matcher (end-position-set semantics, so complement and intersection are handled exactly), exhaustively over every word of length <= 4 on a 3-letter alphabet, for a battery of 17 regexes covering every supported constructor, with moduli 2..4 and two choices of `sigma` — 12342 checks. It also pins down concrete `regex_residues` results, including the `. & ~a` idiom above.

Note the comment in the test explaining why `forced` is **not** a subset of `profiles`: unrealizable profiles (e.g. length 1 with two `sigma`s) are vacuously forced but never appear in `profiles`.

### Impact on master

None — this is additive only (665 insertions, 0 deletions). Nothing on master calls the module yet; the only reference outside the module and its own test is the test registration in `src/test/main.cpp`. Full build is clean and the unit-test suite passes.

I have driven it from a downstream branch, where it replaces ~266 lines of equivalent in-solver code; an A/B over a 1476-file regex corpus showed identical results (same set decided, no contradictions) confirming the extraction is behavior-preserving.
