### PR TITLE
opt: reuse nlsat state across Pareto checks

### DIFF
--- a/src/nlsat/nlsat_explain.cpp
+++ b/src/nlsat/nlsat_explain.cpp
@@ -24,6 +24,7 @@ Revision History:
 #include "nlsat/nlsat_common.h"
 #include "util/ref_buffer.h"
 #include "util/mpq.h"
+#include "util/util.h"
 
 namespace nlsat {
 
@@ -129,6 +130,15 @@ namespace nlsat {
             for (literal lit : *m_result) 
                 m_already_added_literal[lit.index()] = false;
             SASSERT(check_already_added());
+        }
+
+        // Clear duplicate marks before cancellation lets the caller discard the
+        // result buffer; otherwise a retry can silently omit required literals.
+        void reset_result() {
+            if (m_result) {
+                reset_already_added();
+                m_result = nullptr;
+            }
         }
 
         
@@ -750,9 +760,8 @@ namespace nlsat {
 
         void test_root_literal(atom::kind k, var y, unsigned i, poly * p, scoped_literal_vector& result) {
             m_result = &result;
+            on_scope_exit reset([&] { reset_result(); });
             add_root_literal(k, y, i, p);
-            reset_already_added();
-            m_result = nullptr;
         }
 
         
@@ -1583,18 +1592,16 @@ namespace nlsat {
             while (true) {
                 try {
                     m_result = &result;
+                    on_scope_exit reset([&] { reset_result(); });
                     process(num, ls);
-                    reset_already_added();
-                    m_result = nullptr;
+                    reset_result();
                     TRACE(nlsat_explain, display(tout << "[explain] result\n", m_solver, result) << "\n";);
                     CASSERT("nlsat", check_already_added());
                     break;
                 }
                 catch (add_all_coeffs_restart const&) {
                     TRACE(nlsat_explain, tout << "restarting explanation with all coefficients\n";);
-                    reset_already_added();
                     result.shrink(base);
-                    m_result = nullptr;
                 }
             }
         }
@@ -1611,6 +1618,7 @@ namespace nlsat {
                   );
 
             m_result = &result;
+            on_scope_exit reset([&] { reset_result(); });
             m_lower_stage_polys.reset();
             collect_polys(num, ls, m_ps);
             for (unsigned i = 0; i < m_lower_stage_polys.size(); i++) {
@@ -1625,8 +1633,7 @@ namespace nlsat {
             SASSERT(levelwise_ok);
             m_solver.record_levelwise_result(levelwise_ok);
 
-            reset_already_added();
-            m_result = nullptr;
+            reset_result();
             TRACE(nlsat_explain, display(tout << "[explain] result\n", m_solver, result) << "\n";);
             CASSERT("nlsat", check_already_added());
         }
@@ -1638,6 +1645,7 @@ namespace nlsat {
                 bool reordered = false;
                 try {
                     m_result = &result;
+                    on_scope_exit reset([&] { reset_result(); });
                     svector<literal> lits;
                     TRACE(nlsat, tout << "project x" << x << "\n"; 
                           m_solver.display(tout, num, ls);
@@ -1667,15 +1675,13 @@ namespace nlsat {
                         }
                         elim_vanishing(m_ps);
                         project(m_ps, mx_var);
-                        reset_already_added();
-                        m_result = nullptr;
+                        reset_result();
                         if (reordered) {
                             m_solver.restore_order();
                         }
                     }
                     else {
-                        reset_already_added();
-                        m_result = nullptr;
+                        reset_result();
                     }
                     for (unsigned i = 0; i < result.size(); ++i) {
                         result.set(i, ~result[i]);
@@ -1693,12 +1699,10 @@ namespace nlsat {
                 }
                 catch (add_all_coeffs_restart const&) {
                     TRACE(nlsat_explain, tout << "restarting projection with all coefficients\n";);
-                    reset_already_added();
                     if (reordered) {
                         m_solver.restore_order();
                     }
                     result.shrink(base);
-                    m_result = nullptr;
                 }
             }
         }
@@ -1730,6 +1734,7 @@ namespace nlsat {
     }
 
     void explain::reset() {
+        m_imp->reset_result();
         m_imp->m_core1.reset();
         m_imp->m_core2.reset();
     }

--- a/src/nlsat/nlsat_explain.h
+++ b/src/nlsat/nlsat_explain.h
@@ -63,6 +63,10 @@ namespace nlsat {
                  - (s_1 or ... or s_m or ~ls[0] or ... or ~ls[n-1]) is a valid clause
                  - s_1, ..., s_m do not contain variable x.
                  - s_1, ..., s_m are false in the current interpretation
+
+           If this operation throws, result may contain partial output and must
+           be cleared before retrying. Internal duplicate-literal marks are
+           cleared even on exception, so the explanation engine can be reused.
         */
         void compute_conflict_explanation(unsigned n, literal const * ls, scoped_literal_vector & result);
 

--- a/src/nlsat/nlsat_solver.cpp
+++ b/src/nlsat/nlsat_solver.cpp
@@ -2261,6 +2261,56 @@ namespace nlsat {
             m_asm.linearize(m_lemma_assumptions.get(), deps);
         }
 
+        void get_dependencies(clause const& c, vector<assumption, false>& deps) const {
+            deps.reset();
+            m_asm.linearize(static_cast<_assumption_set>(c.assumptions()), deps);
+        }
+
+        /**
+           \brief Undo the temporary clause group identified by scope_tag without
+           rebuilding the solver, for example after a Pareto improvement climb.
+
+           Remove both the tagged input clauses and learned clauses whose
+           derivations depend on scope_tag; keeping those consequences could
+           incorrectly exclude models after the group is removed. Clear search state first
+           so trails and explanations no longer reference clauses being deleted.
+           Other input clauses survive, along with at most max_lemmas learned
+           clauses independent of scope_tag, preferring shorter ones. The previous
+           model and unsat core are invalidated.
+        */
+        void retract(assumption scope_tag, unsigned max_lemmas) {
+            if (!m_incremental || !scope_tag)
+                throw default_exception("nlsat retraction requires an incremental solver and a non-null assumption");
+            init_search();
+            m_explain.reset();
+            m_lemma.reset();
+            m_lazy_clause.reset();
+            m_lemma_assumptions = nullptr;
+            vector<assumption, false> deps;
+            auto remove = [&](clause_vector& clauses) {
+                unsigned j = 0;
+                for (clause* c : clauses) {
+                    get_dependencies(*c, deps);
+                    if (std::find(deps.begin(), deps.end(), scope_tag) != deps.end())
+                        del_clause(c);
+                    else
+                        clauses[j++] = c;
+                }
+                clauses.shrink(j);
+            };
+            remove(m_clauses);
+            remove(m_learned);
+            del_clauses(m_valids);
+            if (m_learned.size() > max_lemmas) {
+                std::stable_sort(m_learned.begin(), m_learned.end(),
+                                 [](clause* a, clause* b) { return a->size() < b->size(); });
+                while (m_learned.size() > max_lemmas) {
+                    del_clause(m_learned.back());
+                    m_learned.pop_back();
+                }
+            }
+        }
+
         void collect(literal_vector const& assumptions, clause_vector& clauses) {
             unsigned j  = 0;
             for (clause * c : clauses) {
@@ -4678,6 +4728,18 @@ namespace nlsat {
         
     void solver::mk_clause(unsigned num_lits, literal * lits, assumption a) {
         return m_imp->mk_external_clause(num_lits, lits, a);
+    }
+
+    ptr_vector<clause> const& solver::get_lemmas() const {
+        return m_imp->m_learned;
+    }
+
+    void solver::get_dependencies(clause const& c, vector<assumption, false>& deps) const {
+        m_imp->get_dependencies(c, deps);
+    }
+
+    void solver::retract(assumption scope_tag, unsigned max_lemmas) {
+        m_imp->retract(scope_tag, max_lemmas);
     }
 
     std::ostream& solver::display(std::ostream & out) const {

--- a/src/nlsat/nlsat_solver.cpp
+++ b/src/nlsat/nlsat_solver.cpp
@@ -2679,7 +2679,18 @@ namespace nlsat {
         struct scoped_reset_marks {
             imp& i;
             scoped_reset_marks(imp& i):i(i) {}
-            ~scoped_reset_marks() { if (i.m_num_marks > 0) { i.m_num_marks = 0; for (char& m : i.m_marks) m = 0; } }
+            ~scoped_reset_marks() {
+                if (i.m_num_marks > 0) {
+                    i.m_num_marks = 0;
+                    for (char& m : i.m_marks)
+                        m = 0;
+                }
+                else {
+                    // The counter tracks pending trail literals, not those
+                    // already in the lemma when cancellation interrupts resolution.
+                    i.reset_marks();
+                }
+            }
         };
 
 

--- a/src/nlsat/nlsat_solver.h
+++ b/src/nlsat/nlsat_solver.h
@@ -133,6 +133,21 @@ namespace nlsat {
         */
         void mk_clause(unsigned num_lits, literal * lits, assumption a = nullptr);
 
+        /**
+           \brief Borrow the learned clauses and inspect their external assumption tags.
+           Clause pointers remain valid only until the next solver mutation.
+        */
+        ptr_vector<clause> const& get_lemmas() const;
+        void get_dependencies(clause const& c, vector<assumption, false>& deps) const;
+
+        /**
+           \brief Retract clauses depending on the non-null external scope_tag,
+           preserving independent learned clauses without rebuilding surviving atoms.
+           Keep at most max_lemmas learned clauses, preferring shorter clauses.
+           Requires an incremental solver. Invalidates the model and unsat core.
+        */
+        void retract(assumption scope_tag, unsigned max_lemmas = UINT_MAX);
+
         // -----------------------
         //
         // Basic

--- a/src/nlsat/tactic/goal2nlsat.cpp
+++ b/src/nlsat/tactic/goal2nlsat.cpp
@@ -59,12 +59,13 @@ struct goal2nlsat::imp {
     expr2var &                m_t2x;
     nlsat_expr2polynomial     m_expr2poly;
     polynomial::factor_params m_fparams;
+    nlsat::assumption         m_assumption;
 
     unsigned long long        m_max_memory;
     bool                      m_factor;
 
 
-    imp(ast_manager & _m, params_ref const & p, nlsat::solver & s, expr2var & a2b, expr2var & t2x):
+    imp(ast_manager & _m, params_ref const & p, nlsat::solver & s, expr2var & a2b, expr2var & t2x, nlsat::assumption a):
         m(_m),
         m_solver(s),
         m_pm(s.pm()),
@@ -72,7 +73,8 @@ struct goal2nlsat::imp {
         m_util(m),
         m_a2b(a2b),
         m_t2x(t2x),
-        m_expr2poly(m_solver, m, m_solver.pm(), &m_t2x) {
+        m_expr2poly(m_solver, m, m_solver.pm(), &m_t2x),
+        m_assumption(a) {
         updt_params(p);
     }
 
@@ -248,7 +250,7 @@ struct goal2nlsat::imp {
         for (unsigned i = 0; i < num_lits; ++i) {
             ls.push_back(process_literal(lits[i]));
         }
-        m_solver.mk_clause(ls.size(), ls.data(), dep);
+        m_solver.mk_clause(ls.size(), ls.data(), m_assumption ? m_assumption : dep);
     }
 
     void operator()(goal const & g) {
@@ -288,8 +290,11 @@ void goal2nlsat::collect_param_descrs(param_descrs & r) {
     polynomial::factor_params::get_param_descrs(r);
 }
     
-void goal2nlsat::operator()(goal const & g, params_ref const & p, nlsat::solver & s, expr2var & a2b, expr2var & t2x) {
-    imp local_imp(g.m(), p, s, a2b, t2x);
+void goal2nlsat::operator()(goal const & g, params_ref const & p, nlsat::solver & s, expr2var & a2b, expr2var & t2x,
+                          nlsat::assumption a) {
+    if (a && g.unsat_core_enabled())
+        throw tactic_exception("external nlsat assumptions cannot replace goal unsat-core dependencies");
+    imp local_imp(g.m(), p, s, a2b, t2x, a);
     scoped_set_imp setter(*this, local_imp);
     local_imp(g);
 }

--- a/src/nlsat/tactic/goal2nlsat.h
+++ b/src/nlsat/tactic/goal2nlsat.h
@@ -46,9 +46,11 @@ public:
        
        \remark a2b and t2x m don't need to be empty. The definitions there are reused.
 
-       The input is expected to be in CNF
+       The input is expected to be in CNF. A non-null external assumption tags
+       every compiled clause; in this case the goal must not track unsat cores.
     */
-    void operator()(goal const & g, params_ref const & p, nlsat::solver & s, expr2var & a2b, expr2var & t2x);
+    void operator()(goal const & g, params_ref const & p, nlsat::solver & s, expr2var & a2b, expr2var & t2x,
+                    nlsat::assumption a = nullptr);
     
 };
 
@@ -67,4 +69,3 @@ public:
     expr_ref operator()(nlsat::solver& s, u_map<expr*> const& b2a, u_map<expr*> const& x2t, nlsat::literal l);
 
 };
-

--- a/src/opt/CMakeLists.txt
+++ b/src/opt/CMakeLists.txt
@@ -9,6 +9,7 @@ z3_add_component(z3_opt
     opt_lns.cpp
     opt_nlsat.cpp
     opt_pareto.cpp
+    opt_pareto_solver.cpp
     opt_parse.cpp
     opt_preprocess.cpp
     optsmt.cpp

--- a/src/opt/opt_context.cpp
+++ b/src/opt/opt_context.cpp
@@ -50,6 +50,7 @@ Notes:
 #include "opt/opt_context.h"
 #include "opt/opt_solver.h"
 #include "opt/opt_nlsat.h"
+#include "opt/opt_pareto_solver.h"
 #include "opt/opt_params.hpp"
 
 
@@ -777,6 +778,7 @@ namespace opt {
         m_pareto_exact_comparison = false;
         if (!optp.pareto_nlsat() || m_has_assumptions)
             return m_solver.get();
+        expr_ref_vector terms(m_hard_constraints);
         for (objective const& obj : m_objectives) {
             if (obj.m_type != O_MAXIMIZE && obj.m_type != O_MINIMIZE)
                 return m_solver.get();
@@ -784,22 +786,37 @@ namespace opt {
                 return m_solver.get();
             if (!in_nra_fragment(m, m_arith, m_hard_constraints, obj.m_term))
                 return m_solver.get();
+            terms.push_back(obj.m_term);
         }
-        tactic_ref t = mk_qfnra_nlsat_tactic(m, m_params);
-        solver* s = mk_tactic2solver(m, t.get(), m_params);
+        solver* s;
+        bool reuse_nlsat_solver = optp.pareto_nlsat_reuse() && can_reuse_nlsat_solver(terms);
+        if (reuse_nlsat_solver)
+            s = mk_pareto_nlsat_solver(m, m_params);
+        else {
+            tactic_ref t = mk_qfnra_nlsat_tactic(m, m_params);
+            s = mk_tactic2solver(m, t.get(), m_params);
+        }
         for (expr* f : m_hard_constraints)
             s->assert_expr(f);
         m_pareto_exact_comparison = true;
-        IF_VERBOSE(2, verbose_stream() << "(opt.pareto :solver qfnra-nlsat)\n");
+        IF_VERBOSE(2, verbose_stream() << "(opt.pareto :solver " << (reuse_nlsat_solver ? "incremental-nlsat" : "qfnra-nlsat") << ")\n");
         return s;
     }
 
     lbool context::execute_pareto() {
         if (!m_pareto) {
+            m_pareto_unknown.clear();
             set_pareto(alloc(gia_pareto, m, *this, mk_pareto_solver(), m_params));
         }
         lbool is_sat = (*(m_pareto.get()))();
         if (is_sat != l_true) {
+            if (is_sat == l_undef)
+                m_pareto_unknown = m_pareto->reason_unknown();
+            if (m_pareto_exact_comparison) {
+                statistics stats;
+                m_pareto->collect_statistics(stats);
+                add_statistics(stats);
+            }
             set_pareto(nullptr);
         }
         if (is_sat == l_true) {
@@ -813,6 +830,8 @@ namespace opt {
         if (!m.inc()) {
             return Z3_CANCELED_MSG;
         }
+        if (!m_pareto_unknown.empty())
+            return m_pareto_unknown;
         if (m_solver.get()) {
             return m_solver->reason_unknown();
         }
@@ -1841,6 +1860,7 @@ namespace opt {
 
     void context::clear_state() {
         m_pareto = nullptr;
+        m_pareto_unknown.clear();
         m_pareto1 = false;
         m_box_index = UINT_MAX;
         m_box_models.reset();
@@ -1858,6 +1878,8 @@ namespace opt {
     void context::collect_statistics_core(statistics& stats) const {
         if (m_solver) 
             m_solver->collect_statistics(stats);
+        if (m_pareto && m_pareto_exact_comparison)
+            m_pareto->collect_statistics(stats);
         if (m_simplify) 
             m_simplify->collect_statistics(stats);        
         for (auto const& kv : m_maxsmts) 

--- a/src/opt/opt_context.h
+++ b/src/opt/opt_context.h
@@ -207,6 +207,7 @@ namespace opt {
         symbol                       m_logic;
         svector<symbol>              m_labels;
         std::string                  m_unknown;
+        std::string                  m_pareto_unknown;
     public:
         context(ast_manager& m);
         ~context() override;
@@ -386,4 +387,3 @@ namespace opt {
     };
 
 }
-

--- a/src/opt/opt_params.pyg
+++ b/src/opt/opt_params.pyg
@@ -5,6 +5,8 @@ def_module_params('opt',
                           ('optsmt_bisect_rounds', UINT, 64, 'maximal number of solver calls spent bisecting the interval between the best model value and the refuted arithmetic bound of a real-valued objective (e.g. under nonlinear constraints); when exhausted the objective is reported as unknown with that interval'),
                           ('optsmt_nlsat', BOOL, True, 'optimize real objectives under nonlinear constraints exactly over nlsat cells (algebraic optima print as root-obj; unboundedness proven by nlqsat queries under an escalating rlimit budget)'),
                           ('pareto_nlsat', BOOL, True, 'enumerate Pareto fronts of pure NRA problems over an nlsat-backed solver, comparing objectives against exact algebraic model values instead of rounded isolating-interval endpoints'),
+                          ('pareto_nlsat_reuse', BOOL, True, 'reuse nlsat clauses across Pareto checks on polynomial real problems; false keeps the exact solver that starts each check from scratch'),
+                          ('pareto_nlsat_max_lemmas', UINT, 128, 'maximum number of independent learned clauses retained between Pareto climbs; shorter clauses are preferred'),
                           ('maxsat_engine', SYMBOL, 'maxres', "select engine for maxsat: 'core_maxsat', 'wmax', 'maxres', 'maxresw', 'pd-maxres', 'maxres-bin', 'rc2'"),
                           ('priority', SYMBOL, 'lex', "select how to prioritize objectives: 'lex' (lexicographic), 'pareto', 'box'"),
                           ('dump_benchmarks', BOOL, False, 'dump benchmarks for profiling'),
@@ -34,8 +36,6 @@ def_module_params('opt',
                           ('maxres.pivot_on_correction_set', BOOL, True, 'reduce soft constraints if the current correction set is smaller than current core')
 
                           ))
-
-
 
 
 

--- a/src/opt/opt_pareto.h
+++ b/src/opt/opt_pareto.h
@@ -63,6 +63,7 @@ namespace opt {
         virtual void collect_statistics(statistics & st) const {
             m_solver->collect_statistics(st);
         }
+        std::string reason_unknown() const { return m_solver->reason_unknown(); }
         virtual void display(std::ostream & out) const {
             m_solver->display(out);
         }
@@ -104,4 +105,3 @@ namespace opt {
         lbool operator()() override;
     };
 }
-

--- a/src/opt/opt_pareto_solver.cpp
+++ b/src/opt/opt_pareto_solver.cpp
@@ -1,0 +1,296 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+Module Name:
+
+    opt_pareto_solver.cpp
+
+Abstract:
+
+    Keep nlsat clauses and expression mappings across Pareto improvement
+    checks. Scope-local assertions and their learned consequences carry
+    an opaque assumption tag and are retracted together.
+
+--*/
+#include "opt/opt_pareto_solver.h"
+#include "opt/opt_params.hpp"
+#include "ast/arith_decl_plugin.h"
+#include "ast/expr2var.h"
+#include "ast/for_each_expr.h"
+#include "nlsat/nlsat_solver.h"
+#include "nlsat/tactic/goal2nlsat.h"
+#include "solver/solver_na2as.h"
+#include "tactic/arith/purify_arith_tactic.h"
+#include "tactic/core/elim_term_ite_tactic.h"
+#include "tactic/core/simplify_tactic.h"
+#include "tactic/core/tseitin_cnf_tactic.h"
+#include "tactic/tactical.h"
+
+namespace opt {
+
+    bool can_reuse_nlsat_solver(expr_ref_vector const& terms) {
+        ast_manager& m = terms.m();
+        arith_util a(m);
+        for (expr* e : subterms::all(terms)) {
+            if (!is_app(e))
+                return false;
+            app* n = to_app(e);
+            if (!m.is_bool(e) && !a.is_real(e) && !a.is_numeral(e))
+                return false;
+            if (is_uninterp_const(e) || n->get_family_id() == m.get_basic_family_id())
+                continue;
+            if (n->get_family_id() != a.get_family_id())
+                return false;
+            rational r;
+            switch (n->get_decl_kind()) {
+            case OP_NUM: case OP_IRRATIONAL_ALGEBRAIC_NUM:
+            case OP_LE: case OP_GE: case OP_LT: case OP_GT:
+            case OP_ADD: case OP_SUB: case OP_UMINUS: case OP_MUL:
+                break;
+            case OP_DIV:
+                if (!a.is_numeral(n->get_arg(1), r) || r.is_zero())
+                    return false;
+                break;
+            case OP_POWER:
+                if (!a.is_numeral(n->get_arg(1), r) || !r.is_unsigned() || r.is_zero())
+                    return false;
+                break;
+            default:
+                return false;
+            }
+        }
+        return true;
+    }
+
+    namespace {
+
+    params_ref incremental_params(params_ref const& p) {
+        params_ref result(p);
+        // Keep root atoms and external variable IDs stable, also on cancellation.
+        result.set_bool("reorder", false);
+        result.set_bool("shuffle_vars", false);
+        result.set_uint("variable_ordering_strategy", 0);
+        return result;
+    }
+
+    tactic* mk_preprocessor(ast_manager& m, params_ref const& p) {
+        params_ref simp(p), purify(p);
+        simp.set_bool("elim_and", true);
+        simp.set_bool("blast_distinct", true);
+        simp.set_bool("expand_power", true);
+        purify.set_bool("complete", false);
+        // No solve-eqs or unconstrained-variable elimination: later assertions
+        // must still refer to the same original constants.
+        return and_then(
+            using_params(mk_simplify_tactic(m, p), simp),
+            using_params(mk_purify_arith_tactic(m, p), purify),
+            mk_elim_term_ite_tactic(m, p),
+            using_params(mk_purify_arith_tactic(m, p), purify),
+            using_params(mk_simplify_tactic(m, p), simp),
+            mk_tseitin_cnf_core_tactic(m, p),
+            using_params(mk_simplify_tactic(m, p), simp));
+    }
+
+    class pareto_nlsat_solver : public solver_na2as {
+        expr_ref_vector m_assertions;
+        expr_ref_vector m_tags;
+        expr_ref_vector m_scope_tags;
+        unsigned_vector m_limits;
+        unsigned m_head = 0;
+        mutable nlsat::solver m_nlsat;
+        expr2var m_a2b, m_t2x;
+        tactic_ref m_preprocessor;
+        model_ref m_model;
+        expr_ref_vector m_core;
+        std::string m_unknown;
+        unsigned m_checks = 0, m_retractions = 0, m_retained_lemmas = 0;
+
+        void invalidate() {
+            m_model = nullptr;
+            m_core.reset();
+        }
+
+        void internalize() {
+            while (m_head < m_assertions.size()) {
+                expr* tag = m_tags.get(m_head);
+                unsigned end = m_head + 1;
+                while (end < m_assertions.size() && m_tags.get(end) == tag)
+                    ++end;
+                goal_ref g = alloc(goal, m, false, false, false);
+                for (unsigned i = m_head; i < end; ++i)
+                    g->assert_expr(m_assertions.get(i));
+                goal_ref_buffer result;
+                m_preprocessor->cleanup();
+                (*m_preprocessor)(g, result);
+                if (result.size() != 1)
+                    throw tactic_exception("Pareto nlsat preprocessing requires a single goal");
+                if (result[0]->inconsistent())
+                    m_nlsat.mk_clause(0, nullptr, tag);
+                else {
+                    goal2nlsat g2n;
+                    g2n(*result[0], get_params(), m_nlsat, m_a2b, m_t2x, tag);
+                }
+                m_head = end;
+            }
+        }
+
+        void extract_model() {
+            arith_util a(m);
+            m_model = alloc(model, m);
+            // Preprocessing only introduces auxiliaries; projecting onto the
+            // original constants hides them without scope-sensitive converters.
+            for (expr* e : subterms::all(m_assertions)) {
+                if (!is_uninterp_const(e))
+                    continue;
+                if (m_t2x.is_var(e)) {
+                    expr_ref value(a.mk_numeral(m_nlsat.am(), m_nlsat.value(m_t2x.to_var(e)), false), m);
+                    m_model->register_decl(to_app(e)->get_decl(), value);
+                }
+                else if (m_a2b.is_var(e)) {
+                    lbool value = m_nlsat.bvalue(m_a2b.to_var(e));
+                    if (value != l_undef)
+                        m_model->register_decl(to_app(e)->get_decl(), value == l_true ? m.mk_true() : m.mk_false());
+                }
+            }
+        }
+
+        lbool check() {
+            ++m_checks;
+            m_unknown.clear();
+            try {
+                internalize();
+                lbool result = m_nlsat.check();
+                if (result == l_true)
+                    extract_model();
+                else if (result == l_undef)
+                    m_unknown = "incomplete nlsat search";
+                return result;
+            }
+            catch (tactic_exception& ex) {
+                m_unknown = ex.what();
+            }
+            catch (nlsat::solver_exception& ex) {
+                m_unknown = ex.what();
+            }
+            IF_VERBOSE(2, verbose_stream() << "(opt.pareto nlsat: " << m_unknown << ")\n");
+            return l_undef;
+        }
+
+    public:
+        pareto_nlsat_solver(ast_manager& m, params_ref const& p):
+            solver_na2as(m), m_assertions(m), m_tags(m), m_scope_tags(m),
+            m_nlsat(m.limit(), incremental_params(p), true), m_a2b(m), m_t2x(m),
+            m_preprocessor(mk_preprocessor(m, p)), m_core(m) {
+            solver::updt_params(p);
+        }
+
+        solver* translate(ast_manager& m, params_ref const& p) override {
+            throw default_exception("the private Pareto nlsat solver cannot be translated");
+        }
+
+        ast_manager& get_manager() const override { return m; }
+
+        void updt_params(params_ref const& p) override {
+            solver::updt_params(p);
+            m_nlsat.updt_params(incremental_params(get_params()));
+            m_preprocessor->updt_params(get_params());
+        }
+
+        void collect_param_descrs(param_descrs& r) override {
+            solver::collect_param_descrs(r);
+            m_preprocessor->collect_param_descrs(r);
+            nlsat::solver::collect_param_descrs(r);
+        }
+
+        void assert_expr_core(expr* e) override {
+            m_assertions.push_back(e);
+            m_tags.push_back(m_scope_tags.empty() ? nullptr : m_scope_tags.back());
+            invalidate();
+        }
+
+        void push_core() override {
+            m_limits.push_back(m_assertions.size());
+            m_scope_tags.push_back(m.mk_fresh_const("pareto.nlsat.scope", m.mk_bool_sort()));
+            invalidate();
+        }
+
+        void pop_core(unsigned n) override {
+            SASSERT(n <= m_limits.size());
+            if (!n)
+                return;
+            unsigned level = m_limits.size() - n;
+            unsigned limit = m_limits[level];
+            opt_params optp(get_params());
+            for (unsigned i = m_limits.size(); i-- > level;) {
+                m_nlsat.retract(m_scope_tags.get(i), optp.pareto_nlsat_max_lemmas());
+                ++m_retractions;
+                m_retained_lemmas += m_nlsat.get_lemmas().size();
+            }
+            m_assertions.shrink(limit);
+            m_tags.shrink(limit);
+            m_head = std::min(m_head, limit);
+            m_limits.shrink(level);
+            m_scope_tags.shrink(level);
+            invalidate();
+        }
+
+        lbool check_sat_core2(unsigned n, expr* const* assumptions) override {
+            invalidate();
+            if (!n)
+                return check();
+            lbool result;
+            model_ref model;
+            {
+                solver::scoped_push scope(*this);
+                for (unsigned i = 0; i < n; ++i)
+                    assert_expr(assumptions[i]);
+                result = check();
+                model = m_model;
+            }
+            m_model = model;
+            if (result == l_false)
+                m_core.append(n, assumptions);
+            return result;
+        }
+
+        unsigned get_num_assertions() const override { return m_assertions.size(); }
+        expr* get_assertion(unsigned i) const override { return m_assertions.get(i); }
+        void get_model_core(model_ref& model) override { model = m_model; }
+        void get_unsat_core(expr_ref_vector& core) override { core.append(m_core); }
+        proof* get_proof_core() override { return nullptr; }
+        void get_labels(svector<symbol>& labels) override { labels.reset(); }
+        std::string reason_unknown() const override { return m_unknown; }
+        void set_reason_unknown(char const* msg) override { m_unknown = msg; }
+
+        void collect_statistics_core(statistics& st) const override {
+            m_nlsat.collect_statistics(st);
+            st.update("pareto nlsat checks", m_checks);
+            st.update("pareto nlsat retractions", m_retractions);
+            st.update("pareto nlsat retained lemmas", m_retained_lemmas);
+        }
+
+        void set_progress_callback(progress_callback*) override {}
+        void set_phase(expr*) override {}
+        phase* get_phase() override { return nullptr; }
+        void set_phase(phase*) override {}
+        void move_to_front(expr*) override {}
+        expr* congruence_root(expr* e) override { return e; }
+        expr* congruence_next(expr* e) override { return e; }
+        expr_ref congruence_explain(expr* a, expr* b) override { return expr_ref(m.mk_eq(a, b), m); }
+        expr_ref_vector cube(expr_ref_vector&, unsigned) override {
+            throw default_exception("cubing is not supported by the private Pareto nlsat solver");
+        }
+        void get_levels(ptr_vector<expr> const&, unsigned_vector&) override {
+            throw default_exception("levels are not supported by the private Pareto nlsat solver");
+        }
+        expr_ref_vector get_trail(unsigned) override {
+            throw default_exception("trails are not supported by the private Pareto nlsat solver");
+        }
+    };
+
+    }
+
+    solver* mk_pareto_nlsat_solver(ast_manager& m, params_ref const& p) {
+        return alloc(pareto_nlsat_solver, m, p);
+    }
+}

--- a/src/opt/opt_pareto_solver.h
+++ b/src/opt/opt_pareto_solver.h
@@ -1,0 +1,23 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+Module Name:
+
+    opt_pareto_solver.h
+
+Abstract:
+
+    Incremental nlsat backend for polynomial real Pareto problems.
+
+--*/
+#pragma once
+
+#include "ast/ast.h"
+#include "util/params.h"
+
+class solver;
+
+namespace opt {
+    bool can_reuse_nlsat_solver(expr_ref_vector const& terms);
+    solver* mk_pareto_nlsat_solver(ast_manager& m, params_ref const& p);
+}

--- a/src/test/nlsat.cpp
+++ b/src/test/nlsat.cpp
@@ -20,6 +20,7 @@ Notes:
 #include "nlsat/nlsat_interval_set.h"
 #include "nlsat/nlsat_evaluator.h"
 #include "nlsat/nlsat_solver.h"
+#include "nlsat/nlsat_clause.h"
 #include "nlsat/levelwise.h"
 #include "util/util.h"
 #include "nlsat/nlsat_explain.h"
@@ -2594,7 +2595,82 @@ static void tst_pick_max() {
     ENSURE(am.eq(sup, one));
 }
 
+static void tst_retract_assumptions() {
+    params_ref ps;
+    ps.set_bool("reorder", false);
+    reslimit rlim;
+    nlsat::solver s(rlim, ps, true);
+    nlsat::literal p(s.mk_bool_var(), false);
+    nlsat::literal q(s.mk_bool_var(), false);
+    nlsat::literal r(s.mk_bool_var(), false);
+    s.mk_clause(1, &r);
+    nlsat::clause* independent = s.mk_clause(1, &r, true, nullptr);
+    unsigned tag_a = 0, tag_b = 0;
+    nlsat::literal clauses[4][2] = { {p, q}, {p, ~q}, {~p, q}, {~p, ~q} };
+    s.mk_clause(2, clauses[0], &tag_a);
+    s.mk_clause(2, clauses[1], &tag_a);
+    s.mk_clause(2, clauses[2], &tag_b);
+    s.mk_clause(2, clauses[3], &tag_b);
+    ENSURE(s.check() == l_false);
+    vector<nlsat::assumption, false> deps;
+    s.get_core(deps);
+    ENSURE(deps.contains(&tag_a));
+    ENSURE(deps.contains(&tag_b));
+    bool learned_with_assumptions = false;
+    for (nlsat::clause* c : s.get_lemmas()) {
+        s.get_dependencies(*c, deps);
+        learned_with_assumptions |= !deps.empty();
+    }
+    ENSURE(learned_with_assumptions);
+
+    s.retract(&tag_a);
+    ENSURE(s.get_lemmas().contains(independent));
+    for (nlsat::clause* c : s.get_lemmas()) {
+        s.get_dependencies(*c, deps);
+        ENSURE(!deps.contains(&tag_a));
+    }
+    ENSURE(s.check() == l_true);
+    ENSURE(s.bvalue(p.var()) == l_false);
+    ENSURE(s.bvalue(r.var()) == l_true);
+    s.retract(&tag_b);
+    ENSURE(s.check() == l_true);
+    for (nlsat::clause* c : s.get_lemmas()) {
+        s.get_dependencies(*c, deps);
+        ENSURE(deps.empty());
+    }
+
+    nlsat::literal not_r = ~r;
+    for (unsigned i = 0; i < 10; ++i) {
+        s.mk_clause(1, &not_r, &tag_a);
+        ENSURE(s.check() == l_false);
+        s.retract(&tag_a);
+        ENSURE(s.check() == l_true);
+        ENSURE(s.get_lemmas().contains(independent));
+    }
+    s.retract(&tag_a, 0);
+    ENSURE(s.get_lemmas().empty());
+    ENSURE(s.check() == l_true);
+    bool rejected = false;
+    try {
+        s.retract(nullptr);
+    }
+    catch (default_exception&) {
+        rejected = true;
+    }
+    ENSURE(rejected);
+    nlsat::solver non_incremental(rlim, ps, false);
+    rejected = false;
+    try {
+        non_incremental.retract(&tag_a);
+    }
+    catch (default_exception&) {
+        rejected = true;
+    }
+    ENSURE(rejected);
+}
+
 void tst_nlsat() {
+    tst_retract_assumptions();
     tst_pick_max();
     std::cout << "------------------\n";
     tst_22();

--- a/src/test/nlsat.cpp
+++ b/src/test/nlsat.cpp
@@ -2595,6 +2595,76 @@ static void tst_pick_max() {
     ENSURE(am.eq(sup, one));
 }
 
+static void tst_cancelled_explanation() {
+    // Retrying without a pop also needs clean state: cleanup must happen on
+    // leaving the explanation, not depend solely on the solver's reset path.
+    for (bool retract : {true, false}) {
+        bool interrupted = false;
+        unsigned max_budget = 1;
+        for (unsigned budget = 1; budget <= max_budget && !interrupted; ++budget) {
+            params_ref ps;
+            ps.set_bool("reorder", false);
+            reslimit rlim;
+            nlsat::solver s(rlim, ps, true);
+            auto& pm = s.pm();
+            auto& am = s.am();
+            auto& ex = s.get_explain();
+            nlsat::var y = s.mk_var(false), z = s.mk_var(false), x = s.mk_var(false);
+            polynomial_ref px(pm), py(pm), pz(pm), p(pm), q(pm);
+            px = pm.mk_polynomial(x);
+            py = pm.mk_polynomial(y);
+            pz = pm.mk_polynomial(z);
+            p = py * px * px + px - pz;
+            q = px * px - px * pz;
+            nlsat::scoped_literal_vector core(s), expected(s), result(s);
+            core.push_back(mk_gt(s, p));
+            core.push_back(mk_eq(s, q));
+            nlsat::assignment sample(am);
+            set_assignment_value(sample, am, y, rational(0));
+            set_assignment_value(sample, am, z, rational(5));
+            s.set_rvalues(sample);
+
+            // Normalizing at y = 0 records a projection literal before processing
+            // the conflict: x > 5 excludes both roots of x^2 - 5*x = 0.
+            auto start = rlim.count();
+            ex.compute_conflict_explanation(core.size(), core.data(), expected);
+            ENSURE(!expected.empty());
+            if (budget == 1) {
+                ENSURE(rlim.count() - start <= UINT_MAX);
+                max_budget = static_cast<unsigned>(rlim.count() - start);
+            }
+            bool cancelled = false;
+            {
+                scoped_rlimit limit(rlim, budget);
+                try {
+                    ex.compute_conflict_explanation(core.size(), core.data(), result);
+                }
+                catch (default_exception const&) {
+                    ENSURE(rlim.is_canceled());
+                    cancelled = true;
+                }
+            }
+            // A tiny limit can stop before projection. Require cancellation after
+            // a literal is emitted, when stale duplicate marks can corrupt a retry.
+            if (!cancelled || result.empty())
+                continue;
+            interrupted = true;
+            std::cout << "nlsat: cancelled explanation after " << budget << " steps\n";
+            if (retract) {
+                unsigned tag = 0;
+                s.retract(&tag);
+                s.set_rvalues(sample);
+            }
+            result.reset();
+            ex.compute_conflict_explanation(core.size(), core.data(), result);
+            ENSURE(result.size() == expected.size());
+            for (auto lit : expected)
+                ENSURE(std::find(result.begin(), result.end(), lit) != result.end());
+        }
+        ENSURE(interrupted);
+    }
+}
+
 static void tst_retract_assumptions() {
     params_ref ps;
     ps.set_bool("reorder", false);
@@ -2670,6 +2740,7 @@ static void tst_retract_assumptions() {
 }
 
 void tst_nlsat() {
+    tst_cancelled_explanation();
     tst_retract_assumptions();
     tst_pick_max();
     std::cout << "------------------\n";

--- a/src/test/opt_pareto.cpp
+++ b/src/test/opt_pareto.cpp
@@ -20,56 +20,64 @@ Author:
 
 --*/
 #include "opt/opt_context.h"
+#include "opt/opt_pareto_solver.h"
 #include "ast/reg_decl_plugins.h"
 
-static void set_pareto_priority(opt::context& ctx) {
+static void set_pareto_priority(opt::context& ctx, bool reuse_nlsat_solver = true) {
+    // Use Pareto enumeration rather than lexicographic optimization.
     params_ref p;
     p.set_sym("priority", symbol("pareto"));
+    // On eligible problems, retain the nlsat instance and its learned clauses
+    // between checks; false selects a fresh exact nlsat solver for each check.
+    p.set_bool("pareto_nlsat_reuse", reuse_nlsat_solver);
     ctx.updt_params(p);
 }
 
-// maximize x, maximize y s.t. x^2 = 2, y = -x: the front is the two
-// incomparable points (sqrt(2), -sqrt(2)) and (-sqrt(2), sqrt(2)); the
-// third round is unsat and the model values are algebraic numerals.
-static void tst_irrational_front() {
+static void tst_irrational_front(bool reuse_nlsat_solver) {
+    // Check that both incomparable irrational Pareto points are returned once,
+    // and that their model coordinates are exact algebraic numerals.
     std::cout << "opt_pareto: irrational front\n";
     ast_manager m;
     reg_decl_plugins(m);
     arith_util a(m);
     opt::context ctx(m);
-    set_pareto_priority(ctx);
+    set_pareto_priority(ctx, reuse_nlsat_solver);
     expr_ref x(m.mk_const(symbol("x"), a.mk_real()), m);
     expr_ref y(m.mk_const(symbol("y"), a.mk_real()), m);
     expr_ref two(a.mk_numeral(rational(2), false), m);
+    // x^2 = 2 and y = -x leave (sqrt(2), -sqrt(2)) and (-sqrt(2), sqrt(2)).
+    // Maximizing both coordinates makes neither point dominate the other.
     ctx.add_hard_constraint(m.mk_eq(a.mk_mul(x, x), two));
     ctx.add_hard_constraint(m.mk_eq(y, a.mk_uminus(x)));
     ctx.add_objective(to_app(x.get()), true);
     ctx.add_objective(to_app(y.get()), true);
     expr_ref_vector asms(m);
     model_ref mdl;
+    // Either point may be returned first; retain its exact x coordinate.
     ENSURE(ctx.optimize(asms) == l_true);
     ctx.get_model(mdl);
     expr_ref x1 = (*mdl)(x);
     ENSURE(a.is_irrational_algebraic_numeral(x1));
+    // Blocking the first point must leave the other root, not a duplicate.
     ENSURE(ctx.optimize(asms) == l_true);
     ctx.get_model(mdl);
     expr_ref x2 = (*mdl)(x);
     ENSURE(a.is_irrational_algebraic_numeral(x2));
     ENSURE(x1 != x2);
+    // Both feasible points have now been blocked, so enumeration is UNSAT.
     ENSURE(ctx.optimize(asms) == l_false);
 }
 
-// two incomparable points whose coordinates differ by 10^-14, below the
-// 12-digit bracket of the rounded comparison: (sqrt(2), sqrt(3) - 10^-14)
-// and (sqrt(2) - 10^-14, sqrt(3)). The exact dominance constraints tell
-// them apart, so both are enumerated before the front is exhausted.
-static void tst_nearly_tied_front() {
+static void tst_nearly_tied_front(bool reuse_nlsat_solver) {
+    // Check that exact dominance comparisons keep two distinct Pareto points
+    // even when their coordinates differ by only 10^-14, below the 12-digit
+    // bracket used by rounded comparisons.
     std::cout << "opt_pareto: nearly tied front\n";
     ast_manager m;
     reg_decl_plugins(m);
     arith_util a(m);
     opt::context ctx(m);
-    set_pareto_priority(ctx);
+    set_pareto_priority(ctx, reuse_nlsat_solver);
     sort* real = a.mk_real();
     expr_ref x(m.mk_const(symbol("x"), real), m);
     expr_ref w(m.mk_const(symbol("w"), real), m);
@@ -78,52 +86,387 @@ static void tst_nearly_tied_front() {
     expr_ref two(a.mk_numeral(rational(2), false), m);
     expr_ref three(a.mk_numeral(rational(3), false), m);
     expr_ref zero(a.mk_numeral(rational(0), false), m);
-    expr_ref eps(a.mk_numeral(rational(1, 100000000000000ull), false), m);
+    // Exact 10^-14, below the 10^-12 rounding bracket. Rational exponentiation
+    // avoids narrowing a large integer literal or introducing floating-point rounding.
+    expr_ref eps(a.mk_numeral(rational(1) / power(rational(10), 14), false), m);
+    // Fix r2 = sqrt(2) and r3 = sqrt(3) by selecting their positive roots.
     ctx.add_hard_constraint(m.mk_eq(a.mk_mul(r2, r2), two));
     ctx.add_hard_constraint(a.mk_gt(r2, zero));
     ctx.add_hard_constraint(m.mk_eq(a.mk_mul(r3, r3), three));
     ctx.add_hard_constraint(a.mk_gt(r3, zero));
+    // The choices are (sqrt(2), sqrt(3) - eps) and (sqrt(2) - eps, sqrt(3)).
+    // Each is better in one coordinate and worse in the other.
     expr_ref pt1(m.mk_and(m.mk_eq(x, r2), m.mk_eq(w, a.mk_sub(r3, eps))), m);
     expr_ref pt2(m.mk_and(m.mk_eq(x, a.mk_sub(r2, eps)), m.mk_eq(w, r3)), m);
     ctx.add_hard_constraint(m.mk_or(pt1, pt2));
     ctx.add_objective(to_app(x.get()), true);
     ctx.add_objective(to_app(w.get()), true);
     expr_ref_vector asms(m);
+    // After returning one point, the nearly tied other point must remain SAT.
     ENSURE(ctx.optimize(asms) == l_true);
     ENSURE(ctx.optimize(asms) == l_true);
+    // Only these two points are feasible, so blocking both makes the next call UNSAT.
     ENSURE(ctx.optimize(asms) == l_false);
 }
 
-// an uninterpreted function puts the problem outside the NRA fragment: the
-// loop falls back to the smt solver and still enumerates the (rational)
-// two-point front.
-static void tst_uf_fallback() {
+static void tst_uf_fallback(bool reuse_nlsat_solver) {
+    // Check that an uninterpreted function forces the general SMT fallback
+    // without losing either point of a rational Pareto front.
     std::cout << "opt_pareto: uf fallback\n";
     ast_manager m;
     reg_decl_plugins(m);
     arith_util a(m);
     opt::context ctx(m);
-    set_pareto_priority(ctx);
+    set_pareto_priority(ctx, reuse_nlsat_solver);
     sort* real = a.mk_real();
     expr_ref x(m.mk_const(symbol("x"), real), m);
     expr_ref w(m.mk_const(symbol("w"), real), m);
     func_decl_ref f(m.mk_func_decl(symbol("f"), real, real), m);
     expr_ref zero(a.mk_numeral(rational(0), false), m);
     expr_ref one(a.mk_numeral(rational(1), false), m);
+    // Maximizing both coordinates makes (1, 0) and (0, 1) incomparable.
     expr_ref pt1(m.mk_and(m.mk_eq(x, one), m.mk_eq(w, zero)), m);
     expr_ref pt2(m.mk_and(m.mk_eq(x, zero), m.mk_eq(w, one)), m);
     ctx.add_hard_constraint(m.mk_or(pt1, pt2));
+    // f(x) >= 0 is satisfiable at either point, but is outside pure NRA.
     ctx.add_hard_constraint(a.mk_ge(m.mk_app(f, x.get()), zero));
     ctx.add_objective(to_app(x.get()), true);
     ctx.add_objective(to_app(w.get()), true);
     expr_ref_vector asms(m);
+    // The SMT fallback must return both points, despite the extra UF constraint.
     ENSURE(ctx.optimize(asms) == l_true);
     ENSURE(ctx.optimize(asms) == l_true);
+    // No third point remains after the two Pareto points have been blocked.
     ENSURE(ctx.optimize(asms) == l_false);
 }
 
+static unsigned counter(statistics const& st, char const* key) {
+    // Treat a missing reuse-specific counter as zero on fresh/fallback paths.
+    for (unsigned i = 0; i < st.size(); ++i)
+        if (std::string(st.get_key(i)) == key)
+            return st.get_uint_value(i);
+    return 0;
+}
+
+static void tst_finite_front(bool reuse_nlsat_solver) {
+    // Enumerate a known finite front without duplicates and check the reusable
+    // solver's check and scope-retraction counts.
+    ast_manager m;
+    reg_decl_plugins(m);
+    arith_util a(m);
+    opt::context ctx(m);
+    set_pareto_priority(ctx, reuse_nlsat_solver);
+    expr_ref x(m.mk_const("x", a.mk_real()), m);
+    expr_ref y(m.mk_const("y", a.mk_real()), m);
+    unsigned const bound = 12;
+    expr_ref_vector choices(m), asms(m);
+    // Restrict x to 0, ..., 12 and set y = 12 - x. Increasing x decreases y,
+    // so all 13 feasible points belong to the max/max Pareto front.
+    for (unsigned i = 0; i <= bound; ++i)
+        choices.push_back(m.mk_eq(x, a.mk_numeral(rational(i), false)));
+    ctx.add_hard_constraint(m.mk_or(choices.size(), choices.data()));
+    ctx.add_hard_constraint(m.mk_eq(a.mk_add(x, y), a.mk_numeral(rational(bound), false)));
+    ctx.add_objective(to_app(x.get()), true);
+    ctx.add_objective(to_app(y.get()), true);
+    // Require 13 SAT models, each feasible and previously unseen; order is irrelevant.
+    bool_vector seen(bound + 1, false);
+    for (unsigned i = 0; i <= bound; ++i) {
+        ENSURE(ctx.optimize(asms) == l_true);
+        model_ref model;
+        ctx.get_model(model);
+        rational xv, yv;
+        ENSURE(a.is_numeral((*model)(x), xv) && xv.is_unsigned());
+        ENSURE(a.is_numeral((*model)(y), yv));
+        ENSURE(xv + yv == rational(bound));
+        ENSURE(xv <= rational(bound));
+        unsigned k = xv.get_unsigned();
+        ENSURE(!seen[k]);
+        seen[k] = true;
+    }
+    // All feasible points have been returned and blocked, so the next call is UNSAT.
+    ENSURE(ctx.optimize(asms) == l_false);
+    // Each point needs a SAT candidate check and an UNSAT dominance check;
+    // popping its dominance scope causes one retraction. Add one final UNSAT
+    // check for exhaustion. Fresh solvers do not publish these reuse counters.
+    statistics st;
+    ctx.collect_statistics(st);
+    ENSURE(counter(st, "pareto nlsat checks") == (reuse_nlsat_solver ? 2 * (bound + 1) + 1 : 0));
+    ENSURE(counter(st, "pareto nlsat retractions") == (reuse_nlsat_solver ? bound + 1 : 0));
+}
+
+static void tst_mixed_directions(bool reuse_nlsat_solver) {
+    // Check that Pareto dominance respects a mix of maximization and minimization.
+    ast_manager m;
+    reg_decl_plugins(m);
+    arith_util a(m);
+    opt::context ctx(m);
+    set_pareto_priority(ctx, reuse_nlsat_solver);
+    expr_ref x(m.mk_const("x", a.mk_real()), m);
+    expr_ref y(m.mk_const("y", a.mk_real()), m);
+    expr_ref two(a.mk_numeral(rational(2), false), m);
+    // The feasible points are (2, -2) and (-2, 2).
+    ctx.add_hard_constraint(m.mk_or(m.mk_eq(x, two), m.mk_eq(x, a.mk_uminus(two))));
+    ctx.add_hard_constraint(m.mk_eq(y, a.mk_uminus(x)));
+    // Maximizing x and minimizing y both favor (2, -2), which dominates (-2, 2).
+    ctx.add_objective(to_app(x.get()), true);
+    ctx.add_objective(to_app(y.get()), false);
+    expr_ref_vector asms(m);
+    ENSURE(ctx.optimize(asms) == l_true);
+    model_ref model;
+    ctx.get_model(model);
+    rational xv, yv;
+    ENSURE(a.is_numeral((*model)(x), xv) && xv == rational(2));
+    ENSURE(a.is_numeral((*model)(y), yv) && yv == rational(-2));
+    // The blocker excludes the returned point and its dominated alternative: UNSAT.
+    ENSURE(ctx.optimize(asms) == l_false);
+}
+
+static void tst_solver_scopes() {
+    // Check that nested scopes and per-call assumptions retract cleanly in the
+    // reusable nlsat solver, including after UNSAT and resource-limit unknown
+    // results, and that saved algebraic models remain usable.
+    ast_manager m;
+    reg_decl_plugins(m);
+    arith_util a(m);
+    params_ref p;
+    solver_ref s = opt::mk_pareto_nlsat_solver(m, p);
+    expr_ref x(m.mk_const("x", a.mk_real()), m);
+    expr_ref zero(a.mk_numeral(rational(0), false), m);
+    expr_ref two(a.mk_numeral(rational(2), false), m);
+    expr_ref positive(a.mk_gt(x, zero), m);
+    expr_ref negative(a.mk_lt(x, zero), m);
+    // Keep x^2 = 2 at the base level throughout: without sign restrictions,
+    // either sqrt(2) or -sqrt(2) is feasible.
+    s->assert_expr(m.mk_eq(a.mk_mul(x, x), two));
+    // The outer scope selects x > 0; adding x < 0 in a nested scope is UNSAT.
+    s->push();
+    s->assert_expr(positive);
+    s->push();
+    s->assert_expr(negative);
+    ENSURE(s->check_sat() == l_false);
+    // Pop only x < 0. The remaining x^2 = 2 and x > 0 are SAT at sqrt(2).
+    s->pop(1);
+    ENSURE(s->check_sat() == l_true);
+    model_ref model;
+    s->get_model(model);
+    ENSURE(model->is_true(positive));
+    // Expose only x in the model, not the solver's internal scope constants.
+    ENSURE(model->get_num_constants() == 1);
+    // Pop x > 0 as well, leaving x^2 = 2, then select x < 0 in a new scope.
+    // This must be SAT at -sqrt(2), with no positive-root restriction left over.
+    s->pop(1);
+    s->push();
+    s->assert_expr(negative);
+    ENSURE(s->check_sat() == l_true);
+    s->get_model(model);
+    ENSURE(model->is_true(negative));
+    expr_ref value = (*model)(x);
+    // Reuse the exact model value -sqrt(2) in a new assertion. With x^2 = 2
+    // and x < 0 still active, x > -sqrt(2) excludes the only root: UNSAT.
+    s->push();
+    s->assert_expr(a.mk_gt(x, value));
+    ENSURE(s->check_sat() == l_false);
+    // The saved SAT model must still satisfy x^2 = 2 after the UNSAT check.
+    ENSURE(model->is_true(m.mk_eq(a.mk_mul(x, x), two)));
+    // Pop both the bound and x < 0. On the base formula, a per-call x > 0
+    // assumption is SAT and selects the positive root.
+    s->pop(2);
+    expr_ref_vector assumptions(m);
+    assumptions.push_back(positive);
+    ENSURE(s->check_sat(assumptions) == l_true);
+    s->get_model(model);
+    ENSURE(model->is_true(positive));
+    // The assumptions now contain both x > 0 and x < 0, so this call is UNSAT.
+    assumptions.push_back(negative);
+    ENSURE(s->check_sat(assumptions) == l_false);
+    // With no assumptions, x^2 = 2 is SAT again: neither assumption may leak.
+    ENSURE(s->check_sat() == l_true);
+    // Force an unknown result with a tiny resource limit, not a contradiction,
+    // and require the solver to explain why it could not finish.
+    s->push();
+    {
+        scoped_rlimit limit(m.limit(), 1);
+        ENSURE(s->check_sat() == l_undef);
+        ENSURE(!s->reason_unknown().empty());
+    }
+    // With the temporary limit gone, pop the scope and recover a SAT result.
+    s->pop(1);
+    ENSURE(s->check_sat() == l_true);
+}
+
+static void tst_reuse_fragment() {
+    // Check which arithmetic terms are eligible for the reusable nlsat path.
+    ast_manager m;
+    reg_decl_plugins(m);
+    arith_util a(m);
+    expr_ref x(m.mk_const("x", a.mk_real()), m);
+    expr_ref i(m.mk_const("i", a.mk_int()), m);
+    expr_ref two(a.mk_numeral(rational(2), false), m);
+    expr_ref_vector terms(m);
+    // Division by a nonzero numeral is polynomial arithmetic up to scaling.
+    terms.push_back(a.mk_div(x, two));
+    ENSURE(opt::can_reuse_nlsat_solver(terms));
+    // Adding 2/x introduces a variable denominator, so the whole vector is rejected.
+    terms.push_back(a.mk_div(two, x));
+    ENSURE(!opt::can_reuse_nlsat_solver(terms));
+    // Start an independent case: to_real(i) still contains an integer variable
+    // and must not enter the real-only reuse fragment.
+    terms.reset();
+    terms.push_back(a.mk_to_real(i));
+    ENSURE(!opt::can_reuse_nlsat_solver(terms));
+}
+
+static void tst_sampled_fronts() {
+    // For each seed s in {0, ..., 15}, generate the finite feasible set
+    //
+    //   u(s, i) = (3*s + 5*i) mod 11 - 5,
+    //   v(s, i) = (s + i*i + 3*i) mod 9 - 4,       i in {0, ..., 7},
+    //   c(s)    = sqrt(2) if bit 2 of s is set, and 1 otherwise,
+    //   F(s)    = { c(s) * (u(s, i), v(s, i)) : i in {0, ..., 7} }.
+    //
+    // The problem is to Pareto-optimize x and y subject to (x, y) in F(s).
+    // Bit 0 selects max x when set and min x otherwise; bit 1 does the same
+    // for y. If sign_x is 1 for max and -1 for min (and likewise for sign_y),
+    // then q dominates p exactly when
+    //
+    //   sign_x*q.x >= sign_x*p.x  and  sign_y*q.y >= sign_y*p.y,
+    //
+    // with at least one strict inequality. The expected front consists of all
+    // p in F(s) for which no such q exists. The full seed varies the points;
+    // its low bits additionally select the four direction pairs and the scale.
+    // Every problem is run with fresh and reused nlsat, for 32 solver runs.
+    //
+    // Compute the expected front with plain integer comparisons, independently
+    // of Z3, and store its point indices in front. Ask Z3 to return exactly
+    // those points in any order, without duplicates, with fresh and reused
+    // nlsat solvers. Positive scaling preserves the expected front while
+    // exercising both rational and algebraic coordinates.
+    struct point { int x, y; };
+    for (unsigned seed = 0; seed < 16; ++seed) {
+        // Vary the point set reproducibly; the seed's low two bits choose the
+        // four combinations of objective directions.
+        svector<point> points;
+        for (unsigned i = 0; i < 8; ++i)
+            points.push_back({static_cast<int>((3 * seed + 5 * i) % 11) - 5,
+                              static_cast<int>((seed + i * i + 3 * i) % 9) - 4});
+        bool max_x = (seed & 1) != 0, max_y = (seed & 2) != 0;
+        unsigned_vector front;
+        // A point j dominates i only if j is no worse in either objective and
+        // strictly better in at least one. Keep exactly the undominated points.
+        for (unsigned i = 0; i < points.size(); ++i) {
+            bool dominated = false;
+            for (unsigned j = 0; j < points.size(); ++j) {
+                if (i == j)
+                    continue;
+                bool better_x = max_x ? points[j].x >= points[i].x : points[j].x <= points[i].x;
+                bool better_y = max_y ? points[j].y >= points[i].y : points[j].y <= points[i].y;
+                dominated |= better_x && better_y &&
+                    (points[j].x != points[i].x || points[j].y != points[i].y);
+            }
+            if (!dominated)
+                front.push_back(i);
+        }
+        // Run the same instance with a fresh-per-check and a reusable nlsat solver.
+        for (bool reuse_nlsat_solver : {false, true}) {
+            ast_manager m;
+            reg_decl_plugins(m);
+            arith_util a(m);
+            opt::context ctx(m);
+            set_pareto_priority(ctx, reuse_nlsat_solver);
+            expr_ref x(m.mk_const("x", a.mk_real()), m);
+            expr_ref y(m.mk_const("y", a.mk_real()), m);
+            // Use scale 1 or positive sqrt(2). A common positive scale preserves
+            // the oracle's ordering while adding cases with algebraic coordinates.
+            expr_ref scale(a.mk_numeral(rational(1), false), m);
+            if (seed & 4) {
+                scale = m.mk_const("scale", a.mk_real());
+                ctx.add_hard_constraint(m.mk_eq(a.mk_mul(scale, scale), a.mk_numeral(rational(2), false)));
+                ctx.add_hard_constraint(a.mk_gt(scale, a.mk_numeral(rational(0), false)));
+            }
+            auto coordinate = [&](int k) {
+                return expr_ref(a.mk_mul(a.mk_numeral(rational(k), false), scale), m);
+            };
+            // Admit exactly the scaled sample points, with the chosen min/max directions.
+            expr_ref_vector choices(m), asms(m);
+            for (point const& p : points)
+                choices.push_back(m.mk_and(m.mk_eq(x, coordinate(p.x)), m.mk_eq(y, coordinate(p.y))));
+            ctx.add_hard_constraint(m.mk_or(choices.size(), choices.data()));
+            ctx.add_objective(to_app(x.get()), max_x);
+            ctx.add_objective(to_app(y.get()), max_y);
+            // Match each result to a previously unseen oracle point using exact
+            // model equalities; do not assume any enumeration order.
+            bool_vector seen(front.size(), false);
+            for (unsigned i = 0; i < front.size(); ++i) {
+                ENSURE(ctx.optimize(asms) == l_true);
+                model_ref model;
+                ctx.get_model(model);
+                bool found = false;
+                for (unsigned j = 0; j < front.size(); ++j) {
+                    point const& p = points[front[j]];
+                    if (model->is_true(m.mk_eq(x, coordinate(p.x))) && model->is_true(m.mk_eq(y, coordinate(p.y)))) {
+                        ENSURE(!seen[j]);
+                        seen[j] = true;
+                        found = true;
+                    }
+                }
+                ENSURE(found);
+            }
+            // Pareto enumeration retains blockers for each returned point and
+            // every point it dominates. Once the entire front has been returned,
+            // all feasible samples are blocked, so the next call must be UNSAT.
+            // This means enumeration is exhausted, not that the original problem
+            // was infeasible: even with empty asms, the context keeps its blockers.
+            ENSURE(ctx.optimize(asms) == l_false);
+        }
+    }
+}
+
+static void tst_assumption_fallback() {
+    // Check that Optimize calls with assumptions use the SMT fallback and
+    // enumerate only the Pareto front permitted by those assumptions.
+    ast_manager m;
+    reg_decl_plugins(m);
+    arith_util a(m);
+    opt::context ctx(m);
+    set_pareto_priority(ctx);
+    expr_ref x(m.mk_const("x", a.mk_real()), m);
+    expr_ref y(m.mk_const("y", a.mk_real()), m);
+    expr_ref zero(a.mk_numeral(rational(0), false), m);
+    expr_ref one(a.mk_numeral(rational(1), false), m);
+    // Without assumptions, the max/max front consists of (0, 1) and (1, 0).
+    ctx.add_hard_constraint(m.mk_or(m.mk_and(m.mk_eq(x, zero), m.mk_eq(y, one)),
+                                    m.mk_and(m.mk_eq(x, one), m.mk_eq(y, zero))));
+    ctx.add_objective(to_app(x.get()), true);
+    ctx.add_objective(to_app(y.get()), true);
+    expr_ref_vector asms(m);
+    // Assuming x = 1 excludes (0, 1), leaving only (1, 0) as a SAT front point.
+    asms.push_back(m.mk_eq(x, one));
+    ENSURE(ctx.optimize(asms) == l_true);
+    model_ref model;
+    ctx.get_model(model);
+    ENSURE(model->is_true(asms.get(0)));
+    // Under the same assumption, blocking (1, 0) leaves no feasible point: UNSAT.
+    ENSURE(ctx.optimize(asms) == l_false);
+    // Assumption handling must not invoke the reusable nlsat solver.
+    statistics st;
+    ctx.collect_statistics(st);
+    ENSURE(counter(st, "pareto nlsat checks") == 0);
+}
+
 void tst_opt_pareto() {
-    tst_irrational_front();
-    tst_nearly_tied_front();
-    tst_uf_fallback();
+    // Cover solver state, fragment selection, and Pareto enumeration/fallback.
+    tst_solver_scopes();
+    tst_reuse_fragment();
+    // Sampled fronts already exercise both nlsat modes; assumptions force SMT.
+    tst_sampled_fronts();
+    tst_assumption_fallback();
+    // Run the remaining front tests with and without nlsat reuse. The UF case
+    // must stay on the general SMT solver regardless of this setting.
+    for (bool reuse_nlsat_solver : {false, true}) {
+        tst_irrational_front(reuse_nlsat_solver);
+        tst_nearly_tied_front(reuse_nlsat_solver);
+        tst_uf_fallback(reuse_nlsat_solver);
+        tst_finite_front(reuse_nlsat_solver);
+        tst_mixed_directions(reuse_nlsat_solver);
+    }
 }

--- a/src/test/opt_pareto.cpp
+++ b/src/test/opt_pareto.cpp
@@ -294,6 +294,55 @@ static void tst_solver_scopes() {
     ENSURE(s->check_sat() == l_true);
 }
 
+static void tst_cancelled_solver() {
+    ast_manager m;
+    reg_decl_plugins(m);
+    arith_util a(m);
+    params_ref p;
+    expr_ref x(m.mk_const("x", a.mk_real()), m);
+    expr_ref y(m.mk_const("y", a.mk_real()), m);
+    expr_ref z(m.mk_const("z", a.mk_real()), m);
+    expr_ref zero(a.mk_numeral(rational(0), false), m);
+    expr_ref five(a.mk_numeral(rational(5), false), m);
+    expr_ref square(a.mk_mul(x, x), m);
+    expr_ref_vector constraints(m);
+    constraints.push_back(m.mk_eq(y, zero));
+    constraints.push_back(m.mk_eq(z, five));
+    constraints.push_back(a.mk_gt(a.mk_add(a.mk_mul(y, square), x), z));
+    constraints.push_back(m.mk_eq(square, a.mk_mul(z, x)));
+    auto make_solver = [&]() {
+        solver_ref s = opt::mk_pareto_nlsat_solver(m, p);
+        s->assert_expr(constraints);
+        s->push();
+        return s;
+    };
+    // With y = 0 and z = 5, x > 5 excludes both roots of x^2 = 5*x.
+    auto full = make_solver();
+    auto start = m.limit().count();
+    ENSURE(full->check_sat() == l_false);
+    ENSURE(m.limit().count() - start <= UINT_MAX);
+    unsigned max_budget = static_cast<unsigned>(m.limit().count() - start);
+    bool interrupted = false;
+    for (unsigned budget = 1; budget <= max_budget; ++budget) {
+        auto s = make_solver();
+        {
+            scoped_rlimit limit(m.limit(), budget);
+            lbool result = s->check_sat();
+            ENSURE(result == l_false || result == l_undef);
+            if (result == l_undef) {
+                ENSURE(m.limit().is_canceled());
+                ENSURE(!s->reason_unknown().empty());
+                interrupted = true;
+            }
+        }
+        // Sweep cancellation through preprocessing and search. The permanent
+        // conflict survives this empty scope, so recovery must still prove UNSAT.
+        s->pop(1);
+        ENSURE(s->check_sat() == l_false);
+    }
+    ENSURE(interrupted);
+}
+
 static void tst_reuse_fragment() {
     // Check which arithmetic terms are eligible for the reusable nlsat path.
     ast_manager m;
@@ -456,6 +505,7 @@ static void tst_assumption_fallback() {
 void tst_opt_pareto() {
     // Cover solver state, fragment selection, and Pareto enumeration/fallback.
     tst_solver_scopes();
+    tst_cancelled_solver();
     tst_reuse_fragment();
     // Sampled fronts already exercise both nlsat modes; assumptions force SMT.
     tst_sampled_fronts();


### PR DESCRIPTION
## Summary

Follow-up to Z3Prover/z3#10736. Reuse nlsat state across exact Pareto candidate and dominance checks instead of starting each check from scratch, without carrying temporary dominance constraints into later front points.

- Add a persistent nlsat-backed solver with stable expression mappings and incremental goal translation. Tag scoped assertions and their learned consequences so popping a scope removes dependent clauses while preserving independent lemmas.
- Enable reuse for supported polynomial Real problems with `opt.pareto_nlsat_reuse=true`. Preserve the fresh exact solver with `false`, and the general SMT fallback for Optimize assumptions and unsupported fragments.
- Cap independent learned clauses retained between climbs with `opt.pareto_nlsat_max_lemmas` (default 128, preferring shorter clauses). Setting it to 0 drops learned clauses without rebuilding the solver.
- Make conflict-explanation and conflict-resolution mark cleanup safe on cancellation. This prevents stale duplicate marks from suppressing required literals on a direct retry or after scope retraction. Document partial-result handling on exceptions.

## Validation

- Built `z3` and `test-z3` in Release and Debug; `test-z3 /j:2 nlsat opt_nlsat opt_pareto 13` passes in both.
- Added regressions that cancel after an explanation literal has been emitted, compare recovered explanations with uninterrupted results, and cover retries with and without retraction. A solver-level resource-budget sweep covers `unknown -> pop -> retry`. The pre-fix implementation reproduced a debug assertion and missing explanation literals in Release.
- Both existing algebraic Pareto golden-output regressions pass unchanged in Release and Debug with model validation.
- Verified exactly the same 91 unique expected grid triples, followed by UNSAT, with fresh solving, default lemma reuse, and a zero retained-lemma cap.

The earlier companion regression updates in Z3Prover/z3test#68 are already merged; no new z3test changes are required. The continuous-front benchmark remains a known baseline timeout, also observed with reuse disabled.