### PR TITLE
[CMake] Add CI coverage for co-installed static and shared packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,18 @@ jobs:
         with:
           cmake-version: ${{ matrix.consumer_cmake }}
 
+      # jwlawson's old CMake/ctest binaries are linked against libidn.so.11,
+      # which Ubuntu dropped after focal; pull just that runtime lib from the
+      # focal archive since noble no longer ships it.
+      - name: Install libidn11 for old ctest binary
+        if: matrix.consumer_cmake != 'latest'
+        run: |
+          echo "deb http://archive.ubuntu.com/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/focal.list
+          sudo apt-get update
+          sudo apt-get install -y libidn11
+          sudo rm /etc/apt/sources.list.d/focal.list
+          sudo apt-get update
+
       - name: Consume shared package component
         run: >-
           ctest --build-and-test cmake/tests/package consume-shared

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,28 +436,23 @@ jobs:
       - name: Install Ninja
         run: sudo apt-get update && sudo apt-get install -y libgmp-dev ninja-build
 
-      - name: Build shared and static libraries
+      - name: Build and install shared library
         run: |
-          cmake -S . -B build-shared -G Ninja \
+          cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=ON \
-            -DZ3_BUILD_EXECUTABLE=ON \
-            -DZ3_BUILD_TEST_EXECUTABLES=OFF \
-            -DZ3_ENABLE_EXAMPLE_TARGETS=OFF
-          cmake --build build-shared --target libz3 shell
-          cmake -S . -B build-static -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DBUILD_SHARED_LIBS=OFF \
             -DZ3_USE_LIB_GMP=ON \
             -DZ3_BUILD_EXECUTABLE=ON \
             -DZ3_BUILD_TEST_EXECUTABLES=OFF \
             -DZ3_ENABLE_EXAMPLE_TARGETS=OFF
-          cmake --build build-static --target libz3 shell
+          cmake --build build --target libz3 shell
+          cmake --install build --prefix "$PWD/install"
 
-      - name: Co-install both library variants
+      - name: Reconfigure in-place and build and install static library
         run: |
-          cmake --install build-shared --prefix "$PWD/install"
-          cmake --install build-static --prefix "$PWD/install"
+          cmake -S . -B build -DBUILD_SHARED_LIBS=OFF
+          cmake --build build --target libz3 shell
+          cmake --install build --prefix "$PWD/install"
 
       - name: Setup consumer CMake
         uses: jwlawson/actions-setup-cmake@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,87 @@ jobs:
         if: matrix.runTests
         run: python z3test/scripts/test_benchmarks.py build/z3 z3test/regressions/smt2
 
+  cmake-package:
+    name: "CMake package - ${{ matrix.name }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build_cmake: 3.16
+            consumer_cmake: 3.5
+            name: minimum builder and consumer
+          - build_cmake: latest
+            consumer_cmake: latest
+            name: latest CMake
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7.0.1
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: ${{ matrix.build_cmake }}
+
+      - name: Install Ninja
+        run: sudo apt-get update && sudo apt-get install -y libgmp-dev ninja-build
+
+      - name: Build shared and static libraries
+        run: |
+          cmake -S . -B build-shared -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
+            -DZ3_BUILD_EXECUTABLE=ON \
+            -DZ3_BUILD_TEST_EXECUTABLES=OFF \
+            -DZ3_ENABLE_EXAMPLE_TARGETS=OFF
+          cmake --build build-shared --target libz3 shell
+          cmake -S . -B build-static -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DZ3_USE_LIB_GMP=ON \
+            -DZ3_BUILD_EXECUTABLE=ON \
+            -DZ3_BUILD_TEST_EXECUTABLES=OFF \
+            -DZ3_ENABLE_EXAMPLE_TARGETS=OFF
+          cmake --build build-static --target libz3 shell
+
+      - name: Co-install both library variants
+        run: |
+          cmake --install build-shared --prefix "$PWD/install"
+          cmake --install build-static --prefix "$PWD/install"
+
+      - name: Setup consumer CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: ${{ matrix.consumer_cmake }}
+
+      - name: Consume shared package component
+        run: >-
+          ctest --build-and-test cmake/tests/package consume-shared
+          --build-generator Ninja
+          --build-options
+          -DZ3_TEST_COMPONENT=shared
+          -DZ3_TEST_CONFLICTING_COMPONENT=static
+          -DZ3_TEST_EXPECTED_TYPE=SHARED_LIBRARY
+          -DCMAKE_PREFIX_PATH=$PWD/install
+          --test-command ctest --output-on-failure
+
+      - name: Consume static package component
+        run: >-
+          ctest --build-and-test cmake/tests/package consume-static
+          --build-generator Ninja
+          --build-options
+          -DZ3_TEST_COMPONENT=static
+          -DZ3_TEST_CONFLICTING_COMPONENT=shared
+          -DZ3_TEST_EXPECTED_TYPE=STATIC_LIBRARY
+          -DCMAKE_PREFIX_PATH=$PWD/install
+          --test-command ctest --output-on-failure
+
   # ============================================================================
   # macOS Python Builds
   # ============================================================================

