### PR TITLE
Make NFV audit dispatch advisory

### DIFF
--- a/.github/workflows/nfv-formal-audit-dispatcher.yml
+++ b/.github/workflows/nfv-formal-audit-dispatcher.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
+        # NFV is advisory; report failures below without failing this check.
+        continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.Z3_CI_APP_CLIENT_ID }}
@@ -23,6 +25,9 @@ jobs:
           repositories: bench
 
       - name: Dispatch NFV audit
+        id: dispatch
+        if: steps.app-token.outcome == 'success'
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -39,3 +44,29 @@ jobs:
                 pr: String(pr.number),
               },
             });
+
+      - name: Report NFV dispatch status
+        if: ${{ !cancelled() }}
+        env:
+          TOKEN_OUTCOME: ${{ steps.app-token.outcome }}
+          DISPATCH_OUTCOME: ${{ steps.dispatch.outcome }}
+        shell: bash
+        run: |
+          if [[ "$TOKEN_OUTCOME" != "success" ]]; then
+            message="NFV audit not run: GitHub App token creation failed. See the token step for details."
+            echo "::warning::$message"
+          elif [[ "$DISPATCH_OUTCOME" != "success" ]]; then
+            message="NFV audit not run: workflow dispatch failed or was skipped. See the dispatch step for details."
+            echo "::warning::$message"
+          else
+            message="NFV audit requested in Z3Prover/bench; results are reported there."
+          fi
+          {
+            echo "## NFV audit (advisory)"
+            echo
+            echo "$message"
+            echo
+            echo "This check reports only whether an audit was requested, not whether it passed."
+            echo
+            echo "[NFV audit runs](https://github.com/Z3Prover/bench/actions/workflows/nfv-formal-audit.lock.yml)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/tests/test_nfv_dispatcher.py
+++ b/scripts/tests/test_nfv_dispatcher.py
@@ -1,0 +1,98 @@
+############################################
+# Copyright (c) 2026 Microsoft Corporation
+#
+# Regression tests for advisory NFV dispatch reporting.
+############################################
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[2]
+    / ".github/workflows/nfv-formal-audit-dispatcher.yml"
+)
+
+
+class TestNFVDispatcher(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def step(self, name):
+        return self.workflow.split(
+            "      - name: " + name + "\n", 1
+        )[1].split("\n      - name:", 1)[0]
+
+    def test_failures_are_advisory_but_dispatch_requires_a_token(self):
+        token = self.step("Generate GitHub App token")
+        dispatch = self.step("Dispatch NFV audit")
+        self.assertIn("continue-on-error: true", token)
+        self.assertIn("continue-on-error: true", dispatch)
+        self.assertIn("if: steps.app-token.outcome == 'success'", dispatch)
+        self.assertIn("repositories: bench", token)
+
+    def test_report_uses_original_outcomes_and_respects_cancellation(self):
+        report = self.step("Report NFV dispatch status")
+        self.assertIn("if: ${{ !cancelled() }}", report)
+        self.assertIn("TOKEN_OUTCOME: ${{ steps.app-token.outcome }}", report)
+        self.assertIn("DISPATCH_OUTCOME: ${{ steps.dispatch.outcome }}", report)
+        self.assertNotIn("continue-on-error:", report)
+
+    @unittest.skipUnless(shutil.which("bash"), "The workflow uses Bash")
+    def run_report(self, token_outcome, dispatch_outcome):
+        report = self.step("Report NFV dispatch status")
+        script = textwrap.dedent(report.split("        run: |\n", 1)[1])
+        with tempfile.TemporaryDirectory() as directory:
+            summary = Path(directory) / "summary.md"
+            env = os.environ.copy()
+            env.update(
+                TOKEN_OUTCOME=token_outcome,
+                DISPATCH_OUTCOME=dispatch_outcome,
+                GITHUB_STEP_SUMMARY=str(summary),
+            )
+            result = subprocess.run(
+                ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            text = summary.read_text(encoding="utf-8")
+            self.assertIn("NFV audit (advisory)", text)
+            self.assertIn("not whether it passed", text)
+            self.assertIn("https://github.com/Z3Prover/bench/actions/workflows/", text)
+            return result.stdout, text
+
+    def test_token_failure_warns_and_reports_audit_not_run(self):
+        output, summary = self.run_report("failure", "skipped")
+        self.assertIn("::warning::NFV audit not run:", output)
+        self.assertIn("token creation failed", summary)
+        self.assertNotIn("NFV audit requested", summary)
+
+    def test_dispatch_failure_warns_and_reports_audit_not_run(self):
+        output, summary = self.run_report("success", "failure")
+        self.assertIn("::warning::NFV audit not run:", output)
+        self.assertIn("workflow dispatch failed", summary)
+        self.assertNotIn("NFV audit requested", summary)
+
+    def test_skipped_dispatch_is_not_reported_as_requested(self):
+        output, summary = self.run_report("success", "skipped")
+        self.assertIn("::warning::NFV audit not run:", output)
+        self.assertIn("was skipped", summary)
+        self.assertNotIn("NFV audit requested", summary)
+
+    def test_success_reports_a_request_not_an_audit_verdict(self):
+        output, summary = self.run_report("success", "success")
+        self.assertNotIn("::warning::", output)
+        self.assertIn("NFV audit requested", summary)
+        self.assertNotIn("NFV audit not run", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Make the NFV audit dispatcher advisory so a failure to start the optional audit
does not fail this check on otherwise valid Z3 pull requests.

- Allow GitHub App token creation and workflow dispatch to fail without failing
  the check; attempt dispatch only when token creation succeeds.
- Emit a warning and an explicit **audit not run** job summary for token creation
  failures, dispatch failures, or skipped dispatch.
- On successful dispatch, report **audit requested**, not an audit verdict, and
  link to the NFV workflow runs in `Z3Prover/bench`.
- Preserve cancellation, existing PR event filters, merge/head SHA selection,
  action pins, permissions, and the token's `bench` repository scope.

The original failure is visible in the dispatcher check on #10765:
https://github.com/Z3Prover/z3/actions/runs/34405056076/job/102645921186

This change does not grant missing App permissions, change branch protection,
or alter the NFV audit's own findings or execution status. The dispatcher
reports availability separately from the audit result.

## Validation

- Six regression tests cover the advisory step configuration, original step
  outcomes, cancellation guard, token failure, failed/skipped dispatch, and
  successful request reporting:
  `python3 -m unittest discover -s scripts/tests -p 'test_nfv_dispatcher.py' -v`
- `actionlint -shellcheck= -pyflakes= .github/workflows/nfv-formal-audit-dispatcher.yml`
- Parsed the workflow YAML and compared it with the original to confirm the
  triggers, permissions, token scope, action pins, and dispatch payload are unchanged.
