### PR TITLE
Fix two soundness bugs in nseq: dangling trail reference and reach views fed as memberships

### DIFF
--- a/src/ast/seq/seq_eq_facet.cpp
+++ b/src/ast/seq/seq_eq_facet.cpp
@@ -188,7 +188,8 @@ namespace seq {
         }
 
         if (eq.m_lhs.empty() && eq.m_rhs.empty()) {
-            m_trail.push(value_trail<bool>(m_eqs[idx].m_active, false));
+            m_trail.push(vector_field_trail<equation, bool>(m_eqs, idx, &equation::m_active));
+            m_eqs[idx].m_active = false;
         }
 
         // Any newly-produced sub-equations (from unit-vs-unit
@@ -864,7 +865,8 @@ namespace seq {
                     // distinct leading constants: the two sides can never
                     // be made equal by any future substitution - the
                     // disequation is proved and discharged.
-                    m_trail.push(value_trail<bool>(m_diseqs[i].m_active, false));
+                    m_trail.push(vector_field_trail<disequation, bool>(m_diseqs, i, &disequation::m_active));
+                m_diseqs[i].m_active = false;
                     changed = true;
                     continue;
                 }

--- a/src/ast/seq/seq_eq_facet.cpp
+++ b/src/ast/seq/seq_eq_facet.cpp
@@ -866,7 +866,7 @@ namespace seq {
                     // be made equal by any future substitution - the
                     // disequation is proved and discharged.
                     m_trail.push(vector_field_trail<disequation, bool>(m_diseqs, i, &disequation::m_active));
-                m_diseqs[i].m_active = false;
+                    m_diseqs[i].m_active = false;
                     changed = true;
                     continue;
                 }

