### PR TITLE
[CMake] Silence redundant status messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,7 +604,6 @@ if (Z3_BUILD_LIBZ3_CORE)
         ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
         ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
       COMMENT "Generating \"${dll_module_exports_file}\""
-      USES_TERMINAL
       VERBATIM
     )
     target_sources(libz3 PRIVATE "${dll_module_exports_file}")

--- a/cmake/z3_add_component.cmake
+++ b/cmake/z3_add_component.cmake
@@ -85,7 +85,6 @@ function(z3_add_component component_name)
               ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
       COMMENT "Generating \"${_full_output_file_path}\" from \"${pyg_file}\""
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-      USES_TERMINAL
       VERBATIM
     )
     list(APPEND _list_generated_headers "${_full_output_file_path}")
@@ -217,7 +216,6 @@ function(z3_generate_registration target)
       ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
       "${_install_tactic_deps}"
     COMMENT "Generating \"${CMAKE_CURRENT_BINARY_DIR}/install_tactic.cpp\""
-    USES_TERMINAL
     VERBATIM)
 
   add_custom_command(OUTPUT
@@ -231,7 +229,6 @@ function(z3_generate_registration target)
       "${_mem_init_finalizer_headers}"
     COMMENT "Generating \"${CMAKE_CURRENT_BINARY_DIR}/mem_initializer.cpp\""
     COMMAND_EXPAND_LISTS
-    USES_TERMINAL
     VERBATIM)
 
   add_custom_command(OUTPUT
@@ -246,7 +243,6 @@ function(z3_generate_registration target)
     COMMENT
       "Generating \"${CMAKE_CURRENT_BINARY_DIR}/gparams_register_modules.cpp\""
     COMMAND_EXPAND_LISTS
-    USES_TERMINAL
     VERBATIM)
 
   target_sources("${target}" PRIVATE

--- a/scripts/mk_consts_files.py
+++ b/scripts/mk_consts_files.py
@@ -12,7 +12,7 @@ import sys
 
 
 def main(args):
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.WARNING)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("api_files", nargs="+")
     parser.add_argument("--z3py-output-dir", dest="z3py_output_dir", default=None)

--- a/scripts/mk_def_file.py
+++ b/scripts/mk_def_file.py
@@ -13,7 +13,7 @@ import os
 import sys
 
 def main(args):
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.WARNING)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("output_file", help="output def file path")
     parser.add_argument("dllname", help="dllname to use in def file")
@@ -33,4 +33,3 @@ def main(args):
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))
-

--- a/scripts/mk_gparams_register_modules_cpp.py
+++ b/scripts/mk_gparams_register_modules_cpp.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 def main(args):
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.WARNING)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("destination_dir", help="destination directory")
     parser.add_argument("header_files", nargs="+",
@@ -37,4 +37,3 @@ def main(args):
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))
-

--- a/scripts/mk_install_tactic_cpp.py
+++ b/scripts/mk_install_tactic_cpp.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 def main(args):
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.WARNING)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("destination_dir", help="destination directory")
     parser.add_argument("deps", help="file with header file names to parse")

--- a/scripts/mk_mem_initializer_cpp.py
+++ b/scripts/mk_mem_initializer_cpp.py
@@ -14,7 +14,7 @@ import os
 import sys
 
 def main(args):
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.WARNING)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("destination_dir", help="destination directory")
     parser.add_argument("header_files", nargs="+",
@@ -37,4 +37,3 @@ def main(args):
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))
-

--- a/scripts/mk_pat_db.py
+++ b/scripts/mk_pat_db.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 def main(args):
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.WARNING)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("db_file", help="pattern database file")
     parser.add_argument("output_file", help="output header file path")
@@ -26,4 +26,3 @@ def main(args):
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))
-

--- a/scripts/pyg2hpp.py
+++ b/scripts/pyg2hpp.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 def main(args):
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.WARNING)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("pyg_file", help="pyg file")
     parser.add_argument("destination_dir", help="destination directory")
