### PR TITLE
Fix models from regex split refinement

### DIFF
--- a/src/ast/seq/seq_monadic.cpp
+++ b/src/ast/seq/seq_monadic.cpp
@@ -716,7 +716,7 @@ lbool seq_monadic::materialize(expr* var, expr_ref& word) {
     return materialize_recorded(var, word);
 }
 
-lbool seq_monadic::materialize_recorded(expr* var, expr_ref& word) {
+lbool seq_monadic::materialize_recorded(expr* var, expr_ref& word, bool allow_unconstrained) {
     // without a recorded solution m_solution is empty, and an empty word would pass
     // for a satisfying assignment
     if (!m_config.m_solution)
@@ -731,6 +731,8 @@ lbool seq_monadic::materialize_recorded(expr* var, expr_ref& word) {
         found = m_solution.find(key, views);
     }
     if (!found) {
+        if (!allow_unconstrained)
+            return l_undef;
         word = u().str.mk_empty(var->get_sort());  // unconstrained: any value will do
         return l_true;
     }
@@ -994,7 +996,7 @@ bool seq_monadic::instantiate_word(expr* t, ptr_vector<expr>& elems, bool subst)
     if (m_split_words.find(t, cached))
         return cached && instantiate_word(cached, elems, false);
     expr_ref w(m);
-    if (materialize_recorded(t, w) != l_true) {
+    if (materialize_recorded(t, w, false) != l_true) {
         m_split_words.insert(t, nullptr);         // remember the failure too
         return false;
     }

--- a/src/ast/seq/seq_monadic.h
+++ b/src/ast/seq/seq_monadic.h
@@ -366,8 +366,10 @@ private:
     lbool model_accepts(expr* term, expr* r);
 
     // materialize() without its precondition on the last top-level result, so that the
-    // refinement loop can read the solution of a search it ran itself.
-    lbool materialize_recorded(expr* var, expr_ref& word);
+    // refinement loop can read the solution of a search it ran itself.  When
+    // allow_unconstrained is false, a variable absent from the recorded relaxation is
+    // reported as unknown instead of being assigned epsilon.
+    lbool materialize_recorded(expr* var, expr_ref& word, bool allow_unconstrained = true);
 
     // Decide `memberships` by refining a relaxation of their intersections, for at most
     // m_split_rounds rounds and `allowance` units of work in total.  l_undef leaves the


### PR DESCRIPTION
## Summary
- distinguish variables absent from an intersection-split relaxation from variables genuinely unconstrained by the full problem
- return unknown while validating a dropped conjunct when its relaxed solution did not record a required variable
- retain the existing epsilon default for normal public witness materialization

## Root cause
`decide_split` validates omitted regex conjuncts through `model_accepts`. That path used `materialize_recorded`, which assigned epsilon to variables missing from the relaxed solution. The split could therefore accept a dropped conjunct under epsilon and return SAT without emitting a witness assumption for that variable. The sequence model builder later selected an unrelated fresh value such as `!0!`, producing an invalid model.

## Validation
- all four invalid-model cases from CoZ3 run 1125 now return validated `sat`
- full regex corpus: 1,986 files, 32 workers, `-T:10 smt.seq.regex_monadic=true model_validate=true`; 1,288 sat, 468 unsat, 230 timeout, 0 errors
- `build\test-z3.exe seq_monadic`
- `build\test-z3.exe /a` — 105 passed, 0 failed
- CLI SMT/model smoke test