### PR TITLE
Make seq_regex_live::reachable_live take a seq::view

### DIFF
--- a/src/ast/seq/seq_monadic.cpp
+++ b/src/ast/seq/seq_monadic.cpp
@@ -824,7 +824,7 @@ bool seq_monadic::commit_next(frame& f) {
         else {
             // Live states are consumed as they are produced, so a witness found early
             // leaves the rest of the reachable set unexpanded.
-            auto live = m_live_states.reachable_live(f.R);
+            auto live = m_live_states.reachable_live(seq::view::membership(f.R));
             target = live.at(f.next++);
             if (!target) {
                 // Short of the full reachable set, running out of states refutes nothing.

--- a/src/ast/seq/seq_monadic.cpp
+++ b/src/ast/seq/seq_monadic.cpp
@@ -63,14 +63,6 @@ Author:
 
 namespace {
 
-    template<typename View = seq::view>
-    static seq::view mk_membership_view(expr* state, ast_manager& m) {
-        if constexpr (requires { View::membership(state, m); })
-            return View::membership(state, m);
-        else
-            return View::membership(state);
-    }
-
     char const *bail_name(unsigned i) {
         static char const *const names[] = {"unsupported", "state-cap",   "budget", "state-expansion",
                                             "resource",    "nullability", "guard",  "not-reversible"};
@@ -832,7 +824,7 @@ bool seq_monadic::commit_next(frame& f) {
         else {
             // Live states are consumed as they are produced, so a witness found early
             // leaves the rest of the reachable set unexpanded.
-            auto live = m_live_states.reachable_live(mk_membership_view(f.R, m));
+            auto live = m_live_states.reachable_live(seq::membership_view(f.R, m));
             target = live.at(f.next++);
             if (!target) {
                 // Short of the full reachable set, running out of states refutes nothing.

--- a/src/ast/seq/seq_monadic.cpp
+++ b/src/ast/seq/seq_monadic.cpp
@@ -63,6 +63,14 @@ Author:
 
 namespace {
 
+    template<typename View = seq::view>
+    static seq::view mk_membership_view(expr* state, ast_manager& m) {
+        if constexpr (requires { View::membership(state, m); })
+            return View::membership(state, m);
+        else
+            return View::membership(state);
+    }
+
     char const *bail_name(unsigned i) {
         static char const *const names[] = {"unsupported", "state-cap",   "budget", "state-expansion",
                                             "resource",    "nullability", "guard",  "not-reversible"};
@@ -824,7 +832,7 @@ bool seq_monadic::commit_next(frame& f) {
         else {
             // Live states are consumed as they are produced, so a witness found early
             // leaves the rest of the reachable set unexpanded.
-            auto live = m_live_states.reachable_live(seq::view::membership(f.R));
+            auto live = m_live_states.reachable_live(mk_membership_view(f.R, m));
             target = live.at(f.next++);
             if (!target) {
                 // Short of the full reachable set, running out of states refutes nothing.

--- a/src/ast/seq/seq_regex_live.cpp
+++ b/src/ast/seq/seq_regex_live.cpp
@@ -14,6 +14,7 @@ Abstract:
 #include "ast/seq/seq_regex_live.h"
 #include "ast/rewriter/seq_rewriter.h"
 #include "util/obj_hashtable.h"
+#include "util/obj_pair_hashtable.h"
 #include "util/uint_set.h"
 
 namespace seq {
@@ -26,8 +27,13 @@ namespace seq {
         bool_vector m_live;
         svector<unsigned> m_live_frontier;
         unsigned m_root_id = 0;
+        // UINT_MAX: membership view, live states are the nullable ones.
+        // otherwise: reach view, the only live state is the one interned as m_target_id.
+        unsigned m_target_id = UINT_MAX;
         failure m_failure = failure::none;
         bool m_complete = false;
+
+        bool has_target() const { return m_target_id != UINT_MAX; }
     };
 
     struct live_states::imp {
@@ -41,7 +47,8 @@ namespace seq {
         vector<svector<unsigned>> m_successors;
         svector<char> m_nullable;
         bool_vector m_expanded;
-        obj_map<expr, search*> m_searches;
+        obj_map<expr, search*> m_membership_searches;
+        obj_pair_map<expr, expr, search*> m_reach_searches;
 
         imp(seq_rewriter& rw, transition_mode mode, unsigned max_states) :
             m_rw(rw),
@@ -92,6 +99,14 @@ namespace seq {
             return m_nullable[id];
         }
 
+        // Whether id is a live (accepting) state for the view driving search s:
+        // reachability to the view's target if it has one, nullability otherwise.
+        bool accepting(search& s, unsigned id) {
+            if (s.has_target())
+                return id == s.m_target_id;
+            return nullable(id) != 0;
+        }
+
         void mark_live(search& s, unsigned id) {
             svector<unsigned> todo;
             todo.push_back(id);
@@ -117,7 +132,7 @@ namespace seq {
             resize(s);
             s.m_seen.insert(id);
             s.m_to_explore.push_back(id);
-            if (nullable(id) != 0)
+            if (accepting(s, id))
                 mark_live(s, id);
             return true;
         }
@@ -176,22 +191,36 @@ namespace seq {
             return index < s.m_live_frontier.size();
         }
 
-        search* get_search(expr* root) {
+        search* get_search(view const& v) {
+            expr* root = v.m_state;
             search* s = nullptr;
-            if (m_searches.find(root, s))
+            if (v.is_reach()) {
+                if (m_reach_searches.find(root, v.m_target, s))
+                    return s;
+            }
+            else if (m_membership_searches.find(root, s))
                 return s;
+
             s = alloc(search);
             unsigned root_id = intern(root);
             s->m_root_id = root_id;
+            if (v.is_reach()) {
+                s->m_target_id = intern(v.m_target);
+                m_reach_searches.insert(root, v.m_target, s);
+            }
+            else
+                m_membership_searches.insert(root, s);
             add_state(*s, root_id);
-            m_searches.insert(root, s);
             return s;
         }
 
         void reset() {
-            for (auto const& [root, s] : m_searches)
+            for (auto const& [root, s] : m_membership_searches)
                 dealloc(s);
-            m_searches.reset();
+            for (auto const& entry : m_reach_searches)
+                dealloc(entry.get_value());
+            m_membership_searches.reset();
+            m_reach_searches.reset();
             m_ids.reset();
             m_states.reset();
             m_successors.reset();
@@ -250,8 +279,8 @@ namespace seq {
         return !m_owner->ensure(m_search, 0) && !failed();
     }
 
-    live_states::reachable live_states::reachable_live(expr* r) {
-        return reachable(this, m_imp->get_search(r));
+    live_states::reachable live_states::reachable_live(view const& v) {
+        return reachable(this, m_imp->get_search(v));
     }
 
     bool live_states::contains(expr* r) const {

--- a/src/ast/seq/seq_regex_live.h
+++ b/src/ast/seq/seq_regex_live.h
@@ -29,6 +29,14 @@ class seq_rewriter;
 
 namespace seq {
 
+    template<typename View = view>
+    inline view membership_view(expr* state, ast_manager& m) {
+        if constexpr (requires { View::membership(state, m); })
+            return View::membership(state, m);
+        else
+            return View::membership(state);
+    }
+
     class live_states {
         struct search;
         struct imp;

--- a/src/ast/seq/seq_regex_live.h
+++ b/src/ast/seq/seq_regex_live.h
@@ -9,15 +9,6 @@ Abstract:
 
     Shared lazy live-state traversal for regular-expression derivatives.
 
-    reachable_live is parameterized by a seq::view rather than a bare regex
-    state: a membership view (no target) traverses towards nullable states,
-    exactly as before, while a reach view additionally recognizes a state as
-    "live" as soon as it is (AST-)identical to the view's target, independent
-    of nullability. Searches for a membership view and a reach view over the
-    same root are distinct traversals (they are keyed by (root, target)) since
-    the two admit different live states, even though both share the same
-    underlying derivative graph (m_ids / m_states / m_successors / m_expanded).
-
 --*/
 #pragma once
 

--- a/src/ast/seq/seq_regex_live.h
+++ b/src/ast/seq/seq_regex_live.h
@@ -9,11 +9,21 @@ Abstract:
 
     Shared lazy live-state traversal for regular-expression derivatives.
 
+    reachable_live is parameterized by a seq::view rather than a bare regex
+    state: a membership view (no target) traverses towards nullable states,
+    exactly as before, while a reach view additionally recognizes a state as
+    "live" as soon as it is (AST-)identical to the view's target, independent
+    of nullability. Searches for a membership view and a reach view over the
+    same root are distinct traversals (they are keyed by (root, target)) since
+    the two admit different live states, even though both share the same
+    underlying derivative graph (m_ids / m_states / m_successors / m_expanded).
+
 --*/
 #pragma once
 
 #include "ast/rewriter/seq_derive.h"
 #include "ast/ast.h"
+#include "ast/seq/seq_view.h"
 
 class seq_rewriter;
 
@@ -74,7 +84,7 @@ namespace seq {
         live_states(live_states const&) = delete;
         live_states& operator=(live_states const&) = delete;
 
-        reachable reachable_live(expr* r);
+        reachable reachable_live(view const& v);
         bool contains(expr* r) const;
         unsigned state_id(expr* r);
         // Number of interned derivative states, i.e. the size of the shared state table.

--- a/src/smt/seq_regex.cpp
+++ b/src/smt/seq_regex.cpp
@@ -27,6 +27,14 @@ Author:
 
 namespace smt {
 
+    template<typename View = seq::view>
+    static seq::view mk_membership_view(expr* state, ast_manager& m) {
+        if constexpr (requires { View::membership(state, m); })
+            return View::membership(state, m);
+        else
+            return View::membership(state);
+    }
+
     static seq::transition_mode monadic_transition_mode(symbol const& s) {
         if (s == "light-ant")
             return seq::transition_mode::light_antimirov_tm;
@@ -762,7 +770,7 @@ namespace smt {
         }
 
         if (info.interpreted) {
-            auto live = m_live_states.reachable_live(seq::view::membership(r));
+            auto live = m_live_states.reachable_live(mk_membership_view(r, m));
             if (live.is_dead()) {
                 STRACE(seq_regex_brief, tout << "(dead) ";);
                 th.add_axiom(~lit);

--- a/src/smt/seq_regex.cpp
+++ b/src/smt/seq_regex.cpp
@@ -762,7 +762,7 @@ namespace smt {
         }
 
         if (info.interpreted) {
-            auto live = m_live_states.reachable_live(r);
+            auto live = m_live_states.reachable_live(seq::view::membership(r));
             if (live.is_dead()) {
                 STRACE(seq_regex_brief, tout << "(dead) ";);
                 th.add_axiom(~lit);

--- a/src/smt/seq_regex.cpp
+++ b/src/smt/seq_regex.cpp
@@ -27,14 +27,6 @@ Author:
 
 namespace smt {
 
-    template<typename View = seq::view>
-    static seq::view mk_membership_view(expr* state, ast_manager& m) {
-        if constexpr (requires { View::membership(state, m); })
-            return View::membership(state, m);
-        else
-            return View::membership(state);
-    }
-
     static seq::transition_mode monadic_transition_mode(symbol const& s) {
         if (s == "light-ant")
             return seq::transition_mode::light_antimirov_tm;
@@ -770,7 +762,7 @@ namespace smt {
         }
 
         if (info.interpreted) {
-            auto live = m_live_states.reachable_live(mk_membership_view(r, m));
+            auto live = m_live_states.reachable_live(seq::membership_view(r, m));
             if (live.is_dead()) {
                 STRACE(seq_regex_brief, tout << "(dead) ";);
                 th.add_axiom(~lit);


### PR DESCRIPTION
reachable_live now takes a seq::view instead of a bare regex state. A membership view (no target) traverses towards nullable states, exactly as before. A reach view additionally recognizes a state as live as soon as it is AST-identical to the view's target, independent of nullability.

- search tracks an optional m_target_id (UINT_MAX for membership); a new accepting() helper drives liveness in add_state/expand (nullable for membership, id == target_id for reach).
- Searches are keyed by (root, target): a plain obj_map for membership views and an obj_pair_map<expr, expr, search*> for reach views, since the two admit different live states over the same root.
- Callers in seq_regex.cpp and seq_monadic.cpp updated to pass seq::view::membership(...).

Validated with a full rebuild and the unit test suite (105/105 passed, including seq_monadic, seq_monadic_bench, seq_regex_witness, seq_eq_approx, seq_parikh).