### PR TITLE
opt: build Pareto dominance constraints from algebraic model values

### DIFF
--- a/src/opt/opt_context.cpp
+++ b/src/opt/opt_context.cpp
@@ -677,6 +677,15 @@ namespace opt {
             Z3_fallthrough;
         case O_MAXIMIZE:
             val = (*mdl)(obj.m_term);
+            // The model can pin the objective to an irrational algebraic
+            // value (e.g. sqrt(2) under x^2 = 2). Compare against the sound
+            // side of its rational isolating interval instead: a lower bound
+            // in term >= value, an upper bound in term <= value, whose
+            // negation still demands a genuine strict improvement. The old
+            // fallback to "true" let the Pareto loop keep dominated models
+            // and stop enumerating the front after one point.
+            if (!is_numeral(val, k) && model_value_bound(m_arith, val, is_ge, k))
+                val = m_arith.mk_numeral(k, false);
             if (is_numeral(val, k)) {
                 if (is_ge) {
                     result = mk_ge(obj.m_term, val);
@@ -1555,7 +1564,11 @@ namespace opt {
             case O_MINIMIZE: {
                 val = (*m_model)(obj.m_term);
                 TRACE(opt, tout << obj.m_term << " " << val << "\n";);
-                if (is_numeral(val, r)) {
+                // An irrational algebraic value contributes the side of its
+                // isolating interval that stays sound after the sign
+                // adjustment: adjust_value negates a minimization term,
+                // turning a lower bound of the value into an upper one.
+                if (is_numeral(val, r) || model_value_bound(m_arith, val, is_lower != obj.m_adjust_value.get_negate(), r)) {
                     inf_eps val = inf_eps(obj.m_adjust_value(r));
                     TRACE(opt, tout << "adjusted value: " << val << "\n";);
                     if (is_lower) {
@@ -1570,7 +1583,7 @@ namespace opt {
             case O_MAXIMIZE: {
                 val = (*m_model)(obj.m_term);
                 TRACE(opt, tout << obj.m_term << " " << val << "\n";);
-                if (is_numeral(val, r)) {
+                if (is_numeral(val, r) || model_value_bound(m_arith, val, is_lower != obj.m_adjust_value.get_negate(), r)) {
                     inf_eps val = inf_eps(obj.m_adjust_value(r));
                     TRACE(opt, tout << "adjusted value: " << val << "\n";);
                     if (is_lower) {

--- a/src/opt/opt_context.cpp
+++ b/src/opt/opt_context.cpp
@@ -677,13 +677,14 @@ namespace opt {
             Z3_fallthrough;
         case O_MAXIMIZE:
             val = (*mdl)(obj.m_term);
-            // The model can pin the objective to an irrational algebraic
-            // value (e.g. sqrt(2) under x^2 = 2). Compare against the sound
-            // side of its rational isolating interval instead: a lower bound
-            // in term >= value, an upper bound in term <= value, whose
-            // negation still demands a genuine strict improvement. The old
-            // fallback to "true" let the Pareto loop keep dominated models
-            // and stop enumerating the front after one point.
+            // The model may pin the objective to an irrational algebraic
+            // value v. The smt backend does not internalize an irrational
+            // algebraic numeral (it reports the term unsupported and answers
+            // unknown), so replace v by an endpoint of a rational isolating
+            // interval l < v < u: l in term >= v, u in term <= v. The
+            // weakened atom holds in the current model, and its negation
+            // (term < l, resp. term > u) implies term < v (resp. term > v),
+            // a strict improvement.
             if (!is_numeral(val, k) && model_value_bound(m_arith, val, is_ge, k))
                 val = m_arith.mk_numeral(k, false);
             if (is_numeral(val, k)) {
@@ -695,6 +696,11 @@ namespace opt {
                 }
             }
             else {
+                // The model value is neither a numeral nor an irrational
+                // algebraic number; the trivial constraint silently weakens
+                // the Pareto dominance test.
+                IF_VERBOSE(5, verbose_stream() << "(opt.pareto :unhandled-objective-value "
+                           << val << ")\n");
                 result = m.mk_true();
             }
             break;
@@ -1564,11 +1570,15 @@ namespace opt {
             case O_MINIMIZE: {
                 val = (*m_model)(obj.m_term);
                 TRACE(opt, tout << obj.m_term << " " << val << "\n";);
-                // An irrational algebraic value contributes the side of its
-                // isolating interval that stays sound after the sign
-                // adjustment: adjust_value negates a minimization term,
-                // turning a lower bound of the value into an upper one.
-                if (is_numeral(val, r) || model_value_bound(m_arith, val, is_lower != obj.m_adjust_value.get_negate(), r)) {
+                // The model value v may be irrational algebraic. Substitute
+                // an endpoint of a rational isolating interval l < v < u,
+                // with the side chosen so that the bound survives
+                // adjust_value: negation reverses order (x <= v iff
+                // -x >= -v), so when adjust_value negates the term the
+                // requested side flips.
+                // model_value_bound also accepts plain arithmetic numerals;
+                // the second check backstops bit-vector objective values.
+                if (model_value_bound(m_arith, val, is_lower != obj.m_adjust_value.get_negate(), r) || m_bv.is_numeral(val, r)) {
                     inf_eps val = inf_eps(obj.m_adjust_value(r));
                     TRACE(opt, tout << "adjusted value: " << val << "\n";);
                     if (is_lower) {
@@ -1583,7 +1593,7 @@ namespace opt {
             case O_MAXIMIZE: {
                 val = (*m_model)(obj.m_term);
                 TRACE(opt, tout << obj.m_term << " " << val << "\n";);
-                if (is_numeral(val, r) || model_value_bound(m_arith, val, is_lower != obj.m_adjust_value.get_negate(), r)) {
+                if (model_value_bound(m_arith, val, is_lower != obj.m_adjust_value.get_negate(), r) || m_bv.is_numeral(val, r)) {
                     inf_eps val = inf_eps(obj.m_adjust_value(r));
                     TRACE(opt, tout << "adjusted value: " << val << "\n";);
                     if (is_lower) {

--- a/src/opt/opt_solver.cpp
+++ b/src/opt/opt_solver.cpp
@@ -252,18 +252,13 @@ namespace opt {
         return true;
     }
 
-    // An irrational algebraic model value (e.g. 1/sqrt(2) for an objective
-    // pinned by nonlinear equations) does not fit in inf_eps; the requested
-    // side of its isolating interval is still a sound bound - a floor, since
-    // optsmt objectives are always maximized. Without the floor the objective
-    // value stays -oo and geometric_lex reports -oo as the optimum of a
-    // satisfiable objective; the exact algebraic optimum is recovered later
-    // by the nlsat fallback. The interval side is rounded outward to 12
-    // decimal digits to keep the constant decimal-like: bounds derived from
-    // it are asserted back into the solver, and the deep dyadic denominators
-    // of the raw interval bounds (2^-40 and finer) look like derived-bound
-    // artifacts to the nonlinear solver (nra_solver::is_dyadic_artifact),
-    // which drops such constraints and answers unknown.
+    // Irrational algebraic model values do not fit in inf_eps, so use the
+    // requested side of their isolating interval as a sound bound. Without
+    // it, geometric_lex can report -oo for a satisfiable objective. Replace a
+    // lower endpoint n by floor(10^12*n)/10^12 and an upper endpoint n by
+    // ceil(10^12*n)/10^12. Each reduced denominator divides 10^12, so its
+    // dyadic valuation is at most 12. nra_solver omits generated bounds with
+    // valuation at least 24 to avoid large coefficients after clearing denominators.
     bool model_value_bound(arith_util& a, expr* val, bool lower, rational& n) {
         if (a.is_numeral(val, n))
             return true;
@@ -277,6 +272,10 @@ namespace opt {
                 a.am().get_upper(a.to_irrational_algebraic_numeral(val), n, 40);
                 n = ceil(n * den) / den;
             }
+            IF_VERBOSE(10, verbose_stream() << "(opt.model-value-bound :value "
+                       << mk_pp(val, a.get_manager())
+                       << " :side " << (lower ? "lower" : "upper")
+                       << " :bound " << n << ")\n");
             return true;
         }
         return false;

--- a/src/opt/opt_solver.cpp
+++ b/src/opt/opt_solver.cpp
@@ -252,20 +252,31 @@ namespace opt {
         return true;
     }
 
-    // Extract from a model value of an objective a rational the model proves
-    // attainable. A rational numeral is the value itself. An irrational
-    // algebraic value (e.g. 1/sqrt(2) for an objective pinned by nonlinear
-    // equations) does not fit in inf_eps; a rational lower bound of its
-    // isolating interval is still a sound floor, since optsmt objectives are
-    // always maximized. Without this floor the objective value stays -oo and
-    // geometric_lex reports -oo as the optimum of a satisfiable objective;
-    // the exact algebraic optimum is recovered later by the nlsat fallback.
-    bool opt_solver::model_objective_floor(expr* value, rational& r) {
-        arith_util a(m);
-        if (a.is_numeral(value, r))
+    // An irrational algebraic model value (e.g. 1/sqrt(2) for an objective
+    // pinned by nonlinear equations) does not fit in inf_eps; the requested
+    // side of its isolating interval is still a sound bound - a floor, since
+    // optsmt objectives are always maximized. Without the floor the objective
+    // value stays -oo and geometric_lex reports -oo as the optimum of a
+    // satisfiable objective; the exact algebraic optimum is recovered later
+    // by the nlsat fallback. The interval side is rounded outward to 12
+    // decimal digits to keep the constant decimal-like: bounds derived from
+    // it are asserted back into the solver, and the deep dyadic denominators
+    // of the raw interval bounds (2^-40 and finer) look like derived-bound
+    // artifacts to the nonlinear solver (nra_solver::is_dyadic_artifact),
+    // which drops such constraints and answers unknown.
+    bool model_value_bound(arith_util& a, expr* val, bool lower, rational& n) {
+        if (a.is_numeral(val, n))
             return true;
-        if (a.is_irrational_algebraic_numeral(value)) {
-            a.am().get_lower(a.to_irrational_algebraic_numeral(value), r, 40);
+        if (a.is_irrational_algebraic_numeral(val)) {
+            rational const den = rational(10).expt(12);
+            if (lower) {
+                a.am().get_lower(a.to_irrational_algebraic_numeral(val), n, 40);
+                n = floor(n * den) / den;
+            }
+            else {
+                a.am().get_upper(a.to_irrational_algebraic_numeral(val), n, 40);
+                n = ceil(n * den) / den;
+            }
             return true;
         }
         return false;
@@ -277,7 +288,7 @@ namespace opt {
         arith_util a(m);
         rational r;
         expr_ref obj_val = (*baseline_model)(m_objective_terms.get(i));
-        if (model_objective_floor(obj_val, r) && inf_eps(r) > m_objective_values[i]) {
+        if (model_value_bound(a, obj_val, true, r) && inf_eps(r) > m_objective_values[i]) {
             m_objective_values[i] = inf_eps(r);
             if (!m_objective_models[i])
                 m_objective_models.set(i, baseline_model.get());
@@ -362,9 +373,10 @@ namespace opt {
         // current optimal.
         // 
         auto update_objective = [&]() {
+            arith_util a(m);
             rational r;
             expr_ref value = (*m_model)(m_objective_terms.get(i));
-            if (model_objective_floor(value, r) && inf_eps(r) > m_objective_values[i])
+            if (model_value_bound(a, value, true, r) && inf_eps(r) > m_objective_values[i])
                 m_objective_values[i] = inf_eps(r);
         };
 

--- a/src/opt/opt_solver.h
+++ b/src/opt/opt_solver.h
@@ -31,9 +31,17 @@ Notes:
 #include "smt/theory_opt.h"
 #include "ast/converters/generic_model_converter.h"
 
+class arith_util;
+
 namespace opt {
 
     typedef inf_eps_rational<inf_rational> inf_eps;
+
+    // Extract from a model value of an objective term a rational bound on it:
+    // the value itself when it is a rational numeral, otherwise, for an
+    // irrational algebraic value (e.g. sqrt(2) for an objective pinned by
+    // x^2 = 2), the requested side of its isolating interval.
+    bool model_value_bound(arith_util& a, expr* val, bool lower, rational& n);
 
     // Adjust bound bound |-> m_offset + (m_negate?-1:1)*bound
     class adjust_value {
@@ -171,7 +179,6 @@ namespace opt {
         bool maximize_objectives1(expr_ref_vector& blockers);
         bool maximize_objective_isolated(unsigned i, model_ref& baseline_model, expr_ref& blocker);
         void update_from_baseline_model(unsigned i, model_ref& baseline_model, expr_ref& blocker);
-        bool model_objective_floor(expr* value, rational& r);
         inf_eps const & saved_objective_value(unsigned obj_index);
         // The optimization hint of the last maximize_objective call and what
         // check_bound established about it: l_true - a model attains it;


### PR DESCRIPTION
Follow-up to #10723: the same irrational-model-value skip existed in the Pareto combinator.

## The bug

The GIA Pareto loop (`gia_pareto`, driven through `opt_context::mk_cmp`) compared an objective against its model value only when that value was a rational numeral. An objective pinned to an irrational algebraic value silently degraded the comparison to `true`, collapsing both the `dominates` and `not_dominated_by` constraints to `false`.

```smt2
(set-option :opt.priority pareto)
(declare-const x Real)
(declare-const y Real)
(assert (= (* x x) 2))
(assert (= y (- x)))
(maximize x)
(maximize y)
(check-sat)   ; sat   - one front point, possibly a dominated one
(check-sat)   ; unsat - false "front exhausted" after a single point
(check-sat)   ; sat   - contradicts the unsat by restarting from scratch
```

The objective space has exactly the two incomparable points (sqrt(2), -sqrt(2)) and (-sqrt(2), sqrt(2)). All reported intervals stayed at (-oo, oo) because `update_bound` skipped irrational values as well.

## The fix

`model_objective_floor` (from #10723) is generalized into a shared helper `opt::model_value_bound` that returns the requested side of the value's isolating interval:

- `mk_cmp` uses a lower bound in `term >= value` and an upper bound in `term <= value`, so the negation used for strict improvement still demands a genuine improvement;
- `update_bound` picks the side that stays sound after the minimize negation (`is_lower != adjust_value.get_negate()`) and tests each value form once: `model_value_bound` first (it already accepts rational numerals), a direct bit-vector numeral check as the only fallback;
- the bound is rounded **outward to 12 decimal digits**. This is load-bearing: the raw interval bounds have denominators around 2^160, and `nra_solver::is_dyadic_artifact` (#10568) drops constraints with deeply dyadic constants as derived-bound artifacts, which left the whole loop `unknown`. The same rounding now also applies to the #10723 floor, whose value is asserted back as a blocker;
- the substituted bound is logged under `-v:10`, and a value form `mk_cmp` cannot handle is logged under `-v:5` instead of silently weakening the dominance test.

The example now answers `sat` (-sqrt(2), sqrt(2)), `sat` (sqrt(2), -sqrt(2)), `unsat` - the exact two-point front, each coordinate reported as a 12-digit bracket.

## Limitations and follow-up

This is a soundness repair with a documented approximation, not the exact treatment:

- Every answer stays sound: each reported point is a genuine model, and the strict-improvement disjunct compares against the upper endpoint (`term > u` with `u > value`), so each accepted climb step improves some objective by a real positive margin.
- The pointwise "at least as good" side compares against the lower endpoint, so another coordinate may regress by up to the bracket width. Dominance on irrational coordinates is therefore exact up to ~10^-12: an improvement smaller than the bracket can be missed.
- The 12-digit constant is coupled to `nra_solver::is_dyadic_artifact` (2-adic denominator valuation threshold 24); if that threshold moves, this constant must follow.
- The exact treatment is a planned follow-up, not this PR: nlsat decides atoms over algebraic constants natively (asserting `t >= root-obj(...)` under `qfnra-nlsat` answers correctly), while the smt core the loop runs on reports such numerals unsupported at internalization (`theory_arith_core.h`). Running the dominance checks on an nlsat-backed solver on the NRA fragment (no uninterpreted functions - the gate `opt_nlsat` already uses) removes the rounding entirely.

## Validation

- `test-z3 -a`: 103/103
- z3test `regressions/smt2`: all pass
- OMT benchmark set: no verdict change besides the new pareto instance passing

Companion z3test regression: `opt_algebraic_pareto_front` (PR to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