--- a/cmake/tests/package/CMakeLists.txt
+++ b/cmake/tests/package/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(Z3_PACKAGE_TEST LANGUAGES CXX)
+
+set(Z3_TEST_COMPONENT "" CACHE STRING
+  "Z3 package component to request (static or shared)")
+set(Z3_TEST_EXPECTED_TYPE "" CACHE STRING
+  "Expected type of the imported z3::libz3 target")
+set(Z3_TEST_CONFLICTING_COMPONENT "" CACHE STRING
+  "Opposite Z3 package component that should be rejected")
+
+if (Z3_TEST_COMPONENT)
+  find_package(Z3 REQUIRED CONFIG COMPONENTS "${Z3_TEST_COMPONENT}")
+else()
+  find_package(Z3 REQUIRED CONFIG)
+endif()
+
+if (NOT TARGET z3::libz3)
+  message(FATAL_ERROR "The Z3 package did not define z3::libz3")
+endif()
+
+if (Z3_TEST_CONFLICTING_COMPONENT)
+  get_target_property(_z3_initial_type z3::libz3 TYPE)
+  find_package(Z3 QUIET CONFIG COMPONENTS
+    "${Z3_TEST_CONFLICTING_COMPONENT}")
+  if (Z3_FOUND)
+    message(FATAL_ERROR
+      "Z3 accepted conflicting package component "
+      "`${Z3_TEST_CONFLICTING_COMPONENT}`")
+  endif()
+  get_target_property(_z3_type_after_conflict z3::libz3 TYPE)
+  if (NOT _z3_type_after_conflict STREQUAL _z3_initial_type)
+    message(FATAL_ERROR "A conflicting package request replaced z3::libz3")
+  endif()
+endif()
+if (Z3_TEST_EXPECTED_TYPE)
+  get_target_property(_z3_actual_type z3::libz3 TYPE)
+  if (NOT _z3_actual_type STREQUAL Z3_TEST_EXPECTED_TYPE)
+    message(FATAL_ERROR
+      "Expected z3::libz3 to be ${Z3_TEST_EXPECTED_TYPE}, "
+      "but it is ${_z3_actual_type}")
+  endif()
+  if (_z3_actual_type STREQUAL "SHARED_LIBRARY" AND NOT Z3_SHARED_LIBS)
+    message(FATAL_ERROR "The shared package did not set Z3_SHARED_LIBS")
+  elseif (_z3_actual_type STREQUAL "STATIC_LIBRARY" AND Z3_SHARED_LIBS)
+    message(FATAL_ERROR "The static package set Z3_SHARED_LIBS")
+  endif()
+endif()
+
+add_executable(z3_package_test package_test.cpp)
+target_link_libraries(z3_package_test PRIVATE z3::libz3)
+
+enable_testing()
+add_test(NAME z3_package_test COMMAND z3_package_test)

--- a/cmake/tests/package/package_test.cpp
+++ b/cmake/tests/package/package_test.cpp
@@ -1,0 +1,9 @@
+#include <z3++.h>
+
+int main() {
+    z3::context context;
+    z3::solver solver(context);
+    z3::expr value = context.bool_const("value");
+    solver.add(value);
+    return solver.check() == z3::sat ? 0 : 1;
+}


### PR DESCRIPTION
A common pitfall with CMake is that declaring `cmake_minimum_required` does not guarantee compatibility with the stated version. The reason is that it's a _backwards-compatibility_ setting, not a _forwards-compatibility_ one. For instance, you can set `cmake_minimum_required(VERSION 3.16)` and then use a generator expression introduced in a newer version, and it will silently break compatibility with 3.16. Newer versions can run builds authored with older versions, but not vice versa. Therefore, one must test the build with the stated version in CI to ensure compatibility.

This PR adds a workflow to test package building at the promised minimum (currently 3.16) and consuming at the consumer minimum (via `find_package`, currently 3.5). It also tests the shared and static package variants to ensure the loading logic is correct.

I had wanted to add this to #10717 but it was merged too quickly 🙂