### PR TITLE
Dispatch NFV audits for pull request updates

### DIFF
--- a/.github/workflows/nfv-formal-audit-dispatcher.yml
+++ b/.github/workflows/nfv-formal-audit-dispatcher.yml
@@ -1,0 +1,41 @@
+name: Dispatch NFV formal audit
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, synchronize, closed]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    if: github.event.action != 'closed' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.Z3_CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.Z3_CI_APP_PRIVATE_KEY }}
+          owner: Z3Prover
+          repositories: bench
+
+      - name: Dispatch NFV audit
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const pr = context.payload.pull_request;
+            const sha = pr.merged ? pr.merge_commit_sha : pr.head.sha;
+            await github.rest.actions.createWorkflowDispatch({
+              owner: "Z3Prover",
+              repo: "bench",
+              workflow_id: "nfv-formal-audit.lock.yml",
+              ref: "main",
+              inputs: {
+                sha,
+                pr: String(pr.number),
+              },
+            });


### PR DESCRIPTION
## Summary

- dispatch `Z3Prover/bench`'s NFV formal audit when a PR targeting `master` is opened or synchronized
- dispatch the final merge/squash commit when that PR is merged
- ignore closed, unmerged PRs
- use `pull_request_target` only for event metadata; never check out or execute pull-request code

## Authentication and security

The dispatcher mints a short-lived `z3prover-ci-bot` installation token scoped to `Z3Prover/bench`, using the same `Z3_CI_APP_CLIENT_ID` variable and `Z3_CI_APP_PRIVATE_KEY` secret already provisioned for Z3 workflows. The App has Workflows write permission on `bench`, which is required to call `createWorkflowDispatch`.

The two actions are pinned to full commit SHAs. No untrusted PR value is interpolated into shell commands, and the workflow grants its default token only `contents: read`.

The receiving workflow support landed in Z3Prover/bench commit `38fad33ea`.