### PR TITLE
opt: floor the objective with algebraic model values instead of reporting -oo

### DIFF
--- a/src/opt/opt_solver.cpp
+++ b/src/opt/opt_solver.cpp
@@ -252,13 +252,32 @@ namespace opt {
         return true;
     }
 
+    // Extract from a model value of an objective a rational the model proves
+    // attainable. A rational numeral is the value itself. An irrational
+    // algebraic value (e.g. 1/sqrt(2) for an objective pinned by nonlinear
+    // equations) does not fit in inf_eps; a rational lower bound of its
+    // isolating interval is still a sound floor, since optsmt objectives are
+    // always maximized. Without this floor the objective value stays -oo and
+    // geometric_lex reports -oo as the optimum of a satisfiable objective;
+    // the exact algebraic optimum is recovered later by the nlsat fallback.
+    bool opt_solver::model_objective_floor(expr* value, rational& r) {
+        arith_util a(m);
+        if (a.is_numeral(value, r))
+            return true;
+        if (a.is_irrational_algebraic_numeral(value)) {
+            a.am().get_lower(a.to_irrational_algebraic_numeral(value), r, 40);
+            return true;
+        }
+        return false;
+    }
+
     // If baseline_model evaluates objective i to a value better than the
     // current optimum, adopt that value and update the blocker.
     void opt_solver::update_from_baseline_model(unsigned i, model_ref& baseline_model, expr_ref& blocker) {
         arith_util a(m);
         rational r;
         expr_ref obj_val = (*baseline_model)(m_objective_terms.get(i));
-        if (a.is_numeral(obj_val, r) && inf_eps(r) > m_objective_values[i]) {
+        if (model_objective_floor(obj_val, r) && inf_eps(r) > m_objective_values[i]) {
             m_objective_values[i] = inf_eps(r);
             if (!m_objective_models[i])
                 m_objective_models.set(i, baseline_model.get());
@@ -345,8 +364,8 @@ namespace opt {
         auto update_objective = [&]() {
             rational r;
             expr_ref value = (*m_model)(m_objective_terms.get(i));
-            if (arith_util(m).is_numeral(value, r) && r > m_objective_values[i])
-                m_objective_values[i] = inf_eps(r);   
+            if (model_objective_floor(value, r) && inf_eps(r) > m_objective_values[i])
+                m_objective_values[i] = inf_eps(r);
         };
 
         update_objective();

--- a/src/opt/opt_solver.h
+++ b/src/opt/opt_solver.h
@@ -171,6 +171,7 @@ namespace opt {
         bool maximize_objectives1(expr_ref_vector& blockers);
         bool maximize_objective_isolated(unsigned i, model_ref& baseline_model, expr_ref& blocker);
         void update_from_baseline_model(unsigned i, model_ref& baseline_model, expr_ref& blocker);
+        bool model_objective_floor(expr* value, rational& r);
         inf_eps const & saved_objective_value(unsigned obj_index);
         // The optimization hint of the last maximize_objective call and what
         // check_bound established about it: l_true - a model attains it;

--- a/src/opt/optsmt.cpp
+++ b/src/opt/optsmt.cpp
@@ -271,25 +271,12 @@ namespace opt {
                 else {
                     ++steps;
                 }
-                // A real objective that keeps producing better models while
-                // no arithmetic bound above it was ever refuted may be
-                // unbounded (e.g. maximize x under x*y = 1 /\ y > 0): every
-                // model-derived step below stays satisfiable, so the loop
-                // climbs forever and never reaches the nlsat/bisect fallback.
-                // After a streak of such rounds try to decide the question
-                // with prove_unbounded_above (README section 3.3): on the
-                // proof, commit +oo with the current model as a witness.
-                // A bounded objective climbing to its optimum in small steps
-                // shows the same streak, and on it the nlqsat query is pure
-                // waste that can dwarf the whole optimization (a 0.1s
-                // benchmark regressed past 180s firing it once), so the query
-                // runs under a resource-count budget (an rlimit, not
-                // wall-clock time, so the same input behaves the same on
-                // every machine and build), and every inconclusive attempt
-                // doubles both the budget and the streak required for the
-                // next attempt: a truly unbounded climb still gets decided,
-                // a bounded one spends at most a fixed share of its rounds
-                // here.
+                // A real objective may improve forever without refuting an
+                // upper bound. After a streak, use prove_unbounded_above to
+                // commit +oo with the current model as a witness. Bounded
+                // objectives can show the same pattern, so limit the query by
+                // deterministic resource count and exponentially back off
+                // inconclusive retries.
                 if (is_int || refuted_hint.is_finite())
                     climb_rounds = 0;
                 else if (m_optsmt_nlsat && ++climb_rounds >= unbounded_check_rounds) {
@@ -396,10 +383,17 @@ namespace opt {
             return l_undef;
         }
 
+        // A satisfiable objective whose lower bound is still -oo means no
+        // model value was ever extracted before the loop stalled. Tightening
+        // below would then report -oo as the optimum of a satisfiable
+        // objective; report the interval as unknown instead.
+        if (!m_lower[obj_index].is_finite() && m_lower[obj_index].is_neg())
+            return l_undef;
+
         // set the solution tight. An algebraic optimum keeps its rational
         // bracket [m_lower, m_upper]; the exact value is in m_exact.
         if (!m_exact.get(obj_index))
-            m_upper[obj_index] = m_lower[obj_index];    
+            m_upper[obj_index] = m_lower[obj_index];
         if (!is_box)
             for (unsigned i = obj_index+1; i < m_lower.size(); ++i)
                 m_lower[i] = inf_eps(rational(-1), inf_rational(0));


### PR DESCRIPTION
## The bug

```smt2
(declare-const x Real)
(declare-const y Real)
(assert (= (* x x) 2.0))
(assert (>= x 1.0))
(assert (= (* x y) 1.0))
(maximize y)
(check-sat)
(get-objectives)
```

The objective is pinned by the equations to the single value y = 1/sqrt(2), yet z3 answered `sat` with `(y (* (- 1) oo))`.

## Root cause

Preprocessing solves y = 1/x and purifies the objective into a fresh constant equal to `1/x`. The model assigns that constant the irrational algebraic value `(root-obj (+ (* 2 (^ x 2)) (- 1)) 2)`. Both places where `opt_solver` reads the objective's value out of a model (`update_objective` in `maximize_objective`, and `update_from_baseline_model`) accepted only rational numerals, so the algebraic value was silently dropped and `m_objective_values` stayed `-oo`. The LP hints slightly overshoot the true optimum and are refuted by `check_bound`, so the climb in `optsmt::geometric_lex` stalled; the nlsat/bisect fallback is gated on a finite lower bound and was never reached; the final tightening set upper = lower = `-oo` and reported it as the optimum of a satisfiable objective.

## The fix

- `opt_solver::model_objective_floor`: a rational numeral is taken as-is; an irrational algebraic model value now contributes a rational lower bound of its isolating interval (`am().get_lower(.., 40)`, the precision `opt_nlsat` already uses). This is a sound floor because optsmt objectives are always maximize-normalized (minimize is negated at registration). The finite floor un-starves the climb, and the existing nlsat fallback then returns the exact algebraic optimum:

```
sat
(objectives
 (y (root-obj (+ (* 2 (^ x 2)) (- 1)) 2))
)
```

- `optsmt::geometric_lex`: a guard refuses to tighten a still-infinite lower bound into a claimed optimum and reports the interval as unknown instead, so any future value-extraction gap degrades to an honest interval rather than a wrong answer.

## Validation

- `test-z3 -a`: 103/103 pass.
- z3test `regressions/smt2`: all pass with `model_validate=true` (a companion z3test PR adds `opt_nlsat_pinned_by_equation.smt2` covering this case).
- OMT benchmark set: 1 WRONG -> 0 WRONG, no other verdict changes; minimize direction and equation variants (two inequalities, extra occurrences of y, explicit `set-logic QF_NRA`) all produce the exact root-obj.
- `regressions/opt_bug.smt2` output is byte-identical before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)