@@ -33,4 +33,3 @@ def main(args):
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))
-

--- a/scripts/update_api.py
+++ b/scripts/update_api.py
@@ -22,7 +22,7 @@ import re
 import os
 import sys
 
-VERBOSE = True
+VERBOSE = False
 def is_verbose():
     return VERBOSE
 
@@ -2060,7 +2060,6 @@ def generate_files(api_files,
       return open(os.path.join(output_dir, file_name), mode)
     else:
       # Return a file that we can write to without caring
-      print("Faking emission of '{}'".format(file_name))
       import tempfile
       return tempfile.TemporaryFile(mode=mode)
 
@@ -2086,7 +2085,8 @@ def generate_files(api_files,
             print("Generated '{}'".format(log_h.name))
             print("Generated '{}'".format(log_c.name))
             print("Generated '{}'".format(exe_c.name))
-            print("Generated '{}'".format(core_py.name))
+            if z3py_output_dir:
+              print("Generated '{}'".format(core_py.name))
 
   if dotnet_output_dir:
     with open(os.path.join(dotnet_output_dir, 'Native.cs'), 'w') as dotnet_file:

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -27,7 +27,6 @@ add_custom_command(OUTPUT ${generated_files}
           ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
           ${Z3_FULL_PATH_API_HEADER_FILES_TO_SCAN}
   COMMENT "Generating ${generated_files}"
-  USES_TERMINAL
   VERBATIM
 )
 

--- a/src/api/dotnet/CMakeLists.txt
+++ b/src/api/dotnet/CMakeLists.txt
@@ -19,7 +19,6 @@ add_custom_command(OUTPUT "${Z3_DOTNET_NATIVE_FILE}"
     "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
   COMMENT "Generating ${Z3_DOTNET_NATIVE_FILE}"
-  USES_TERMINAL
 )
 
 # Generate Enumerations.cs
@@ -35,7 +34,6 @@ add_custom_command(OUTPUT "${Z3_DOTNET_CONST_FILE}"
     "${PROJECT_SOURCE_DIR}/scripts/mk_consts_files.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
   COMMENT "Generating ${Z3_DOTNET_CONST_FILE}"
-  USES_TERMINAL
 )
 
 set(Z3_DOTNET_ASSEMBLY_SOURCES_IN_SRC_TREE
@@ -195,4 +193,3 @@ if(Z3_INSTALL_DOTNET_BINDINGS)
 #  set(PREFIX "${CMAKE_INSTALL_PREFIX}")
 #  set(VERSION "${Z3_VERSION}")
 endif()
-

--- a/src/api/java/CMakeLists.txt
+++ b/src/api/java/CMakeLists.txt
@@ -30,7 +30,6 @@ add_custom_command(OUTPUT "${Z3_JAVA_NATIVE_JAVA}" "${Z3_JAVA_NATIVE_CPP}"
     "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
   COMMENT "Generating \"${Z3_JAVA_NATIVE_JAVA}\" and \"${Z3_JAVA_NATIVE_CPP}\""
-  USES_TERMINAL
 )
 
 # Add rule to build native code that provides a bridge between
@@ -94,7 +93,6 @@ add_custom_command(OUTPUT ${Z3_JAVA_ENUMERATION_PACKAGE_FILES_FULL_PATH}
     "${PROJECT_SOURCE_DIR}/scripts/mk_consts_files.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
   COMMENT "Generating ${Z3_JAVA_PACKAGE_NAME}.enumerations package"
-  USES_TERMINAL
 )
 
 set(Z3_JAVA_JAR_SOURCE_FILES

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -52,7 +52,6 @@ add_custom_command(OUTPUT "${z3py_bindings_build_dest}/z3/z3core.py"
     "${PROJECT_SOURCE_DIR}/scripts/update_api.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
   COMMENT "Generating z3core.py"
-  USES_TERMINAL
 )
 list(APPEND build_z3_python_bindings_target_depends "${z3py_bindings_build_dest}/z3/z3core.py")
 
@@ -68,7 +67,6 @@ add_custom_command(OUTPUT "${z3py_bindings_build_dest}/z3/z3consts.py"
     "${PROJECT_SOURCE_DIR}/scripts/mk_consts_files.py"
     ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
   COMMENT "Generating z3consts.py"
-  USES_TERMINAL
 )
 list(APPEND build_z3_python_bindings_target_depends "${z3py_bindings_build_dest}/z3/z3consts.py")
 

--- a/src/ast/pattern/CMakeLists.txt
+++ b/src/ast/pattern/CMakeLists.txt
@@ -15,7 +15,6 @@ add_custom_command(OUTPUT "database.h"
   DEPENDS "${PROJECT_SOURCE_DIR}/scripts/mk_pat_db.py"
           ${Z3_GENERATED_FILE_EXTRA_DEPENDENCIES}
   COMMENT "Generating \"database.h\""
-  USES_TERMINAL
   VERBATIM
 )
 

--- a/src/sat/smt/arith_diagnostics.cpp
+++ b/src/sat/smt/arith_diagnostics.cpp
@@ -209,8 +209,6 @@ namespace arith {
         case hint_type::nla_h:
             name = "nla";
             break;
-        default:
-            UNREACHABLE();
         }
 
         auto push_eq = [&](bool is_eq, enode* x, enode* y) {


### PR DESCRIPTION
The CMake build is pretty noisy by default. This PR adjusts log-levels and removes unnecessary `USES_TERMINAL` directives to allow a CMake-generated Ninja build to produce no additional output when the build succeeds.

After this PR, I see:

```console
$ cmake --build build
[906/906] Linking CXX executable z3
```

Ninja overwrites the previous status line when a command produces no output. But on `master`, I see this:

<details>
<summary>Overly verbose build output</summary>

```console
$ cmake --build build
[52/906] Generating "/Users/areinking/dev/z3/build/src/math/polynomial/algebraic_params.hpp" from "algebraic_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/math/polynomial/algebraic_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/math/polynomial/algebraic_params.hpp"
[58/906] Generating "/Users/areinking/dev/z3/build/src/math/realclosure/rcf_params.hpp" from "rcf_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/math/realclosure/rcf_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/math/realclosure/rcf_params.hpp"
[78/906] Generating "/Users/areinking/dev/z3/build/src/ast/pp_params.hpp" from "pp_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/ast/pp_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/ast/pp_params.hpp"
[136/906] Generating "/Users/areinking/dev/z3/build/src/params/arith_rewriter_params.hpp" from "arith_rewriter_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/arith_rewriter_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/arith_rewriter_params.hpp"
[137/906] Generating "/Users/areinking/dev/z3/build/src/params/array_rewriter_params.hpp" from "array_rewriter_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/array_rewriter_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/array_rewriter_params.hpp"
[138/906] Generating "/Users/areinking/dev/z3/build/src/params/bool_rewriter_params.hpp" from "bool_rewriter_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/bool_rewriter_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/bool_rewriter_params.hpp"
[139/906] Generating "/Users/areinking/dev/z3/build/src/params/bv_rewriter_params.hpp" from "bv_rewriter_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/bv_rewriter_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/bv_rewriter_params.hpp"
[140/906] Generating "/Users/areinking/dev/z3/build/src/params/fpa_rewriter_params.hpp" from "fpa_rewriter_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/fpa_rewriter_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/fpa_rewriter_params.hpp"
[141/906] Generating "/Users/areinking/dev/z3/build/src/params/fpa2bv_rewriter_params.hpp" from "fpa2bv_rewriter_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/fpa2bv_rewriter_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/fpa2bv_rewriter_params.hpp"
[142/906] Generating "/Users/areinking/dev/z3/build/src/params/pattern_inference_params_helper.hpp" from "pattern_inference_params_helper.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/pattern_inference_params_helper.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/pattern_inference_params_helper.hpp"
[143/906] Generating "/Users/areinking/dev/z3/build/src/params/poly_rewriter_params.hpp" from "poly_rewriter_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/poly_rewriter_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/poly_rewriter_params.hpp"
[144/906] Generating "/Users/areinking/dev/z3/build/src/params/rewriter_params.hpp" from "rewriter_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/rewriter_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/rewriter_params.hpp"
[145/906] Generating "/Users/areinking/dev/z3/build/src/params/sat_params.hpp" from "sat_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/sat_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/sat_params.hpp"
[146/906] Generating "/Users/areinking/dev/z3/build/src/params/seq_rewriter_params.hpp" from "seq_rewriter_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/seq_rewriter_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/seq_rewriter_params.hpp"
[147/906] Generating "/Users/areinking/dev/z3/build/src/params/sls_params.hpp" from "sls_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/sls_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/sls_params.hpp"
[148/906] Generating "/Users/areinking/dev/z3/build/src/params/smt_params_helper.hpp" from "smt_params_helper.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/smt_params_helper.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/smt_params_helper.hpp"
[149/906] Generating "/Users/areinking/dev/z3/build/src/params/solver_params.hpp" from "solver_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/solver_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/solver_params.hpp"
[150/906] Generating "/Users/areinking/dev/z3/build/src/params/tactic_params.hpp" from "tactic_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/tactic_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/tactic_params.hpp"
[151/906] Generating "/Users/areinking/dev/z3/build/src/params/tptp.hpp" from "tptp.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/params/tptp.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/params/tptp.hpp"
[219/906] Generating "/Users/areinking/dev/z3/build/src/parsers/util/parser_params.hpp" from "parser_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/parsers/util/parser_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/parsers/util/parser_params.hpp"
[225/906] Generating "/Users/areinking/dev/z3/build/src/sat/sat_asymm_branch_params.hpp" from "sat_asymm_branch_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/sat/sat_asymm_branch_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/sat/sat_asymm_branch_params.hpp"
[229/906] Generating "/Users/areinking/dev/z3/build/src/ast/normal_forms/nnf_params.hpp" from "nnf_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/ast/normal_forms/nnf_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/ast/normal_forms/nnf_params.hpp"
[230/906] Generating "/Users/areinking/dev/z3/build/src/model/model_evaluator_params.hpp" from "model_evaluator_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/model/model_evaluator_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/model/model_evaluator_params.hpp"
[236/906] Generating "/Users/areinking/dev/z3/build/src/model/model_params.hpp" from "model_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/model/model_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/model/model_params.hpp"
[243/906] Generating "/Users/areinking/dev/z3/build/src/sat/sat_scc_params.hpp" from "sat_scc_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/sat/sat_scc_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/sat/sat_scc_params.hpp"
[244/906] Generating "/Users/areinking/dev/z3/build/src/sat/sat_simplifier_params.hpp" from "sat_simplifier_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/sat/sat_simplifier_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/sat/sat_simplifier_params.hpp"
[362/906] Generating "/Users/areinking/dev/z3/build/src/solver/combined_solver_params.hpp" from "combined_solver_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/solver/combined_solver_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/solver/combined_solver_params.hpp"
[366/906] Generating "/Users/areinking/dev/z3/build/src/solver/parallel_params.hpp" from "parallel_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/solver/parallel_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/solver/parallel_params.hpp"
[369/906] Generating "/Users/areinking/dev/z3/build/src/nlsat/nlsat_params.hpp" from "nlsat_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/nlsat/nlsat_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/nlsat/nlsat_params.hpp"
[380/906] Building CXX object src/sat/smt/CMakeFiles/sat_smt.dir/arith_diagnostics.cpp.o
/Users/areinking/dev/z3/src/sat/smt/arith_diagnostics.cpp:212:9: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]
  212 |         default:
      |         ^
1 warning generated.
[421/906] Generating "/Users/areinking/dev/z3/build/src/math/lp/lp_params_helper.hpp" from "lp_params_helper.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/math/lp/lp_params_helper.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/math/lp/lp_params_helper.hpp"
[532/906] Generating "/Users/areinking/dev/z3/build/src/ackermannization/ackermannization_params.hpp" from "ackermannization_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/ackermannization/ackermannization_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/ackermannization/ackermannization_params.hpp"
[536/906] Generating "database.h"
INFO:root:Generated "/Users/areinking/dev/z3/build/src/ast/pattern/database.h"
[630/906] Generating "/Users/areinking/dev/z3/build/src/ackermannization/ackermannize_bv_tactic_params.hpp" from "ackermannize_bv_tactic_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/ackermannization/ackermannize_bv_tactic_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/ackermannization/ackermannize_bv_tactic_params.hpp"
[701/906] Generating "/Users/areinking/dev/z3/build/src/muz/base/fp_params.hpp" from "fp_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/muz/base/fp_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/muz/base/fp_params.hpp"
[807/906] Generating "/Users/areinking/dev/z3/build/src/tactic/smtlogics/qfufbv_tactic_params.hpp" from "qfufbv_tactic_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/tactic/smtlogics/qfufbv_tactic_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/tactic/smtlogics/qfufbv_tactic_params.hpp"
[826/906] Generating "/Users/areinking/dev/z3/build/src/opt/opt_params.hpp" from "opt_params.pyg"
INFO:root:Using /Users/areinking/dev/z3/src/opt/opt_params.pyg
INFO:root:Generated "/Users/areinking/dev/z3/build/src/opt/opt_params.hpp"
[849/906] Generating api_commands.cpp;api_log_macros.cpp;api_log_macros.h
Faking emission of 'z3/z3core.py'
Generated '/Users/areinking/dev/z3/build/src/api/api_log_macros.h'
Generated '/Users/areinking/dev/z3/build/src/api/api_log_macros.cpp'
Generated '/Users/areinking/dev/z3/build/src/api/api_commands.cpp'
Generated '6'
[883/906] Generating "/Users/areinking/dev/z3/build/src/api/dll/gparams_register_modules.cpp"
INFO:root:Generated "/Users/areinking/dev/z3/build/src/api/dll/gparams_register_modules.cpp"
[884/906] Generating "/Users/areinking/dev/z3/build/src/api/dll/install_tactic.cpp"
INFO:root:Generated "/Users/areinking/dev/z3/build/src/api/dll/install_tactic.cpp"
[885/906] Generating "/Users/areinking/dev/z3/build/src/api/dll/mem_initializer.cpp"
INFO:root:Generated "/Users/areinking/dev/z3/build/src/api/dll/mem_initializer.cpp"
[886/906] Generating "/Users/areinking/dev/z3/build/src/shell/gparams_register_modules.cpp"
INFO:root:Generated "/Users/areinking/dev/z3/build/src/shell/gparams_register_modules.cpp"
[888/906] Generating "/Users/areinking/dev/z3/build/src/shell/install_tactic.cpp"
INFO:root:Generated "/Users/areinking/dev/z3/build/src/shell/install_tactic.cpp"
[889/906] Generating "/Users/areinking/dev/z3/build/src/shell/mem_initializer.cpp"
INFO:root:Generated "/Users/areinking/dev/z3/build/src/shell/mem_initializer.cpp"
[906/906] Linking CXX executable z3
```
</details>

The countless `INFO:root:...` lines just name the same files as the `COMMENT` lines Ninja outputs regardless. The "Faking emission of 'z3/z3core.py'" line reads like a problem, but is benign. The only code change is to silence this warning:

```
[380/906] Building CXX object src/sat/smt/CMakeFiles/sat_smt.dir/arith_diagnostics.cpp.o
/Users/areinking/dev/z3/src/sat/smt/arith_diagnostics.cpp:212:9: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]
  212 |         default:
      |         ^
1 warning generated.
```