--- a/src/ast/seq/seq_eq_facet.h
+++ b/src/ast/seq/seq_eq_facet.h
@@ -277,8 +277,15 @@ namespace seq {
         // value_trail (restored to true on backtrack) - no shifting, no
         // index invalidation for any other facet/iterator holding onto
         // `idx`.
+        // NB: the undo must address the flag by vector+index, not by
+        // reference. Callers routinely follow a removal with add_equation
+        // (eq_split replaces one equation by two), and that push_back can
+        // reallocate m_eqs - a value_trail<bool> capturing m_eqs[idx].m_active
+        // would then restore through a dangling reference, leaving the
+        // equation permanently inactive on backtracking (silent false SAT).
         void remove_equation_trailed(unsigned idx) {
-            m_trail.push(value_trail<bool>(m_eqs[idx].m_active, false));
+            m_trail.push(vector_field_trail<equation, bool>(m_eqs, idx, &equation::m_active));
+            m_eqs[idx].m_active = false;
         }
 
         vector<equation> const& equations() const { return m_eqs; }
@@ -620,9 +627,12 @@ namespace seq {
 
         // Trailed removal of the disequation at `idx` (e.g. deq_split
         // discharging/replacing a stuck disequation): append-only, so
-        // this just flips m_active to false via a value_trail.
+        // this just flips m_active to false. As with equations the undo is
+        // addressed by vector+index so it survives a later push_back that
+        // reallocates m_diseqs.
         void remove_disequation_trailed(unsigned idx) {
-            m_trail.push(value_trail<bool>(m_diseqs[idx].m_active, false));
+            m_trail.push(vector_field_trail<disequation, bool>(m_diseqs, idx, &disequation::m_active));
+            m_diseqs[idx].m_active = false;
         }
 
         // -- stx::facet_i --

--- a/src/ast/seq/seq_mem_facet.cpp
+++ b/src/ast/seq/seq_mem_facet.cpp
@@ -397,6 +397,18 @@ namespace seq {
         m_mon.set_orientation(orientation);
         m_mon.set_split_rounds(split_rounds);
         for (auto const& sm : mems) {
+            // Only plain memberships (str in re) may be handed to
+            // seq_monadic: its add() takes a start state and interprets
+            // the term as a word of the language, so feeding a reach view
+            // (state, target) would silently drop m_target and assert the
+            // strictly stronger `term in L(state)`. For a reach view with
+            // state == target and an empty term that turns a trivially
+            // TRUE constraint into a false one whenever L(state) is not
+            // nullable, and seq_monadic then refutes every branch - a
+            // false conflict, hence unsat on a satisfiable input.
+            // mem_propagation::propagate applies the same is_view() guard.
+            if (sm.is_view())
+                continue;
             sort* s = u.re.to_seq(sm.m_view.m_state->get_sort());
             expr_ref term(u.str.mk_concat(sm.m_str.size(), sm.m_str.data(), s), m);
             m_mon.add(term, sm.m_view.m_state, sm.m_dep);
@@ -427,6 +439,12 @@ namespace seq {
         // on its own so a solution is a vector of view x dependency pairs.
         for (unsigned i = mf.memberships().size(); i-- > 0; ) {
             auto const& sm = mf.memberships()[i];
+            // Reach views were never handed to seq_monadic (see the
+            // constructor), so `sol` says nothing about them - rewriting
+            // one into per-variable membership views here would assert a
+            // constraint the branch does not justify.
+            if (sm.is_view())
+                continue;
             bool all_found = all_of(sm.m_str, [&](expr* t) { return u.str.is_unit(t) || sol.contains(t); });
             if (!all_found) 
                 continue;
@@ -493,17 +511,25 @@ namespace seq {
         auto& mf = get_ambient(n).mem_facet_ref();
         if (mf.memberships().empty() || mf.is_satisfied())
             return nullptr;
+        // Reach views are not fed to seq_monadic (see iterator's ctor); if
+        // nothing plain is left there is no conjunction to decide and, in
+        // particular, no basis on which to report a refutation.
+        if (!any_of(mf.memberships(), [](str_mem const& sm) { return !sm.is_view(); }))
+            return nullptr;
         scoped_ptr<iterator> it(alloc(iterator, n, m_rw, m, u, mf.memberships(), m_budget, m_orientation, m_split_rounds));
         if (it->is_refuted()) {
-            // seq_monadic proved the conjunction of ALL memberships fed to it is
-            // UNSAT (see seq_monadic::iterator's class comment): every branch was
-            // pruned as empty and none of that pruning was a give-up. That is a
-            // genuine conflict, not merely "nothing to offer" - report it rather
-            // than silently discarding it, or a real unsat instance is misreported
-            // as unknown (see NSB code review above this class).
+            // seq_monadic proved the conjunction of the PLAIN memberships fed to
+            // it is UNSAT (see seq_monadic::iterator's class comment): every branch
+            // was pruned as empty and none of that pruning was a give-up. Refuting
+            // on a subset of the node's constraints is sound - the dependency below
+            // just names that subset. That is a genuine conflict, not merely
+            // "nothing to offer" - report it rather than silently discarding it, or
+            // a real unsat instance is misreported as unknown (see NSB code review
+            // above this class).
             eq_tree::dep_tracker dep = nullptr;
             for (auto const& sm : mf.memberships())
-                dep = mf.dm().mk_join(dep, sm.m_dep);
+                if (!sm.is_view())
+                    dep = mf.dm().mk_join(dep, sm.m_dep);
             m_stats.m_num_refuted++;
             n.set_conflict(stx::br_plugin_base, dep);
             return nullptr;


### PR DESCRIPTION
Two independent soundness bugs in the `nseq` search tree, each of which makes it
answer a satisfiable instance `unsat` or an unsatisfiable one `sat`. Both were
found by A/B-ing `smt.string_solver=nseq` against `theory_seq` on the
ClemensRegex corpus (1476 files) and adjudicating every disagreement.

Together they account for **all 8** disagreements between `nseq` and
`theory_seq` on that corpus — 6 false `sat` and 2 false `unsat`.

## 1. `seq_eq_facet`: deactivation undo through a dangling reference (false SAT)

An equation/disequation is "removed" by flipping `m_active` to false, undone on
backtracking so the constraint is live again in sibling branches. The undo was:

```cpp
m_trail.push(value_trail<bool>(m_eqs[idx].m_active, false));
```

`value_trail<T>` stores a `T&`. Callers routinely follow a removal with
`add_equation` — `eq_split` replaces one equation by two, `deq_split` does the
same for disequations — and that `push_back` can **reallocate** `m_eqs`. The
trail entry then references freed storage, so `undo()` writes `true` through a
dangling reference instead of into the live element and the equation stays
inactive for the rest of the search.

`eq_facet::is_satisfied()` is "every equation is inactive", so an unrelated
sibling branch reports the dropped equation as discharged and the search returns
`sat` with a model that violates it. On the reduced case this produced
`x="2", z="", y="2"`, falsifying the very equation that had been deactivated;
`model_validate=true` reported *"an invalid model was generated"*.

Fix: address the flag by vector + index + member using the `vector_field_trail`
helper already defined in this header for exactly this reason — *"addressed by
vector+index+member so it stays valid across later vector reallocation"*. All
four deactivation sites are converted. A sweep confirms no other `value_trail`
in the sequence code captures a vector element.

## 2. `mem_monadic_split`: reach views fed as plain memberships (false UNSAT)

`mem_facet` stores two kinds of entry: plain memberships (`str in re`,
`m_view.m_target == nullptr`) and reach views `(state, target)`, meaning
"reading `str` takes the automaton from `state` to `target`".
`seq_monadic::add(term, state, dep)` only understands the first kind — it
asserts `term in L(state)`.

The iterator constructor fed **every** entry to it:

```cpp
m_mon.add(term, sm.m_view.m_state, sm.m_dep);   // m_view.m_target dropped
```

silently discarding `m_target` and thereby strengthening a reach view into a
plain membership. The empty-string case makes the consequence sharp: a reach
view with an empty term and `state == target` is trivially **true**, but
reinterpreted as a membership it becomes `"" in L(state)`, which is false
whenever `L(state)` is not nullable. `seq_monadic` then refutes every branch,
`is_refuted()` reports a genuine conflict, and a satisfiable input is answered
`unsat`.

Observed directly — this entry, with `state == target` and so trivially
satisfied, was refuted:

```
[view] "" IN (re.++ "2" (re.union (re.* "1") (re.* "2")))
       target = (re.++ "2" (re.union (re.* "1") (re.* "2")))
```

Fix: apply the same `is_view()` guard `mem_propagation::propagate` already uses,
in all three places that assumed `seq_monadic` had seen every entry:

- the iterator constructor no longer feeds reach views;
- `iterator::next()` no longer rewrites reach views from the branch solution,
  which says nothing about entries never handed over;
- `split()` declines when nothing plain is left (no basis for a refutation) and
  joins the conflict dependency only over the memberships actually fed.

Refuting on a subset of the constraints stays sound; the conflict just carries a
smaller, more precise dependency.

Note this matches the intent already expressed in the older `seq_nielsen_regex`
implementation of the same rule, which skips non-plain memberships with
`if (!mi.is_plain() || ...) continue;` and the comment *"A view has no
plain-regex counterpart"*. The port into the facet framework dropped that guard.

## Validation

ClemensRegex corpus, 1476 files, `T=10`, `smt.string_solver=nseq`, against the
same corpus run under a reference build:

|                  | before | after |
| ---------------- | ------ | ----- |
| contradictions vs `theory_seq` | **8** | **0** |
| decided          | 1420   | 1402  |
| commonly decided | 197.8s | 147.2s (**-25.6%**) |

The pre-fix decided count was inflated by the wrong answers themselves; the
post-fix numbers are the trustworthy ones. The net decrease in decided files is
the expected cost of no longer refuting on reach views — `mem_monadic_split` is
now conservative where it was previously unsound. Recovering that ground
properly (via `seq_monadic`'s `check()`/`core()` surface, which also supplies
the minimized conflict dependencies requested in the code-review comment at the
top of `seq_mem_facet.cpp`) is follow-up work, deliberately kept out of this PR
so the soundness fixes can land on their own.

`test-z3 /a`: 112/112 pass.
