### PR TITLE
Add associative and sequence EUF plugins

### DIFF
--- a/src/ast/euf/CMakeLists.txt
+++ b/src/ast/euf/CMakeLists.txt
@@ -1,6 +1,7 @@
 z3_add_component(euf
   SOURCES
     euf_ac_plugin.cpp
+    euf_assoc_plugin.cpp
     euf_arith_plugin.cpp
     euf_bv_plugin.cpp
     euf_egraph.cpp

--- a/src/ast/euf/CMakeLists.txt
+++ b/src/ast/euf/CMakeLists.txt
@@ -10,6 +10,7 @@ z3_add_component(euf
     euf_justification.cpp
     euf_mam.cpp
     euf_plugin.cpp
+    euf_seq_plugin.cpp
     euf_specrel_plugin.cpp
     ho_matcher.cpp
   COMPONENT_DEPENDENCIES

--- a/src/ast/euf/euf_assoc_plugin.cpp
+++ b/src/ast/euf/euf_assoc_plugin.cpp
@@ -158,7 +158,7 @@ namespace euf {
         int n1 = static_cast<int>(lhs1.size());
         int n2 = static_cast<int>(lhs2.size());
         for (int offset = 1 - n2; offset < n1; ++offset) {
-            if (m_stats.m_num_superpositions >= m_max_superpositions)
+            if (m_num_superpositions >= m_max_superpositions)
                 return;
             int begin = std::max(0, offset);
             int end = std::min(n1, offset + n2);
@@ -167,6 +167,7 @@ namespace euf {
                 overlaps = lhs1[i]->get_root() == lhs2[i - offset]->get_root();
             if (!overlaps)
                 continue;
+            ++m_num_superpositions;
             ++m_stats.m_num_superpositions;
             int first = std::min(0, offset);
             int last = std::max(n1, offset + n2);
@@ -187,9 +188,9 @@ namespace euf {
 
     void assoc_plugin::complete() {
         while (m_completion_head < m_rules.size() &&
-               m_stats.m_num_superpositions < m_max_superpositions) {
+               m_num_superpositions < m_max_superpositions) {
             unsigned i = m_completion_head++;
-            for (unsigned j = 0; j <= i && m_stats.m_num_superpositions < m_max_superpositions; ++j)
+            for (unsigned j = 0; j <= i && m_num_superpositions < m_max_superpositions; ++j)
                 add_overlaps(m_rules[i], m_rules[j]);
         }
     }
@@ -214,6 +215,7 @@ namespace euf {
     }
 
     void assoc_plugin::push_scope_eh() {
+        m_superposition_lim.push_back(m_num_superpositions);
         push_undo(undo_kind::is_push_scope);
     }
 
@@ -236,6 +238,8 @@ namespace euf {
             m_completion_head = std::min(m_completion_head, m_rules.size());
             break;
         case undo_kind::is_push_scope:
+            m_num_superpositions = m_superposition_lim.back();
+            m_superposition_lim.pop_back();
             break;
         }
     }

--- a/src/ast/euf/euf_assoc_plugin.cpp
+++ b/src/ast/euf/euf_assoc_plugin.cpp
@@ -1,0 +1,286 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+Module Name:
+
+    euf_assoc_plugin.cpp
+
+Abstract:
+
+    Completion plugin for associative functions.
+
+--*/
+
+#include "ast/euf/euf_assoc_plugin.h"
+#include "ast/euf/euf_egraph.h"
+
+namespace euf {
+
+    assoc_plugin::assoc_plugin(egraph& g, theory_id fid):
+        plugin(g),
+        m_fid(fid),
+        m_dep_manager(get_region()) {
+    }
+
+    void assoc_plugin::set_completion_limits(
+        unsigned max_rules, unsigned max_superpositions,
+        unsigned max_word_size, unsigned max_rewrite_steps) {
+        m_max_rules = max_rules;
+        m_max_superpositions = max_superpositions;
+        m_max_word_size = max_word_size;
+        m_max_rewrite_steps = max_rewrite_steps;
+    }
+
+    void assoc_plugin::push_undo(undo_kind k) {
+        m_undo.push_back(k);
+        push_plugin_undo(get_id());
+        if (m_undo_notify)
+            m_undo_notify();
+    }
+
+    void assoc_plugin::flatten(enode* n, word& w) const {
+        if (is_assoc(n)) {
+            for (auto* arg : enode_args(n))
+                flatten(arg, w);
+        }
+        else {
+            w.push_back(n);
+        }
+    }
+
+    bool assoc_plugin::equal(word const& a, word const& b) const {
+        if (a.size() != b.size())
+            return false;
+        for (unsigned i = 0; i < a.size(); ++i)
+            if (a[i]->get_root() != b[i]->get_root())
+                return false;
+        return true;
+    }
+
+    bool assoc_plugin::match(word const& w, unsigned offset, word const& pattern) const {
+        if (offset + pattern.size() > w.size())
+            return false;
+        for (unsigned i = 0; i < pattern.size(); ++i)
+            if (w[offset + i]->get_root() != pattern[i]->get_root())
+                return false;
+        return true;
+    }
+
+    int assoc_plugin::compare(word const& a, word const& b) const {
+        unsigned a_vars = 0, b_vars = 0, a_units = 0, b_units = 0;
+        for (auto* n : a) {
+            a_vars += is_variable(n);
+            a_units += is_unit(n);
+        }
+        for (auto* n : b) {
+            b_vars += is_variable(n);
+            b_units += is_unit(n);
+        }
+        if (a_vars != b_vars)
+            return a_vars > b_vars ? 1 : -1;
+        if (a_units != b_units)
+            return a_units > b_units ? 1 : -1;
+        unsigned sz = std::min(a.size(), b.size());
+        for (unsigned i = 0; i < sz; ++i) {
+            unsigned ai = a[i]->get_root()->get_id();
+            unsigned bi = b[i]->get_root()->get_id();
+            if (ai != bi)
+                return ai > bi ? 1 : -1;
+        }
+        if (a.size() == b.size())
+            return 0;
+        return a.size() > b.size() ? 1 : -1;
+    }
+
+    bool assoc_plugin::orient(word& lhs, word& rhs) const {
+        int c = compare(lhs, rhs);
+        if (c == 0)
+            return false;
+        if (c < 0)
+            std::swap(lhs, rhs);
+        return true;
+    }
+
+    justification assoc_plugin::join(justification j1, justification j2) {
+        auto* d1 = m_dep_manager.mk_leaf(j1);
+        auto* d2 = m_dep_manager.mk_leaf(j2);
+        return justification::dependent(m_dep_manager.mk_join(d1, d2));
+    }
+
+    bool assoc_plugin::reduce(word& w, justification& j, rule const* except) {
+        bool changed = false;
+        unsigned steps = 0;
+        while (steps++ < m_max_rewrite_steps) {
+            bool reduced = false;
+            for (auto const& r : m_rules) {
+                if (&r == except || r.lhs.empty() || r.lhs.size() > w.size())
+                    continue;
+                for (unsigned i = 0; i + r.lhs.size() <= w.size(); ++i) {
+                    if (!match(w, i, r.lhs))
+                        continue;
+                    word next;
+                    next.append(i, w.data());
+                    next.append(r.rhs);
+                    next.append(w.size() - i - r.lhs.size(), w.data() + i + r.lhs.size());
+                    w.swap(next);
+                    j = join(j, r.j);
+                    changed = reduced = true;
+                    break;
+                }
+                if (reduced)
+                    break;
+            }
+            if (!reduced)
+                break;
+        }
+        return changed;
+    }
+
+    bool assoc_plugin::add_rule(word lhs, word rhs, justification j) {
+        reduce(lhs, j);
+        reduce(rhs, j);
+        if (!orient(lhs, rhs) || lhs.empty() || lhs.size() > m_max_word_size || rhs.size() > m_max_word_size)
+            return false;
+        for (auto const& r : m_rules)
+            if (equal(lhs, r.lhs) && equal(rhs, r.rhs))
+                return false;
+        if (m_rules.size() >= m_max_rules)
+            return false;
+        m_rules.push_back({ std::move(lhs), std::move(rhs), j });
+        ++m_stats.m_num_rules;
+        push_undo(undo_kind::is_add_rule);
+        return true;
+    }
+
+    void assoc_plugin::add_overlaps(rule const& r1, rule const& r2) {
+        word lhs1(r1.lhs), rhs1(r1.rhs), lhs2(r2.lhs), rhs2(r2.rhs);
+        justification j1 = r1.j, j2 = r2.j;
+        int n1 = static_cast<int>(lhs1.size());
+        int n2 = static_cast<int>(lhs2.size());
+        for (int offset = 1 - n2; offset < n1; ++offset) {
+            if (m_stats.m_num_superpositions >= m_max_superpositions)
+                return;
+            int begin = std::max(0, offset);
+            int end = std::min(n1, offset + n2);
+            bool overlaps = begin < end;
+            for (int i = begin; overlaps && i < end; ++i)
+                overlaps = lhs1[i]->get_root() == lhs2[i - offset]->get_root();
+            if (!overlaps)
+                continue;
+            ++m_stats.m_num_superpositions;
+            int first = std::min(0, offset);
+            int last = std::max(n1, offset + n2);
+            word left, right;
+            for (int i = first; i < 0; ++i)
+                left.push_back(lhs2[i - offset]);
+            left.append(rhs1);
+            for (int i = n1; i < last; ++i)
+                left.push_back(lhs2[i - offset]);
+            for (int i = first; i < offset; ++i)
+                right.push_back(lhs1[i]);
+            right.append(rhs2);
+            for (int i = offset + n2; i < last; ++i)
+                right.push_back(lhs1[i]);
+            add_rule(std::move(left), std::move(right), join(j1, j2));
+        }
+    }
+
+    void assoc_plugin::complete() {
+        while (m_completion_head < m_rules.size() &&
+               m_stats.m_num_superpositions < m_max_superpositions) {
+            unsigned i = m_completion_head++;
+            for (unsigned j = 0; j <= i && m_stats.m_num_superpositions < m_max_superpositions; ++j)
+                add_overlaps(m_rules[i], m_rules[j]);
+        }
+    }
+
+    void assoc_plugin::register_node(enode* n) {
+        if ((!is_assoc(n) && !is_variable(n) && !is_unit(n)) ||
+            m_is_shared.get(n->get_id(), false))
+            return;
+        word w;
+        flatten(n, w);
+        m_is_shared.reserve(n->get_id() + 1, false);
+        m_is_shared[n->get_id()] = true;
+        m_shared.push_back({ n, std::move(w) });
+        push_undo(undo_kind::is_register_shared);
+    }
+
+    void assoc_plugin::merge_eh(enode* n1, enode* n2) {
+        if (n1 == n2)
+            return;
+        m_queued.push_back({ n1, n2 });
+        push_undo(undo_kind::is_queue_eq);
+    }
+
+    void assoc_plugin::push_scope_eh() {
+        push_undo(undo_kind::is_push_scope);
+    }
+
+    void assoc_plugin::undo() {
+        undo_kind k = m_undo.back();
+        m_undo.pop_back();
+        switch (k) {
+        case undo_kind::is_queue_eq:
+            m_queued.pop_back();
+            m_queue_head = std::min(m_queue_head, m_queued.size());
+            break;
+        case undo_kind::is_register_shared: {
+            auto const& s = m_shared.back();
+            m_is_shared[s.n->get_id()] = false;
+            m_shared.pop_back();
+            break;
+        }
+        case undo_kind::is_add_rule:
+            m_rules.pop_back();
+            m_completion_head = std::min(m_completion_head, m_rules.size());
+            break;
+        case undo_kind::is_push_scope:
+            break;
+        }
+    }
+
+    void assoc_plugin::propagate_shared() {
+        for (unsigned i = 0; i < m_shared.size(); ++i) {
+            word wi(m_shared[i].w);
+            justification ji = justification::axiom(get_id());
+            reduce(wi, ji);
+            for (unsigned j = 0; j < i; ++j) {
+                word wj(m_shared[j].w);
+                justification jj = justification::axiom(get_id());
+                reduce(wj, jj);
+                if (equal(wi, wj))
+                    push_merge(m_shared[i].n, m_shared[j].n, join(ji, jj));
+            }
+        }
+    }
+
+    void assoc_plugin::propagate() {
+        while (m_queue_head < m_queued.size()) {
+            auto [lhs, rhs] = m_queued[m_queue_head++];
+            word l, r;
+            flatten(lhs, l);
+            flatten(rhs, r);
+            add_rule(std::move(l), std::move(r), justification::equality(lhs, rhs));
+        }
+        complete();
+        propagate_shared();
+    }
+
+    std::ostream& assoc_plugin::display(std::ostream& out) const {
+        for (auto const& r : m_rules) {
+            for (auto* n : r.lhs)
+                out << n->get_root()->get_id() << " ";
+            out << "-> ";
+            for (auto* n : r.rhs)
+                out << n->get_root()->get_id() << " ";
+            out << "\n";
+        }
+        return out;
+    }
+
+    void assoc_plugin::collect_statistics(statistics& st) const {
+        st.update("assoc rules", m_stats.m_num_rules);
+        st.update("assoc superpositions", m_stats.m_num_superpositions);
+    }
+}

--- a/src/ast/euf/euf_assoc_plugin.h
+++ b/src/ast/euf/euf_assoc_plugin.h
@@ -58,6 +58,8 @@ namespace euf {
         enode_pair_vector m_queued;
         bool_vector m_is_shared;
         svector<undo_kind> m_undo;
+        unsigned_vector m_superposition_lim;
+        unsigned m_num_superpositions = 0;
         unsigned m_queue_head = 0;
         unsigned m_completion_head = 0;
         unsigned m_max_rules = 64;

--- a/src/ast/euf/euf_assoc_plugin.h
+++ b/src/ast/euf/euf_assoc_plugin.h
@@ -1,0 +1,111 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+Module Name:
+
+    euf_assoc_plugin.h
+
+Abstract:
+
+    Completion plugin for associative functions.
+
+--*/
+
+#pragma once
+
+#include <functional>
+#include "ast/euf/euf_plugin.h"
+
+namespace euf {
+
+    class assoc_plugin : public plugin {
+    public:
+        using recognizer = std::function<bool(enode const*)>;
+
+    private:
+        using word = enode_vector;
+
+        struct rule {
+            word lhs;
+            word rhs;
+            justification j;
+        };
+
+        struct shared {
+            enode* n;
+            word w;
+        };
+
+        struct stats {
+            unsigned m_num_rules = 0;
+            unsigned m_num_superpositions = 0;
+        };
+
+        enum class undo_kind {
+            is_queue_eq,
+            is_register_shared,
+            is_add_rule,
+            is_push_scope
+        };
+
+        theory_id m_fid;
+        recognizer m_is_assoc;
+        recognizer m_is_variable;
+        recognizer m_is_unit;
+        justification::dependency_manager m_dep_manager;
+        vector<rule> m_rules;
+        vector<shared> m_shared;
+        enode_pair_vector m_queued;
+        bool_vector m_is_shared;
+        svector<undo_kind> m_undo;
+        unsigned m_queue_head = 0;
+        unsigned m_completion_head = 0;
+        unsigned m_max_rules = 64;
+        unsigned m_max_superpositions = 256;
+        unsigned m_max_word_size = 64;
+        unsigned m_max_rewrite_steps = 1024;
+        stats m_stats;
+        std::function<void(void)> m_undo_notify;
+
+        bool is_assoc(enode const* n) const { return m_is_assoc && m_is_assoc(n); }
+        bool is_variable(enode const* n) const { return m_is_variable && m_is_variable(n); }
+        bool is_unit(enode const* n) const { return m_is_unit && m_is_unit(n); }
+
+        void push_undo(undo_kind k);
+        void flatten(enode* n, word& w) const;
+        bool equal(word const& a, word const& b) const;
+        bool match(word const& w, unsigned offset, word const& pattern) const;
+        int compare(word const& a, word const& b) const;
+        bool orient(word& lhs, word& rhs) const;
+        justification join(justification j1, justification j2);
+        bool reduce(word& w, justification& j, rule const* except = nullptr);
+        bool add_rule(word lhs, word rhs, justification j);
+        void add_overlaps(rule const& r1, rule const& r2);
+        void complete();
+        void propagate_shared();
+
+    public:
+        assoc_plugin(egraph& g, theory_id fid);
+
+        theory_id get_id() const override { return m_fid; }
+
+        void register_associative(recognizer f) { m_is_assoc = std::move(f); }
+        void register_variable(recognizer f) { m_is_variable = std::move(f); }
+        void register_unit(recognizer f) { m_is_unit = std::move(f); }
+
+        void set_completion_limits(unsigned max_rules, unsigned max_superpositions,
+                                   unsigned max_word_size = 64, unsigned max_rewrite_steps = 1024);
+
+        unsigned num_rules() const { return m_rules.size(); }
+
+        void register_node(enode* n) override;
+        void merge_eh(enode* n1, enode* n2) override;
+        void undo() override;
+        void push_scope_eh() override;
+        void propagate() override;
+        std::ostream& display(std::ostream& out) const override;
+        void collect_statistics(statistics& st) const override;
+
+        void set_undo(std::function<void(void)> u) { m_undo_notify = std::move(u); }
+    };
+}

--- a/src/ast/euf/euf_seq_plugin.cpp
+++ b/src/ast/euf/euf_seq_plugin.cpp
@@ -1,0 +1,54 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+Module Name:
+
+    euf_seq_plugin.cpp
+
+Abstract:
+
+    EUF plugin for associative sequence concatenation.
+
+--*/
+
+#include "ast/euf/euf_seq_plugin.h"
+#include "ast/euf/euf_egraph.h"
+
+namespace euf {
+
+    seq_plugin::seq_plugin(egraph& g):
+        plugin(g),
+        m_seq(g.get_manager()),
+        m_concat(g, get_id()) {
+        m_concat.register_associative([this](enode const* n) { return is_concat(n); });
+        m_concat.register_variable([this](enode const* n) { return is_variable(n); });
+        m_concat.register_unit([this](enode const* n) { return is_unit(n); });
+    }
+
+    bool seq_plugin::is_concat(enode const* n) const {
+        return m_seq.str.is_concat(n->get_expr());
+    }
+
+    bool seq_plugin::is_unit(enode const* n) const {
+        expr* e = n->get_expr();
+        zstring value;
+        return m_seq.str.is_unit(e) || (m_seq.str.is_string(e, value) && !value.empty());
+    }
+
+    bool seq_plugin::is_variable(enode const* n) const {
+        expr* e = n->get_expr();
+        return m_seq.is_seq(e) && !is_concat(n) && !is_unit(n) && !m_seq.str.is_empty(e);
+    }
+
+    void seq_plugin::register_node(enode* n) {
+        m_concat.register_node(n);
+    }
+
+    void seq_plugin::merge_eh(enode* n1, enode* n2) {
+        m_concat.merge_eh(n1, n2);
+    }
+
+    void seq_plugin::undo() {
+        m_concat.undo();
+    }
+}

--- a/src/ast/euf/euf_seq_plugin.cpp
+++ b/src/ast/euf/euf_seq_plugin.cpp
@@ -32,7 +32,7 @@ namespace euf {
     bool seq_plugin::is_unit(enode const* n) const {
         expr* e = n->get_expr();
         zstring value;
-        return m_seq.str.is_unit(e) || (m_seq.str.is_string(e, value) && !value.empty());
+        return m_seq.str.is_unit(e) || (m_seq.str.is_string(e, value) && value.length() == 1);
     }
 
     bool seq_plugin::is_variable(enode const* n) const {

--- a/src/ast/euf/euf_seq_plugin.h
+++ b/src/ast/euf/euf_seq_plugin.h
@@ -1,0 +1,42 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+Module Name:
+
+    euf_seq_plugin.h
+
+Abstract:
+
+    EUF plugin for associative sequence concatenation.
+
+--*/
+
+#pragma once
+
+#include "ast/seq_decl_plugin.h"
+#include "ast/euf/euf_assoc_plugin.h"
+
+namespace euf {
+
+    class seq_plugin : public plugin {
+        seq_util m_seq;
+        assoc_plugin m_concat;
+
+        bool is_concat(enode const* n) const;
+        bool is_variable(enode const* n) const;
+        bool is_unit(enode const* n) const;
+
+    public:
+        seq_plugin(egraph& g);
+
+        theory_id get_id() const override { return m_seq.get_family_id(); }
+
+        void register_node(enode* n) override;
+        void merge_eh(enode* n1, enode* n2) override;
+        void undo() override;
+        void push_scope_eh() override { m_concat.push_scope_eh(); }
+        void propagate() override { m_concat.propagate(); }
+        std::ostream& display(std::ostream& out) const override { return m_concat.display(out); }
+        void collect_statistics(statistics& st) const override { m_concat.collect_statistics(st); }
+    };
+}

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(test-z3
   dlist.cpp
   egraph.cpp
   escaped.cpp
+  euf_assoc_plugin.cpp
   euf_bv_plugin.cpp
   euf_arith_plugin.cpp
   ex.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(test-z3
   escaped.cpp
   euf_assoc_plugin.cpp
   euf_bv_plugin.cpp
+  euf_seq_plugin.cpp
   euf_arith_plugin.cpp
   ex.cpp
   expr_rand.cpp

--- a/src/test/euf_assoc_plugin.cpp
+++ b/src/test/euf_assoc_plugin.cpp
@@ -1,0 +1,144 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+--*/
+
+#include "util/util.h"
+#include "ast/euf/euf_assoc_plugin.h"
+#include "ast/euf/euf_egraph.h"
+
+namespace {
+
+    struct assoc_test {
+        ast_manager m;
+        euf::egraph g;
+        sort_ref s;
+        func_decl_ref f;
+        euf::assoc_plugin* p;
+        unsigned next_var = 0;
+
+        assoc_test(unsigned max_rules = 64):
+            g(m),
+            s(m.mk_uninterpreted_sort(symbol("S")), m),
+            f(m.mk_func_decl(symbol("f"), s, s, s), m),
+            p(alloc(euf::assoc_plugin, g, user_sort_family_id)) {
+            p->register_associative([this](euf::enode const* n) { return n->get_decl() == f; });
+            p->register_variable([](euf::enode const* n) {
+                return n->num_args() == 0 && n->get_decl()->get_name() == symbol("x");
+            });
+            p->register_unit([](euf::enode const* n) {
+                return n->num_args() == 0 && n->get_decl()->get_name() != symbol("x");
+            });
+            p->set_completion_limits(max_rules, 256);
+            g.add_plugin(p);
+        }
+
+        expr_ref constant(char const* name) {
+            return expr_ref(m.mk_const(symbol(name), s), m);
+        }
+
+        expr_ref app(expr* a, expr* b) {
+            expr* args[2] = { a, b };
+            return expr_ref(m.mk_app(f.get(), 2, args), m);
+        }
+
+        euf::enode* node(expr* e) {
+            if (auto* n = g.find(e))
+                return n;
+            euf::enode_vector args;
+            for (expr* arg : *to_app(e))
+                args.push_back(node(arg));
+            auto* n = g.mk(e, 0, args.size(), args.data());
+            g.add_th_var(n, next_var++, user_sort_family_id);
+            return n;
+        }
+    };
+
+    void test_associative_not_commutative() {
+        assoc_test t;
+        expr_ref a = t.constant("a"), b = t.constant("b"), c = t.constant("c");
+        expr_ref ab = t.app(a, b), ba = t.app(b, a);
+        expr_ref ab_c = t.app(ab, c), a_bc = t.app(a, t.app(b, c));
+        auto* n_ab = t.node(ab);
+        auto* n_ba = t.node(ba);
+        auto* n_ab_c = t.node(ab_c);
+        auto* n_a_bc = t.node(a_bc);
+        t.g.propagate();
+        ENSURE(n_ab_c->get_root() == n_a_bc->get_root());
+        ENSURE(n_ab->get_root() != n_ba->get_root());
+    }
+
+    void test_simplification() {
+        assoc_test t;
+        expr_ref x = t.constant("x"), a = t.constant("a"), b = t.constant("b"), c = t.constant("c");
+        expr_ref ab = t.app(a, b);
+        expr_ref xc = t.app(x, c);
+        expr_ref abc = t.app(ab, c);
+        auto* n_x = t.node(x);
+        auto* n_ab = t.node(ab);
+        auto* n_xc = t.node(xc);
+        auto* n_abc = t.node(abc);
+        t.g.merge(n_x, n_ab, nullptr);
+        t.g.propagate();
+        ENSURE(n_xc->get_root() == n_abc->get_root());
+    }
+
+    void test_completion() {
+        assoc_test t;
+        expr_ref a = t.constant("a"), b = t.constant("b"), c = t.constant("c");
+        expr_ref u = t.constant("u"), v = t.constant("v");
+        expr_ref ab = t.app(a, b), bc = t.app(b, c);
+        expr_ref uc = t.app(u, c), av = t.app(a, v);
+        auto* n_ab = t.node(ab);
+        auto* n_bc = t.node(bc);
+        auto* n_u = t.node(u);
+        auto* n_v = t.node(v);
+        auto* n_uc = t.node(uc);
+        auto* n_av = t.node(av);
+        t.g.merge(n_ab, n_u, nullptr);
+        t.g.merge(n_bc, n_v, nullptr);
+        t.g.propagate();
+        ENSURE(n_uc->get_root() == n_av->get_root());
+        ENSURE(t.p->num_rules() >= 3);
+    }
+
+    void test_completion_bound() {
+        assoc_test t(2);
+        expr_ref a = t.constant("a"), b = t.constant("b"), c = t.constant("c");
+        expr_ref u = t.constant("u"), v = t.constant("v");
+        auto* n_ab = t.node(t.app(a, b));
+        auto* n_bc = t.node(t.app(b, c));
+        auto* n_u = t.node(u);
+        auto* n_v = t.node(v);
+        t.g.merge(n_ab, n_u, nullptr);
+        t.g.merge(n_bc, n_v, nullptr);
+        t.g.propagate();
+        ENSURE(t.p->num_rules() == 2);
+    }
+
+    void test_backtracking() {
+        assoc_test t;
+        expr_ref x = t.constant("x"), a = t.constant("a"), b = t.constant("b"), c = t.constant("c");
+        auto* n_x = t.node(x);
+        auto* n_ab = t.node(t.app(a, b));
+        auto* n_xc = t.node(t.app(x, c));
+        auto* n_abc = t.node(t.app(t.app(a, b), c));
+        t.g.propagate();
+        ENSURE(n_xc->get_root() != n_abc->get_root());
+        t.g.push();
+        t.g.merge(n_x, n_ab, nullptr);
+        t.g.propagate();
+        ENSURE(n_xc->get_root() == n_abc->get_root());
+        t.g.pop(1);
+        ENSURE(n_xc->get_root() != n_abc->get_root());
+        ENSURE(t.p->num_rules() == 0);
+    }
+}
+
+void tst_euf_assoc_plugin() {
+    test_associative_not_commutative();
+    test_simplification();
+    test_completion();
+    test_completion_bound();
+    test_backtracking();
+}

--- a/src/test/euf_seq_plugin.cpp
+++ b/src/test/euf_seq_plugin.cpp
@@ -68,6 +68,7 @@ namespace {
         auto* ab = t.node(t.concat(a, b));
         auto* ba = t.node(t.concat(b, a));
         t.egraph().propagate();
+        TRACE(seq, tout << "sequence associativity\n" << t.egraph() << "\n";);
         ENSURE(left->get_root() == right->get_root());
         ENSURE(ab->get_root() != ba->get_root());
     }
@@ -88,6 +89,7 @@ namespace {
         t.egraph().merge(ab, nu, nullptr);
         t.egraph().merge(bc, nv, nullptr);
         t.egraph().propagate();
+        TRACE(seq, tout << "sequence completion\n" << t.egraph() << "\n";);
         ENSURE(uc->get_root() == av->get_root());
     }
 
@@ -104,6 +106,7 @@ namespace {
         auto* abc = t.node(t.concat(t.concat(a, b), c));
         t.egraph().merge(nx, ab, nullptr);
         t.egraph().propagate();
+        TRACE(seq, tout << "sequence variable simplification\n" << t.egraph() << "\n";);
         ENSURE(xc->get_root() == abc->get_root());
     }
 
@@ -123,8 +126,10 @@ namespace {
         t.egraph().push();
         t.egraph().merge(nx, ab, nullptr);
         t.egraph().propagate();
+        TRACE(seq, tout << "sequence backtracking before pop\n" << t.egraph() << "\n";);
         ENSURE(xc->get_root() == abc->get_root());
         t.egraph().pop(1);
+        TRACE(seq, tout << "sequence backtracking after pop\n" << t.egraph() << "\n";);
         ENSURE(xc->get_root() != abc->get_root());
     }
 }

--- a/src/test/euf_seq_plugin.cpp
+++ b/src/test/euf_seq_plugin.cpp
@@ -1,0 +1,137 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+--*/
+
+#include "util/util.h"
+#include "ast/euf/euf_egraph.h"
+#include "ast/euf/euf_seq_plugin.h"
+#include "ast/reg_decl_plugins.h"
+
+namespace {
+
+    class seq_euf_test {
+        ast_manager m;
+        seq_util seq;
+        euf::egraph g;
+        unsigned next_var = 0;
+
+        static ast_manager& initialize(ast_manager& m) {
+            reg_decl_plugins(m);
+            return m;
+        }
+
+        euf::enode* node_core(expr* e) {
+            if (auto* n = g.find(e))
+                return n;
+            euf::enode_vector args;
+            for (expr* arg : *to_app(e))
+                args.push_back(node_core(arg));
+            auto* n = g.mk(e, 0, args.size(), args.data());
+            if (seq.is_seq(e))
+                g.add_th_var(n, next_var++, seq.get_family_id());
+            return n;
+        }
+
+    public:
+        seq_euf_test():
+            seq(initialize(m)),
+            g(m) {
+            g.add_plugin(alloc(euf::seq_plugin, g));
+        }
+
+        expr_ref variable(char const* name, sort* s) {
+            return expr_ref(m.mk_const(symbol(name), s), m);
+        }
+
+        expr_ref unit(expr* e) {
+            return expr_ref(seq.str.mk_unit(e), m);
+        }
+
+        expr_ref concat(expr* a, expr* b) {
+            return expr_ref(seq.str.mk_concat(a, b), m);
+        }
+
+        sort* element_sort() { return m.mk_uninterpreted_sort(symbol("E")); }
+        sort* sequence_sort(sort* e) { return seq.str.mk_seq(e); }
+        euf::enode* node(expr* e) { return node_core(e); }
+        euf::egraph& egraph() { return g; }
+    };
+
+    void test_sequence_associativity() {
+        seq_euf_test t;
+        sort* e = t.element_sort();
+        expr_ref ea = t.variable("a", e), eb = t.variable("b", e), ec = t.variable("c", e);
+        expr_ref a = t.unit(ea), b = t.unit(eb), c = t.unit(ec);
+        auto* left = t.node(t.concat(t.concat(a, b), c));
+        auto* right = t.node(t.concat(a, t.concat(b, c)));
+        auto* ab = t.node(t.concat(a, b));
+        auto* ba = t.node(t.concat(b, a));
+        t.egraph().propagate();
+        ENSURE(left->get_root() == right->get_root());
+        ENSURE(ab->get_root() != ba->get_root());
+    }
+
+    void test_sequence_completion() {
+        seq_euf_test t;
+        sort* e = t.element_sort();
+        expr_ref ea = t.variable("a", e), eb = t.variable("b", e), ec = t.variable("c", e);
+        expr_ref eu = t.variable("u", e), ev = t.variable("v", e);
+        expr_ref a = t.unit(ea), b = t.unit(eb), c = t.unit(ec);
+        expr_ref u = t.unit(eu), v = t.unit(ev);
+        auto* ab = t.node(t.concat(a, b));
+        auto* bc = t.node(t.concat(b, c));
+        auto* nu = t.node(u);
+        auto* nv = t.node(v);
+        auto* uc = t.node(t.concat(u, c));
+        auto* av = t.node(t.concat(a, v));
+        t.egraph().merge(ab, nu, nullptr);
+        t.egraph().merge(bc, nv, nullptr);
+        t.egraph().propagate();
+        ENSURE(uc->get_root() == av->get_root());
+    }
+
+    void test_sequence_variable_simplification() {
+        seq_euf_test t;
+        sort* e = t.element_sort();
+        sort* s = t.sequence_sort(e);
+        expr_ref ea = t.variable("a", e), eb = t.variable("b", e), ec = t.variable("c", e);
+        expr_ref a = t.unit(ea), b = t.unit(eb), c = t.unit(ec);
+        expr_ref x = t.variable("x", s);
+        auto* nx = t.node(x);
+        auto* ab = t.node(t.concat(a, b));
+        auto* xc = t.node(t.concat(x, c));
+        auto* abc = t.node(t.concat(t.concat(a, b), c));
+        t.egraph().merge(nx, ab, nullptr);
+        t.egraph().propagate();
+        ENSURE(xc->get_root() == abc->get_root());
+    }
+
+    void test_sequence_backtracking() {
+        seq_euf_test t;
+        sort* e = t.element_sort();
+        sort* s = t.sequence_sort(e);
+        expr_ref ea = t.variable("a", e), eb = t.variable("b", e), ec = t.variable("c", e);
+        expr_ref a = t.unit(ea), b = t.unit(eb), c = t.unit(ec);
+        expr_ref x = t.variable("x", s);
+        auto* nx = t.node(x);
+        auto* ab = t.node(t.concat(a, b));
+        auto* xc = t.node(t.concat(x, c));
+        auto* abc = t.node(t.concat(t.concat(a, b), c));
+        t.egraph().propagate();
+        ENSURE(xc->get_root() != abc->get_root());
+        t.egraph().push();
+        t.egraph().merge(nx, ab, nullptr);
+        t.egraph().propagate();
+        ENSURE(xc->get_root() == abc->get_root());
+        t.egraph().pop(1);
+        ENSURE(xc->get_root() != abc->get_root());
+    }
+}
+
+void tst_euf_seq_plugin() {
+    test_sequence_associativity();
+    test_sequence_completion();
+    test_sequence_variable_simplification();
+    test_sequence_backtracking();
+}

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -207,6 +207,7 @@
     X(euf_bv_plugin) \
     X(euf_assoc_plugin) \
     X(euf_arith_plugin) \
+    X(euf_seq_plugin) \
     X(sls_test) \
     X(scoped_vector) \
     X(sls_seq_plugin) \

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -205,6 +205,7 @@
     X(totalizer) \
     X(distribution) \
     X(euf_bv_plugin) \
+    X(euf_assoc_plugin) \
     X(euf_arith_plugin) \
     X(sls_test) \
     X(scoped_vector) \


### PR DESCRIPTION
## Summary
- add an ordered associative EUF completion plugin with callback-based node, variable, and unit classification
- orient and simplify word equations with bounded overlap completion and backtracking support
- add a sequence EUF plugin that applies associative completion to sequence concatenation
- add focused associative and sequence unit tests, including non-commutativity, completion, and backtracking

## Testing
- `test-z3 euf_assoc_plugin`
- `test-z3 euf_seq_plugin`
- `test-z3 /a`