### PR TITLE
Split seq_parikh unit test: keep fast grids in -a, move the rest to seq_parikh_long

### DIFF
--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -151,6 +151,7 @@
     X(zstring)
 
 #define FOR_EACH_EXTRA_TEST(X, X_ARGV) \
+    X(seq_parikh_long) \
     X(tptp) \
     X(tptp_crashes) \
     X(ext_numeral) \

--- a/src/test/seq_parikh.cpp
+++ b/src/test/seq_parikh.cpp
@@ -253,12 +253,29 @@ void tst_seq_parikh() {
     }
 
     test_shared_alphabet();
-    for (unsigned n = 1; n <= 4; ++n) {
+    // Only the random grids that finish in a few seconds run here. The
+    // larger grids spend most of their time on systems that exhaust the
+    // resource bound and read as `allowed`, which no assertion consumes;
+    // they run in seq_parikh_long, only when named (see FOR_EACH_EXTRA_TEST
+    // in main.cpp).
+    for (unsigned n = 1; n <= 2; ++n) {
         test_random(80, 1, n);
     }
-    for (unsigned n = 1; n <= 3; ++n) {
+    for (unsigned n = 1; n <= 2; ++n) {
         test_random(25, 2, n);
     }
     std::cout << "seq_parikh: " << g_checks << " directed cases, " << g_failures << " failures" << std::endl;
+    ENSURE(g_failures == 0);
+}
+
+// The random grids dominated by the resource bound (about 1.5 minutes).
+// Not part of `test-z3 -a`; run as `test-z3 seq_parikh_long`.
+void tst_seq_parikh_long() {
+    g_failures = 0;
+    for (unsigned n = 3; n <= 4; ++n) {
+        test_random(80, 1, n);
+    }
+    test_random(25, 2, 3);
+    std::cout << "seq_parikh_long: " << g_failures << " failures" << std::endl;
     ENSURE(g_failures == 0);
 }


### PR DESCRIPTION
`seq_parikh` accounted for 97 of the 101 seconds of `test-z3 -a` (tests run in parallel worker processes, so it set the whole suite's wall time). Per-grid timing shows the cost sits in the random grids (1,3), (1,4) and (2,3): together they hold ~88% of the runtime, almost all of it spent on 58 equation systems that exhaust the 2,000,000-tick resource bound and read as `allowed` — a verdict the test never checks (only `refuted` equations get the brute-force soundness cross-check).

## Change

- `tst_seq_parikh` (still in `-a`) keeps the 44 directed cases, the shared-alphabet check, and the random grids that finish in a few seconds: (1,1), (1,2), (2,1), (2,2).
- New `tst_seq_parikh_long` runs the three bound-dominated grids. It is registered under `FOR_EACH_EXTRA_TEST` (the existing "tests only run when explicitly named" tier): `test-z3 seq_parikh_long`.

Combined coverage is unchanged — same grids, same seed, and the split tiers reproduce the original refutation/bound counts exactly ((1,3) 40 refuted / 14 bounded, (1,4) 31/31, (2,3) 11/11; 201 refutation cross-checks in total).

## Measurements (release build, macOS)

| run | before | after |
|---|---|---|
| `test-z3 -a` wall time | 101s | 12.6s (103/103 pass) |
| `test-z3 seq_parikh` | 99s | 11.9s |
| `test-z3 seq_parikh_long` | — | 87s, 0 failures |

The suite's critical path is now `seq_eq_approx` (12.4s); the same treatment could apply there if desired.

cc @CEisenhofer

🤖 Generated with [Claude Code](https://claude.com/claude-code)