### PR TITLE
Extract sequence view product checker

### DIFF
--- a/src/ast/seq/CMakeLists.txt
+++ b/src/ast/seq/CMakeLists.txt
@@ -9,6 +9,7 @@ z3_add_component(seq
     seq_regex_live.cpp
     seq_skolem.cpp
     seq_view.cpp
+    seq_view_witness.cpp
   COMPONENT_DEPENDENCIES
     rewriter
 )

--- a/src/ast/seq/seq_monadic.cpp
+++ b/src/ast/seq/seq_monadic.cpp
@@ -50,16 +50,12 @@ Author:
 --*/
 
 #include "ast/seq/seq_monadic.h"
-#include "ast/rewriter/guard_set.h"
-#include "ast/rewriter/seq_range_collapse.h"
 #include "ast/for_each_expr.h"
 #include <set>
 #include <vector>
-#include <map>
 #include <tuple>
 #include <functional>
 #include <algorithm>
-#include <unordered_set>
 
 namespace {
 
@@ -96,118 +92,7 @@ expr_ref seq_monadic::der_elem(expr* r, expr* elem) {
 }
 
 lbool seq_monadic::nullable(expr* r) {
-    // Nullability is a structural property, and the seq plugin already computes it as
-    // part of the regex info -- cached by expr id and, unlike seq_rewriter's op_cache
-    // (capped at 10000 and flushed whole), never evicted.  Use it whenever it is
-    // determined; only fall back to building the symbolic nullability formula for the
-    // regexes whose info leaves it undetermined.
-    lbool i = re().get_info(r).nullable;
-    if (i != l_undef)
-        return i;
-    char v = 0;
-    if (m_nullable_cache.find(r, v)) {
-        if (v == 1) return l_true;
-        if (v == 0) return l_false;
-        return l_undef;
-    }
-    expr_ref nb = m_rw.is_nullable(r);
-    lbool res = m.is_true(nb) ? l_true : m.is_false(nb) ? l_false : l_undef;
-    m_pin.push_back(r);
-    m_nullable_cache.insert(r, res == l_true ? 1 : res == l_false ? 0 : 2);
-    return res;
-}
-
-expr_ref_pair_vector const& seq_monadic::derivative_cofactors(expr* r) {
-    ++m_stats.m_cofactor_calls;
-    return m_rw.get_derive().get_cached_cofactors(m_config.m_mode, r);
-}
-
-void seq_monadic::reset_ivl_cache() {
-    for (auto& kv : m_ivl_cache)
-        dealloc(kv.m_value);
-    m_ivl_cache.reset();
-    m_ivl_pin.reset();
-}
-
-// Canonical interval form of r's derivative: the cofactor guards, translated into the
-// range algebra, refined into a sorted list of disjoint ranges, each labelled with the
-// targets reachable on it.  Adjacent ranges with identical target sets are merged, so the
-// result is the minimal ordered-ITE ("t-regex") representation of the transition relation.
-// Returns null when some guard falls outside the range algebra.
-seq_monadic::ivl_list const* seq_monadic::interval_cofactors(expr* r, expr* v0) {
-    ivl_list* res = nullptr;
-    if (m_ivl_cache.find(r, res))
-        return res && res->ok ? res : nullptr;
-
-    unsigned max_char = u().max_char();
-    res = alloc(ivl_list);
-    m_ivl_cache.insert(r, res);
-    m_ivl_pin.push_back(r);
-
-    // (lo, hi, target) triples, plus the boundary set of this state's own partition.
-    struct tr_t { unsigned lo, hi; expr* t; };
-    svector<tr_t> tr;
-    svector<unsigned> bounds;
-    bounds.push_back(0);
-    for (auto const& [g, t] : derivative_cofactors(r)) {
-        if (re().is_empty(t))
-            continue;
-        seq::range_predicate* p = nullptr;
-        if (!m_rp_cache.find(g, p)) {
-            p = m_rp_cache.fresh(max_char);
-            if (!seq::guard_to_range_predicate(u(), v0, g, *p)) {
-                m_rp_cache.insert(g, nullptr);
-                res->ok = false;
-                return nullptr;
-            }
-            m_rp_cache.insert(g, p);
-        }
-        else if (!p) {
-            res->ok = false;
-            return nullptr;
-        }
-        m_ivl_pin.push_back(t);
-        for (auto const& rg : p->ranges()) {
-            tr.push_back({ rg.first, rg.second, t });
-            bounds.push_back(rg.first);
-            if (rg.second < max_char)
-                bounds.push_back(rg.second + 1);
-        }
-    }
-    if (tr.empty())
-        return res;                            // dead state: no outgoing transition
-
-    std::sort(bounds.begin(), bounds.end());
-    bounds.shrink((unsigned)(std::unique(bounds.begin(), bounds.end()) - bounds.begin()));
-
-    ptr_vector<expr> hits;
-    for (unsigned bi = 0; bi < bounds.size(); ++bi) {
-        unsigned lo = bounds[bi];
-        unsigned hi = bi + 1 < bounds.size() ? bounds[bi + 1] - 1 : max_char;
-        hits.reset();
-        for (auto const& e : tr) {
-            if (e.lo <= lo && lo <= e.hi)
-                hits.push_back(e.t);
-        }
-        if (hits.empty())
-            continue;                          // gap: no transition on this range
-        // extend the previous range when it carries exactly the same target set
-        if (!res->ranges.empty()) {
-            ivl_range& prev = res->ranges.back();
-            if (prev.hi + 1 == lo && prev.count == hits.size()) {
-                bool same = true;
-                for (unsigned k = 0; k < hits.size() && same; ++k)
-                    same = res->targets[prev.first + k] == hits[k];
-                if (same) {
-                    prev.hi = hi;
-                    continue;
-                }
-            }
-        }
-        res->ranges.push_back({ lo, hi, res->targets.size(), hits.size() });
-        res->targets.append(hits.size(), hits.data());
-    }
-    return res;
+    return m_view_witness.nullable(r);
 }
 
 bool seq_monadic::out_of_budget() {
@@ -226,285 +111,7 @@ bool seq_monadic::out_of_budget() {
 }
 
 lbool seq_monadic::product_nonempty(expr* var, seq::view_vector const& comps, expr_ref* witness_word) {
-    sort *elem_sort = nullptr;
-    auto seq_sort = var->get_sort();
-    if (!u().is_seq(seq_sort, elem_sort))
-        return l_undef;
-    unsigned n = comps.size();
-    if (n == 0) {
-        if (witness_word)
-            *witness_word = expr_ref(u().str.mk_empty(seq_sort), m);
-        return l_true;
-    }
-
-    expr_ref var0(m.mk_var(0, elem_sort), m);     // the element variable the guards range over
-    typedef std::vector<unsigned> key;
-    struct key_hash {
-        size_t operator()(key const& k) const {
-            uint64_t h = 1469598103934665603ull;
-            for (unsigned x : k)
-                h = (h ^ x) * 1099511628211ull;
-            return static_cast<size_t>(h);
-        }
-    };
-
-    // Product states are held in a flat stack of stride n; `visited` owns one copy of the
-    // id-tuple of every discovered state.  Both avoid a per-state heap allocation, which
-    // dominated the search when this ran per derivative step of the outer decomposition.
-    ptr_vector<expr> work;
-    std::unordered_set<key, key_hash> visited;
-    key kbuf;
-    kbuf.resize(n);
-
-    ptr_vector<expr> st;
-    st.resize(n);
-    ptr_vector<expr> cur;
-    cur.resize(n);
-
-    auto fill_key = [&](ptr_vector<expr> const& s) -> key const& {
-        for (unsigned i = 0; i < n; ++i)
-            kbuf[i] = s[i]->get_id();
-        return kbuf;
-    };
-
-    bool undecided = false;
-    auto is_accept = [&]() -> bool {
-        for (unsigned i = 0; i < n; ++i) {
-            if (comps[i].m_target) {
-                if (st[i] != comps[i].m_target) return false;
-            }
-            else {
-                lbool nb = nullable(st[i]);
-                if (nb == l_true) continue;
-                if (nb == l_false) return false;
-                undecided = true; return false;
-            }
-        }
-        return true;
-    };
-
-    // tree of first-discovery edges for witness reconstruction (only built when a
-    // witness is requested): child-key -> (parent-key, element read on the edge).
-    std::map<key, std::pair<key, expr*>> parent;
-    key start_key;
-    start_key.resize(n);
-    for (unsigned i = 0; i < n; ++i) {
-        work.push_back(comps[i].m_state);
-        start_key[i] = comps[i].m_state->get_id();
-    }
-    visited.insert(start_key);
-
-    auto reconstruct = [&](key end_key) -> expr_ref {
-        ptr_vector<expr> elems;              // collected in accept..start order
-        key k = end_key;
-        while (k != start_key) {
-            auto it = parent.find(k);
-            if (it == parent.end()) break;   // safety (should not happen)
-            elems.push_back(it->second.second);
-            k = it->second.first;
-        }
-        expr_ref_vector es(m);               // start..accept order
-        for (unsigned idx = elems.size(); idx-- > 0; )
-            es.push_back(u().str.mk_unit(elems[idx]));
-        return expr_ref(u().str.mk_concat(es.size(), es.data(), seq_sort), m);
-    };
-
-    // Hoisted out of the search loop: the per-view cofactor vectors are owned by the
-    // cofactor cache and stay valid for the whole search, so they are referenced rather
-    // than copied (copying re-materialized every branch as expr_ref pairs on every pop).
-    svector<expr_ref_pair_vector const*> branches;
-    branches.resize(n);
-    key st_key;
-    bool bail = false;
-
-    // Bound the work spent expanding a single product state.  The main budget counts
-    // product states, so inner loops get a separate cap to preserve the budget's meaning.
-    uint64_t const inner_limit = 1u << 16;
-    uint64_t inner_steps = 0;
-    auto inner_step = [&]() -> bool {
-        ++inner_steps;
-        if (inner_steps > m_stats.m_max_state_expansion)
-            m_stats.m_max_state_expansion = static_cast<unsigned>(inner_steps);
-        if (inner_steps <= inner_limit)
-            return false;
-        m_stats.inc_bail(bail_reason::state_expansion);
-        m_giveup = true;
-        return true;
-    };
-
-    // ---- interval-refinement ("t-regex merge") product --------------------------
-    // Over the character sort every cofactor guard denotes a union of ranges, so each
-    // view's derivative has a canonical ordered-interval ("t-regex") form, cached
-    // per state by interval_cofactors.  The joint transitions are then exactly the cells
-    // of the common refinement of those n interval lists, obtained by a cursor merge in
-    // O(sum_i intervals_i) -- whereas the cartesian enumeration below tries
-    // prod_i(k_i) combinations, almost all of which are pruned as empty.
-    bool const sweep_ok = u().is_char(elem_sort);
-    unsigned const max_char = sweep_ok ? u().max_char() : 0;
-    svector<ivl_list const*> sw_lists;
-    svector<unsigned> sw_cur, sw_odo;
-    sw_lists.resize(n);
-    sw_cur.resize(n);
-    sw_odo.resize(n);
-
-    // Returns false when some guard falls outside the range algebra, in which case the
-    // caller falls back to the cartesian enumeration for this product state.
-    auto sweep = [&]() -> bool {
-        for (unsigned i = 0; i < n; ++i) {
-            sw_lists[i] = interval_cofactors(st[i], var0);
-            if (!sw_lists[i])
-                return false;
-            if (sw_lists[i]->ranges.empty())
-                return true;                  // view is stuck: no joint transition
-            sw_cur[i] = 0;
-        }
-        uint64_t b = 0;
-        while (b <= max_char) {
-            if (inner_step()) {
-                bail = true;
-                return true;
-            }
-            uint64_t next = (uint64_t)max_char + 1;
-            bool covered = true, done = false;
-            for (unsigned i = 0; i < n; ++i) {
-                auto const& rs = sw_lists[i]->ranges;
-                unsigned& c = sw_cur[i];
-                while (c < rs.size() && rs[c].hi < b)
-                    ++c;
-                if (c == rs.size()) {         // this view has no transition left
-                    done = true;
-                    break;
-                }
-                if (rs[c].lo > b) {           // gap in this view: skip ahead
-                    covered = false;
-                    next = std::min(next, (uint64_t)rs[c].lo);
-                }
-                else
-                    next = std::min(next, (uint64_t)rs[c].hi + 1);
-            }
-            if (done)
-                break;
-            if (covered) {
-                // Emit every combination of the targets active on this cell.  The modes
-                // whose cofactors partition the domain give exactly one target per
-                // view; the antimirov-style modes may give several.
-                for (unsigned i = 0; i < n; ++i)
-                    sw_odo[i] = 0;
-                while (true) {
-                    if (inner_step()) {
-                        bail = true;
-                        return true;
-                    }
-                    for (unsigned i = 0; i < n; ++i) {
-                        auto const& r = sw_lists[i]->ranges[sw_cur[i]];
-                        cur[i] = sw_lists[i]->targets[r.first + sw_odo[i]];
-                    }
-                    key const& ck = fill_key(cur);
-                    if (visited.find(ck) == visited.end()) {
-                        visited.insert(ck);
-                        if (witness_word) {
-                            expr* e = u().mk_char((unsigned)b);
-                            m_pin.push_back(e);
-                            parent[ck] = { st_key, e };
-                        }
-                        for (unsigned j = 0; j < n; ++j)
-                            work.push_back(cur[j]);
-                    }
-                    unsigned i = n;
-                    while (i-- > 0) {
-                        if (++sw_odo[i] < sw_lists[i]->ranges[sw_cur[i]].count)
-                            break;
-                        sw_odo[i] = 0;
-                    }
-                    if (i == UINT_MAX)
-                        break;                // odometer wrapped: cell exhausted
-                }
-            }
-            b = next;
-        }
-        return true;
-    };
-
-    std::function<void(unsigned, guard_set const&)> rec =
-        [&](unsigned i, guard_set const& acc) {
-            if (bail) return;
-            if (inner_step()) {
-                bail = true;
-                return;
-            }
-            if (i == n) {
-                key const& ck = fill_key(cur);
-                if (visited.find(ck) == visited.end()) {
-                    visited.insert(ck);
-                    if (witness_word) {
-                        expr_ref e(m);
-                        if (acc.eval(&e) == l_true) {
-                            m_pin.push_back(e);
-                            parent[ck] = { st_key, e.get() };
-                        }
-                    }
-                    for (unsigned j = 0; j < n; ++j)
-                        work.push_back(cur[j]);
-                }
-                return;
-            }
-            for (auto const& [g, t] : *branches[i]) {
-                if (re().is_empty(t)) continue;
-                guard_set nacc = acc;
-                nacc.conjoin(g);
-                lbool ne = nacc.eval(nullptr);
-                if (ne == l_undef) {
-                    m_stats.inc_bail(bail_reason::guard);
-                    bail = true;
-                    return;
-                }
-                if (ne == l_false) continue;                  // empty joint guard: prune
-                cur[i] = t;
-                rec(i + 1, nacc);
-                if (bail) return;
-            }
-        };
-
-    while (!work.empty()) {
-        if (out_of_budget())
-            return l_undef;
-        inner_steps = 0;                          // each state gets its own expansion allowance
-        for (unsigned i = n; i-- > 0; ) {
-            st[i] = work.back();
-            work.pop_back();
-        }
-        if (is_accept()) {
-            if (witness_word)
-                *witness_word = reconstruct(fill_key(st));
-            return l_true;
-        }
-        if (undecided) {
-            m_stats.inc_bail(bail_reason::nullability);
-            return l_undef;
-        }
-
-        if (witness_word)
-            st_key = fill_key(st);
-
-        if (sweep_ok) {
-            bool const swept = sweep();
-            if (bail)
-                return l_undef;
-            if (swept)
-                continue;
-        }
-
-        for (unsigned i = 0; i < n; ++i)
-            branches[i] = &derivative_cofactors(st[i]);
-
-        // joint transitions = cartesian product of the branches with the guards
-        // conjoined; prune as soon as the accumulated guard is empty, bail on unknown.
-        guard_set top(m, u(), elem_sort, var0, &m_rp_cache);
-        rec(0, top);
-        if (bail)
-            return l_undef;
-    }
-    return l_false;
+    return m_view_witness.product_nonempty(var, comps, witness_word);
 }
 
 bool seq_monadic::parse_term(expr* t, vector<atom>& atoms) {
@@ -553,7 +160,7 @@ void seq_monadic::reset_search() {
     m_last_occ.reset();
     m_group_cache.clear();
     m_der_cache.reset();
-    m_nullable_cache.reset();
+    m_view_witness.reset_cache();
     m_undef_vars = 0;
     m_any_undef = false;
     m_live_states.reset();
@@ -680,6 +287,22 @@ lbool seq_monadic::group_nonempty(unsigned vi) {
     else
         dedup_views(g, comps);
     lbool r = product_nonempty(m_vars[vi], comps, nullptr);
+    if (r == l_undef) {
+        switch (m_view_witness.get_failure_reason()) {
+        case seq::view_failure_reason::state_expansion:
+            m_stats.inc_bail(bail_reason::state_expansion);
+            m_giveup = true;
+            break;
+        case seq::view_failure_reason::nullability:
+            m_stats.inc_bail(bail_reason::nullability);
+            break;
+        case seq::view_failure_reason::guard:
+            m_stats.inc_bail(bail_reason::guard);
+            break;
+        default:
+            break;
+        }
+    }
     m_group_cache.emplace(sig, r);            // sig is m_sig_buf; emplace copies it
     return r;
 }
@@ -919,8 +542,7 @@ lbool seq_monadic::decide_oriented(membership_vec const& memberships, bool rever
     ++m_search_gen;                               // any suspended iterator loses its stack
     reset_search();                               // clear the caches before dropping the
     m_pin.reset();                                // pins that keep their keys alive
-    m_rp_cache.maybe_reset(1u << 16);
-    reset_ivl_cache();
+    m_view_witness.reset_cache();
     m_rw.get_derive().maybe_reset_cached_cofactors(1u << 16);
     m_budget = budget;
     m_giveup = false;
@@ -1472,13 +1094,12 @@ std::ostream& seq_monadic::display(std::ostream& out) const {
         << "     :undefined-variables " << m_undef_vars << "\n"
         << "     :group-cache-size " << m_group_cache.size() << "\n"
         << "     :derivative-cache-size " << m_der_cache.size() << "\n"
-        << "     :nullable-cache-size " << m_nullable_cache.size() << "\n"
         << "     :live-cache-size " << m_live_states.num_states() << "\n"
         << "     :pinned-expressions " << m_pin.size() << ")\n";
 
     out << "  :statistics\n"
-        << "    (:cofactor-calls " << m_stats.m_cofactor_calls << "\n"
-        << "     :states " << m_stats.m_states;
+        << "    (:cofactor-calls " << m_view_witness.cofactor_calls() << "\n"
+        << "     :states " << m_stats.m_states + m_view_witness.states();
     for (unsigned i = 0; i < static_cast<unsigned>(bail_reason::num_reasons); ++i)
         out << "\n     :bail-" << bail_name(i) << " " << m_stats.m_bails[i];
     return out << "))\n";
@@ -1498,9 +1119,9 @@ void seq_monadic::collect_statistics(::statistics& st) const {
     static_assert(sizeof(bail_names) / sizeof(bail_names[0]) ==
                   static_cast<unsigned>(bail_reason::num_reasons),
                   "bail_names must list every bail_reason");
-    st.update("seq monadic cofactor calls", m_stats.m_cofactor_calls);
-    st.update("seq monadic states", m_stats.m_states);
-    st.update("seq monadic max state expansion", m_stats.m_max_state_expansion);
+    st.update("seq monadic cofactor calls", m_view_witness.cofactor_calls());
+    st.update("seq monadic states", m_stats.m_states + m_view_witness.states());
+    st.update("seq monadic max state expansion", m_view_witness.max_state_expansion());
     st.update("seq monadic split calls", m_stats.m_split_calls);
     st.update("seq monadic split rounds", m_stats.m_split_rounds);
     st.update("seq monadic split decided", m_stats.m_split_decided);

--- a/src/ast/seq/seq_monadic.h
+++ b/src/ast/seq/seq_monadic.h
@@ -65,6 +65,7 @@ Author:
 #include "ast/expr_substitution.h"
 #include "ast/rewriter/seq_rewriter.h"
 #include "ast/seq/seq_view.h"
+#include "ast/seq/seq_view_witness.h"
 #include "ast/rewriter/seq_range_predicate.h"
 #include "ast/seq/seq_regex_live.h"
 #include "ast/rewriter/guard_set.h"
@@ -142,24 +143,7 @@ private:
     statistics      m_stats;
     obj_map<expr, seq::view_vector> m_solution;  // var -> views, from the last decide()
     obj_map<expr, expr*> m_split_words;     // var -> witness word, cached per refinement round
-    guard_set::cache m_rp_cache;             // cofactor guard -> range predicate
-    // Interval ("t-regex") form of a state's derivative cofactors over the character sort:
-    // a canonical list of disjoint ranges in increasing order, each carrying the targets
-    // reachable on that range.  Built once per state and merged by the product, so the
-    // product enumerates only the cells of the common refinement.
-    struct ivl_range { unsigned lo, hi, first, count; };
-    struct ivl_list {
-        svector<ivl_range> ranges;
-        ptr_vector<expr>   targets;   // ranges[i] owns targets[first .. first+count)
-        bool               ok = true; // false: some guard is outside the range algebra
-    };
-    obj_map<expr, ivl_list*> m_ivl_cache;
-    expr_ref_vector          m_ivl_pin;      // pins the states and targets the cache refers to
-    ivl_list const* interval_cofactors(expr* r, expr* v0);
-    void reset_ivl_cache();
     obj_pair_map<expr, expr, expr*> m_der_cache;  // memoizes der_elem per (regex, element)
-    obj_map<expr, char> m_nullable_cache;   // memoizes nullability (0 false / 1 true / 2 unknown);
-                                            // seq_rewriter's own cache is capped and flushed whole
     using membership_vec = vector<std::tuple<expr_ref, expr_ref, void*>>;
 
     membership_vec m_memberships;           // asserted (term in regex, dep) for check()
@@ -234,6 +218,7 @@ private:
     group_sig m_sig_buf;                    // reused by group_nonempty (avoids allocating per lookup)
     std::unordered_map<group_sig, lbool, group_sig_hash> m_group_cache;
     seq::live_states m_live_states;
+    seq::view_witness m_view_witness;
 
     // Names the reversed reading of a sequence variable while the search runs backwards.
     // The marker is stripped before witnesses are reported.
@@ -246,16 +231,6 @@ private:
     // Memoized nullability of a derivative state: l_true / l_false / l_undef (unknown).
     lbool nullable(expr* r);
 
-    // Symbolic transition cofactors in the selected mode.  The returned vector is owned
-    // by seq_rewriter's mode-specific cofactor cache.
-    expr_ref_pair_vector const& derivative_cofactors(expr* r);
-
-    // Product-reachability emptiness of a conjunction of views (all on one
-    // variable).  l_false = empty (unsat), l_true = non-empty (sat), l_undef = gave up
-    // (cap overrun, non-range guard, or undecidable nullability).
-    // On l_true, if `witness_word` is non-null it is set to a concrete sequence term
-    // (over the element sort) whose value drives every view to acceptance
-    // simultaneously -- i.e. a witness value for the variable the views constrain.
     lbool product_nonempty(expr* var, seq::view_vector const& comps, expr_ref* witness_word = nullptr);
 
     // Flatten a str.++ term into atoms; false on an unsupported shape (non-constant unit).
@@ -386,10 +361,16 @@ public:
     seq_monadic(seq_rewriter& rw, trail_stack& undo_trail,
                 seq::transition_mode mode = seq::transition_mode::light_antimirov_tm) :
         m(rw.m()), m_rw(rw), m_thrw(rw.m()), m_undo_trail(undo_trail),
-        m_pin(rw.m()), m_config(mode), m_rp_cache(rw.m()), m_ivl_pin(rw.m()),
-        m_regexes(rw.m()), m_live_states(rw, mode, 1u << 12), m_rev_decl(rw.m()) {}
-
-    ~seq_monadic() { reset_ivl_cache(); }
+        m_pin(rw.m()), m_config(mode), m_regexes(rw.m()),
+        m_live_states(rw, mode, 1u << 12),
+        m_view_witness(undo_trail, rw, m_live_states, mode), m_rev_decl(rw.m()) {
+        m_view_witness.set_checkpoint([this]() {
+            if (!out_of_budget())
+                return seq::view_failure_reason::none;
+            return m_budget == 0 ? seq::view_failure_reason::budget :
+                                   seq::view_failure_reason::resource;
+        });
+    }
 
     void collect_statistics(::statistics &st) const;
 

--- a/src/ast/seq/seq_view_witness.cpp
+++ b/src/ast/seq/seq_view_witness.cpp
@@ -1,0 +1,524 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+Module Name:
+
+    seq_view_witness.cpp
+
+Abstract:
+
+    Incremental non-emptiness checking for products of sequence views.
+
+--*/
+
+#include "ast/seq/seq_view_witness.h"
+#include <algorithm>
+#include <functional>
+#include <set>
+#include <unordered_set>
+
+namespace seq {
+
+    view_witness::view_witness(trail_stack& t, seq_rewriter& rw, live_states& live,
+                               transition_mode mode) :
+        m(rw.m()),
+        m_rw(rw),
+        m_trail(t),
+        m_live(live),
+        m_mode(mode),
+        m_pin(m),
+        m_witness_pin(m),
+        m_rp_cache(m),
+        m_ivl_pin(m) {
+    }
+
+    view_witness::~view_witness() {
+        reset_ivl_cache();
+    }
+
+    void view_witness::add(expr* x, view const& v, void* dependency) {
+        m_assertions.push_back(assertion(x, v, dependency, m));
+        m_trail.push(push_back_vector(m_assertions));
+        m_last_result = l_undef;
+        m_core.reset();
+        m_witnesses.reset();
+        m_witness_pin.reset();
+    }
+
+    void view_witness::dedup_views(view_vector const& in, view_vector& out) {
+        std::set<view::sig> seen;
+        for (auto const& v : in)
+            if (seen.insert(v.key()).second)
+                out.push_back(v);
+    }
+
+    view_witness::signature view_witness::mk_signature(view_vector const& views) {
+        signature sig;
+        for (auto const& v : views)
+            sig.push_back(v.key());
+        std::sort(sig.begin(), sig.end());
+        sig.erase(std::unique(sig.begin(), sig.end()), sig.end());
+        return sig;
+    }
+
+    bool view_witness::checkpoint() {
+        if (!m_checkpoint)
+            return false;
+        m_failure = m_checkpoint();
+        return m_failure != view_failure_reason::none;
+    }
+
+    lbool view_witness::nullable(expr* r) {
+        lbool i = re().get_info(r).nullable;
+        if (i != l_undef)
+            return i;
+        char v = 0;
+        if (m_nullable_cache.find(r, v)) {
+            if (v == 1)
+                return l_true;
+            if (v == 0)
+                return l_false;
+            return l_undef;
+        }
+        expr_ref nb = m_rw.is_nullable(r);
+        lbool result = m.is_true(nb) ? l_true : m.is_false(nb) ? l_false : l_undef;
+        m_pin.push_back(r);
+        m_nullable_cache.insert(r, result == l_true ? 1 : result == l_false ? 0 : 2);
+        return result;
+    }
+
+    expr_ref_pair_vector const& view_witness::derivative_cofactors(expr* r) {
+        ++m_cofactor_calls;
+        return m_rw.get_derive().get_cached_cofactors(m_mode, r);
+    }
+
+    void view_witness::reset_ivl_cache() {
+        for (auto& kv : m_ivl_cache)
+            dealloc(kv.m_value);
+        m_ivl_cache.reset();
+        m_ivl_pin.reset();
+    }
+
+    view_witness::ivl_list const* view_witness::interval_cofactors(expr* r, expr* v0) {
+        ivl_list* result = nullptr;
+        if (m_ivl_cache.find(r, result))
+            return result && result->ok ? result : nullptr;
+
+        unsigned max_char = u().max_char();
+        result = alloc(ivl_list);
+        m_ivl_cache.insert(r, result);
+        m_ivl_pin.push_back(r);
+
+        struct transition {
+            unsigned lo, hi;
+            expr* target;
+        };
+        svector<transition> transitions;
+        svector<unsigned> bounds;
+        bounds.push_back(0);
+        for (auto const& [guard, target] : derivative_cofactors(r)) {
+            if (re().is_empty(target))
+                continue;
+            range_predicate* predicate = nullptr;
+            if (!m_rp_cache.find(guard, predicate)) {
+                predicate = m_rp_cache.fresh(max_char);
+                if (!guard_to_range_predicate(u(), v0, guard, *predicate)) {
+                    m_rp_cache.insert(guard, nullptr);
+                    result->ok = false;
+                    return nullptr;
+                }
+                m_rp_cache.insert(guard, predicate);
+            }
+            else if (!predicate) {
+                result->ok = false;
+                return nullptr;
+            }
+            m_ivl_pin.push_back(target);
+            for (auto const& range : predicate->ranges()) {
+                transitions.push_back({ range.first, range.second, target });
+                bounds.push_back(range.first);
+                if (range.second < max_char)
+                    bounds.push_back(range.second + 1);
+            }
+        }
+        if (transitions.empty())
+            return result;
+
+        std::sort(bounds.begin(), bounds.end());
+        bounds.shrink(static_cast<unsigned>(std::unique(bounds.begin(), bounds.end()) - bounds.begin()));
+
+        ptr_vector<expr> hits;
+        for (unsigned i = 0; i < bounds.size(); ++i) {
+            unsigned lo = bounds[i];
+            unsigned hi = i + 1 < bounds.size() ? bounds[i + 1] - 1 : max_char;
+            hits.reset();
+            for (auto const& transition : transitions)
+                if (transition.lo <= lo && lo <= transition.hi)
+                    hits.push_back(transition.target);
+            if (hits.empty())
+                continue;
+            if (!result->ranges.empty()) {
+                ivl_range& previous = result->ranges.back();
+                if (previous.hi + 1 == lo && previous.count == hits.size()) {
+                    bool same = true;
+                    for (unsigned j = 0; j < hits.size() && same; ++j)
+                        same = result->targets[previous.first + j] == hits[j];
+                    if (same) {
+                        previous.hi = hi;
+                        continue;
+                    }
+                }
+            }
+            result->ranges.push_back({ lo, hi, result->targets.size(), hits.size() });
+            result->targets.append(hits.size(), hits.data());
+        }
+        return result;
+    }
+
+    lbool view_witness::product_nonempty(expr* var, view_vector const& input, expr_ref* witness_word) {
+        m_failure = view_failure_reason::none;
+        sort* elem_sort = nullptr;
+        sort* seq_sort = var->get_sort();
+        if (!u().is_seq(seq_sort, elem_sort)) {
+            m_failure = view_failure_reason::unsupported;
+            return l_undef;
+        }
+
+        view_vector views;
+        dedup_views(input, views);
+        unsigned n = views.size();
+        if (n == 0) {
+            if (witness_word)
+                *witness_word = expr_ref(u().str.mk_empty(seq_sort), m);
+            return l_true;
+        }
+
+        expr_ref var0(m.mk_var(0, elem_sort), m);
+        ptr_vector<expr> work;
+        std::unordered_set<key, key_hash> visited;
+        key key_buffer(n);
+        ptr_vector<expr> state;
+        state.resize(n);
+        ptr_vector<expr> current;
+        current.resize(n);
+
+        auto fill_key = [&](ptr_vector<expr> const& values) -> key const& {
+            for (unsigned i = 0; i < n; ++i)
+                key_buffer[i] = values[i]->get_id();
+            return key_buffer;
+        };
+
+        bool undecided = false;
+        auto is_accept = [&]() {
+            for (unsigned i = 0; i < n; ++i) {
+                if (views[i].m_target) {
+                    if (state[i] != views[i].m_target)
+                        return false;
+                }
+                else {
+                    lbool nb = nullable(state[i]);
+                    if (nb == l_true)
+                        continue;
+                    if (nb == l_false)
+                        return false;
+                    undecided = true;
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        std::map<key, std::pair<key, expr*>> parent;
+        key start_key(n);
+        for (unsigned i = 0; i < n; ++i) {
+            work.push_back(views[i].m_state);
+            start_key[i] = views[i].m_state->get_id();
+        }
+        visited.insert(start_key);
+
+        auto reconstruct = [&](key end_key) {
+            ptr_vector<expr> elements;
+            key k = end_key;
+            while (k != start_key) {
+                auto it = parent.find(k);
+                if (it == parent.end())
+                    break;
+                elements.push_back(it->second.second);
+                k = it->second.first;
+            }
+            expr_ref_vector units(m);
+            for (unsigned i = elements.size(); i-- > 0; )
+                units.push_back(u().str.mk_unit(elements[i]));
+            return expr_ref(u().str.mk_concat(units.size(), units.data(), seq_sort), m);
+        };
+
+        svector<expr_ref_pair_vector const*> branches;
+        branches.resize(n);
+        key state_key;
+        bool bail = false;
+        uint64_t const inner_limit = 1u << 16;
+        uint64_t inner_steps = 0;
+        auto inner_step = [&]() {
+            ++inner_steps;
+            m_max_state_expansion = std::max(m_max_state_expansion, static_cast<unsigned>(inner_steps));
+            if (inner_steps <= inner_limit)
+                return false;
+            m_failure = view_failure_reason::state_expansion;
+            return true;
+        };
+
+        bool const sweep_ok = u().is_char(elem_sort);
+        unsigned const max_char = sweep_ok ? u().max_char() : 0;
+        svector<ivl_list const*> sweep_lists;
+        svector<unsigned> sweep_cursors, sweep_odometer;
+        sweep_lists.resize(n);
+        sweep_cursors.resize(n);
+        sweep_odometer.resize(n);
+
+        auto sweep = [&]() {
+            for (unsigned i = 0; i < n; ++i) {
+                sweep_lists[i] = interval_cofactors(state[i], var0);
+                if (!sweep_lists[i])
+                    return false;
+                if (sweep_lists[i]->ranges.empty())
+                    return true;
+                sweep_cursors[i] = 0;
+            }
+            uint64_t begin = 0;
+            while (begin <= max_char) {
+                if (inner_step()) {
+                    bail = true;
+                    return true;
+                }
+                uint64_t next = static_cast<uint64_t>(max_char) + 1;
+                bool covered = true, done = false;
+                for (unsigned i = 0; i < n; ++i) {
+                    auto const& ranges = sweep_lists[i]->ranges;
+                    unsigned& cursor = sweep_cursors[i];
+                    while (cursor < ranges.size() && ranges[cursor].hi < begin)
+                        ++cursor;
+                    if (cursor == ranges.size()) {
+                        done = true;
+                        break;
+                    }
+                    if (ranges[cursor].lo > begin) {
+                        covered = false;
+                        next = std::min(next, static_cast<uint64_t>(ranges[cursor].lo));
+                    }
+                    else {
+                        next = std::min(next, static_cast<uint64_t>(ranges[cursor].hi) + 1);
+                    }
+                }
+                if (done)
+                    break;
+                if (covered) {
+                    for (unsigned i = 0; i < n; ++i)
+                        sweep_odometer[i] = 0;
+                    while (true) {
+                        if (inner_step()) {
+                            bail = true;
+                            return true;
+                        }
+                        for (unsigned i = 0; i < n; ++i) {
+                            auto const& range = sweep_lists[i]->ranges[sweep_cursors[i]];
+                            current[i] = sweep_lists[i]->targets[range.first + sweep_odometer[i]];
+                        }
+                        key const& child_key = fill_key(current);
+                        if (!visited.contains(child_key)) {
+                            visited.insert(child_key);
+                            if (witness_word) {
+                                expr* element = u().mk_char(static_cast<unsigned>(begin));
+                                m_pin.push_back(element);
+                                parent[child_key] = { state_key, element };
+                            }
+                            for (unsigned i = 0; i < n; ++i)
+                                work.push_back(current[i]);
+                        }
+                        unsigned i = n;
+                        while (i-- > 0) {
+                            if (++sweep_odometer[i] <
+                                sweep_lists[i]->ranges[sweep_cursors[i]].count)
+                                break;
+                            sweep_odometer[i] = 0;
+                        }
+                        if (i == UINT_MAX)
+                            break;
+                    }
+                }
+                begin = next;
+            }
+            return true;
+        };
+
+        std::function<void(unsigned, guard_set const&)> enumerate =
+            [&](unsigned i, guard_set const& accumulated) {
+                if (bail)
+                    return;
+                if (inner_step()) {
+                    bail = true;
+                    return;
+                }
+                if (i == n) {
+                    key const& child_key = fill_key(current);
+                    if (!visited.contains(child_key)) {
+                        visited.insert(child_key);
+                        if (witness_word) {
+                            expr_ref element(m);
+                            if (accumulated.eval(&element) == l_true) {
+                                m_pin.push_back(element);
+                                parent[child_key] = { state_key, element.get() };
+                            }
+                        }
+                        for (unsigned j = 0; j < n; ++j)
+                            work.push_back(current[j]);
+                    }
+                    return;
+                }
+                for (auto const& [guard, target] : *branches[i]) {
+                    if (re().is_empty(target))
+                        continue;
+                    guard_set next = accumulated;
+                    next.conjoin(guard);
+                    lbool nonempty = next.eval(nullptr);
+                    if (nonempty == l_undef) {
+                        m_failure = view_failure_reason::guard;
+                        bail = true;
+                        return;
+                    }
+                    if (nonempty == l_false)
+                        continue;
+                    current[i] = target;
+                    enumerate(i + 1, next);
+                    if (bail)
+                        return;
+                }
+            };
+
+        while (!work.empty()) {
+            if (checkpoint())
+                return l_undef;
+            ++m_states;
+            inner_steps = 0;
+            for (unsigned i = n; i-- > 0; ) {
+                state[i] = work.back();
+                work.pop_back();
+            }
+            if (is_accept()) {
+                if (witness_word)
+                    *witness_word = reconstruct(fill_key(state));
+                return l_true;
+            }
+            if (undecided) {
+                m_failure = view_failure_reason::nullability;
+                return l_undef;
+            }
+            if (witness_word)
+                state_key = fill_key(state);
+            if (sweep_ok) {
+                bool swept = sweep();
+                if (bail)
+                    return l_undef;
+                if (swept)
+                    continue;
+            }
+            for (unsigned i = 0; i < n; ++i)
+                branches[i] = &derivative_cofactors(state[i]);
+            guard_set top(m, u(), elem_sort, var0, &m_rp_cache);
+            enumerate(0, top);
+            if (bail)
+                return l_undef;
+        }
+        return l_false;
+    }
+
+    void view_witness::minimize_core(expr* var, unsigned_vector const& indices) {
+        unsigned_vector keep(indices);
+        for (unsigned i = 0; i < keep.size(); ) {
+            view_vector trial;
+            for (unsigned j = 0; j < keep.size(); ++j)
+                if (j != i)
+                    trial.push_back(m_assertions[keep[j]].m_view);
+            if (product_nonempty(var, trial) == l_false)
+                keep.erase(keep.begin() + i);
+            else
+                ++i;
+        }
+        for (unsigned index : keep) {
+            void* dependency = m_assertions[index].m_dependency;
+            if (dependency && !m_core.contains(dependency))
+                m_core.push_back(dependency);
+        }
+    }
+
+    lbool view_witness::check() {
+        m_core.reset();
+        m_witnesses.reset();
+        m_witness_pin.reset();
+        m_failure = view_failure_reason::none;
+
+        obj_map<expr, unsigned> group_ids;
+        ptr_vector<expr> vars;
+        vector<unsigned_vector> groups;
+        for (unsigned i = 0; i < m_assertions.size(); ++i) {
+            expr* var = m_assertions[i].m_var;
+            unsigned group = 0;
+            if (!group_ids.find(var, group)) {
+                group = groups.size();
+                group_ids.insert(var, group);
+                vars.push_back(var);
+                groups.push_back(unsigned_vector());
+            }
+            groups[group].push_back(i);
+        }
+
+        for (unsigned group = 0; group < groups.size(); ++group) {
+            view_vector views;
+            for (unsigned index : groups[group])
+                views.push_back(m_assertions[index].m_view);
+            signature sig = mk_signature(views);
+            auto cached = m_product_cache.find(sig);
+            lbool result = cached == m_product_cache.end() ? l_undef : cached->second;
+            expr_ref witness(m);
+            if (result != l_true || m_enable_witness)
+                result = product_nonempty(vars[group], views, m_enable_witness ? &witness : nullptr);
+            if (result == l_undef) {
+                m_last_result = l_undef;
+                return l_undef;
+            }
+            m_product_cache[sig] = result;
+            if (result == l_false) {
+                minimize_core(vars[group], groups[group]);
+                m_last_result = l_false;
+                return l_false;
+            }
+            if (m_enable_witness) {
+                m_witness_pin.push_back(vars[group]);
+                m_witness_pin.push_back(witness);
+                m_witnesses.insert(vars[group], witness);
+            }
+        }
+        m_last_result = l_true;
+        return l_true;
+    }
+
+    expr_ref view_witness::materialize_witness(expr* x) {
+        expr_ref result(m);
+        if (!m_enable_witness || m_last_result != l_true)
+            return result;
+        expr* witness = nullptr;
+        if (m_witnesses.find(x, witness))
+            return expr_ref(witness, m);
+        sort* elem_sort = nullptr;
+        if (u().is_seq(x->get_sort(), elem_sort))
+            result = u().str.mk_empty(x->get_sort());
+        return result;
+    }
+
+    void view_witness::reset_cache() {
+        reset_ivl_cache();
+        m_nullable_cache.reset();
+        m_product_cache.clear();
+        m_pin.reset();
+        m_rp_cache.maybe_reset(1u << 16);
+    }
+}

--- a/src/ast/seq/seq_view_witness.h
+++ b/src/ast/seq/seq_view_witness.h
@@ -1,0 +1,139 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+Module Name:
+
+    seq_view_witness.h
+
+Abstract:
+
+    Incremental non-emptiness checking for products of sequence views.
+
+--*/
+#pragma once
+
+#include "ast/rewriter/guard_set.h"
+#include "ast/rewriter/seq_range_collapse.h"
+#include "ast/seq/seq_regex_live.h"
+#include "ast/seq/seq_view.h"
+#include "util/trail.h"
+#include <functional>
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+namespace seq {
+
+    enum class view_failure_reason {
+        none,
+        unsupported,
+        budget,
+        resource,
+        state_expansion,
+        nullability,
+        guard
+    };
+
+    class view_witness {
+        struct assertion {
+            expr_ref m_var;
+            view     m_view;
+            void*    m_dependency;
+
+            assertion(expr* var, view const& v, void* dependency, ast_manager& m) :
+                m_var(var, m), m_view(v), m_dependency(dependency) {}
+        };
+
+        struct ivl_range {
+            unsigned lo, hi, first, count;
+        };
+
+        struct ivl_list {
+            svector<ivl_range> ranges;
+            ptr_vector<expr>   targets;
+            bool               ok = true;
+        };
+
+        using key = std::vector<unsigned>;
+
+        struct key_hash {
+            size_t operator()(key const& k) const {
+                uint64_t h = 1469598103934665603ull;
+                for (unsigned x : k)
+                    h = (h ^ x) * 1099511628211ull;
+                return static_cast<size_t>(h);
+            }
+        };
+
+        using signature = std::vector<view::sig>;
+
+        struct signature_hash {
+            size_t operator()(signature const& s) const {
+                uint64_t h = 1469598103934665603ull;
+                for (auto const& p : s) {
+                    h = (h ^ p.state) * 1099511628211ull;
+                    h = (h ^ p.target) * 1099511628211ull;
+                }
+                return static_cast<size_t>(h);
+            }
+        };
+
+        ast_manager&      m;
+        seq_rewriter&     m_rw;
+        trail_stack&      m_trail;
+        live_states&      m_live;
+        transition_mode   m_mode;
+        vector<assertion> m_assertions;
+        ptr_vector<void>  m_core;
+        obj_map<expr, expr*> m_witnesses;
+        expr_ref_vector   m_pin;
+        expr_ref_vector   m_witness_pin;
+        guard_set::cache  m_rp_cache;
+        obj_map<expr, ivl_list*> m_ivl_cache;
+        expr_ref_vector   m_ivl_pin;
+        obj_map<expr, char> m_nullable_cache;
+        std::unordered_map<signature, lbool, signature_hash> m_product_cache;
+        std::function<view_failure_reason()> m_checkpoint;
+        view_failure_reason m_failure = view_failure_reason::none;
+        lbool            m_last_result = l_undef;
+        bool             m_enable_witness = false;
+        unsigned         m_cofactor_calls = 0;
+        unsigned         m_states = 0;
+        unsigned         m_max_state_expansion = 0;
+
+        seq_util& u() const { return m_rw.u(); }
+        seq_util::rex& re() const { return m_rw.u().re; }
+
+        expr_ref_pair_vector const& derivative_cofactors(expr* r);
+        ivl_list const* interval_cofactors(expr* r, expr* v0);
+        void reset_ivl_cache();
+        bool checkpoint();
+        static void dedup_views(view_vector const& in, view_vector& out);
+        static signature mk_signature(view_vector const& views);
+        void minimize_core(expr* var, unsigned_vector const& indices);
+
+    public:
+        view_witness(trail_stack& t, seq_rewriter& rw, live_states& live,
+                     transition_mode mode = transition_mode::light_antimirov_tm);
+        ~view_witness();
+
+        void add(expr* x, view const& v, void* dependency);
+        lbool check();
+        ptr_vector<void> core() const { return m_core; }
+        expr_ref materialize_witness(expr* x);
+        void set_enable_witness(bool f) { m_enable_witness = f; }
+        void set_enable_witnes(bool f) { set_enable_witness(f); }
+        view_failure_reason get_failure_reason() const { return m_failure; }
+
+        lbool product_nonempty(expr* var, view_vector const& views, expr_ref* witness = nullptr);
+        lbool nullable(expr* r);
+        void set_checkpoint(std::function<view_failure_reason()> const& checkpoint) {
+            m_checkpoint = checkpoint;
+        }
+        void reset_cache();
+
+        unsigned cofactor_calls() const { return m_cofactor_calls; }
+        unsigned states() const { return m_states; }
+        unsigned max_state_expansion() const { return m_max_state_expansion; }
+    };
+}

--- a/src/test/seq_monadic.cpp
+++ b/src/test/seq_monadic.cpp
@@ -23,6 +23,7 @@ Author:
 #include "ast/arith_decl_plugin.h"
 #include "ast/rewriter/seq_rewriter.h"
 #include "ast/seq/seq_monadic.h"
+#include "ast/seq/seq_view_witness.h"
 #include "ast/rewriter/expr_safe_replace.h"
 #include "cmd_context/cmd_context.h"
 #include "parsers/smt2/smt2parser.h"
@@ -119,6 +120,7 @@ class seq_monadic_test {
             if (target == R) {
                 found_R = eval_guard(guard, 'a') && eval_guard(guard, 'b');
             }
+
             else if (target == dot3) {
                 found_dot3 = eval_guard(guard, 'a') && !eval_guard(guard, 'b');
             }
@@ -130,6 +132,54 @@ class seq_monadic_test {
         if (!ok) ++m_fail;
         std::cout << (ok ? "  OK   " : "  FAIL ")
                   << mode_name() << " cofactor construction\n";
+    }
+
+    void check_view_witness() {
+        std::cout << "=== seq_view_witness: incremental product checking ===\n";
+        expr_ref x = var("view-x");
+        expr_ref aa = word("aa");
+        expr_ref a = word("a");
+        expr_ref even = star(aa);
+        expr_ref odd = cat(a, even);
+        unsigned dep_even = 0, dep_odd = 1;
+        seq::live_states live(m_rw, m_mode, 1u << 12);
+        seq::view_witness witness(m_trail, m_rw, live, m_mode);
+
+        m_trail.push_scope();
+        witness.add(x, seq::view::membership(even, m), &dep_even);
+        lbool first = witness.check();
+        unsigned calls = witness.cofactor_calls();
+        lbool repeated = witness.check();
+        bool cached = first == l_true && repeated == l_true &&
+                      calls == witness.cofactor_calls();
+
+        m_trail.push_scope();
+        witness.add(x, seq::view::membership(odd, m), &dep_odd);
+        lbool conflict = witness.check();
+        ptr_vector<void> core = witness.core();
+        bool core_ok = conflict == l_false && core.contains(&dep_even) &&
+                       core.contains(&dep_odd) && core.size() == 2;
+        m_trail.pop_scope(1);
+
+        witness.set_enable_witness(true);
+        lbool after_pop = witness.check();
+        expr_ref value = witness.materialize_witness(x);
+        bool materialized = after_pop == l_true && value;
+        m_trail.pop_scope(1);
+
+        witness.set_checkpoint([]() { return seq::view_failure_reason::budget; });
+        m_trail.push_scope();
+        witness.add(x, seq::view::membership(odd, m), nullptr);
+        lbool undef = witness.check();
+        bool reason_ok = undef == l_undef &&
+                         witness.get_failure_reason() == seq::view_failure_reason::budget;
+        m_trail.pop_scope(1);
+
+        bool ok = cached && core_ok && materialized && reason_ok;
+        if (!ok)
+            ++m_fail;
+        std::cout << (ok ? "  OK   " : "  FAIL ")
+                  << "cache, trail, core, and witness\n";
     }
 
     void check(char const* name, expr* term, expr* R, lbool expected) {
@@ -1169,6 +1219,7 @@ public:
             m_mon.set_budget(saved_budget);
         }
 
+        check_view_witness();
         std::cout << "=== seq_monadic: " << (m_fail == 0 ? "ALL PASS" : "FAILURES") << " ("
                   << m_fail << " fail) ===\n";
         ENSURE(m_fail == 0);


### PR DESCRIPTION
## Summary
- extract product-of-views non-emptiness checking from `seq_monadic` into `seq::view_witness`
- add trailed incremental constraints, dependency-core extraction, optional witness materialization, and failure reporting
- preserve `seq_monadic` budget accounting, failure statistics, transition modes, and product-search optimizations
- add focused coverage for caching, backtracking, cores, witnesses, and undefined results

## Validation
- `ninja -C build seq test-z3`
- `build\test-z3.exe seq_monadic`
- `build\test-z3.exe /a` — 105 passed, 0 failed
- `build\z3.exe` smoke tests for version, SMT solving, model generation, and help
- regex corpus: 1,986 files, 32 workers, `-T:10`; 1,267 sat, 377 unsat, 342 timeout, 0 errors